### PR TITLE
I18n love applied.

### DIFF
--- a/app/resources/translations/de/messages.de.yml
+++ b/app/resources/translations/de/messages.de.yml
@@ -256,3 +256,5 @@
 "Rename %foldername%": "%foldername% umbenennen"
 "Delete %foldername%": "%foldername% löschen"
 "Folder permissions insufficient": "Verzeichnisberechtigungen lassen das nicht zu"
+"Saved": "Speicherte"
+"Recently edited %contenttypes%": "Kürzlich editierte %contenttypes%"


### PR DESCRIPTION
Saved: Right underneath Recent activities: I didn't feel like changing the order of the Contenttype - i18n'd text because I'd have to Uppercase the first letter so meh... Rather translate to past tense.

Recently edited: Beyond the create- buttons of the contenttypes on the dashboard.
