### PR TITLE
Bootstrap improvements

### DIFF
--- a/app/src/Bolt/Configuration/ResourceManager.php
+++ b/app/src/Bolt/Configuration/ResourceManager.php
@@ -40,7 +40,9 @@ class ResourceManager
     /**
      * Constructor initialises on the app root path.
      *
-     * @param string $path
+     * @param string $loader ClassLoader | string
+     * Classloader instance will use introspection to find root path
+     * String will be treated as an existing directory.
      */
     public function __construct($loader, Request $request = null, $verifier = null)
     {


### PR DESCRIPTION
Whilst using the loader is ok for out of the box installs it removes the ability for custom bootstraps to instantiate an app. This adjusts the ResourceManager constructor to support both types.
