### PR TITLE
One missed getDBOptions() in Storage.php

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -1376,7 +1376,7 @@ class Storage
         } else {
             $par_order = safeString($order_value);
             if ($par_order == 'RANDOM') {
-                $dboptions = getDBOptions($this->app['config']);
+                $dboptions = $this->app['config']->getDBOptions();
                 $order = $dboptions['randomfunction'];
             } elseif ($this->isValidColumn($par_order, $contenttype, true)) {
                 $order = $this->getEscapedSortorder($par_order, false);


### PR DESCRIPTION
I found this while testing the `getContent()` with parameter  `random`  order specified, Guess this was missed in re-factoring or no need it any more!
