### PR TITLE
Undefined variable in Permissions.php returned (typo?!)

### DIFF
--- a/app/src/Bolt/Permissions.php
+++ b/app/src/Bolt/Permissions.php
@@ -101,7 +101,7 @@ class Permissions
             default:
                 $roles = $this->getDefinedRoles();
                 if (isset($roles[$roleName])) {
-                    return $role[$roleName];
+                    return $roles[$roleName];
                 } else {
                     return null;
                 }


### PR DESCRIPTION
Assume, that's `$roles`, not `$role` (At least it would make sense:-)
