### PR TITLE
Fixes data-constraint error when inserting lorem ipsum stuff

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -198,6 +198,9 @@ class Storage
                 case 'date':
                     $content[$field] = date('Y-m-d', time() - rand(-365 * 24 * 60 * 60, 365 * 24 * 60 * 60));
                     break;
+                case 'checkbox':
+                    $content[$field] = rand(0,1);
+                    break;                
                 case 'float':
                 case 'number': // number is deprecated..
                 case 'integer':


### PR DESCRIPTION
This patch fixes an error I just encountered when trying to add dummy content on a fresh bolt-installation (might be related to #782 )

![screenshot 2013-12-21 03 39 02](https://f.cloud.github.com/assets/1737019/1795109/1df7997c-69ea-11e3-94f0-38cce9d5f21f.png)

Clearly, mySQL doesn't like that "" is set as the value for `checkbox`, it expects an int (of type TINYINT). I'm running the latest mySQL build and just encountered a very similar error on a different project that I've never had before. My guess is that at some point MySQL introduced stricter handling of datatypes. Any inputs on this topic?
