### PR TITLE
Correcting 'Invalid template exception' in Frontend.php

### DIFF
--- a/app/classes/lib.php
+++ b/app/classes/lib.php
@@ -805,7 +805,7 @@ function getPaths($original = array() )
         'hostname' => !empty($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : "localhost",
         'root' => $path_prefix,
         'rootpath' => realpath(__DIR__ . "/../../"),
-        'theme' => $path_prefix . $theme . "/",
+        'theme' => $path_prefix . "theme/" . $theme . "/",
         'themepath' => realpath(__DIR__ . "/../../theme/" . $theme),
         'app' => $path_prefix . "app/",
         'apppath' => realpath(__DIR__ . "/.."),
@@ -825,11 +825,11 @@ function getPaths($original = array() )
     // Temp fix! @todo: Fix this properly.
     if ($config instanceof \Bolt\Config) {
         if ($config->get('general/theme_path')) {
-            $paths['themepath'] = BOLT_PROJECT_ROOT_DIR . $config->get('general/theme_path');
+            $paths['themepath'] = BOLT_PROJECT_ROOT_DIR . $config->get('general/theme_path') . '/' . $theme;
         }
     } else {
         if ( isset( $config['general']['theme_path'] ) ) {
-            $paths['themepath'] = BOLT_PROJECT_ROOT_DIR . $config['general']['theme_path'];
+            $paths['themepath'] = BOLT_PROJECT_ROOT_DIR . $config['general']['theme_path'] . '/' . $theme;
         }
     }
 

--- a/app/src/Bolt/Controllers/Frontend.php
+++ b/app/src/Bolt/Controllers/Frontend.php
@@ -382,8 +382,8 @@ class Frontend
       if(!preg_match('/\\.twig$/i', $template))
         $template .= '.twig';
 
-      $themePath    = realpath($app['paths']['themepath'] . $app['paths']['theme']);
-      $templatePath = realpath($app['paths']['themepath'] . $app['paths']['theme'] . '/' . $template);
+      $themePath    = realpath($app['paths']['themepath'] . '/');
+      $templatePath = realpath($app['paths']['themepath'] . '/' . $template);
 
       // Verify that the resulting template path is located in the theme directory
       if($themePath !== substr($templatePath, 0, strlen($themePath)))


### PR DESCRIPTION
Seems to me there are some inconsistencies in 'theme' and 'themepath' variables stored in $app['path'] array. This patch repairs the case when _theme_path_ config value points to a customized path but I'm not sure other parts of code isn't affected badly by this modification. I'm not sure at the moment what was your original idea about the two, 'theme' and 'themepath' indexed variables and how they are using properly. So please check out affected code chunks.
I found references at BaseExtension.php:281, BaseExtension.php:302
