### PR TITLE
Add 'contenttype' twig var to listing templates

### DIFF
--- a/app/src/Bolt/Controllers/Frontend.php
+++ b/app/src/Bolt/Controllers/Frontend.php
@@ -223,6 +223,7 @@ class Frontend
         // So that they're also available in menu's and templates rendered by extensions.
         $app['twig']->addGlobal('records', $content);
         $app['twig']->addGlobal($contenttype['slug'], $content);
+        $app['twig']->addGlobal('contenttype', $contenttype['name']);
 
         return $app['render']->render($template);
 


### PR DESCRIPTION
As suggested from #837

Adds the ability to call {{ contenttype }} to show the name of the contenttype being requested. Useful when the designer would like to show the end-user that no records exist, without hard-coding the name. As such, specifically good for those who do not use content-type-specific listing templates.
