### PR TITLE
Updated with date_default_timezone_set

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -60,6 +60,10 @@ $app['debugbar'] = false;
 
 list ($app['locale'], $app['territory']) = explode('_', $app['config']->get('general/locale'));
 
+// Set The Timezone Based on the Config, fallback to UTC
+date_default_timezone_set(
+    $app['config']->get('general/timezone')?:'UTC'
+);
 
 $app->register(new Silex\Provider\TwigServiceProvider(), array(
     'twig.path' => $app['config']->get('twigpath'),


### PR DESCRIPTION
Not sure if it happens on the dev version as well, but on the latest package available date_default_timezone_set isn't set.
After installation it throws a nice error in which it asks you to set it.
