### PR TITLE
Handle empty config.yml files in loadConfigFile()

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -120,7 +120,11 @@ abstract class BaseExtension extends \Twig_Extension implements BaseExtensionInt
         // If it's readable, we're cool
         if (is_readable($configfile)) {
             $new_config = $yamlparser->parse(file_get_contents($configfile) . "\n");
-            $this->config = array_merge($this->config, $new_config);
+
+            // Don't error on empty config files
+            if (is_array($new_config)) {
+                $this->config = array_merge($this->config, $new_config);
+            }
         }
         // Otherwise, check if there's a config.yml.dist
         elseif (is_readable($configdistfile)) {


### PR DESCRIPTION
Fixes the following error seen when running nut on a site naughty enough to have empty config.yml files for extensions:

`PHP Warning:  array_merge(): Argument #2 is not an array in /var/www/sites/example.com/app/src/Bolt/BaseExtension.php on line 123`
