### PR TITLE
 Bolt no longer add html-snippets 'at random'.

### DIFF
--- a/app/app.php
+++ b/app/app.php
@@ -111,22 +111,19 @@ if ($app['debug'] && ($app['session']->has('user') || $app['config']['general'][
 
 $app->after(function (Request $request, Response $response) use ($app) {
 
-    $end = getWhichEnd();
+    // true if we need to consider adding html snippets
+    if (isset($app['htmlsnippets']) && ($app['htmlsnippets'] === true)) {
 
-    if ($end == "frontend") {
-
-        $html = $response->getContent();
-
-        // Insert our 'generator' after the last <meta ..> tag.
-        // @todo Find a neat solution for this
-        if (stripos($response->headers->get('Content-Type'), 'xml') === false){
+        // only add when content-type is text/html
+        if (strpos($response->headers->get('Content-Type'), 'text/html') !== false) {
             $app['extensions']->insertSnippet(\Bolt\Extensions\Snippets\Location::AFTER_META, '<meta name="generator" content="Bolt">');
+
+            $html = $response->getContent();
+
+            $html = $app['extensions']->processSnippetQueue($html);
+
+            $response->setContent($html);
         }
-
-        $html = $app['extensions']->processSnippetQueue($html);
-
-        $response->setContent($html);
-
     }
 
 });

--- a/app/src/Bolt/Controllers/Frontend.php
+++ b/app/src/Bolt/Controllers/Frontend.php
@@ -68,7 +68,8 @@ class Frontend implements ControllerProviderInterface
             return redirect('useredit', array('id' => ""));
         }
 
-        $app['debugbar'] = true;
+        $app['debugbar']     = true;
+        $app['htmlsnippets'] = true;
 
     }
 


### PR DESCRIPTION
Bolt only adds snippets when the controllers sets the 'app-global'
'htmlsnippets' to 'true' and the content is text/html.
By default, the Frontend controller enables it.
