### PR TITLE
Fix "Send" button label being ignored

### DIFF
--- a/app/extensions/SimpleForms/extension.php
+++ b/app/extensions/SimpleForms/extension.php
@@ -61,7 +61,7 @@ class Extension extends \Bolt\BaseExtension
         $this->addCSS($this->config['stylesheet']);
 
         // Set the button text.
-        if (!empty($this->config['button_text'])) {
+        if (empty($this->config['button_text'])) {
             $this->config['button_text'] = "Send";
         }
 


### PR DESCRIPTION
Custom label for "Send" button was being ignored because of a wrong "if" logic.
