### PR TITLE
Slug update on typing

### DIFF
--- a/app/view/js/bolt.js
+++ b/app/view/js/bolt.js
@@ -299,7 +299,7 @@ function makeUri(contenttypeslug, id, usesfields, slugfield, fulluri) {
             })
             clearTimeout(makeuritimeout);
             makeuritimeout = setTimeout( function(){ makeUriAjax(usesvalue, contenttypeslug, id, this, slugfield, fulluri); }, 200);
-        }).trigger('propertychange.bolt input.bolt change.bolt');
+        }).trigger('change.bolt');
     });
 
 }


### PR DESCRIPTION
Re-add the propertychange and input event so slug gets updated when typing. Keep change event for supporting a select. Were removed in #346 but shouldn't be.
