### PR TITLE
Escape search output

### DIFF
--- a/theme/base-2013/_sub_searchbox.twig
+++ b/theme/base-2013/_sub_searchbox.twig
@@ -1,5 +1,5 @@
 <li class="search">
     <form method="get" action="{{ paths.root }}search" id="searchform" enctype="text/plain">
-        <input type="search" value="{% if search is defined %}{{ search }}{% endif %}" placeholder="Search.." name="search">
+        <input type="search" value="{% if search is defined %}{{ search|escape }}{% endif %}" placeholder="Search.." name="search">
     </form>
 </li>

--- a/theme/base-2013/listing.twig
+++ b/theme/base-2013/listing.twig
@@ -31,7 +31,7 @@
            code in the 'else' part of the for-loop is used. #}
         {% if search is defined %}
             <h1>
-                {{ __('Search results for <b> %search% </b>.', { '%search%': search }) }}
+                {{ __('Search results for <b> %search% </b>.', { '%search%': search|escape }) }}
             </h1>
         {% endif %}
 
@@ -71,7 +71,7 @@
                 {% if search is defined %}
 
                     <p>
-                        {{ __("No results found for '%search%'. Please try another search.", { '%search%': search }) }}
+                        {{ __("No results found for '%search%'. Please try another search.", { '%search%': search|escape }) }}
                     </p>
 
                 {% else %}


### PR DESCRIPTION
If you make a search the output is not properly escaped so you can insert html tags into the markup i.e.

/search?search=foo%3Cscript%20type=%22text/javascript%22%3Ealert%28%27Oo%27%29%3B%0A%0A/*
/search?search=foo%3Cmarquee%3E

the search is sanitized means that does not lead directly to an XSS problem but as shown in the example this could be abused or maybe bypassed. Its probably safer to simply escape the output
