### PR TITLE
Error in TwigExtension::menu() when the menu is empty

### DIFF
--- a/app/src/Bolt/TwigExtension.php
+++ b/app/src/Bolt/TwigExtension.php
@@ -1057,6 +1057,12 @@ class TwigExtension extends \Twig_Extension
             $menu = util::array_first($menus);
         }
 
+        // If the menu loaded is null, replace it with an empty array instead of
+        // throwing an error.
+        if (!is_array($menu)) {
+            $menu = array();
+        }
+
         foreach ($menu as $key => $item) {
             $menu[$key] = $this->menuHelper($item);
             if (isset($item['submenu'])) {


### PR DESCRIPTION
In app/config/menu.yml, if you comment or remove all the links from your only one menu : 

```
main:
#  - label: Home
#    path: homepage
```

and if you try to render it : 

```
{{ menu('main', '_sub_menu.twig') }}
```

 Bolt will throw this error : 

```
An exception has been thrown during the rendering of a template ("Invalid argument supplied for foreach()")
```

It's because the twig function menu() in app/src/Bolt/TwigExtension.php doesn't check if the menu retrieved is valid. In case of an empty menu in the config file, $menu will be 'null'.

I assume this is an error which shouldn't happen.

For fixing this error, I added a simple condition which replace $menu with an empty array if it isn't valid. It allow twig to render the template without error.
