### PR TITLE
Fix long imagelists from flowing over the next field.

### DIFF
--- a/app/view/css/bolt.css
+++ b/app/view/css/bolt.css
@@ -1,4 +1,3 @@
-
 /**
  * Colour scheme:
  * - #204460 - Bolt blue
@@ -687,6 +686,10 @@ fieldset.checkbox div {
     display: inline-block;
     padding: 0 3px;
     cursor: pointer;
+}
+
+#editcontent div.imagelistholder.dropzone {
+    height: auto;
 }
 
 #editcontent div.imagelistholder textarea {


### PR DESCRIPTION
This small css tweak sets the imagelistholder.dropzone height to auto to prevent overflowing caused by the general .dropzone height setting of 120px.
