### PR TITLE
Key "totalpages" ... does not exist

### DIFF
--- a/app/view/overview.twig
+++ b/app/view/overview.twig
@@ -4,10 +4,12 @@
 <div class="row">
 
     <div class="col-lg-12">
-        <h1 class="page-header">            {{ title|raw }}
-            <span>{% if pager is defined and pager.totalpages > 1 %}
-                {{ __('Showing') }} {{ pager.showing_from }} - {{ pager.showing_to }} {{ __('of') }} {{ pager.count }}
-            {%endif %}</span></h1>
+        <h1 class="page-header">{{ title|raw }}
+            {% set pager_ct = pager[contenttype.slug]|default %}
+            {% if pager_ct and pager_ct.totalpages > 1 %}
+                <span>{{ __('Showing') }} {{ pager_ct.showing_from }} - {{ pager_ct.showing_to }} {{ __('of') }} {{ pager_ct.count }}</span>
+            {%endif %}
+        </h1>
     </div>
 
     <div class="col-md-9">


### PR DESCRIPTION
Bugfix: "totalpages" for array with keys "kitchensink" does not exist in "overview.twig" at line 8
