### PR TITLE
Updates to RSSFeed extension

### DIFF
--- a/app/extensions/RSSFeed/config.yml.dist
+++ b/app/extensions/RSSFeed/config.yml.dist
@@ -1,6 +1,11 @@
 # This is the config file for the RSS Feed extension.
-# Feed will be accessible at the following url:
-# <yoursite>/contenttype/rss/feed.(xml|rss)
+# Feed will be accessible at the following urls:
+# Site RSS:
+#     <yoursite>/rss/feed.(xml|rss)
+#
+# Contenttype RSS:
+#     <yoursite>/contenttype/rss/feed.(xml|rss)
+#
 # The contenttype is what you define in this config.
 
 # Block structure
@@ -13,15 +18,24 @@
 
 # Explanation
 # -----------
-# contenttype: the content type for which to enable the feed
+# contenttype: the content type for which to enable the feed, or 'sitewide' for the whole site
 # enabled: this one is easy huh? When set to false, returns a 404 on request
 # feed_records: the number of records to provide in the feed
 # feed_template: which template to use. This needs to be in the assets directory.
 # content_length: the number of characters in the content. If set to '0', the content will
 #    not be trimmed, and HTML (links, markup, etc) will be kept intact.
 
-# Examples
-# --------
+# Site RSS Example
+# ----------------
+#sitewide:
+#    enabled: true
+#    feed_records: 10
+#    feed_template: rss.twig
+#    content_length: 250
+#    content_types: [entries, pages]
+
+# Contenttype specific RSS Examples
+# ---------------------------------
 #pages:
 #    enabled: true
 #    feed_records: 10


### PR DESCRIPTION
This update allows a site-wide RSS feed from multiple content types to be defined.  This mirrors functionality in other systems that people migrating to Bolt may want/need.

I emailed Patrick and he is happy for you to review this on his behalf, @bobdenotter
