### PR TITLE
Only use default  for TEXT fields in Sqlite

### DIFF
--- a/app/src/Bolt/Database/IntegrityChecker.php
+++ b/app/src/Bolt/Database/IntegrityChecker.php
@@ -3,7 +3,7 @@
 namespace Bolt\Database;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\ColumnDiff;
@@ -24,6 +24,11 @@ class IntegrityChecker
      * @var string
      */
     private $prefix;
+    /**
+     * Default value for TEXT fields, differs per platform
+     * @var string|null
+     */
+    private $textDefault = null;
 
     public function __construct(\Bolt\Application $app)
     {
@@ -38,6 +43,10 @@ class IntegrityChecker
 
         // Check the table integrity only once per hour, per session. (since it's pretty time-consuming.
         $this->checktimer = 3600;
+
+        if($this->app['db']->getDatabasePlatform() instanceof SqlitePlatform) {
+            $this->textDefault = '';
+        }
 
     }
 
@@ -454,7 +463,7 @@ class IntegrityChecker
                     case 'markdown':
                     case 'geolocation':
                     case 'imagelist':
-                        $myTable->addColumn($field, "text", array("default" => ""));
+                        $myTable->addColumn($field, "text", array("default" => $this->textDefault));
                         break;
                     case 'datetime':
                         $myTable->addColumn($field, "datetime");


### PR DESCRIPTION
Only use default  for TEXT fields in Sqlite since it requires the default (see #448). Don't use this for other platforms since it gives warnings and even errors. 
Fixes #470
