### PR TITLE
Attempt to fix broken insertion of JavaScript in extensions

### DIFF
--- a/app/src/Bolt/Extensions.php
+++ b/app/src/Bolt/Extensions.php
@@ -810,7 +810,7 @@ class Extensions
         }
 
         // then, attempt to insert it after the last <script> tag within context, matching indentation..
-        if (preg_match_all("~^([ \t]*)</script (.*)~mi", $context, $matches)) {
+        if (preg_match_all("~</script>~mi", $context, $matches)) {
             // matches[0] has some elements, the last index is -1, because zero indexed.
             $last = count($matches[0]) - 1;
             $replacement = sprintf("%s\n%s%s", $matches[0][$last], $matches[1][$last], $tag);


### PR DESCRIPTION
Attempt to fix broken insertion of JavaScript in \Bolt\Extensions::insertAfterJs()
In an extension, calling the following causes the passed JS to be inserted inside the last <script></script> block:
`$this->insertSnippet(SnippetLocation::END_OF_BODY, $js );`

And example of this is enableing the Google Analytics and RateIt extensions, the RateIt code will be inserted inside the GA script block (assuming Google Analytics is listed before RateIt in the `enabled_extensions` config parameter)
