### PR TITLE
Extension config and installed with Composer

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -70,6 +70,11 @@ abstract class BaseExtension extends \Twig_Extension implements BaseExtensionInt
         $configfile = $this->basepath . '/config.yml';
         $configdistfile = $this->basepath . '/config.yml.dist';
 
+        if(BOLT_COMPOSER_INSTALLED && file_exists(BOLT_CONFIG_DIR . DIRECTORY_SEPARATOR . $this->namespace . '.yml'))
+        {
+            $configfile = BOLT_CONFIG_DIR . DIRECTORY_SEPARATOR . $this->namespace . '.yml';
+        }
+
         // If it's readable, we're cool
         if (is_readable($configfile)) {
             $yamlparser = new \Symfony\Component\Yaml\Parser();


### PR DESCRIPTION
When Bolt is installed with Composer, look for config in config/ExtensionName.yml so it exists in the config dir outside the Bolt dir
