### PR TITLE
Can set charset in database config

### DIFF
--- a/app/classes/lib.php
+++ b/app/classes/lib.php
@@ -893,6 +893,9 @@ function getDBOptions($config)
             'port'      => (isset($configdb['port']) ? $configdb['port'] : '3306'),
             'randomfunction' => $randomfunction
         );
+        if (isset($configdb['charset'])) {
+            $dboptions['charset'] = $configdb['charset'];
+        }
 
     }
 


### PR DESCRIPTION
Can set charset to use in the config, so utf8 works. Example:

database:
  driver: mysql
  charset: utf8
  databasename: name
  username: user
  password: pass
