### PR TITLE
Update default routes to include a trailing slash

### DIFF
--- a/app/config/routing.yml.dist
+++ b/app/config/routing.yml.dist
@@ -17,29 +17,29 @@ homepage:
   defaults:           { _controller: 'Bolt\Controllers\Frontend::homepage' }
 
 search:
-  path:               /search
+  path:               /search/
   defaults:           { _controller: 'Bolt\Controllers\Frontend::search' }
 
 preview:
-  path:               /preview/{contenttypeslug}
+  path:               /preview/{contenttypeslug}/
   defaults:           { _controller: 'Bolt\Controllers\Frontend::preview' }
   requirements:
     contenttypeslug:  'Bolt\Controllers\Routing::getAnyContentTypeRequirement'
 
 contentlink:
-  path:               /{contenttypeslug}/{slug}
+  path:               /{contenttypeslug}/{slug}/
   defaults:           { _controller: 'Bolt\Controllers\Frontend::record' }
   requirements:
     contenttypeslug:  'Bolt\Controllers\Routing::getAnyContentTypeRequirement'
 
 taxonomylink:
-  path:               /{taxonomytype}/{slug}
+  path:               /{taxonomytype}/{slug}/
   defaults:           { _controller: 'Bolt\Controllers\Frontend::taxonomy' }
   requirements:
     taxonomytype:     'Bolt\Controllers\Routing::getAnyTaxonomyTypeRequirement'
 
 contentlisting:
-  path:               /{contenttypeslug}
+  path:               /{contenttypeslug}/
   defaults:           { _controller: 'Bolt\Controllers\Frontend::listing' }
   requirements:
     contenttypeslug:  'Bolt\Controllers\Routing::getPluralContentTypeRequirement'


### PR DESCRIPTION
[`\Symfony\Component\Routing\Matcher\RedirectableUrlMatcher`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Matcher/RedirectableUrlMatcher.php) will automatically redirect to the same URL with a slash appended if it is omitted.

This will make the default routes more robust.
