### PR TITLE
Path configuration

### DIFF
--- a/app/src/Bolt/Config.php
+++ b/app/src/Bolt/Config.php
@@ -37,6 +37,7 @@ class Config
     public function __construct(Application $app)
     {
         $this->app = $app;
+        $this->initializePaths();
 
         if (!$this->loadCache()) {
             $this->getConfig();


### PR DESCRIPTION
This commit is a start on a bit of a refactor to try and remove some of the hard-coded dependency on constants. The goal is to make it a bit more easy to bootstrap an app especially for testing purposes when you can't really depend on any of the standard paths being around.

Application level configuration can be passed into the Bolt\Application constructor, if they aren't set then the config class will continue to use the constants.
