### PR TITLE
Allow call any function/method outside the extension's scope on addWidget

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -379,7 +379,7 @@ abstract class BaseExtension extends \Twig_Extension implements BaseExtensionInt
      *
      * @param string $type
      * @param string $location
-     * @param string $callback
+     * @param mixed $callback
      * @param string $additionalhtml
      * @param bool $defer
      * @param int $cacheduration

--- a/app/src/Bolt/Extensions.php
+++ b/app/src/Bolt/Extensions.php
@@ -376,11 +376,11 @@ class Extensions
                 if ($this->app['cache']->contains($cachekey)) {
                     // Present in the cache ..
                     $html = $this->app['cache']->fetch($cachekey);
-                } else if (method_exists($this->initialized[$widget['extension']], $widget['callback'])) {
+                } else if (is_string($widget['callback']) && method_exists($this->initialized[$widget['extension']], $widget['callback'])) {
                     // Widget is defined in the extension itself.
                     $html = $this->initialized[$widget['extension']]->parseWidget($widget['callback'], $widget['extraparameters']);
                     $this->app['cache']->save($cachekey, $html, $widget['cacheduration']);
-                } else if (function_exists($widget['callback'])) {
+                } else if (is_callable($widget['callback'])) {
                     // Widget is a callback in the 'global scope'
                     $html = call_user_func($widget['callback'], $this->app, $widget['extraparameters']);
                     $this->app['cache']->save($cachekey, $html, $widget['cacheduration']);


### PR DESCRIPTION
This modification is simple. It allows the developer to add functions as callable to widgets.

In my project I created a complex extension and moved logic outside the extensions class. I use that class only for connect my code to the bolt engine. With this change I can avoid creating a huge class with too many lines and can keep my logic in one place.

I think this can be usefull to anybody.

I replaced function_exists in line 383 to is_callable because it's capable to handle the more complex verification of callables (can handle array and object as callable).
