### PR TITLE
Fix when multiple is not defined for select in contenttype and using strict variables

### DIFF
--- a/app/view/_sub_editfields.twig
+++ b/app/view/_sub_editfields.twig
@@ -96,7 +96,7 @@
 
 {% if field.type == "select" %}
     <label><b><span class='left'>{% if field.label is defined %}{{field.label|trans}}{% else %}{{ key|ucfirst|trans}}{%endif%}</span></b></label>
-    {% if field.multiple %}
+    {% if field.multiple is defined and field.multiple %}
         <select name="{{key}}[]" id="{{key}}" multiple>
             {% for value in field.values %}
                 <option value="{{value}}" {% if value in content.get(key) %}selected{% endif %}>{{value}}</option>


### PR DESCRIPTION
Gave an error when select was not defined
