### PR TITLE
Only set empty slug when not set

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -523,7 +523,9 @@ class Storage
             $this->app['dispatcher']->dispatch(StorageEvents::preSave, $event);
         }
 
-        $fieldvalues['slug'] = ''; // Prevent 'slug may not be NULL'
+        if (!isset($fieldvalues['slug'])) {
+            $fieldvalues['slug'] = ''; // Prevent 'slug may not be NULL'
+        }
 
         // add the fields for this contenttype,
         foreach ($contenttype['fields'] as $key => $values) {


### PR DESCRIPTION
I introduced a bug in #346 which always generates a new slug based on "uses", even when the slug is locked. Sorry for that, fixed with this.
