### PR TITLE
Custom listing should use slug instead name as filename

### DIFF
--- a/app/view/custom/listing/pages.twig.dist
+++ b/app/view/custom/listing/pages.twig.dist
@@ -1,6 +1,6 @@
 {# Example template for individual listings in dashboard and overview
 
-   Add a template "/app/view/custom/listing/<contenttypename>.twig" and add the blocks you want to display different.
+   Add a template "/app/view/custom/listing/<contenttypeslug>.twig" and add the blocks you want to display different.
    Unchanged Blocks use the defaults
 #}
 {% extends '_listing-base.twig' %}

--- a/app/view/dashboard.twig
+++ b/app/view/dashboard.twig
@@ -64,7 +64,7 @@
                 {% for content in multiplecontent %}
 
                     {% set editable = isallowed('edit', content) %}
-                    {% include ['custom/listing/'~contenttype|lower~'.twig', '_sub_listing.twig'] with { 'excerptlength': 280, 'thumbsize': 54, 'compact': true } %}
+                    {% include ['custom/listing/'~content.contenttype.slug~'.twig', '_sub_listing.twig'] with { 'excerptlength': 280, 'thumbsize': 54, 'compact': true } %}
 
                 {% endfor %}
             </table>

--- a/app/view/overview.twig
+++ b/app/view/overview.twig
@@ -16,9 +16,8 @@
 
         {% for content in multiplecontent %}
 
-
             {% set editable = isallowed('edit', content) %}
-            {% include ['custom/listing/'~contenttype.name|lower~'.twig', '_sub_listing.twig'] with { 'excerptlength': 380, 'thumbsize': 80, 'compact': false } %}
+            {% include ['custom/listing/'~contenttype.slug~'.twig', '_sub_listing.twig'] with { 'excerptlength': 380, 'thumbsize': 80, 'compact': false } %}
             {% if content.group.name is defined and (loop.first or content.group.name != lastgroup) %}
                 {% set lastgroup = content.group.name %}
             {% endif %}


### PR DESCRIPTION
Second try. Made it wrong in the first place, so it's my task to correct it :cry:

Instead of the human readable name the machine readable and filesystem friendly slug is the better choice.
