### PR TITLE
Removed floating from .imageholder in mobile media query to fix positioning & sizing bug on certain mobile devices.

### DIFF
--- a/theme/base-2013/stylesheets/app.css
+++ b/theme/base-2013/stylesheets/app.css
@@ -265,8 +265,9 @@ div.pagination ul li.active a:hover, ul.pagination li.current a:focus { backgrou
     font-size: 15px;
   }
 
-div.imageholder {
-  background-color: #FFF;
-  margin: 0 -17px 10px -17px;
+  div.imageholder {
+    float: none;
+    margin: 0 -17px 10px -17px;
+  }
 
 }


### PR DESCRIPTION
Certain mobile phones (for example Nokia Lumias) have an issue with the float: right in imageholder and display images like this then:
http://i.imgur.com/DkcIQUk.jpg

So I removed the float: right from .imageholder and also added a closing bracket for the mobile media query, and this is what it looks like now:
http://i.imgur.com/aGP7Lpb.jpg
