### PR TITLE
Fix Browscap exception with connection problems

### DIFF
--- a/app/classes/lib.php
+++ b/app/classes/lib.php
@@ -1384,23 +1384,23 @@ function containsHTML($str)
 function getBrowserInfo() {
 
     // Create a new Browscap object (loads or creates the cache)
-    $bc = new \phpbrowscap\Browscap(dirname(__DIR__)."/cache/");
+    $browser = '?';
+    try { // Browscap fails when it can't connect / no connection is available
+        $bc = new \phpbrowscap\Browscap(dirname(__DIR__)."/cache/");
 
-    $browser = $bc->getBrowser()->Parent;
-    if (strpos($bc->getBrowser()->browser_name, "CriOS") > 0) {
-        $browser = "Chrome";
+        $browser = $bc->getBrowser()->Parent;
+        if (strpos($bc->getBrowser()->browser_name, "CriOS") > 0) {
+            $browser = "Chrome";
+        }
+        $platformversion = ($bc->getBrowser()->Platform_Version == "unknown") ? "" : $bc->getBrowser()->Platform_Version;
+
+        $browser = sprintf("%s / %s %s",
+            $browser,
+            $bc->getBrowser()->Platform,
+            $platformversion
+        );
+    } catch(Exception $e) {
     }
-
-    $platformversion = ($bc->getBrowser()->Platform_Version == "unknown") ? "" : $bc->getBrowser()->Platform_Version;
-
-    $browser = sprintf("%s / %s %s",
-        $browser,
-        $bc->getBrowser()->Platform,
-        $platformversion
-    );
-
-    //\util::var_dump($bc->getBrowser());
-
     return trim($browser);
 
 }


### PR DESCRIPTION
Catch "Your server can't connect to external resources. Please update th...e file manually." exception from Browscap when there are network problems.
Caught this when my internet connection went down.
