### PR TITLE
Optimized usage of composer on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,7 @@ before_install:
   - git submodule init
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar self-update
-  - php composer.phar install --prefer-source
+  - composer self-update || true
+  - composer install --prefer-source
   - mkdir -p tests/_log
   - chmod 777 tests/_log
-


### PR DESCRIPTION
There is a preinstalled version of composer on travis-ci, so we should use it.
But still keeping the `self-update`, but making it failsafe with `|| true`, if getcomposer.org might be down.
