### PR TITLE
Fallback for when sortorder is explicitly set.

### DIFF
--- a/app/src/Bolt/Content.php
+++ b/app/src/Bolt/Content.php
@@ -448,6 +448,11 @@ class Content implements \ArrayAccess
             $this->sortorder = $sortorder;
         }
 
+        // Fallback for when sortorder is explicitly set.
+        if (is_int($sortorder) && (strpos($value, "#") === false)) {
+            $value .= "#" . $sortorder;
+        }
+
         // Make the 'key' of the array an absolute link to the taxonomy.
         $link = sprintf("%s%s/%s", $this->app['paths']['root'], $taxonomytype, $value);
 


### PR DESCRIPTION
Useful for when programmatically creating and updating content (e.g. when importing). This fix allows groupings with sortorders to be saved properly.
