### PR TITLE
Allow taxonomies to be used in routing.

### DIFF
--- a/app/src/Bolt/Content.php
+++ b/app/src/Bolt/Content.php
@@ -752,7 +752,7 @@ class Content implements \ArrayAccess
             }
         }
 
-        // Set up the 'parameters' to pass to url_generator->generate..
+        // Set up the 'parameters' to pass to url_generator->generate.
         $params = array(
             'contenttypeslug' => $this->contenttype['singular_slug'],
             'id' => $this->id,
@@ -774,12 +774,21 @@ class Content implements \ArrayAccess
                 // special case, if we need to have a date.
                 if ($reqvalue == '\d{4}-\d{2}-\d{2}') {
                     $params[$req] = substr($this->values[$req], 0, 10);
+                } elseif (isset($this->taxonomy[$req])) {
+                    // turn something like '/chapters/meta' to 'meta'
+                    $taxonomyslug = explode( '/', array_shift(array_keys($this->taxonomy[$req])) );
+                    $taxonomyslug = array_pop($taxonomyslug);
+                    $params[$req] = $taxonomyslug;
                 } else {
                     // or, just add the value.
                     $params[$req] = $this->values[$req];
                 }
             }
         }
+
+        // Filter empty values and then use the route's defaults values.
+        $params = array_filter($params);
+        $params = array_merge($route['defaults'], $params);
 
         $link = $this->app['url_generator']->generate($linkbinding, $params);
 

--- a/app/src/Bolt/Controllers/Routing.php
+++ b/app/src/Bolt/Controllers/Routing.php
@@ -139,6 +139,10 @@ class Routing implements ControllerProviderInterface
      */
     private function getProperRegexp($regexp)
     {
+        if (is_array($regexp)) {
+            return call_user_func_array($regexp[0], $regexp[1]);
+        }
+
         if (strpos($regexp, '::') > 0) {
             return call_user_func($regexp);
         }
@@ -176,5 +180,25 @@ class Routing implements ControllerProviderInterface
     public static function getPluralTaxonomyTypeRequirement()
     {
         return self::$app['storage']->getTaxonomyTypeAssert(false);
+    }
+
+    /**
+     * Return slugs of existing taxonomy values.
+     */
+    public static function getTaxonomyRequirement($taxonomyName, $emptyValue = null)
+    {
+        $taxonomyValues = self::$app['config']->get('taxonomy/'.$taxonomyName.'/options');
+        
+        // If by accident, someone uses a "tags" taxonomy.
+        if ($taxonomyValues==null) {
+            return "[a-z0-9-_]+";
+        }
+        $taxonomyValues = array_keys($taxonomyValues);
+        $requirements = implode('|', $taxonomyValues);
+
+        if ($emptyValue!=null) {
+            $requirements .= '|'.$emptyValue;
+        }
+        return $requirements;
     }
 }


### PR DESCRIPTION
Allows taxonomies to be used in routing.
- Grouping: works
- Categories: works, picks the first one
- Tags: kinda works, picks the first one (not recommended)

Not sure if this syntax is ideal?

```
chapterbinding:
  path: /{chapters}/{slug}
  defaults: { _controller: 'Bolt\Controllers\Frontend::record', 'contenttypeslug': 'kitchensinks', 'chapters': 'none' }
  requirements:
    chapters: [ 'Bolt\Controllers\Routing::getTaxonomyRequirement', ['chapters', 'none'] ]
  contenttype: kitchensinks
```

The `none` is only required in the case when an empty value is set for that `contenttype`. Usually you want anything in the URL to be non-empty.
