### PR TITLE
Setting $app variable to protected, which may be useful for 0c18498c

### DIFF
--- a/app/src/Bolt/Content.php
+++ b/app/src/Bolt/Content.php
@@ -6,7 +6,7 @@ use Silex;
 
 class Content implements \ArrayAccess
 {
-    private $app;
+    protected $app;
     public $id;
     public $values;
     public $taxonomy;


### PR DESCRIPTION
Otherwise override in constructor, like so:

```
    public function __construct(Silex\Application $app, $contenttype = "", $values = "")
    {
        parent::__construct($app, $contenttype, $values);
        $this->app = $app;
    }
```
