### PR TITLE
Added missing / before .htaccess during setup

### DIFF
--- a/app/classes/lowlevelchecks.php
+++ b/app/classes/lowlevelchecks.php
@@ -51,7 +51,7 @@ class lowlevelchecks
 
         // Check if .htaccess is present and readable
         if (!is_readable(BOLT_WEB_DIR.'/.htaccess')) {
-            $this->lowlevelError("The file <code>" . BOLT_WEB_DIR . ".htaccess</code> doesn't exist. Make sure it's " .
+            $this->lowlevelError("The file <code>" . BOLT_WEB_DIR . "/.htaccess</code> doesn't exist. Make sure it's " .
                 "present and readable to the user that the webserver is using.");
         }
 


### PR DESCRIPTION
During setup there is a typo if you haven't included the .htaccess file.  There is a missing / before the .htaccess file name.
