### PR TITLE
use the global to ensure the correct path is selected

### DIFF
--- a/app/classes/lib.php
+++ b/app/classes/lib.php
@@ -56,7 +56,8 @@ function findFiles($term, $extensions = "")
 
 function findFilesHelper($additional, &$files, $term = '', $extensions = array())
 {
-    $basefolder = __DIR__ . '/../../files/';
+    global $app;
+    $basefolder = $app['resources']->getPath('files');
 
     $currentfolder = realpath($basefolder . '/' . $additional);
 


### PR DESCRIPTION
Ok, this is a very temporary hack, I feel ill looking at the use of `global` but there's a few functions that still use them inside this file and until we bring all these inside the app DI container this is the only way to access the app configuration outside of the app.

I will fix this very soon, promise.
