### PR TITLE
HTTPS fix for Google Maps in _sub_editfields.twig

### DIFF
--- a/app/view/_sub_editfields.twig
+++ b/app/view/_sub_editfields.twig
@@ -633,7 +633,7 @@
                 </script>
             </div>
         </div>
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
+<script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script>
 <script type="text/javascript" src="{{ paths.app }}view/js/jquery.gomap-1.3.2.min.js"></script>
 
     {% endif %}


### PR DESCRIPTION
Make Google Maps use HTTPS so that it doesn't kill JavaScript when viewed via SSL.

Issue: #1159 
