### PR TITLE
Bugfix: grouping taxonomies get reset in overviewss.

### DIFF
--- a/app/src/Bolt/Storage.php
+++ b/app/src/Bolt/Storage.php
@@ -2574,6 +2574,14 @@ class Storage
                 // If it's like 'desktop#10', split it into value and sortorder..
                 list($slug, $sortorder) = explode('#', $slug . "#");
 
+                // @todo clean up and/or refactor
+                // If you save this content via anything other than the Bolt
+                // backend (see Content->setFromPost), then taxonomies that
+                // behave like groupings, will have their sortorders reset to 0.
+                if ($configTaxonomies[$taxonomytype]['behaves_like'] == 'grouping' && empty($sortorder) && $sortorder !== '0') {
+                    $sortorder = $currentsortorder;
+                }
+
                 if (empty($sortorder)) {
                     $sortorder = 0;
                 }
@@ -2609,6 +2617,7 @@ class Storage
                         'name' => $name,
                         'sortorder' => $sortorder
                     );
+
                     $this->app['db']->insert($tablename, $row);
                 }
 
@@ -2619,8 +2628,9 @@ class Storage
 
                 // Make it look like 'desktop#10'
                 $valuewithorder = $slug . "#" . $currentsortorder;
+                $slugkey = '/'.$configTaxonomies[$taxonomytype]['slug'].'/'.$slug;
 
-                if (!in_array($slug, $newslugs) && !in_array($valuewithorder, $newslugs)) {
+                if (!in_array($slug, $newslugs) && !in_array($valuewithorder, $newslugs) && !array_key_exists($slugkey, $newslugs)) {
                     $this->app['db']->delete($tablename, array('id' => $id));
                 }
             }


### PR DESCRIPTION
When saving content and taxonomy via the overview (i.e. anywhere
except via the post function in editcontent).
