### PR TITLE
Prevent "Illegal offset type" warnings for multiple choice items.

### DIFF
--- a/app/extensions/SimpleForms/extension.php
+++ b/app/extensions/SimpleForms/extension.php
@@ -393,7 +393,10 @@ class Extension extends \Bolt\BaseExtension
                     $options[safeString($option)] = $option;
                 }
 
-                $data[$key] = $options[$value];
+                // For multiple choices, prevent "Illegal offset type" warnings.
+                if (!is_array($value) && isset($options[$value])) {
+                    $data[$key] = $options[$value];
+                }
             }
         }
 


### PR DESCRIPTION
This prevents "illegal offset type" warnings for when multiple items are selected.
