### PR TITLE
Make _listing-base.twig not complain about missing group.name  anymore.

### DIFF
--- a/app/view/_listing-base.twig
+++ b/app/view/_listing-base.twig
@@ -16,7 +16,7 @@
 
             {# print the header for the first row.. #}
             {% if not compact and (loop.first or (content.group.name is defined and content.group.name != lastgroup)) %}
-                {% set lastgroup = content.group.name %}
+                {% set lastgroup = content.group.name|default %}
                 {% if "filter" in app.request.query.all|keys %}
                     {% set filter = "filter=" ~ app.request.query.all.filter ~ "&" %}
                 {% else %}


### PR DESCRIPTION
Just a little bug
