### PR TITLE
Added a check to the menu's current-Twigfilter.

### DIFF
--- a/app/src/Bolt/TwigExtension.php
+++ b/app/src/Bolt/TwigExtension.php
@@ -544,6 +544,15 @@ class TwigExtension extends \Twig_Extension
             return true;
         }
 
+        // check against entrance page url from general configuration
+        $entrancePage = $this->app['config']->get('general/homepage');
+        $entrancePage = (substr($entrancePage, 0, 1) !== '/')
+                            ? '/' . $entrancePage
+                            : $entrancePage;
+        if ($link == $entrancePage) {
+            return true;
+        }
+
         // No contenttypeslug or slug -> not 'current'
         if (empty($route_params['contenttypeslug']) || empty($route_params['slug'])) {
             return false;


### PR DESCRIPTION
When you set up your page entrance url at the general site config (param
"homepage"), the current-filter won't catch this particular case and you
wont be able to mark your welcome page as active in the menu. Pretty
simple fix.
