### PR TITLE
Fix of Homepage action

### DIFF
--- a/app/src/Bolt/Controllers/Frontend.php
+++ b/app/src/Bolt/Controllers/Frontend.php
@@ -78,10 +78,16 @@ class Frontend implements ControllerProviderInterface
         if (!empty($app['config']['general']['homepage_template'])) {
             $template = $app['config']['general']['homepage_template'];
             $content = $app['storage']->getContent($app['config']['general']['homepage']);
-            $twigvars = array(
-                'record' => $content,
-                $content->contenttype['singular_slug'] => $content
-            );
+            if (is_array($content)) {
+                $twigvars = array(
+                    'records' => $content
+                );
+            } else {
+                $twigvars = array(
+                    'record' => $content,
+                    $content->contenttype['singular_slug'] => $content
+                );
+            }
             $chosen = 'homepage config';
         } else {
             $template = 'index.twig';


### PR DESCRIPTION
Hey, guys, thank you for the awesome CMS!
This evening I merged my project with remote upstream and it became broken, the homepage was showing:

<pre>
Whoops \ Exception \ ErrorException
Trying to get property of non-object
</pre>


with a stacktrace

<pre>
Bolt\Controllers\Frontend homepage
<#unknown>0
call_user_func_array
/home/nrg/www/blog/vendor/symfony/http-kernel/Symfony/Component/HttpKernel/HttpKernel.php131
Symfony\Component\HttpKernel\HttpKernel handleRaw
/home/nrg/www/blog/vendor/symfony/http-kernel/Symfony/Component/HttpKernel/HttpKernel.php73
Symfony\Component\HttpKernel\HttpKernel handle
/home/nrg/www/blog/vendor/silex/silex/src/Silex/Application.php504
Silex\Application handle
/home/nrg/www/blog/vendor/silex/silex/src/Silex/Application.php481
Silex\Application run
/home/nrg/www/blog/index.php12
</pre>


But I was able to see this error message only in case I was logged into the application. After some time spent to research the issue I've found that I was able to see this error page due to the Whoops strictness (because everything was good for the unlogged user and therefore switched off Whoops) and it seems that the issue is quite old enough. If homepage and homepage_template are commented in config.yml, then according to the getConfig() function their default settings are 

``` php
'homepage' => 'page/*',
'homepage_template' => 'index.twig'
```

.ie the default content consists of multiple records. But Bolt\Controllers\Frontpage::homepage() has been always assume that the content is single record:

``` php
$content = $app['storage']->getContent($app['config']['general']['homepage']);
$twigvars = array(
    'record' => $content,
    $content->contenttype['singular_slug'] => $content
);
```

Since default homepage settings produce a set of pages it's impossible to deal with content as an object and operate with contenttype property. I've assumed that the fix of the available Twig variables can be a simple and clear solution.

PS: Sorry for my messed English, it's not good, I know it (...
