### PR TITLE
Avoids to call checkTablesIntegrity() in checkConfig() method...

### DIFF
--- a/app/src/Bolt/Config.php
+++ b/app/src/Bolt/Config.php
@@ -23,7 +23,7 @@ class Config
         'text', 'integer', 'float', 'geolocation', 'imagelist', 'image', 'file', 'filelist', 'video', 'html',
         'textarea', 'datetime', 'date', 'select', 'templateselect', 'markdown', 'checkbox', 'slug'
     );
-    
+
     public $fields;
 
     static private $yamlParser;
@@ -356,9 +356,9 @@ class Config
                     }
                 }
 
-                // If the field has a 'group', make sure it's added to the 'groups' array, so we can turn 
+                // If the field has a 'group', make sure it's added to the 'groups' array, so we can turn
                 // them into tabs while rendering. This also makes sure that once you started with a group,
-                // all others have a group too. 
+                // all others have a group too.
                 if (!empty($temp['fields'][$key]['group'])) {
                     $currentgroup = $temp['fields'][$key]['group'];
                     $temp['groups'][] = $currentgroup;
@@ -481,6 +481,7 @@ class Config
                          $field['type'])
                     );
                     $this->app['session']->getFlashBag()->set('error', $error);
+                    $wrongctype = true && $this->app['users']->getCurrentUsername();
                 }
             }
 
@@ -498,7 +499,7 @@ class Config
         }
 
         // Check DB-tables integrity
-        if ($this->app['integritychecker']->needsCheck() &&
+        if (!$wrongctype && $this->app['integritychecker']->needsCheck() &&
            (count($this->app['integritychecker']->checkTablesIntegrity()) > 0) &&
             $this->app['users']->getCurrentUsername()) {
             $msg = __(
@@ -539,7 +540,7 @@ class Config
             }
         }
     }
-    
+
     /**
      * A getter to access the fields manager
      *


### PR DESCRIPTION
...because it throws 

```
PHP Fatal error:  Call to a member function getStorageType() on a non-object in /home/rix/bolt-comp/app/src/Bolt/Database/IntegrityChecker.php on line 618
```

in the case when you removed a previously installed extension that extends a contenttype with a custom field.

Reproducing:
- install `bolt/colourpicker`
- modify `contenttypes.yml` with adding to `pages` a colourpicker field type
- play like a child with
- remove the extension

During integrity checking Bolt wants to check db integrity but handler of the custom field will be missing.
The fix won't let run db integrity checker until improper field types has repaired in `contenttypes.yml`.  
