### PR TITLE
Arbitrary Fix for #965

### DIFF
--- a/app/view/js/bolt.js
+++ b/app/view/js/bolt.js
@@ -577,28 +577,33 @@ function updateGeoCoords(key) {
 
 };
 
-
-
+/**
+ * Catch paste events towards a markdown textarea field.
+ *
+ * We use a fancy service to markdownify pasted html before we actually paste it in the textarea.
+ *
+ * @param  {String} key The ID of the markdown field
+ */
 function bindMarkdown(key) {
-// return pasted.replace(/\d+/,"XXX"); }
-    $('#'+key).catchpaste( function( pasted, options ) {
+    var container = $('#'+key);
+    var containerContent = $('#'+key).html();
+
+    container.catchpaste( function( pasted, options ) {
 
         $.ajax({
             url: asyncpath + 'markdownify',
             type: 'POST',
             data: { html: pasted },
             success: function(data) {
-                $('#'+key).val(data);
+                container.val(containerContent + data);
             },
             error: function() {
                 console.log('failed to get an URI');
-                $('#'+key).val(pasted);
+                container.val(containerContent + pasted);
             }
         });
         return "";
-
     });
-
 }
 
 /**


### PR DESCRIPTION
As the container gets its value set to the stuff that's being returned
by the service (itself: the pasted content), the complete content of the
markdown textarea gets deleted and overwritten by the pasted stuff.
Yikes. This is NOT the final solution, as we need to find out where
within the textarea something was actually pasted. This could become
intresting, since references are supposed to go at the bottom of the
document. Meh.
