### PR TITLE
content changelog doesn't works when update content

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -275,16 +275,16 @@ class Storage
      * This function must be called *before* the actual update, because it
      * fetches the old content from the database.
      */
-    private function logUpdate($contenttype, $contentid, $newContent) {
-        $this->writeChangelog('UPDATE', $contenttype, $contentid, $newContent);
+    private function logUpdate($contenttype, $contentid, $newContent, $oldContent) {
+        $this->writeChangelog('UPDATE', $contenttype, $contentid, $newContent, $oldContent);
     }
 
     /**
      * Writes a content-changelog entry for a deleted entry.
      * This function must be called *before* the actual update, because it
      */
-    private function logDelete($contenttype, $contentid) {
-        $this->writeChangelog('DELETE', $contenttype, $contentid);
+    private function logDelete($contenttype, $contentid, $content) {
+        $this->writeChangelog('DELETE', $contenttype, $contentid, null, $content);
     }
 
     /**
@@ -295,7 +295,8 @@ class Storage
      * @param int $contentid ID of the content item to log.
      * @param array $newContent For 'INSERT' and 'UPDATE', the new content;
      *                          null for 'DELETE'.
-     *
+     * @param array $oldContent For 'UPDATE' and 'DELETE', the current content;
+     *                          null for 'INSTERT'.
      * For the 'UPDATE' and 'DELETE' actions, this function fetches the
      * previous data from the database; this means that you must call it
      * _before_ running the actual update/delete query; for the 'INSERT'
@@ -303,20 +304,13 @@ class Storage
      * an ID, you can only really call the logging function _after_ the update.
      * @throws \Exception
      */
-    private function writeChangelog($action, $contenttype, $contentid, $newContent = null) {
+    private function writeChangelog($action, $contenttype, $contentid, $newContent = null, $oldContent = null) {
         $allowed = array('INSERT', 'UPDATE', 'DELETE');
         if (!in_array($action, $allowed)) {
             throw new \Exception("Invalid action '$action' specified for changelog (must be one of [ " . implode(', ', $allowed) . " ])");
         }
 
         if ($this->app['config']->get('general/changelog/enabled')) {
-            $tablename = $this->getTablename($contenttype);
-            if ($action === 'INSERT') {
-                $oldContent = null;
-            }
-            else {
-                $oldContent = $this->app['db']->fetchAssoc("SELECT * FROM $tablename WHERE id = ?", array($contentid));
-            }
             if (empty($oldContent) && empty($newContent)) {
                 throw new \Exception("Tried to log something that cannot be: both old and new content are empty");
             }
@@ -722,9 +716,11 @@ class Storage
             $contenttype = $contenttype['slug'];
         }
 
-        $this->logDelete($contenttype, $id);
-
         $tablename = $this->getTablename($contenttype);
+
+        $oldContent = $this->findContent($tablename, $id);
+
+        $this->logDelete($contenttype, $id, $oldContent);
 
         $res = $this->app['db']->delete($tablename, array('id' => $id));
 
@@ -785,6 +781,8 @@ class Storage
 
         $tablename = $this->getTablename($contenttype);
 
+        $oldContent = $this->findContent($tablename, $content['id']);
+
         $content['datechanged'] = date('Y-m-d H:i:s');
 
         // Keep datecreated around, for when we might need to 'insert' instead of 'update' after all
@@ -794,7 +792,7 @@ class Storage
         $res = $this->app['db']->update($tablename, $content, array('id' => $content['id']));
 
         if ($res == true) {
-            $this->logUpdate($contenttype, $content['id'], $content);
+            $this->logUpdate($contenttype, $content['id'], $content, $oldContent);
             return true;
         } else {
             // Attempt to _insert_ it, instead of updating..
@@ -2898,6 +2896,18 @@ class Storage
 
         return intval($count) > 0;
 
+    }
+
+    /**
+     * Find record from Content Type and Content Id
+     * @param string $tablename Table name
+     * @param int    $contentId Content Id
+     * @return array
+     */
+    protected function findContent($tablename, $contentId) {
+
+        $oldContent = $this->app['db']->fetchAssoc("SELECT * FROM $tablename WHERE id = ?", array($contentId));
+        return $oldContent;
     }
 
 }


### PR DESCRIPTION
When Content Change Log is enabled the logUpdate gets the current content in database and the Diff not get anything, because is the same content.

That right behaviour should be: get old content before to call update method in DB.

This PR fixes that behaviour.
