### PR TITLE
Refactored so the extension can be used in PHP 5.3 as well. Fixes issue #172

### DIFF
--- a/app/extensions/NiceUrls/extension.php
+++ b/app/extensions/NiceUrls/extension.php
@@ -21,12 +21,12 @@ class Extension extends \Bolt\BaseExtension
             'description' => "Allows some shortcuts and nicer urls like example.org/about to link through to example.org/page/about",
             'author' => "WeDesignIt, Patrick van Kouteren",
             'link' => "http://www.wedesignit.nl",
-            'version' => "0.2",
+            'version' => "0.3",
             'required_bolt_version' => "1.0 RC",
             'highest_bolt_version' => "1.0 RC",
             'type' => "General",
             'first_releasedate' => "2012-11-06",
-            'latest_releasedate' => "2013-01-28"
+            'latest_releasedate' => "2013-02-05"
         );
 
         return $data;
@@ -45,9 +45,10 @@ class Extension extends \Bolt\BaseExtension
         foreach ($config as $routingData) {
             if ($this->isValidRoutingData($routingData)) {
                 $from = $this->transformWildCard($routingData['from']['slug']);
+                $app = $this->app;
                 $this->app->match('/' . $from, function (Request $request) use ($app, $from, $routingData) {
-                    $this->app['end'] = 'frontend';
-                    $to = $this->transformWildCard($routingData['to']['contenttypeslug'] . '/' . $routingData['to']['slug']);
+                    $app['end'] = 'frontend';
+                    $to = \NiceUrls\Extension::transformWildCard($routingData['to']['contenttypeslug'] . '/' . $routingData['to']['slug']);
                     foreach ($request->get('_route_params') as $rparam => $rval) {
                         $to = str_replace('{' . $rparam . '}', $rval, $to);
                     }
@@ -58,7 +59,7 @@ class Extension extends \Bolt\BaseExtension
                         $subRequest->setSession($request->getSession());
                     }
 
-                    return $this->app->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
+                    return $app->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
                 })
                     ->before('Bolt\Controllers\Frontend::before')
                     ->assert('contenttypeslug', $this->app['storage']->getContentTypeAssert());
@@ -72,7 +73,7 @@ class Extension extends \Bolt\BaseExtension
      * @param $string
      * @return mixed
      */
-    function transformWildCard($string)
+    public static function transformWildCard($string)
     {
         preg_match_all('/%%[A-Za-z0-9]+%%/', $string, $matches);
         $parts = $matches[0];


### PR DESCRIPTION
PHP 5.4 can handle $this in a closure, but PHP 5.3 can't. Made compatible.
