### PR TITLE
Fix warning for taxonomy + use correct config data

### DIFF
--- a/app/src/Bolt/Content.php
+++ b/app/src/Bolt/Content.php
@@ -23,8 +23,8 @@ class Content implements \ArrayAccess
             $this->setContenttype($contenttype);
 
             // If this contenttype has a taxonomy with 'grouping', initialize the group.
-            if (isset($contenttype['taxonomy'])) {
-                foreach ($contenttype['taxonomy'] as $taxonomytype) {
+            if (isset($this->contenttype['taxonomy'])) {
+                foreach ($this->contenttype['taxonomy'] as $taxonomytype) {
                     if ($this->app['config']['taxonomy'][$taxonomytype]['behaves_like'] == "grouping") {
                         $this->setGroup("", $this->app['config']['taxonomy'][$taxonomytype]['has_sortorder']);
                     }


### PR DESCRIPTION
Gave warning when a contentype doesn't have taxonomy setting.
Fix to use correct config data, not the passed in string parameter.
