### PR TITLE
error: timthumb searches 404 image at wrong path

### DIFF
--- a/app/classes/timthumb.php
+++ b/app/classes/timthumb.php
@@ -1359,13 +1359,13 @@ class timthumb {
 
 	}
 	protected function serveImg($file){
-        if (!file_exists($file)) {
-        	$relfile = substr($file, 3);
-			if (BOLT_COMPOSER_INSTALLED) {
-				$file = BOLT_WEB_DIR . '/bolt-public/' . $relfile;
-			} else {
-				$file = BOLT_PROJECT_ROOT_DIR . '/app/' . $relfile;
-			}
+        if (! file_exists($file)) {
+            $relfile = substr($file, 3);
+            if (BOLT_COMPOSER_INSTALLED) {
+                $file = BOLT_WEB_DIR . '/bolt-public/' . $relfile;
+            } else {
+                $file = BOLT_PROJECT_ROOT_DIR . '/app/' . $relfile;
+            }
         }
 		$s = getimagesize($file);
 		if(! ($s && $s['mime'])){


### PR DESCRIPTION
if `BOLT_COMPOSER_INSTALLED` and wrong image location set to `{{ thumbnail() }}` then timthumb tries to response with image from `/web/app/`.
The other hand I made another change that commented in line comment because I'm not sure it can be merged into the core. Please review.
Thanks.
