### PR TITLE
add support for a memory option in sqlite config

### DIFF
--- a/app/src/Bolt/Config.php
+++ b/app/src/Bolt/Config.php
@@ -698,7 +698,8 @@ class Config
             $dboptions = array(
                 'driver' => 'pdo_sqlite',
                 'path' => isset($configdb['path']) ? realpath($configdb["path"])."/".$basename : __DIR__ . '/../../database/' . $basename,
-                'randomfunction' => 'RANDOM()'
+                'randomfunction' => 'RANDOM()',
+                'memory' => isset($configdb['memory']) ? true : false
             );
         } else {
             // Assume we configured it correctly. Yeehaa!


### PR DESCRIPTION
Minor addition which allows use of in-memory sqlite, which is very useful for unit testing.
