### PR TITLE
Set default datecreated as $now, being as that is when it is created...

### DIFF
--- a/app/src/Bolt/Content.php
+++ b/app/src/Bolt/Content.php
@@ -115,8 +115,7 @@ class Content implements \ArrayAccess
 
         if (!isset($this->values['datecreated']) ||
             !preg_match("/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/", $this->values['datecreated'])) {
-            // Not all DB-engines can handle a date like '0000-00-00', so we pick a safe date, that's far enough in the past.
-            $this->values['datecreated'] = "1970-01-01 00:00:00";
+            $this->values['datecreated'] = $now;
         }
 
         if (!isset($this->values['datepublish']) || ($this->values['datepublish'] < "1971-01-01 01:01:01") ||
@@ -905,7 +904,7 @@ class Content implements \ArrayAccess
             'limit' => 1,
             'order' => $field . $order,
             'returnsingle' => true,
-            'hydrate' => false            
+            'hydrate' => false
         );
 
         $next = $this->app['storage']->getContent($this->contenttype['singular_slug'], $params, $dummy, $where);


### PR DESCRIPTION
Greetings from the bleeding edge of Bolt 2 ExtensionLand

If an extension creates its own record, e.g.:

``` php
$contenttype = $this->app['storage']->getContentType('books');
$record = $this->app['storage']->getEmptyContent($contenttype['slug']);
$this->app['storage']->saveContent($record);
```

Then `datepublish` and `datechanged` values are set to `date("Y-m-d H:i:s")`.  Under certain circumstances — such as the developer not setting `datecreated` themselves — that will mean that the records creation date will end up as epoch.  

If we're setting these two fields to $now on creation, it follows that the _actual_ creation date is also now...

An interesting example of how this can bite is when a POST_SAVE dispatcher hook exists during the creation of a new record.  When the user first clicks 'Save', \Bolt\Controllers\Backend::getLatestId() is called and that will return the most recent `datecreated` which generally isn't epoch, however that ID is the one used to build the redirect URL...  Confusion ensued. 
