### PR TITLE
Use DIRECTORY_SEPARATOR when sniffing install path.

### DIFF
--- a/app/classes/timthumb.php
+++ b/app/classes/timthumb.php
@@ -40,7 +40,7 @@ if (empty($matches[1]) || empty($matches[2]) || empty($matches[4])) {
 /**
  * Bolt specific: Set BOLT_PROJECT_ROOT_DIR, and Bolt-specific settings..
  */
-if (substr(__DIR__, -20) == '/bolt-public/classes') { // installed bolt with composer
+if (substr(__DIR__, -20) == DIRECTORY_SEPARATOR.'bolt-public'.DIRECTORY_SEPARATOR.'classes') { // installed bolt with composer
     require_once __DIR__ . '/../../../vendor/bolt/bolt/app/bootstrap.php';
 } else {
     require_once __DIR__ . '/../bootstrap.php';

--- a/app/classes/upload/index.php
+++ b/app/classes/upload/index.php
@@ -12,7 +12,7 @@
 
 error_reporting(E_ALL | E_STRICT);
 
-if (strpos(__DIR__,'/bolt-public/') !== false) { // installed bolt with composer
+if (strpos(__DIR__, DIRECTORY_SEPARATOR.'bolt-public'.DIRECTORY_SEPARATOR) !== false) { // installed bolt with composer
     require_once __DIR__.'/../../../../vendor/bolt/bolt/app/bootstrap.php';
 } else {
     require_once __DIR__.'/../../bootstrap.php';


### PR DESCRIPTION
Hello,

Another `DIRECTORY_SEPARATOR` fix for when Bolt is installed using Composer.
