### PR TITLE
Make the base-2013 index template respect the configured homepage

### DIFF
--- a/theme/base-2013/index.twig
+++ b/theme/base-2013/index.twig
@@ -9,9 +9,9 @@
 
         <article>
 
-            {# use 'setcontent' to set the variable 'home' to "page/1", which is
-               shorthand for "the record in Pages, with id 1". #}
-            {% setcontent home = "page/1" %}
+            {# make the 'home' variable refer to the current record, which is set by the
+               user in config.yml #}
+            {% set home = record %}
             {% if home.title is defined and home.title is not empty %}
                 <h1>{{ home.title }}</h1>
             {% endif %}


### PR DESCRIPTION
`config.yml` provides a `homepage` option to set the record that is passed to the index template. However, the `base-2013` theme ignores this option and instead always displays `page/1`. This commit removes the hardcoded resource from the theme and instead makes it use the global default.

If I'm missing something and there's a reason that the theme behaves this way, please tell me.
