### PR TITLE
Fix ScruntinizerCi phpcpd

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -13,6 +13,10 @@ tools:
         min_lines: 5
         # Minimum number of identical tokens (default: 70)
         min_tokens: 70
+        # A list of names that should be scanned (default: '*.php')
+        names:
+            # Default:
+            - '*.php'
         # A list of excluded directories.
         excluded_dirs: ["vendor", "files"]
         enabled: true


### PR DESCRIPTION
Okay, after diggin around I have found two bugs in Scruntinizer and phpcpd itsself. 

The first was Scruntinizer imploding `exluded_dirs` params like `--exclude param1,param2` but `--exclude param1 --exclude param2` is needed by phpcpd. 

This is fixed. 

The second one is lacking support for wildcards in FinderFacade used by phpcpd it seems. This PR workaround this error.

Thanks 
