### PR TITLE
The gitignore ** pattern is not supported by git until version 1.8.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Bolt specific stuff. Don't put config files, databases or 'vendor' in Git.
 app/cache/*
-app/config/**/*.yml
+app/config/*.yml
+app/config/extensions/*.yml
 app/database/*
 *config.yml
 files/*


### PR DESCRIPTION
CentOS 6 uses 1.7.1, Ubuntu 12.04 LTS uses 1.7.9.

https://github.com/git/git/blob/master/Documentation/RelNotes/1.8.2.txt
