### PR TITLE
Removed unused parameter in Storage::saveContent

### DIFF
--- a/app/extensions/Editable/src/EditableElement.php
+++ b/app/extensions/Editable/src/EditableElement.php
@@ -65,7 +65,7 @@ class EditableElement
         }
 
         $content->values[$this->fieldname] = $value;
-        $id = $this->app['storage']->saveContent($content, $this->contenttypeslug);
+        $id = $this->app['storage']->saveContent($content);
         return $id;
     }
 

--- a/app/src/Bolt/Controllers/Backend.php
+++ b/app/src/Bolt/Controllers/Backend.php
@@ -648,7 +648,7 @@ class Backend implements ControllerProviderInterface
             }
 
             // Save the record, and return to the overview screen, or to the record (if we clicked 'save and continue')
-            if ($statusOK && $app['storage']->saveContent($content, $contenttype['slug'])) {
+            if ($statusOK && $app['storage']->saveContent($content)) {
                 if (!empty($id)) {
                     $app['session']->getFlashBag()->set('success', __('The changes to this %contenttype% have been saved.', array('%contenttype%' => $contenttype['singular_name'])));
                 } else {
@@ -1155,7 +1155,7 @@ class Backend implements ControllerProviderInterface
                                 __("File '%file%' could not be uploaded (wrong/disallowed file type). Make sure the file extension is one of the following: ", array('%file%' => $filename))
                                 . $extensionList);
                         }
-                        
+
                     }
                 } else {
                     $app['session']->getFlashBag()->set('error', __("File '%file%' could not be uploaded.", array('%file%' => $filename)));

--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -568,11 +568,9 @@ class Storage
         }
     }
 
-    public function saveContent($content, $contenttype = "")
+    public function saveContent($content)
     {
-
         $contenttype = $content->contenttype;
-
         $fieldvalues = $content->values;
 
         if (empty($contenttype)) {


### PR DESCRIPTION
No need to call a function with parameters that are overwritten in the next line.
