### PR TITLE
change thumbs to use semantic versining, matching main bolt package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     
     "require": {
         "bolt/dumper": ">=0.7",
-        "bolt/thumbs": "1.0.*@dev",
+        "bolt/thumbs": "~1.6",
         "doctrine/dbal": "~2.4",
         "erusev/parsedown": "1.*",
         "filp/whoops": "1.*",


### PR DESCRIPTION
Move thumbs to semantic versioning, matching current bolt/bolt release version
