### PR TITLE
Fixing the  Undefined index: pager error

### DIFF
--- a/app/src/Bolt/TwigExtension.php
+++ b/app/src/Bolt/TwigExtension.php
@@ -477,12 +477,15 @@ class TwigExtension extends \Twig_Extension
     public function pager(\Twig_Environment $env, $pagerName = '', $surr = 4, $template = '_sub_pager.twig', $class = '')
     {
         // @todo Yuck, $GLOBALS.. figure out a better way to do this.
-        $pager = $GLOBALS['pager'];
-
-        if (!is_array($pager)) {
+        if (
+            !isset($GLOBALS['pager']) OR
+            !is_array($GLOBALS['pager'])
+        ) {
             // nothing to page..
             return "";
         }
+
+        $pager = $GLOBALS['pager'];
 
         if (!empty($pagerName)) {
             $thisPager = $pager[$pagerName];


### PR DESCRIPTION
Not sure why $GLOBALS['pager']; is empty at some times (the site was working fine, at some random refresh it failed, deleted the caching but still no avail).

Since it wasn't doing a proper exist check in any case I've added it until we get rid of the $GLOBALS part :)
