### PR TITLE
Force commit as LF for all text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,10 @@
 #
 # Note: If you are on Windows and wish to checkout as LF instead of CRLF
 # (e.g., you are sharing the working directory with a Unix machine), create
-# a new file at "X:\<bolt-path>\.git\info\attributes" containing "* text=lf"
+# a new file at "X:\<bolt-path>\.git\info\attributes" containing:
+#
+#   * text=lf -crlf
+#
 
 * text=auto
 


### PR DESCRIPTION
Ensures that all text files are committed with Unix (LF) line endings, in case contributors don't have `core.autocrlf` set to `true` on Windows platforms.
