### PR TITLE
Ensure proper datedepublish format

### DIFF
--- a/app/src/Bolt/Content.php
+++ b/app/src/Bolt/Content.php
@@ -231,7 +231,7 @@ class Content implements \ArrayAccess
             return;
         }
 
-        if ($key == 'datecreated' || $key == 'datechanged' || $key == 'datepublish') {
+        if ($key == 'datecreated' || $key == 'datechanged' || $key == 'datepublish' || $key == 'datedepublish') {
             if (!preg_match("/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/", $value)) {
                 // @todo Try better date-parsing, instead of just setting it to 'now'..
                 $value = date("Y-m-d H:i:s");


### PR DESCRIPTION
When saving content, we must make sure that the user hasn't entered an incorrect value for datedepublish (e.g. empty time-value). Otherwise bolt explodes!

![img_1908](https://cloud.githubusercontent.com/assets/1737019/2888156/4626df48-d506-11e3-9c8c-4cb95499143b.png)
