### PR TITLE
Adds type comparison in Bolt\Config::get()

### DIFF
--- a/app/src/Bolt/Config.php
+++ b/app/src/Bolt/Config.php
@@ -133,7 +133,7 @@ class Config
             $part = & $part[$key];
         }
 
-        if ($value != null) {
+        if ($value !== null) {
             return $value;
         }
 


### PR DESCRIPTION
When evaluating if a value is null in the config it should do a type comparison. I'm having a issue when a set `session_use_storage_handler: false` https://github.com/bolt/bolt/blob/master/app/config/config.yml.dist#L213 and in the https://github.com/bolt/bolt/blob/master/app/src/Bolt/Application.php#L53 is returning `NULL`
