### PR TITLE
Some basepath correction ...

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -2,7 +2,7 @@
 
 mb_internal_encoding('UTF-8');
 mb_http_output('UTF-8');
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once BOLT_PROJECT_ROOT_DIR . '/vendor/autoload.php';
 
 if(strpos("/vendor/", __DIR__) !== false) {
     $config = new Bolt\Configuration\ComposerResources(__DIR__."/../");


### PR DESCRIPTION
... in case of Bolt is a composer based subproject and only timthumb.php loads this bootstrap.php. This case BOLT_PROJECT_ROOT_DIR is the fix basepath.
