### PR TITLE
Fix for #937

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,7 +20,7 @@ if ('cli-server' === php_sapi_name()) {
 
 require_once __DIR__ . '/app/bootstrap.php';
 
-if (preg_match("~^/thumbs/(.*)$~", $_SERVER['REQUEST_URI'])) {
+if (preg_match("^thumbs/[0-9]+x[0-9]+[a-z]*/.*^i", $_SERVER['REQUEST_URI'])) {
     // If it's not a prebuilt file, but it is a thumb that needs processing
     require __DIR__ . '/app/classes/timthumb.php';
 } else {


### PR DESCRIPTION
As I mentioned in 0640bca81d16361630ff326cadc9d47a3125b932 I encountered some errors. I figured out the url check for thumbnails is not made properly. The REQUEST_URI variable is not started with /thumbs when Bolt is running from a subdirectory. I also used timthumb.php-s check for proper url format beacuse I think we don't want malformed thumbnail url-s to redirected to timthumb.php.
