### PR TITLE
Fixed the regex in hackislyParseRegexTemplates()

### DIFF
--- a/app/classes/lib.php
+++ b/app/classes/lib.php
@@ -645,12 +645,12 @@ function hackislyParseRegexTemplates($obj)
 {
     $str = print_r($obj, true);
 
-    preg_match_all('/(\/[a-z0-9_\/-]+\.twig)/i', $str, $matches);
+    preg_match_all('| => (.+\.twig)|i', $str, $matches);
 
     $templates = array();
 
     foreach ($matches[1] as $match) {
-        $templates[] = basename(dirname($match)) . "/" . basename($match);
+        $templates[] = str_replace(BOLT_PROJECT_ROOT_DIR . DIRECTORY_SEPARATOR, '', $match);
     }
 
     return $templates;


### PR DESCRIPTION
If you want to organize your twig files in your theme with folders, something like this : 

```
theme/
  default/
    css/
    js/
    views/
      components/
        menu.twig
        header.twig
        footer.twig
    index.twig
```

The list of templates used in the debug bar will be broken : 
![bolt_before](https://cloud.githubusercontent.com/assets/1421130/2839269/7047c830-d044-11e3-82a0-9e584157b3aa.png)

Because the regex doesn't handle the case where the template name can use folders.

This one works with the regex : 

```
{% include 'footer.twig' %}
```

This one is retrieved twice with the regex : 

```
{% include 'components/footer.twig' %}
```

I updated the regex in hackislyParseRegexTemplates($obj) and now the result in the debug bar looks like this, I think it's also more practical to know exactly which file has been used.
![bolt_after](https://cloud.githubusercontent.com/assets/1421130/2839293/fd6cfe42-d044-11e3-86a0-fb60c9653810.png)
