### PR TITLE
Initialise array before use to prevent unintended default select value

### DIFF
--- a/app/src/Bolt/TwigExtension.php
+++ b/app/src/Bolt/TwigExtension.php
@@ -1287,7 +1287,7 @@ class TwigExtension extends \Twig_Extension
      */
     public function selectfield($content, $fieldname)
     {
-        $retval[] = '';
+        $retval[] = array('');
         foreach($content as $c) {
             if(isset($c->values[$fieldname])) {
                 $retval[] = $c->values[$fieldname];


### PR DESCRIPTION
One-liner on my side, looks to clean a bit more whitespace too.
