### PR TITLE
Remove encoding declaration in util.php

### DIFF
--- a/app/classes/util.php
+++ b/app/classes/util.php
@@ -13,8 +13,6 @@
  * @version  1.0.003
  */
 
-declare(encoding='UTF-8');
-
 if ( ! class_exists( 'util' ) ) {
     class util
     {


### PR DESCRIPTION
This line create a warning on PHP 5.4+

> Warning: declare(encoding=...) ignored because Zend multibyte feature is turned off by settings in /Users/jerometamarelle/Code/GitHub/bolt/app/classes/util.php on line 16

See also: http://forge.typo3.org/issues/38055
