### PR TITLE
Allow for use of '()' in json_list 'order'.

### DIFF
--- a/app/extensions/JSONAccess/extension.php
+++ b/app/extensions/JSONAccess/extension.php
@@ -84,7 +84,7 @@ class Extension extends \Bolt\BaseExtension
             $options['order'] = $order;
         }
         if (strtoupper($options['order']) == 'RAND' || strtoupper($options['order']) == 'RANDOM' || strtoupper($options['order']) == 'SHUFFLE') {
-            $opt = $app['config']->getDBOptions();
+            $opt = $this->app['config']->getDBOptions();
             $options['order'] = $opt['randomfunction'];
         }
         $items = $this->app['storage']->getContent($contenttype, $options);


### PR DESCRIPTION
Use case:
Obtaining a random set of results e.g. http://mysite/articles/?order=RAND%28%29&limit=5

Risk:
Possible injection vector.

Possible other options:
Checking 'order' for RAND and RANDOM and inserting them in code.

Will update PR if better idea put forward
