### PR TITLE
error: InvalidArgumentException...

### DIFF
--- a/app/classes/lib.php
+++ b/app/classes/lib.php
@@ -1511,8 +1511,8 @@ function gatherTranslatableStrings($locale=null,$translated=array())
         ->name('*.php')
         ->notName('*~')
         ->exclude(array('cache','config','database','resources','tests'))
-        ->in(BOLT_WEB_DIR.'/theme') //
-        ->in(BOLT_PROJECT_ROOT_DIR.'/app')
+        ->in(dirname($app['paths']['themepath'])) //
+        ->in($app['paths']['apppath'])
     ;
     // regex from: stackoverflow.com/questions/5695240/php-regex-to-ignore-escaped-quotes-within-quotes
     $re_dq = '/"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"/s';


### PR DESCRIPTION
Click on menu in Admin - settings/contenttypes.

`error: InvalidArgumentException`

`The "/home/bolt/websiteX/app" directory does not exist. -
/vendor/symfony/finder/Symfony/Component/Finder/Finder.php:667
/vendor/bolt/bolt/app/classes/lib.php:1515`

If Bolt is running under vendor folder as part of other Composer based project leads to error.
Both `app` and `theme` paths corrected although just `app` causing error. 
(I think theme path should be also aligned but I'm nit sure...)
