### PR TITLE
Add helper for adding console command [#851]

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -3,6 +3,7 @@
 namespace Bolt;
 
 use Bolt\Extensions\BaseExtensionInterface;
+use Symfony\Component\Console\Command\Command;
 
 abstract class BaseExtension extends \Twig_Extension implements BaseExtensionInterface
 {
@@ -422,5 +423,15 @@ abstract class BaseExtension extends \Twig_Extension implements BaseExtensionInt
         } else {
             return false;
         }
+    }
+
+    /**
+     * Add a console command
+     *
+     * @param Command $command
+     */
+    public function addConsoleCommand(Command $command)
+    {
+        $this->app['console']->add($command);
     }
 }


### PR DESCRIPTION
Having chatted with @GawainLynch and @jadwigo on IRC, it seems the preferred approach for #851 is to let an extension developer define their own Command class, and simply register it in the extension.  This allows for full command flexibility, without having to abstract everything into a method (name, description, arguments with name/description/required or not, options, input output handling, etc)

A simple helper has been added to make things more explicit for documentation. (`$this->addConsoleCommand()` rather than `$this->app['console']->add()`).

Cheers!
