### PR TITLE
Duplicate classname causing issues in app/nut

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -2,7 +2,7 @@
 
 namespace Bolt;
 
-interface BaseExtension
+interface BaseExtensionInterface
 {
     public function __construct(Application $app);
     public function initialize();


### PR DESCRIPTION
Fixing "Cannot redeclare class Bolt\BaseExtension in <path>/bolt/app/src/Bolt/BaseExtension.php on line 12" error
