### PR TITLE
Generate widget key properly

### DIFF
--- a/app/src/Bolt/Extensions.php
+++ b/app/src/Bolt/Extensions.php
@@ -325,7 +325,7 @@ class Extensions
 
         $sessionkey = !empty($user['sessionkey']) ? $user['sessionkey'] : "";
 
-        $key = substr(md5(sprintf("%s%s%s%s", $sessionkey, $type, $location, $callback)), 0, 8);
+        $key = substr(md5(sprintf("%s%s%s%s", $sessionkey, $type, $location, !is_array($callback) ? $callback : get_class($callback[0]) . $callback[1])), 0, 8);
 
         $this->widgetqueue[] = array(
             'type' => $type,


### PR DESCRIPTION
Extensions:insertWidget > if the callback function is an array we have an object callback, so generate widget key properly
