### PR TITLE
Fix Modal for Video Fields.

### DIFF
--- a/app/view/twig/editcontent/fields/_video.twig
+++ b/app/view/twig/editcontent/fields/_video.twig
@@ -136,16 +136,20 @@
     </div>
 
     {# Modal video preview #}
-    <div class="modal hide" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-        <div class="modal-body">
-            {% if video.html is defined %}
-                {{ video.html }}
-            {% else %}
-                <p>{{ __('No video url is set, no video to show.') }}</p>
-            {% endif %}
-        </div>
-        <div class="modal-footer">
-            <button class="btn btn-tertiary " data-dismiss="modal" aria-hidden="true">{{ __('Close') }}</button>
+    <div class="modal" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-body">
+                    {% if video.html is defined %}
+                        {{ video.html }}
+                    {% else %}
+                        <p>{{ __('No video url is set, no video to show.') }}</p>
+                    {% endif %}
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-tertiary " data-dismiss="modal" aria-hidden="true">{{ __('Close') }}</button>
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
Probably missed from upgrading from Bootstrap 2 to 3. According to [Bootply](http://webcache.googleusercontent.com/search?q=cache:http://www.bootply.com/bootstrap-3-migration-guide)
- remove `.hide` from the `.modal` (it's now hidden by default)
- wrap `.modal-header` `.modal-body` `.modal-footer` inside `.modal-content`
- wrap `.modal-content` inside `.modal-dialog`

Did a quick `grep` and found no other faulty `modal`s.
