### PR TITLE
Fix: search in tags

### DIFF
--- a/app/src/Bolt/Content.php
+++ b/app/src/Bolt/Content.php
@@ -1005,13 +1005,14 @@ class Content implements \ArrayAccess
     private function getTaxonomyWeights()
     {
         $taxonomies = array();
-
-        foreach ($this->contenttype['taxonomy'] as $key) {
-            if ($this->app['config']->get('taxonomy/'.$key.'/behaves_like') == 'tags') {
-                $taxonomies[$key] = $this->app['config']->get('taxonomy/'.$key.'/searchweight', 75);
+        
+        if (isset($this->contenttype['taxonomy'])) {
+            foreach ($this->contenttype['taxonomy'] as $key) {
+                if ($this->app['config']->get('taxonomy/'.$key.'/behaves_like') == 'tags') {
+                    $taxonomies[$key] = $this->app['config']->get('taxonomy/'.$key.'/searchweight', 75);
+                }
             }
         }
-
         return $taxonomies;
     }
 


### PR DESCRIPTION
Fixed an error when no taxonomies exists for a contenttype.
