### PR TITLE
Error parsing messages.es.yml

### DIFF
--- a/app/resources/translations/es/messages.es.yml
+++ b/app/resources/translations/es/messages.es.yml
@@ -12,7 +12,7 @@
 "About": "Acerca"
 "Actions for %contenttypes%": "Acciones para %contenttypes%"
 "Actions for Users": "Acciones para usuarios"
-"Actions for this %contenttype%": "Acciones para %contenttype%"h
+"Actions for this %contenttype%": "Acciones para %contenttype%"
 "Below are the third party libraries that are used by Bolt.": "Enseguida se muestran las librerías de terceros usadas por Bolt."
 "Body": "Contenido"
 "Bolt - Fatal error.": "Bolt - Error fatal"


### PR DESCRIPTION
I change the locale to es_ES and a parse error it's fired. The error is in messages.es.yml where in line 15 there is an extra "h" at the end of the line.
