### PR TITLE
Fix for buttons of Select and Taxonomy/Category fields.

### DIFF
--- a/app/view/twig/editcontent/_taxonomies.twig
+++ b/app/view/twig/editcontent/_taxonomies.twig
@@ -106,9 +106,9 @@
 
             {% if taxonomy.multiple is defined and taxonomy.multiple == 1 %}
             <label><span class='left' style="line-height: 1px;">&nbsp;</span></label>
-            <div style="margin-top: -14px;">
-                <a href="#" class="btn bnt-info btn-mini" onclick="jQuery('#taxonomy-{{taxonomy.slug}} option').prop('selected', true); return false;">{{ __("Select all") }}</a>
-                <a href="#" class="btn bnt-info btn-mini" onclick="jQuery('#taxonomy-{{taxonomy.slug}} option').prop('selected', false); return false;">{{ __("Select none") }}</a>
+            <div style="margin-top: -14px;">{# TODO:onclick-events to JS #}
+                <a href="#" class="btn btn-tertiary btn-xs" onclick="jQuery('#taxonomy-{{taxonomy.slug}} option').prop('selected', true); return false;">{{ __("Select all") }}</a>
+                <a href="#" class="btn btn-tertiary btn-xs" onclick="jQuery('#taxonomy-{{taxonomy.slug}} option').prop('selected', false); return false;">{{ __("Select none") }}</a>
             </div>
             {% endif %}
 

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -51,9 +51,9 @@
                 {% endfor %}
             </select>
 
-            <div>{# TODO: move style to CSS, onclick-events to JS #}
-                <a style="padding-top:0;" href="#" class="btn bnt-info btn-mini" onclick="jQuery('#{{ key }} option').prop('selected', true); return false;">{{ __("Select all") }}</a>
-                <a style="padding-top:0;" href="#" class="btn bnt-info btn-mini" onclick="jQuery('#{{ key }} option').prop('selected', false); return false;">{{ __("Select none") }}</a>
+            <div style='margin-top: 8px;'>{# TODO: move style to CSS, onclick-events to JS #}
+                <a href="#" class="btn btn-tertiary btn-xs" onclick="jQuery('#{{ key }} option').prop('selected', true); return false;">{{ __("Select all") }}</a>
+                <a href="#" class="btn btn-tertiary btn-xs" onclick="jQuery('#{{ key }} option').prop('selected', false); return false;">{{ __("Select none") }}</a>
             </div>
         </div>
 


### PR DESCRIPTION
- Fix typo in `bnt-info`, fixed to `btn-tertiary`, because `btn-info` might be too _flashy_.
- `btn-mini` should be `btn-xs` in Bootstrap 3
- No idea what happens with the margins, might want to refactor that out in the future.

TODO: In general, check the Kitchensink page and clean things up (i.e. make things a bit more aligned and uniform).
