### PR TITLE
fix display of taxonomy name or singular_name, maybe

### DIFF
--- a/app/theme_defaults/_sub_taxonomylinks.twig
+++ b/app/theme_defaults/_sub_taxonomylinks.twig
@@ -2,9 +2,9 @@
     {% for type, values in record.taxonomy %}
         <em>
         {% if values|length < 2 %}
-            {{ app.config.taxonomy[type].singular_name }}:
+            {{ config.get('taxonomy')[type].singular_name }}:
         {% else %}
-            {{ app.config.taxonomy[type].name }}:
+            {{ config.get('taxonomy')[type].name }}:
         {% endif %}
         </em>
         {% for link, value in values %}


### PR DESCRIPTION
default installation, can't get nothing displayed using app.config.taxonomy or config.taxonomy (even if print() of app.config and config have values in it).
