### PR TITLE
Fix for bug introduced with #1378

### DIFF
--- a/app/view/twig/extensions/_panel.twig
+++ b/app/view/twig/extensions/_panel.twig
@@ -10,8 +10,11 @@
                            type="button" data-toggle="modal" >{{ __('View Readme') }}</a>
                     {% endif %}
                     {% if extension.config is defined %}
-                        <a href="{{ path('fileedit', { 'file': extension.config } ) }}" class="btn btn-default btn-xs"
-                               type="button">{% if extension.config_writable %}{{ __('Edit Config') }}{% else %}{{ __('View Config') }}{% endif %}</a>
+                        {% for cnf in extension.config %}
+                            <a href="{{ path('fileedit', { 'file': cnf.file }) }}" class="btn btn-default btn-xs" type="button">
+                                {% if cnf.writable %}{{ __('Edit Config') }}{% else %}{{ __('View Config') }}{% endif %}
+                            </a>
+                        {% endfor %}
                     {% endif %}
                 </div>
             </h3>


### PR DESCRIPTION
Seems the path for the Edit Config button perhaps shouldn't be an abolute one.
At least, the page renders again and as this twig is replaced soon anyway...
