### PR TITLE
Enable the extension autoloader to load generated classmap

### DIFF
--- a/app/src/Bolt/Extensions.php
+++ b/app/src/Bolt/Extensions.php
@@ -106,6 +106,12 @@ class Extensions
             foreach ($map as $namespace => $path) {
                 $loader->setPsr4($namespace, $path);
             }
+
+            $mapfile = $this->basefolder . '/vendor/composer/autoload_classmap.php';
+            if (is_readable($mapfile)) {
+                $map = require_once $mapfile;
+                $loader->addClassMap($map);
+            }
             $loader->register();
         }
 


### PR DESCRIPTION
This allows extension authors to use classmap autoloading in their extension where they include external libraries that are not namespace compliant. e.g.

``` json
"classmap" : [
            "lib/UsefulLib/",
            "lib/OtherLib/"
        ]
```

Ping @rossriley
