### PR TITLE
Separate editfields

### DIFF
--- a/app/view/_macro.twig
+++ b/app/view/_macro.twig
@@ -36,10 +36,40 @@
     {% if field.required is defined and field.required %}required="required"{% endif %}
 {% endmacro %}
 
+{# outputs tag attributes #}
+{% macro attr(attributes) %}
+    {% spaceless %}
+        {% for attrname, value in attributes if value is not empty %}
+            {% if attrname in ['required', 'checked', 'disabled', 'autofocus'] %}
+                {{ attrname }}="{{ attrname }}"
+            {% elseif attrname == 'name_id' %}
+                name="{{ value }}" id="{{ value }}"
+            {% else %}
+                {{ attrname }}="{{ value }}"
+            {% endif %}
+        {% endfor %}
+    {% endspaceless %}
+{% endmacro %}
+
+{# label text (TOD: rename to label, when other macro isn't neede anymore) #}
+{% macro labeltxt(key, field) %}
+    {{- field.label ?: key|ucfirst -}}
+{% endmacro %}
+
 {# label for forms when editing content #}
 {% macro label(key, field, class, for) %}
-
-    <label {% if for %}for="{{ for }}" {% endif %}class="{{ class|default('control-label') }}">{% if field.label %}{{field.label}}{% else %}{{ key|ucfirst}}{%endif%}</label>
+    {% spaceless %}
+        <label
+            {# for   #} {% if for %}for="{{ for }}"{% endif %}
+            {# class #} class="{{ class|default('control-label') }}"
+        >
+            {% if field.label %}
+                {{field.label}}
+            {% else %}
+                {{ key|ucfirst}}
+            {%endif%}
+        </label>
+    {% endspaceless %}
 {% endmacro %}
 
 {# Sidebar-menu blocks with links, popover (for desktop) and touch-to-show (for mobile) #}

--- a/app/view/_sub_editfields.twig
+++ b/app/view/_sub_editfields.twig
@@ -15,93 +15,13 @@
 {# --------------- text --------------- #}
 
 {% if field.type == "text" %}
-    {% if field.variant != "inline" %}
-    <div class="col-sm-12">
-    {{ macro.label(key, field) }}
-    {% else %}
-    {{ macro.label(key, field, 'col-sm-3 control-label') }}
-    <div class="col-sm-9">
-    {% endif %}
-    <input type="{% if field.pattern in ['url', 'email'] %}{{ field.pattern }}{% else %}text{% endif %}" name="{{key}}" id="{{key}}"
-           value='{{ content.get(key) }}' {{ macro.requiredattr(field) }}
-           class='{{ field.class }}'
-            {% if field.pattern and field.pattern not in ['url', 'email'] %}pattern="{{ field.pattern }}"{% endif %}
-            >
-    </div>
-{% endif %}
-
-
-
-{# --------------- float, integer or (deprecated) number  --------------- #}
-
-{% if field.type in ["float", "integer", "number"] %}
-    {{ macro.label(key, field, 'col-sm-3 control-label') }}
-    <div class="col-sm-9">
-    <input type="number" name="{{key}}" id="{{key}}" step="{% if field.type != "integer" %}0.0000000{% endif %}1"
-        value='{{ 0 + content.get(key) }}' {{ macro.requiredattr(field) }}
-        class='narrow {{ field.class }}'
-        {% if field.pattern %}pattern="{{ field.pattern }}"{% endif %}
-        >
-    </div>
-{% endif %}
-
-
-
-
-{# --------------- checkbox --------------- #}
-
-{% if field.type  == "checkbox" %}
-    {{ macro.label(key, field, 'col-sm-3 control-label') }}
-    <div class="col-sm-9">
-        {# hidden field, to 'detect' unchecked checkboxes in $_POST. See: http://stackoverflow.com/a/1992745 #}
-        <input type="hidden" name="{{key}}" id="{{key}}" value='0'>
-        <input type="checkbox" name="{{key}}" id="{{key}}" value='1'
-               {% if content.get(key) %}checked{% else %}notchecked{% endif %}
-               class='{{ field.class }}'>
-    </div>
-{% endif %}
-
-{# --------------- slug --------------- #}
-
-{% if field.type == "slug" %}
-<div class="col-sm-12">
-    <label class='permalink'>{{ __('Permalink') }}:
-        <code>/{{ content.contenttype.singular_slug }}/<span id='show-{{key}}'>{{ content.get(key) }}</span></code>
-        <input type="text" name="{{key}}"  id="{{key}}" value='{{ content.get(key) }}' class='editslug'>
-        <span class='sluglocker'><i class='fa fa-lock'></i></span> <span class='slugedit'><i class='fa fa-pencil'></i></span>
-    </label>
-</div>
-
-{% if field.uses is defined %}
-<script type="text/javascript">
-    $(function() {
-        $('.sluglocker').bind('click', function() {
-           if ($('.sluglocker i').hasClass('fa-lock')) {
-               $('.sluglocker i').removeClass('fa-lock').addClass('fa-unlock');
-               makeUri('{{ content.contenttype.slug }}', '{{ content.id }}', {{ field.uses|json_encode|raw }}, '{{key}}', false);
-           } else {
-               $('.sluglocker i').addClass('fa-lock').removeClass('fa-unlock');
-               stopMakeUri({{ field.uses|json_encode|raw }});
-           }
-        });
-        $('.slugedit').bind('click', function() {
-
-            newslug = prompt("Set the slug to:");
-
-            $('.sluglocker i').addClass('fa-lock').removeClass('fa-unlock');
-            stopMakeUri({{ field.uses|json_encode|raw }});
-
-            makeUriAjax(newslug, '{{ content.contenttype.slug }}', '{{ content.id }}', '{{key}}', false)
-
-
-        });
-    {% if content.get(key) is empty  %}
-        $('.sluglocker').trigger('click');
-    {% endif %}
-    });
-</script>
-{% endif %}
-
+    {% include 'editfields/_text.twig' %}
+{% elseif field.type in ["float", "integer", "number"] %}
+    {% include 'editfields/_float-integer.twig' %}
+{% elseif field.type  == "checkbox" %}
+    {% include 'editfields/_checkbox.twig' %}
+{% elseif field.type == "slug" %}
+    {% include 'editfields/_slug.twig' %}
 {% endif %}
 
 {# --------------- select --------------- #}
@@ -190,7 +110,7 @@
         <input type="text" name="{{key}}[file]" id="field-{{key}}"
             value='{{ image.file|default('') }}'
             class='{% if field.class is defined %}{{ field.class }}{% endif %} imageinput wide'
-            accept="{{ field.extensions|join('|') }}"> 
+            accept="{{ field.extensions|join('|') }}">
 
         <p class="filetypes">
             {{ __("Allowed filetypes are:") }} <code>{{ field.extensions|join("</code>, <code>")|raw }}</code>.

--- a/app/view/editfields/_checkbox.twig
+++ b/app/view/editfields/_checkbox.twig
@@ -1,0 +1,23 @@
+{# Available options: class, label #}
+
+{% set attr_chk = {
+    type:     'checkbox',
+    name_id:  key,
+    value:    '1',
+    checked:  content.get(key),
+    class:    field.class,
+}%}
+
+{% set attr_hid = {
+    type:     'hidden',
+    name_id:  key,
+    value:    '0',
+}%}
+
+
+<label class="col-sm-3 control-label">{{ macro.labeltxt(key, field) }}</label>
+<div class="col-sm-9">
+    {# hidden field, to 'detect' unchecked checkboxes in $_POST. See: http://stackoverflow.com/a/1992745 #}
+    <input{{ macro.attr(attr_hid) }}>
+    <input{{ macro.attr(attr_chk) }}>
+</div>

--- a/app/view/editfields/_float-integer.twig
+++ b/app/view/editfields/_float-integer.twig
@@ -1,0 +1,19 @@
+{# Available options: class, label, pattern, placeholder, required, title #}
+
+{% set attr_num = {
+    type:         'number',
+    name_id:      key,
+    step:         (field.type == "integer") ? '1' : '0.00000001',
+    value:        0 + content.get(key),
+    required:     field.required,
+    class:        ('narrow ' ~ field.class)|trim,
+    pattern:      field.pattern ?: '',
+    title:        field.title,
+    placeholder:  field.placeholder,
+}%}
+
+
+<label class="col-sm-3 control-label">{{ macro.labeltxt(key, field) }}</label>
+<div class="col-sm-9">
+    <input{{ macro.attr(attr_num) }}>
+</div>

--- a/app/view/editfields/_slug.twig
+++ b/app/view/editfields/_slug.twig
@@ -1,0 +1,43 @@
+{# Available options: uses #}
+
+{% set attr_slg = {
+    type:     'text',
+    name_id:  key,
+    value:    content.get(key),
+    class:    'editslug',
+}%}
+
+
+<div class="col-sm-12">
+    <label class="permalink">{{ __('Permalink') }}:
+        <code>/{{ content.contenttype.singular_slug }}/<span id="show-{{ key }}">{{ content.get(key) }}</span></code>
+        <input{{ macro.attr(attr_slg) }}>
+        <span class="sluglocker"><i class="fa fa-lock"></i></span> <span class="slugedit"><i class="fa fa-pencil"></i></span>
+    </label>
+</div>
+
+
+{% if field.uses is defined %}
+<script>
+    $(function() {
+        $('.sluglocker').bind('click', function() {
+           if ($('.sluglocker i').hasClass('fa-lock')) {
+               $('.sluglocker i').removeClass('fa-lock').addClass('fa-unlock');
+               makeUri('{{ content.contenttype.slug }}', '{{ content.id }}', {{ field.uses|json_encode|raw }}, '{{ key }}', false);
+           } else {
+               $('.sluglocker i').addClass('fa-lock').removeClass('fa-unlock');
+               stopMakeUri({{ field.uses|json_encode|raw }});
+           }
+        });
+        $('.slugedit').bind('click', function() {
+            newslug = prompt("Set the slug to:");
+            $('.sluglocker i').addClass('fa-lock').removeClass('fa-unlock');
+            stopMakeUri({{ field.uses|json_encode|raw }});
+            makeUriAjax(newslug, '{{ content.contenttype.slug }}', '{{ content.id }}', '{{ key }}', false);
+        });
+    {% if content.get(key) is empty %}
+        $('.sluglocker').trigger('click');
+    {% endif %}
+    });
+</script>
+{% endif %}

--- a/app/view/editfields/_text.twig
+++ b/app/view/editfields/_text.twig
@@ -1,0 +1,25 @@
+{# Available options: class, label, pattern, placeholder, required, title, variant:inline #}
+
+{% set attr_txt = {
+    type:         (field.pattern in ['url', 'email']) ? field.pattern : 'text',
+    name_id:      key,
+    value:        content.get(key),
+    required:     field.required,
+    class:        field.class,
+    pattern:      (field.pattern and field.pattern not in ['url', 'email']) ? field.pattern : '',
+    title:        field.title,
+    placeholder:  field.placeholder,
+}%}
+
+
+{% if field.variant == 'inline' %}
+    <label class="col-sm-3 control-label">{{ macro.labeltxt(key, field) }}</label>
+    <div class="col-sm-9">
+        <input{{ macro.attr(attr_input) }}>
+    </div>
+{% else %}
+    <div class="col-sm-12">
+        <label>{{ macro.labeltxt(key, field) }}</label>
+        <input{{ macro.attr(attr_txt) }}>
+    </div>
+{% endif %}


### PR DESCRIPTION
2nd try :-)

So, Bob. Here's the first bunch of separated editfields.

Also tried to make the (allready separated) better readable. IMHO macros shouldn't replace (outer) tags as this hides the structure, the help of syntax coloring and makes autoformating unusable.

Also tried to HTML5ify some things (type="text/javascript", nonchecked).

What do you think? before I go on I'd like to have your ok.
