### PR TITLE
Storage: organizeQueryParameters order!

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -1320,9 +1320,10 @@ class Storage
     private function organizeQueryParameters($in_parameters = null)
     {
         $ctype_parameters = array();
+        $meta_parameters = array('order' => false); // order in meta_parameters check again in line: 1530!
         if (is_array($in_parameters)) {
             foreach ($in_parameters as $key => $value) {
-                if (in_array($key, array('page', 'limit', 'offset', 'returnsingle', 'printquery', 'paging'))) {
+                if (in_array($key, array('page', 'limit', 'offset', 'returnsingle', 'printquery', 'paging', 'order'))) {
                     $meta_parameters[$key] = $value;
                 } else {
                     $ctype_parameters[$key] = $value;


### PR DESCRIPTION
I use bolt as sort of Scaffolding CMS and bootstrap the Application in Zend to fetch the contents. Today I was going through updating and find that `order` field is expected to be a `$meta_parameters`, yet the list of meta_parameters does not contains the `order` as one.

This throws Notice when checking for `$meta_parameters['order'] == false` in line: 1344! I hope this makes sense and relevant!
