### PR TITLE
fix to force time to set to midnight if not otherwise set on depublication

### DIFF
--- a/app/view/editcontent.twig
+++ b/app/view/editcontent.twig
@@ -43,6 +43,7 @@
             $('#datepublish-date, #datepublish-time').on('change', function(){
                 var date = $('#datepublish-date').datepicker("getDate");
                 var time = $('#datepublish-time').val() + ":00";
+                if(time == ":00") time = "00:00:00";
                 $('#datepublish').val($.datepicker.formatDate('yy-mm-dd', date)+" "+time);
             });
         </script>


### PR DESCRIPTION
Fix for: https://github.com/bolt/bolt/issues/1277

Depublication is automatically set to now if the format is incorrect, if the time is empty it will get set as `:00` which fails, this checks and sets to `00:00:00` instead.
