### PR TITLE
More php strtotime magic plx...

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -1345,19 +1345,9 @@ class Storage
             $operator = "LIKE";
         }
 
-        // special cases, for 'NOW', 'TODAY', 'YESTERDAY', 'TOMORROW'
-        if ($value == "NOW") {
-            $value = date('Y-m-d H:i:s');
-        }
-        if ($value == "TODAY") {
-            $value = date('Y-m-d 00:00:00');
-        }
-        if ($value == "YESTERDAY") {
-            $value = date('Y-m-d 00:00:00', strtotime('yesterday'));
-        }
-        if ($value == "TOMORROW") {
-            $value = date('Y-m-d 00:00:00', strtotime('tomorrow'));
-        }
+	if (($timestamp = strtotime($value)) !== false) {
+	    $value = date('Y-m-d', $timestamp);
+	}
 
         $parameter = sprintf("%s %s %s", $this->app['db']->quoteIdentifier($key), $operator, $this->app['db']->quote($value));
 


### PR DESCRIPTION
I run Bolt on MySQL 5.X, got a active_from and active_to column where I whanted to find out WHERE active_from >= this week's monday and <= active_to this week's saturday.

{% setcontent varname = 'contenttype' where { status: 'published',date/(-time)field: "{OPERATOR}{TWIG_VARIABLE}" } %}
Doesnt work as it would be treated as a comparison string, escaped, and pushed into the query.

{% setcontent varname = 'contenttype' where { status: 'published',date/(-time)field: "{OPERATOR}"{TWIG_VARIABLE} } %}
Insufficient syntax leads to hell of a beautiful whoops error page.

{% setcontent varname = 'contenttype' where { status: 'published',date/(-time)field: "{OPERATOR}{RELATIVE_TIMESTAMP_BEFORE_YESTERDAY}" } %}
Wasn't supported.

A BETWEEN feature isnt there right? Did I oversee something? This does work on mysql. On Date fields. We would need a different date() value for datetime/time fields. Also I do not have a running postgres installation to test it with.

Maybe if you guys tell me how to read the config set database type AND the fieldtype I could write a more flexible solution to this problem.
