### PR TITLE
Little fix for pager

### DIFF
--- a/app/src/Bolt/TwigExtension.php
+++ b/app/src/Bolt/TwigExtension.php
@@ -495,8 +495,8 @@ class TwigExtension extends \Twig_Extension
             'class' => $class
         );
 
-        if (isset($pager['link'])) {
-            $context['link'] = $pager['link'];
+        if (isset($thisPager['link'])) {
+            $context['link'] = $thisPager['link'];
         }
 
         return new \Twig_Markup($env->render($template, $context), 'utf-8');


### PR DESCRIPTION
$pager points to global pager variable, which is an array collection of all pagers, so the link key can be read out only from  $thisPager variable which is the actual displayed pager.
