### PR TITLE
Use theme_path config option in Bolt\Config\setTwigPath()

### DIFF
--- a/app/src/Bolt/Config.php
+++ b/app/src/Bolt/Config.php
@@ -499,8 +499,11 @@ class Config
     private function setTwigPath()
     {
         // I don't think we can set Twig's path in runtime, so we have to resort to hackishness to set the path..
-
-        $themepath = realpath(BOLT_PROJECT_ROOT_DIR . '/theme/' . basename($this->get('general/theme')));
+        if($this->get('general/theme_path')) {
+            $themepath = realpath(BOLT_PROJECT_ROOT_DIR . $this->get('general/theme_path'));
+        } else {
+            $themepath = realpath(BOLT_PROJECT_ROOT_DIR . '/theme/' . basename($this->get('general/theme')));
+        }
 
         $end = $this->getWhichEnd($this->get('general/branding/path'));
 


### PR DESCRIPTION
`theme_path` isn't used here which causes problems if you have defined a non-standard location in the config.
