### PR TITLE
Use BOLT_PROJECT_ROOT_DIR constant in setTwigPath

### DIFF
--- a/app/src/Bolt/Config.php
+++ b/app/src/Bolt/Config.php
@@ -455,7 +455,8 @@ class Config
     private function setTwigPath()
     {
         // I don't think we can set Twig's path in runtime, so we have to resort to hackishness to set the path..
-        $themepath = realpath(__DIR__ . '/../../../theme/' . basename($this->get('general/theme')));
+
+        $themepath = realpath(BOLT_PROJECT_ROOT_DIR . '/theme/' . basename($this->get('general/theme')));
 
         $end = $this->getWhichEnd($this->get('general/branding/path'));
 


### PR DESCRIPTION
We're using bolt based off https://github.com/richardhinkamp/bolt-skeleton, and having the twig path built the way it is results in twig files being served from the vendor directory, rather than the project root. Using the constant alleviates the need to edit themes in the vendor directory.
