### PR TITLE
Allow NiceUrls with only conttenttype

### DIFF
--- a/app/extensions/NiceUrls/config.yml.dist
+++ b/app/extensions/NiceUrls/config.yml.dist
@@ -15,6 +15,15 @@ about_foo:
   to:
     contenttypeslug: entry
     slug: yada
+    
+## Also for contenttype only urls
+pages:
+  from:
+    slug: p
+  to:
+    contenttypeslug: pages
+    slug: ""
+    
 ## (Named) Wildcards are allowed. BUT make sure you don't use wildcards all the
 ## way as the routing can get confused.
 ##

--- a/app/extensions/NiceUrls/extension.php
+++ b/app/extensions/NiceUrls/extension.php
@@ -48,7 +48,9 @@ class Extension extends BoltExtension
                 $app = $this->app;
                 $this->app->match('/' . $from, function (Request $request) use ($app, $from, $routingData) {
                     $app['end'] = 'frontend';
-                    $to = \NiceUrls\Extension::transformWildCard($routingData['to']['contenttypeslug'] . '/' . $routingData['to']['slug']);
+                    $route = $routingData['to']['contenttypeslug'];
+                    $route.= $routingData['to']['slug'] ? '/' . $routingData['to']['slug'] : '';
+                    $to = \NiceUrls\Extension::transformWildCard($route);
                     foreach ($request->get('_route_params') as $rparam => $rval) {
                         $to = str_replace('{' . $rparam . '}', $rval, $to);
                     }

--- a/app/extensions/NiceUrls/readme.md
+++ b/app/extensions/NiceUrls/readme.md
@@ -27,6 +27,14 @@ geo:
   to:
     contenttypeslug: kitchensink
     slug: about
+    
+pages:
+  from:
+    slug: p
+  to:
+    contenttypeslug: pages
+    slug: ""
+        
 </pre>
 
 In this case we have two custom urls, defined by the from slug. Note that the
@@ -37,3 +45,4 @@ This config adds the following routing:
 
 http://example.org/about/foo/bar will show the contents of http://example.org/page/about
 http://example.org/about will show the contents of http://example.org/kitchensink/about
+http://example.org/p will show the contents of http://example.org/pages


### PR DESCRIPTION
In NiceUrl extension, allow contenttype-only urls (to list items of that contenttype):

`http://example.com/p` ==> `http://example.com/pages`
