### PR TITLE
Make each FlashBag message its own div

### DIFF
--- a/app/view/twig/_sub/_messages.twig
+++ b/app/view/twig/_sub/_messages.twig
@@ -7,39 +7,39 @@
     {% endif %}
 
     {% if app.session.flashBag.has('info') %}
-        <div class="alert alert-info">
-            <button class="close" data-dismiss="alert">×</button>
-            {% for msg in app.session.flashBag.get('info') %}
-                {{ msg|ymllink }}
-            {% endfor %}
-        </div>
+        {% for msg in app.session.flashBag.get('info') %}
+            <div class="alert alert-info">
+                <button class="close" data-dismiss="alert">×</button>
+                    {{ msg|ymllink }}
+            </div>
+        {% endfor %}
     {% endif %}
 
     {% if app.session.flashBag.has('error') %}
-        <div class="alert alert-danger">
-            <button class="close" data-dismiss="alert">×</button>
-            {% for msg in app.session.flashBag.get('error') %}
-                {{ msg|ymllink }}
-            {% endfor %}
-        </div>
+        {% for msg in app.session.flashBag.get('error') %}
+            <div class="alert alert-danger">
+                <button class="close" data-dismiss="alert">×</button>
+                    {{ msg|ymllink }}
+            </div>
+        {% endfor %}
     {% endif %}
 
     {% if app.session.flashBag.has('warning') %}
-        <div class="alert alert-warning">
-            <button class="close" data-dismiss="alert">×</button>
-            {% for msg in app.session.flashBag.get('warning') %}
-                {{ msg|ymllink }}
-            {% endfor %}
-        </div>
+        {% for msg in app.session.flashBag.get('warning') %}
+            <div class="alert alert-warning">
+                <button class="close" data-dismiss="alert">×</button>
+                    {{ msg|ymllink }}
+            </div>
+        {% endfor %}
     {% endif %}
 
     {% if app.session.flashBag.has('success') %}
-        <div class="alert alert-success">
-            <button class="close" data-dismiss="alert">×</button>
-            {% for msg in app.session.flashBag.get('success') %}
-                {{ msg|ymllink }}
-            {% endfor %}
-        </div>
+        {% for msg in app.session.flashBag.get('success') %}
+            <div class="alert alert-success">
+                <button class="close" data-dismiss="alert">×</button>
+                    {{ msg|ymllink }}
+            </div>
+        {% endfor %}
     {% endif %}
 
     {% if wrapper is defined and wrapper %}


### PR DESCRIPTION
This may fall into the Leave-the-Design-to-People-Who-Can-At-Least-Draw-Stick-People Department...

But if you queue several FlashBag messages of the one notification type, they end up mashed together on one line...  Ugly goes all the way to 11.
