### PR TITLE
Add caching for dynamic requests

### DIFF
--- a/app/src/Bolt/Render.php
+++ b/app/src/Bolt/Render.php
@@ -102,7 +102,7 @@ class Render
     public function fetchCachedRequest()
     {
         if ($this->checkCacheConditions('request', true)) {
-            $key = md5($this->app['request']->getPathInfo());
+            $key = md5($this->app['request']->getPathInfo() . $this->app['request']->getQueryString());
 
             $result = $this->app['cache']->fetch($key);
 
@@ -152,7 +152,7 @@ class Render
 
             // This is where the magic happens.. We also store it with an empty 'template' name,
             // So we can later fetch it by its request..
-            $key = md5($this->app['request']->getPathInfo());
+            $key = md5($this->app['request']->getPathInfo() . $this->app['request']->getQueryString());
             $this->app['cache']->save($key, $html, $this->cacheDuration());
 
         }


### PR DESCRIPTION
The current code doesn't allow caching for dynamic requests (e.g. requests with pagination, filters, and so on). This behaviour occurs because of the caching key was generated only of the path info. The query string was ignored.

If the cache is invalidated and one browses a moment later to page 2 of a request for an example, or applies an filter to an collection, other visitors of the page would see this users settings for the rest of the cache lifetime.
