### PR TITLE
Postgresql Table Check

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -2906,7 +2906,7 @@ class Storage
         } else {
             // For MySQL and Postgres:
             $databasename = $this->app['config']->get('general/database/databasename');
-            $query = "SELECT count(*) FROM information_schema.tables WHERE table_schema = '$databasename' AND table_name = '$name';";
+            $query = "SELECT count(*) FROM information_schema.tables WHERE (table_schema = '$databasename' OR table_catalog = '$databasename') AND table_name = '$name';";
         }
 
         $res = $this->app['db']->fetchColumn($query);


### PR DESCRIPTION
This may be a case of my server setup process being different to everyone else, so feel free to ignore if noone else has a problem. By default new tables go into the public schema so this query:

```
$query = "SELECT count(*) FROM information_schema.tables WHERE table_schema = '$databasename'  AND table_name = '$name';";
```

Comes back empty. This change to check either the schema or catalog fixes the problem.
