### PR TITLE
Ensure 'ignore_contenttype' config option is set if not specified in config.yml

### DIFF
--- a/app/extensions/Sitemap/extension.php
+++ b/app/extensions/Sitemap/extension.php
@@ -41,6 +41,9 @@ class Extension extends \Bolt\BaseExtension
      */
     function initialize()
     {
+        if (empty($this->config['ignore_contenttype'])) {
+            $this->config['ignore_contenttype'] = array();
+        }
 
         // Set up the routes for the sitemap..
         $this->app->match("/sitemap", array($this, 'sitemap'));


### PR DESCRIPTION
Ensure 'ignore_contenttype' config option is set if not specified in config.yml.  This avoids an error especially liekly to hit existing installs
