### PR TITLE
Updated phpunit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "phpunit/php-code-coverage": "1.2.*@dev",
-        "phpunit/phpunit": "3.7.13"
+        "phpunit/phpunit": "3.7.18"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
In PHPUnit version 3.7.13 the command-line run results in an error
due to a change in PHP_Timer usage (static vs instantiated).

Fatal error: Call to undefined method PHPUnit_TextUI_ResultPrinter::timeSinceStartOfRequest() in vendor/phpunit/php-timer/PHP/Timer.php on line 150
