### PR TITLE
Remove trailing ; to fix <= ie 8

### DIFF
--- a/app/view/js/bolt.js
+++ b/app/view/js/bolt.js
@@ -204,8 +204,7 @@ CKEDITOR.editorConfig = function( config ) {
     config.toolbar = [
         { name: 'styles', items: [ 'Format' ] },
         { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Underline', 'Strike' ] },
-        { name: 'paragraph', items: [ 'NumberedList', 'BulletedList', 'Indent', 'Outdent', '-', 'Blockquote' ] },
-
+        { name: 'paragraph', items: [ 'NumberedList', 'BulletedList', 'Indent', 'Outdent', '-', 'Blockquote' ] }
     ];
 
     if (wysiwyg.anchor) {


### PR DESCRIPTION
The ckeditor instance doesn't load in ie8 and below because of an js-error due to a trailing ;.
