### PR TITLE
[Feature] Allow Setcontent tag accept expression for some attributes

### DIFF
--- a/app/src/Bolt/SetcontentNode.php
+++ b/app/src/Bolt/SetcontentNode.php
@@ -24,7 +24,8 @@ class SetcontentNode extends \Twig_Node
             ->write('$context[\'' . $this->getAttribute('name') . '\'] = ')
             ->write('$template_storage->getContent(')
             ->subcompile($this->getAttribute('contenttype'))
-            ->raw(", " . var_export($arguments, true));
+            ->raw(", ")
+            ->subcompile($arguments);
 
         if (!is_null($this->getNode('wherearguments'))) {
             $compiler
@@ -32,8 +33,7 @@ class SetcontentNode extends \Twig_Node
                 ->subcompile($this->getNode('wherearguments'));
         }
 
-            $compiler
-            ->raw(" );\n");
+        $compiler->raw(" );\n");
 
     }
 }

--- a/app/src/Bolt/SetcontentTokenParser.php
+++ b/app/src/Bolt/SetcontentTokenParser.php
@@ -24,7 +24,7 @@ class SetcontentTokenParser extends \Twig_TokenParser
     {
         $lineno = $token->getLine();
 
-        $arguments = array();
+        $arguments = new \Twig_Node_Expression_Array(array(), $lineno);
         $wherearguments = null;
 
         // name - the new variable with the results
@@ -47,35 +47,38 @@ class SetcontentTokenParser extends \Twig_TokenParser
             // limit parameter
             if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'limit')) {
                 $this->parser->getStream()->next();
-                $limit = $this->parser->getExpressionParser()->parsePrimaryExpression()->getAttribute('value');
-                $arguments['limit'] = $limit;
+                $limit = $this->parser->getExpressionParser()->parseExpression();
+                $arguments->addElement($limit, new \Twig_Node_Expression_Constant('limit', $lineno));
             }
 
             // order / orderby parameter
             if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'order') ||
                 $this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'orderby')) {
                 $this->parser->getStream()->next();
-                $order = $this->parser->getExpressionParser()->parsePrimaryExpression()->getAttribute('value');
-                $arguments['order'] = $order;
+                $order = $this->parser->getExpressionParser()->parseExpression();
+                $arguments->addElement($order, new \Twig_Node_Expression_Constant('order', $lineno));
             }
 
             // paging / allowpaging  parameter
             if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'paging') ||
                 $this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'allowpaging')) {
                 $this->parser->getStream()->next();
-                $arguments['paging'] = true;
+                $arguments->addElement(new \Twig_Node_Expression_Constant(true, $lineno),
+                    new \Twig_Node_Expression_Constant('paging', $lineno));
             }
 
             // printquery  parameter
             if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'printquery')) {
                 $this->parser->getStream()->next();
-                $arguments['printquery'] = true;
+                $arguments->addElement(new \Twig_Node_Expression_Constant(true, $lineno),
+                    new \Twig_Node_Expression_Constant('printquery', $lineno));
             }
 
             // returnsingle  parameter
             if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'returnsingle')) {
                 $this->parser->getStream()->next();
-                $arguments['returnsingle'] = true;
+                $arguments->addElement(new \Twig_Node_Expression_Constant(true, $lineno),
+                    new \Twig_Node_Expression_Constant('returnsingle', $lineno));
             }
 
             // Make sure we don't get stuck in a loop, if a token can't be parsed..


### PR DESCRIPTION
`Setcontent` tag accepts just constants for `order` or `limit` before. The PR allows to use expression or variable as in the #1120 question mention.
