### PR TITLE
Issue#1001

### DIFF
--- a/app/view/_sub_editfields.twig
+++ b/app/view/_sub_editfields.twig
@@ -153,7 +153,6 @@
     {% else %}
         <select name="{{key}}" id="{{key}}" class='{% if field.class is defined %}{{ field.class }}{% endif %}'>
             {% for value in field.values %}
-                {{ print(value | length) }}
                 {% if value is iterable and (value | length) > 1 %}
                     <option value="{{value[0]}}" {% if content.get(key)==value[0] %}selected{% endif %}>{{value[1]}}</option>
                 {% else %}


### PR DESCRIPTION
Simple patch for it.
examples:

```
type: select
values: ['green', 'red', blue']
```

this is generating

```
<select ...
<option value="green">green</option>
...
```

But the

```
type: select
values: [[0,'green'], [1,'red'], [2,blue]']
```

generate the 

```
<select ...
<option value="0">green</option>
...
```
