### PR TITLE
Fix to regression of namespace case

### DIFF
--- a/app/src/Bolt/DataCollector/BoltDataCollector.php
+++ b/app/src/Bolt/DataCollector/BoltDataCollector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bolt\Datacollector;
+namespace Bolt\DataCollector;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
This fix was undone in this merge: https://github.com/bolt/bolt/commit/4be5b435edddbee9328f1bb8f9da8e8e38f9cef8
