### PR TITLE
the autoload path varies in composer installs

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -2,11 +2,11 @@
 
 mb_internal_encoding('UTF-8');
 mb_http_output('UTF-8');
-require_once __DIR__ . '/../vendor/autoload.php';
-
-if(strpos("/vendor/", __DIR__) !== false) {
+if(strpos(__DIR__, "/vendor/") !== false) {
+    require_once __DIR__ . '/../../../../vendor/autoload.php';
     $config = new Bolt\Configuration\ComposerResources(__DIR__."/../");
 } else {
+    require_once __DIR__ . '/../vendor/autoload.php';
     $config = new Bolt\Configuration\ResourceManager(__DIR__."/../");
 }
 $config->compat();


### PR DESCRIPTION
This should fix the problem @rixbeck found in https://github.com/bolt/bolt/pull/1256 

Using the constant won't work because it isn't set now until the initialisation, hence the failing tests. 

Whilst this if check doesn't look too pretty, it does only need to be here until the thumbs and upload separate files are phased out.
