### PR TITLE
Add lowlevel check for existence of writable extensions directory

### DIFF
--- a/app/src/Bolt/Configuration/Composer.php
+++ b/app/src/Bolt/Configuration/Composer.php
@@ -18,7 +18,7 @@ class Composer extends Standard
         parent::__construct($root, $request);
         $this->setPath("composer", "vendor/bolt/bolt");
         $this->setPath("apppath", $this->getPath('composer')."/app");
-        $this->setPath("extensionspath", $this->getPath('app')."/extensions");
+        $this->setPath("extensionspath", $this->root."/extensions");
         $this->setPath("cache", $this->root."/cache");
         $this->setPath("config", $this->root."/config");
         $this->setPath("database", $this->root."/database");

--- a/app/src/Bolt/Configuration/LowlevelChecks.php
+++ b/app/src/Bolt/Configuration/LowlevelChecks.php
@@ -74,6 +74,19 @@ class LowlevelChecks
                 "present and writable to the user that the webserver is using."
             );
         }
+        
+        // Check if there is a writable extension path
+        if (!is_dir($this->config->getPath('extensions'))) {
+            $this->lowlevelError(
+                "The folder <code>" . $this->config->getPath('extensions') . "</code> doesn't exist. Make sure it's " .
+                "present and writable to the user that the webserver is using."
+            );
+        } elseif (!is_writable($this->config->getPath('extensions'))) {
+            $this->lowlevelError(
+                "The folder <code>" . $this->config->getPath('extensions') . "</code> isn't writable. Make sure it's " .
+                "present and writable to the user that the webserver is using."
+            );
+        }
 
         /**
          * This check looks for the presence of the .htaccess file inside the web directory.

--- a/app/tests/Bolt/Tests/ResourceManagerTest.php
+++ b/app/tests/Bolt/Tests/ResourceManagerTest.php
@@ -179,9 +179,9 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
         $config->setPath('database', 'app/database');
         $config->setPath('config', 'app/config');
         $app = new Application(array('resources'=>$config));
-        $this->assertEquals(TEST_ROOT."/vendor/bolt/bolt/app",            $config->getPath("app"));
-        $this->assertEquals(TEST_ROOT."/vendor/bolt/bolt/app/extensions", $config->getPath("extensions"));
-        $this->assertEquals("/bolt-public/",                            $config->getUrl("app"));
+        $this->assertEquals(TEST_ROOT."/vendor/bolt/bolt/app",  $config->getPath("app"));
+        $this->assertEquals(TEST_ROOT."/extensions",            $config->getPath("extensions"));
+        $this->assertEquals("/bolt-public/",                    $config->getUrl("app"));
     }
 
     public function testNonRootDirectory()


### PR DESCRIPTION
also fixes a path error in composer where the tests were looking in the old location for extensions
