### PR TITLE
Composer fixes.

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -4,7 +4,7 @@ mb_internal_encoding('UTF-8');
 mb_http_output('UTF-8');
 
 if (!defined( 'BOLT_PROJECT_ROOT_DIR')) {
-    if (substr(dirname(__FILE__), -21) == '/vendor/bolt/bolt/app') { // installed bolt with composer
+    if (substr(dirname(__FILE__), -21) == implode(DIRECTORY_SEPARATOR, array('', 'vendor', 'bolt', 'bolt', 'app'))) { // installed bolt with composer
         define('BOLT_COMPOSER_INSTALLED', true);
         define('BOLT_PROJECT_ROOT_DIR', substr(dirname(__FILE__), 0, -21));
         define('BOLT_WEB_DIR', BOLT_PROJECT_ROOT_DIR.'/web');
@@ -16,7 +16,7 @@ if (!defined( 'BOLT_PROJECT_ROOT_DIR')) {
 
         // Set the config folder location. If we haven't set the constant in index.php, use one of the
         // default values.
-        if (!defined("BOLT_CONFIG_DIR")) {
+        if (!defined('BOLT_CONFIG_DIR')) {
             if (file_exists(dirname(__FILE__).'/config')) {
                 // Default value, /app/config/..
                 define('BOLT_CONFIG_DIR', dirname(__FILE__).'/config');

--- a/app/src/Bolt/Composer/ScriptHandler.php
+++ b/app/src/Bolt/Composer/ScriptHandler.php
@@ -35,7 +35,6 @@ class ScriptHandler
             $filesystem->mirror(__DIR__ . '/../../../view/' . $dir, $targetDir . '/view/' . $dir);
         }
         $filesystem->mirror(__DIR__ . '/../../../classes/upload', $targetDir . '/classes/upload');
-        $filesystem->copy(__DIR__ . '/../../../app.php', $targetDir . '/app.php');
         $filesystem->copy(__DIR__ . '/../../../classes/timthumb.php', $targetDir . '/classes/timthumb.php');
 
         if (!$filesystem->exists($webDir . '/files/')) {


### PR DESCRIPTION
Hi,

I ran into a couple of issues while trying to install Bolt using Composer. This patch fixes them for me:
- Use `DIRECTORY_SEPARATOR` to check bolt's path so that it works on all
  platforms.
- Update `Bolt\Composer\ScriptHandler\installAssets()` - app.php no longer
  exists and attempting to copy it causes an error.
