### PR TITLE
Don't display ownerid in default record.twig

### DIFF
--- a/theme/base-2013/record.twig
+++ b/theme/base-2013/record.twig
@@ -15,7 +15,7 @@
                 <h3>{{ record.subtitle }}</h3>
             {% endif %}
 
-            {% for key,value in record.values if key not in ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'title', 'subtitle'] %}
+            {% for key,value in record.values if key not in ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'title', 'subtitle', 'ownerid'] %}
 
                 {% if record.fieldtype(key) == "image" and value != "" %}
 


### PR DESCRIPTION
It looks like this key was added in the last release but was never explicitly excluded from the theme. As a result, every record rendered by `record.twig` has a line like "ownerid: 1" at the bottom.
