### PR TITLE
PHP sux: Empty argument never be overriden with "" default parameter, so...

### DIFF
--- a/app/src/Bolt/Cache.php
+++ b/app/src/Bolt/Cache.php
@@ -32,9 +32,9 @@ class Cache extends FilesystemCache
      * @param  string                               $cacheDir
      * @throws \Exception|\InvalidArgumentException
      */
-    public function __construct($cacheDir = "")
+    public function __construct($cacheDir = null)
     {
-        if ($cacheDir == "") {
+        if (!isset($cacheDir)) {
             $cacheDir = BOLT_CACHE_DIR;
         } else {
             // We don't have $app here, so we use the filesystem component


### PR DESCRIPTION
... 'new Cache()' won't initializes with correct BOLT_CACHE_DIR
