### PR TITLE
Removed backticks which were causing PostgreSQL installations to crash

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -2805,7 +2805,7 @@ class Storage
 
         // Get the current values from the DB..
         $query = sprintf(
-            "SELECT id FROM %s ORDER BY `datecreated` DESC LIMIT 1;",
+            "SELECT id FROM %s ORDER BY datecreated DESC LIMIT 1;",
             $tablename
         );
         $id = $this->app['db']->executeQuery($query)->fetch();


### PR DESCRIPTION
I ran into this problem while working on a Bolt + PostgreSQL combo.
