### PR TITLE
Fixes error if table doesn't have a column "title"

### DIFF
--- a/app/view/_sub_editfields.twig
+++ b/app/view/_sub_editfields.twig
@@ -140,7 +140,7 @@
         {% if ',' in lookupfield %}
             {% set lookupfield = lookupfield|split(',') %}
         {% endif %}
-        {% setcontent lookups = lookuptype order 'title' %}
+        {% setcontent lookups = lookuptype order lookupfield|last %}
         {% set values = lookups|selectfield(lookupfield) %}
     {% endif %}
 


### PR DESCRIPTION
This fix will use the last column defined in the values when the field type is select and the values are fetch from a content type.
