### PR TITLE
Remove properties in Bolt\Application

### DIFF
--- a/app/src/Bolt/Application.php
+++ b/app/src/Bolt/Application.php
@@ -4,33 +4,6 @@ namespace Bolt;
 
 use Silex\Application as BaseApplication;
 
-/**
- * @property-read string $bolt_version
- * @property-read string $bolt_name
- *
- * @property array $config
- * @property string $dbPrefix
- * @property \Doctrine\DBAL\Connection $db
- * @property \Symfony\Component\HttpFoundation\Session\Session $session
- * @property \Twig_Environment $twig
- * @property bool $debugbar
- * @property bool $debug
- * @property array $paths
- * @property string $end
- * @property string $editlink
- * @property Log $log
- * @property Extensions $extensions
- * @property Storage $storage
- * @property Users $users
- * @property Content $content
- * @property Cache $cache
- * @property \Symfony\Component\HttpFoundation\Request $request
- * @property \Symfony\Component\Translation\Translator $translator
- * @property array $pager
- * @property \Swift_Mailer $mailer
- * @property \Symfony\Component\Routing\Generator\UrlGenerator $url_generator
- * @property \Symfony\Component\Validator\Validator $validator
- */
 class Application extends BaseApplication
 {
     public function __construct(array $values = array())
@@ -45,9 +18,11 @@ class Application extends BaseApplication
      * @param string $name
      * @return mixed
      * @throws \InvalidArgumentException
+     * @deprecated
      */
     public function __get($name)
     {
+        trigger_error('$app->'.$name.' is deprecated, use $app[\''.$name.'\'] instead',E_USER_DEPRECATED);
         if (isset($name)) {
             return $this[$name];
         }
@@ -62,9 +37,11 @@ class Application extends BaseApplication
     /**
      * @param string $name
      * @param mixed $value
+     * @deprecated
      */
     public function __set($name, $value)
     {
+        trigger_error('$app->'.$name.' is deprecated, use $app[\''.$name.'\'] instead',E_USER_DEPRECATED);
         $this[$name] = $value;
     }
 


### PR DESCRIPTION
Remove from phpdoc and make calls to them give a deprecated warning
Fixes #462

Should this be in future 1.2 or in current 1.1? The props weren't used in Bolt, so maybe in local code or extensions. I think making them deprecated in 1.1 is good, since we reached that agreement way before it was released.
