### PR TITLE
Remove PHP version checking from index, move getPaths() out of checks.

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,25 +1,25 @@
 <?php
 
 if (!defined( 'BOLT_PROJECT_ROOT_DIR')) {
-    if (substr(__DIR__, -21) == '/vendor/bolt/bolt/app') { // installed bolt with composer
+    if (substr(dirname(__FILE__), -21) == '/vendor/bolt/bolt/app') { // installed bolt with composer
         define('BOLT_COMPOSER_INSTALLED', true);
-        define('BOLT_PROJECT_ROOT_DIR', substr(__DIR__, 0, -21));
+        define('BOLT_PROJECT_ROOT_DIR', substr(dirname(__FILE__), 0, -21));
         define('BOLT_WEB_DIR', BOLT_PROJECT_ROOT_DIR.'/web');
         define('BOLT_CONFIG_DIR', BOLT_PROJECT_ROOT_DIR.'/config');
     } else {
         define('BOLT_COMPOSER_INSTALLED', false);
-        define('BOLT_PROJECT_ROOT_DIR', dirname(__DIR__));
+        define('BOLT_PROJECT_ROOT_DIR', dirname(dirname(__FILE__)));
         define('BOLT_WEB_DIR', BOLT_PROJECT_ROOT_DIR);
 
         // Set the config folder location. If we haven't set the constant in index.php, use one of the
         // default values.
         if (!defined("BOLT_CONFIG_DIR")) {
-            if (file_exists(__DIR__.'/config')) {
+            if (file_exists(dirname(__FILE__).'/config')) {
                 // Default value, /app/config/..
-                define('BOLT_CONFIG_DIR', __DIR__.'/config');
+                define('BOLT_CONFIG_DIR', dirname(__FILE__).'/config');
             } else {
                 // otherwise use /config, outside of the webroot folder.
-                define('BOLT_CONFIG_DIR', dirname(dirname(__DIR__)).'/config');
+                define('BOLT_CONFIG_DIR', dirname(dirname(dirname(__FILE__))).'/config');
             }
         }
     }
@@ -27,8 +27,8 @@ if (!defined( 'BOLT_PROJECT_ROOT_DIR')) {
 
 // First, do some low level checks, like whether autoload is present, the cache
 // folder is writable, if the minimum PHP version is present, etc.
-require_once __DIR__.'/classes/lib.php';
-require_once __DIR__.'/classes/lowlevelchecks.php';
+require_once dirname(__FILE__).'/classes/lib.php';
+require_once dirname(__FILE__).'/classes/lowlevelchecks.php';
 
 $checker = new LowlevelChecks();
 $checker->doChecks();

--- a/app/classes/lowlevelchecks.php
+++ b/app/classes/lowlevelchecks.php
@@ -42,12 +42,12 @@ class lowlevelchecks
         }
 
         // Check if the app/cache file is present and writable
-        if (!file_exists(__DIR__.'/../cache')) {
+        if (!file_exists(dirname(__FILE__).'/../cache')) {
             $this->lowlevelError("The folder <code>app/cache/</code> doesn't exist. Make sure it's " .
                 "present and writable to the user that the webserver is using.");
         }
 
-        if (!is_writable(__DIR__.'/../cache')) {
+        if (!is_writable(dirname(__FILE__).'/../cache')) {
             $this->lowlevelError("The folder <code>app/cache/</code> isn't writable. Make sure it's " .
                 "present and writable to the user that the webserver is using.");
         }
@@ -114,13 +114,13 @@ class lowlevelchecks
         }
 
         // Check if the app/database folder and .db file are present and writable
-        if (!is_writable(__DIR__.'/../database')) {
+        if (!is_writable(dirname(__FILE__).'/../database')) {
             $this->lowlevelError("The folder <code>app/database/</code> doesn't exist or it is not writable. Make sure it's " .
                 "present and writable to the user that the webserver is using.");
         }
 
         // If the .db file is present, make sure it is writable
-        if (file_exists(__DIR__.'/../database/'.$filename) && !is_writable(__DIR__.'/../database/'.$filename)) {
+        if (file_exists(dirname(__FILE__).'/../database/'.$filename) && !is_writable(dirname(__FILE__).'/../database/'.$filename)) {
             $this->lowlevelError("The database file <code>app/database/$filename</code> isn't writable. Make sure it's " .
                 "present and writable to the user that the webserver is using. If the file doesn't exist, make sure the folder is writable and Bolt will create the file.");
         }
@@ -160,8 +160,19 @@ class lowlevelchecks
      */
     private function lowlevelError($message)
     {
+        // Set the root
+        $path_prefix = dirname($_SERVER['PHP_SELF'])."/";
+        $path_prefix = preg_replace("/^[a-z]:/i", "", $path_prefix);
+        $path_prefix = str_replace("//", "/", str_replace("\\", "/", $path_prefix));
+        if (empty($path_prefix) || 'cli-server' === php_sapi_name()) {
+            $path_prefix = "/";
+        }
 
-        $paths = getPaths();
+        $app_path = $path_prefix . 'app/';
+
+        if ( BOLT_COMPOSER_INSTALLED ) {
+            $app_path = $path_prefix . "bolt-public/";
+        }
 
         $html = <<< EOM
 <!DOCTYPE html>
@@ -198,7 +209,7 @@ class lowlevelchecks
 EOM;
 
         $html = str_replace("%error%", $message, $html);
-        $html = str_replace("%path%", $paths['app'], $html);
+        $html = str_replace("%path%", $app_path, $html);
 
         echo $html;
 

--- a/index.php
+++ b/index.php
@@ -5,26 +5,23 @@
 
 // One level above the 'webroot'
 // define('BOLT_CONFIG_DIR', dirname(__DIR__) . '/config');
-if (version_compare(PHP_VERSION, '5.3.2') < 0) {
-    die("Bolt requires PHP <u>5.3.2</u> or higher. You have PHP <u>" . PHP_VERSION . "</u>, so Bolt will not run on your current setup.");
-}
 
 // PHP -S (built-in webserver) doesn't handle static assets without a `return false`
 // For more information, see: http://silex.sensiolabs.org/doc/web_servers.html#php-5-4
 if ('cli-server' === php_sapi_name()) {
-    $filename = __DIR__.preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+    $filename = dirname(__FILE__).preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
 
     // If it is a file, just return false.
     if (is_file($filename)) {
         return false;
     } elseif (preg_match("~^/thumbs/(.*)$~", $_SERVER['REQUEST_URI'])) {
         // If it's not a prebuilt file, but it is a thumb that needs processing
-        require __DIR__ . "/app/classes/timthumb.php";
+        require dirname(__FILE__) . "/app/classes/timthumb.php";
         return true;
     }
 }
 
-require_once __DIR__.'/app/bootstrap.php';
+require_once dirname(__FILE__).'/app/bootstrap.php';
 
 if ($app['debug']) {
     $app->run();


### PR DESCRIPTION
Removed PHP version checking from the front controller, making sure compatibility at least down to 5.2 until the low level checks are run.

Remove getPaths() call from lowlevelchecks to allow for refactoring of getPaths.
