### PR TITLE
Initialize Console Application inside the Bolt app

### DIFF
--- a/app/nut
+++ b/app/nut
@@ -1,14 +1,12 @@
 #!/usr/bin/env php
 <?php
 
-require_once __DIR__ . '/bootstrap.php';
-
 use Symfony\Component\Console\Application;
 
-$application = new Application();
+require_once __DIR__ . '/bootstrap.php';
 
-$application->setName('Bolt console tool - Nut');
-$application->setVersion($app->getVersion());
+/** @var Application $application retrieve the Console Application from the Bolt application in the bootstrap */
+$application = $app['console'];
 
 $application->add(new Bolt\Nut\CacheClear($app));
 $application->add(new Bolt\Nut\Info($app));
@@ -28,4 +26,5 @@ $application->add(new Bolt\Nut\UserRoleRemove($app));
 //$application->add(new Bolt\Nut\ExtensionsInstall($app));
 //$application->add(new Bolt\Nut\ExtensionsUpdate($app));
 //$application->add(new Bolt\Nut\ExtensionsUninstall($app));
+
 $application->run();

--- a/app/src/Bolt/Application.php
+++ b/app/src/Bolt/Application.php
@@ -5,6 +5,7 @@ namespace Bolt;
 use RandomLib;
 use SecurityLib;
 use Silex;
+use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -59,6 +60,9 @@ class Application extends Silex\Application
 
         // Initialize the Database Providers.
         $this->initDatabase();
+
+        // Initialize the Console Application for Nut
+        $this->initConsoleApplication();
 
         // Initialize the rest of the Providers.
         $this->initProviders();
@@ -208,6 +212,20 @@ class Application extends Silex\Application
 
         // Mount the 'frontend' controllers, ar defined in our Routing.yml
         $this->mount('', new Controllers\Routing());
+    }
+
+    /**
+     * Initializes the Console Application that is responsible for CLI interactions.
+     */
+    public function initConsoleApplication()
+    {
+        $this['console'] = $this->share(function (Application $app) {
+            $console = new ConsoleApplication();
+            $console->setName('Bolt console tool - Nut');
+            $console->setVersion($app->getVersion());
+
+            return $console;
+        });
     }
 
     public function BeforeHandler(Request $request)


### PR DESCRIPTION
This PR lays the groundwork for issue #851 by initializing the Console
application from within Bolt instead of separately inside the nut shell
script.

By doing this extensions can access the console application using the
`$app['console']` service and can add their own custom commands.
