### PR TITLE
Hack to remove "PRAGMA…" etc, queries from profiler

### DIFF
--- a/app/src/Bolt/Database/DatabaseDataCollector.php
+++ b/app/src/Bolt/Database/DatabaseDataCollector.php
@@ -17,7 +17,7 @@ class DatabaseDataCollector extends DataCollector
     private $logger;
 
     protected $data;
-
+    
     public function __construct(DebugStack $logger)
     {
         $this->logger = $logger;
@@ -38,21 +38,41 @@ class DatabaseDataCollector extends DataCollector
 
     public function getQueryCount()
     {
-        return count($this->data['queries']);
+        return count($this->trim($this->data['queries']));
     }
 
     public function getQueries()
     {
-        return $this->data['queries'];
+        return $this->trim($this->data['queries']);
     }
 
     public function getTime()
     {
         $time = 0;
-        foreach ($this->data['queries'] as $query) {
+        foreach ($this->trim($this->data['queries']) as $query) {
             $time += $query['executionMS'];
         }
 
         return $time;
     }
+    
+    private function trim(array $queries)
+    {   
+        $return = array();
+        foreach ($queries as $query)
+        {
+            // Skip "PRAGMA .." and similar queries by SQLITE.
+            if ( (strpos($query['sql'], "PRAGMA ")===0)
+                || (strpos($query['sql'], "SELECT DISTINCT k.`CONSTRAINT_NAME`")===0)
+                || (strpos($query['sql'], "SELECT TABLE_NAME AS `Table`")===0)
+                || (strpos($query['sql'], "SELECT COLUMN_NAME AS Field")===0) )
+            {
+                continue;
+            }
+            $return[] = $query;
+        }
+        
+        return $return;
+    }
+    
 }

--- a/app/view/db.html.twig
+++ b/app/view/db.html.twig
@@ -47,13 +47,14 @@
         <ul class="alt">
             {% for i, query in collector.queries %}
                 <li class="{{ cycle(['odd', 'even'], i) }}">
-                    <small style="float: right;">
-                        <strong>Parameters</strong>: {{ query.params|json_encode }} <br />
-                        <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
-                    </small>
                     <code >
                         {{ query.sql|raw }}
                     </code>
+                    <br /><br />
+                    <small>
+                        <strong>Parameters</strong>: {{ query.params|json_encode }} <br />
+                        <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
+                    </small>
                 </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
Modification to remove excessive queries from profiler display. Uses
original logger string comparison to remove "not useful" queries.
Tidied up display of results in Doctrine profiler.
