### PR TITLE
Add Frontend::static

### DIFF
--- a/app/config/routing.yml.dist
+++ b/app/config/routing.yml.dist
@@ -113,4 +113,4 @@ contentlisting:
  
 # templatebinding:
 #   path:     /static-page/
-#   defaults: { _controller: 'Bolt\Controllers\Frontend::template', template: 'static-page.twig' }
+#   defaults: { _controller: 'Bolt\Controllers\Frontend::template', template: 'static-page' }

--- a/app/src/Bolt/Controllers/Frontend.php
+++ b/app/src/Bolt/Controllers/Frontend.php
@@ -378,6 +378,10 @@ class Frontend
      * loading any content.
      */
     public static function template(Silex\Application $app, $template) {
+      // Add the template extension if it is missing
+      if(!preg_match('/\\.twig$/i', $template))
+        $template .= '.twig';
+
       $themePath    = realpath($app['paths']['themepath'] . '/');
       $templatePath = realpath($app['paths']['themepath'] . '/' . $template);
 


### PR DESCRIPTION
Add a `static` method to `Bolt\Controllers\Frontend` for displaying recordless content.

Proposed usage:

```
home:
  path: /
  defaults: { _controller: 'Bolt\Controllers\Frontend::static', _template: 'home' }
```

```
public static function static(Silex\Application $app, $_template) {
  return $app['render']->render($_template . '.twig');
}
```

Edit: ok, obviously `static` is a keyword, so maybe `template` instead.
