### PR TITLE
Fix: pager overwritten every time a content is loaded.

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -2002,7 +2002,7 @@ class Storage
             'showing_to' => ($decoded['parameters']['page'] - 1) * $decoded['parameters']['limit'] + count($results)
         );
         $this->setPager($pager_name, $pager);
-        $this->app['twig']->addGlobal('pager', $this->getPager($pager_name));
+        $this->app['twig']->addGlobal('pager', $this->getPager());
 
         $this->app['stopwatch']->stop('bolt.getcontent');
         return $results;
@@ -2942,13 +2942,8 @@ class Storage
      */
     public function setPager($name, $pager)
     {
-        if (! array_key_exists($name, static::$pager)) {
-            static::$pager = array(
-                $name => $pager
-            );
-        } else {
-            static::$pager[$name] = $pager;
-        }
+        static::$pager[$name] = $pager;
+
         return $this;
     }
 


### PR DESCRIPTION
At line 2005 we need to set the global pager in twig, not just what loaded in the call.
At setPager() method the static::$pager array always exists, so we don't need extra check, just have to set the pager object indexed by $name. If the old array_key_exists at line 2945 matched true then the whole pager array overwritten with the object that was passed to the method. I don't think this check even makes sense anyway, because the static::$pager array always exists end the set line always rewrites the key/value.

This was introduced in: 683e11d393f5b0f08fc0247ddbb975a333874507
