### PR TITLE
Fix retrieving of relations by removing unneeded quote()

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -1770,7 +1770,7 @@ class Storage
             "SELECT * FROM %s WHERE from_contenttype=? AND from_id IN (?) ORDER BY id",
             $tablename
         );
-        $params = array($this->app['db']->quote($contenttype), $ids);
+        $params = array($contenttype, $ids);
         $paramTypes = array(\PDO::PARAM_STR, DoctrineConn::PARAM_INT_ARRAY);
         $rows = $this->app['db']->executeQuery($query, $params, $paramTypes)->fetchAll();
 
@@ -1783,7 +1783,7 @@ class Storage
             "SELECT * FROM %s WHERE to_contenttype=? AND to_id IN (?) ORDER BY id",
             $tablename
         );
-        $params = array($this->app['db']->quote($contenttype), $ids);
+        $params = array($contenttype, $ids);
         $paramTypes = array(\PDO::PARAM_STR, DoctrineConn::PARAM_INT_ARRAY);
         $rows = $this->app['db']->executeQuery($query, $params, $paramTypes)->fetchAll();
 

--- a/app/src/Bolt/TwigExtension.php
+++ b/app/src/Bolt/TwigExtension.php
@@ -425,7 +425,7 @@ class TwigExtension extends \Twig_Extension
     public function listcontent($contenttype, $relationoptions, $content)
     {
         // Just the relations for the current record, and just the current $contenttype.
-        $current = $content->relation[$contenttype];
+        $current = isset($content->relation[$contenttype]) ? $content->relation[$contenttype] : null;
 
         // We actually only need the 'order' in options.
         $options = array();


### PR DESCRIPTION
Relations were broken because of and unneeded quote() being used with a prepared statement.
