### PR TITLE
Remove remaining uses of request superglobals

### DIFF
--- a/app/src/Bolt/Controllers/Async.php
+++ b/app/src/Bolt/Controllers/Async.php
@@ -114,10 +114,11 @@ class Async implements ControllerProviderInterface
 
         $term = $request->get('term');
 
-        if (empty($_GET['ext'])) {
+        $ext = $request->query->get('ext');
+        if (empty($ext)) {
             $extensions = 'jpg,jpeg,gif,png';
         } else {
-            $extensions = $_GET['extensions'];
+            $extensions = $request->query->get('extensions');
         }
 
         $files = findFiles($term, $extensions);
@@ -157,7 +158,7 @@ class Async implements ControllerProviderInterface
 
     function markdownify(Silex\Application $app, Request $request) {
 
-        $html = $_POST['html'];
+        $html = $request->request->get('html');
 
         if (isHtml($html)) {
 
@@ -176,7 +177,7 @@ class Async implements ControllerProviderInterface
 
     function makeuri(Silex\Application $app, Request $request) {
 
-        $uri = $app['storage']->getUri($_GET['title'], $_GET['id'], $_GET['contenttypeslug'], $_GET['fulluri']);
+        $uri = $app['storage']->getUri($request->query->get('title'), $request->query->get('id'), $request->query->get('contenttypeslug'), $request->query->get('fulluri'));
 
         return $uri;
 

--- a/app/src/Bolt/Controllers/Backend.php
+++ b/app/src/Bolt/Controllers/Backend.php
@@ -211,7 +211,8 @@ class Backend implements ControllerProviderInterface
 
         // If 'return=edit' is passed, we should return to the edit screen. We do redirect twice, yes,
         // but that's because the newly saved contenttype.yml needs to be re-read.
-        if (isset($_GET['return']) && $_GET['return']=="edit") {
+        $return = $app['request']->query->get('return');
+        if ($return=="edit") {
             if (empty($output)) {
                 $content = "Your database is already up to date.";
             } else {
@@ -302,11 +303,7 @@ class Backend implements ControllerProviderInterface
 
         $contenttype = $app['storage']->getContentType($contenttypeslug);
 
-        if (!empty($_GET['order'])) {
-            $order = $_GET['order'];
-        } else {
-            $order = '';
-        }
+        $app['request']->query->get('order', '');
 
         $page = $app['request']->query->get('page');
         $filter = $app['request']->query->get('filter');
@@ -388,7 +385,8 @@ class Backend implements ControllerProviderInterface
 
         }
 
-        if (!empty($_GET['duplicate'])) {
+        $duplicate = $app['request']->query->get('duplicate');
+        if (!empty($duplicate)) {
             $content->setValue('id', "");
             $content->setValue('datecreated', "");
             $content->setValue('datepublish', "");

--- a/app/src/Bolt/Controllers/Frontend.php
+++ b/app/src/Bolt/Controllers/Frontend.php
@@ -133,7 +133,7 @@ class Frontend implements ControllerProviderInterface
         $contenttype = $app['storage']->getContentType($contenttypeslug);
 
         // First, get some content
-        $page = (!empty($_GET['page']) ? $_GET['page'] : 1);
+        $page = $app['request']->query->get('page', 1);
         $amount = (!empty($contenttype['listing_records']) ? $contenttype['listing_records'] : $app['config']['general']['listing_records']);
         $content = $app['storage']->getContent($contenttype['slug'], array('limit' => $amount, 'order' => 'datepublish desc', 'page' => $page));
 

--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -794,7 +794,7 @@ class Storage
 
         // If we're allowed to use pagination, use the 'page' parameter.
         if (!empty($parameters['paging'])) {
-            $page = !empty($_REQUEST['page']) ? $_REQUEST['page'] : $page;
+            $page = $this->app['request']->get('page', $page);
         }
 
         $queryparams = "";
@@ -916,7 +916,7 @@ class Storage
 
         // If we're allowed to use pagination, use the 'page' parameter.
         if (!empty($parameters['paging'])) {
-            $page = !empty($_REQUEST['page']) ? $_REQUEST['page'] : $page;
+            $page = $this->app['request']->get('page', $page);
         }
         //$tablename = $this->prefix . $contenttypename;
         $tablename = implode(", ", $tables);
@@ -1022,7 +1022,7 @@ class Storage
 
         // If we're allowed to use pagination, use the 'page' parameter.
         if (!empty($parameters['paging'])) {
-            $page = !empty($_REQUEST['page']) ? $_REQUEST['page'] : $page;
+            $page = $this->app['request']->get('page', $page);
         }
 
         $contenttype = $this->getContentType($contenttypeslug);
@@ -1131,7 +1131,8 @@ class Storage
 
         // Iterate over the contenttype's taxonomy, check if there's one we can use for grouping.
         // But only if we're not sorting manually (i.e. have a ?order=.. parameter or $parameter['order'] )
-        if ( empty($_GET['order']) && empty($parameters['order']) ) {
+        $order = $this->app['request']->query->get('page', $parameters['order']);
+        if (empty($order)) {
             if ($this->getContentTypeGrouping($contenttypeslug)) {
                 uasort($content, array($this, 'groupingSort'));
             }

--- a/app/src/Bolt/TwigExtension.php
+++ b/app/src/Bolt/TwigExtension.php
@@ -373,14 +373,12 @@ class TwigExtension extends \Twig_Extension
     public function request($parameter, $first = "")
     {
 
-        if ($first=="get" && isset($_GET[$parameter])) {
-            return $_GET[$parameter];
-        } elseif ($first=="post" && isset($_POST[$parameter])) {
-            return $_POST[$parameter];
-        } elseif (isset($_REQUEST[$parameter])) {
-            return $_REQUEST[$parameter];
+        if ($first=="get") {
+            return $this->app['request']->query->get($parameter, false);
+        } elseif ($first=="post") {
+            return $this->app['request']->request->get($parameter, false);
         } else {
-            return false;
+            return $this->app['request']->get($parameter, false);
         }
 
     }


### PR DESCRIPTION
I went through the application and removed any remaining uses of request superglobals ($_GET, $_POST, $_REQUEST) and replaced them with the relevant Symfony Request API call. The only uses of request superglobals that remain that I could find are those in utility classes not specific to Bolt.

This should resolve issue #72.
