### PR TITLE
Shall be merged after htmlmaid declares utf8. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/validator": "~2.4",
         "symfony/web-profiler-bundle": "~2.4",
         "symfony/yaml": "~2.4",
-        "tdammers/htmlmaid": "> 0.4.0",
+        "tdammers/htmlmaid": ">0.4.0",
         "twig/twig": ">=1.8,<2.0-dev"
     },
     "require-dev": {


### PR DESCRIPTION
HTMLMaid has a default fallback for string inputs, where a default DOM is built around the input. It missed a charset setting, and so the system kind of picked a default charset which screwed UTF-8 Markdown Input pretty bad. When it is fixed, we should jump directly to this upcoming release.
