### PR TITLE
theme config file can't be reached if theme_path doesn't begins with '/'...

### DIFF
--- a/app/classes/lib.php
+++ b/app/classes/lib.php
@@ -808,7 +808,7 @@ function getPaths($original = array() )
         $canonicalpath = $currentpath;
     }
 
-    $theme_path = ltrim($theme_path, '/');
+    $theme_path = trim($theme_path, '/');
     // Set the paths
     $paths = array(
         'hostname' => !empty($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : "localhost",


### PR DESCRIPTION
... in config.yml
It is possible still to place themes out of public web folder with addressing `theme_path` option to relative path in `config.yml`. But in a case when path begins with other than '/' `themepath` key would held wrong value.
