### PR TITLE
Allow proportional scaling of thumbnals and images

### DIFF
--- a/app/classes/timthumb.php
+++ b/app/classes/timthumb.php
@@ -37,9 +37,8 @@ if (!empty($_SERVER['REDIRECT_URL']) &&
 $parsed_url = parse_url($requesturi);
 
 // Match the width, height, cropping type and filename..
-$res = preg_match("^thumbs/([0-9]+)x([0-9]+)([a-z]*)/(.*)^i", $parsed_url['path'] , $matches);
-
-if (empty($matches[1]) || empty($matches[2]) || empty($matches[4])) {
+$res = preg_match("^thumbs/([0-9]+)x([0-9]+)([a-z]*)/(.*)^i", $parsed_url['path'], $matches);
+if (!$res or ($matches[1] == 0 and $matches[2] == 0)) {
     die("Malformed thumbnail URL. Should look like '/thumbs/320x240c/filename.jpg'.");
 }
 


### PR DESCRIPTION
It was impossible to set with or height to 0 as it then always default settings were used.
This is now possible. Default values are now only used if other than digits are in those parameters.
`thumbnail(img, 400, 0, 'r')` now gives you as expected an image with height scaled proportional instead of default height.
