### PR TITLE
Allows extensions with custom nav-item to mark "Extensions" active

### DIFF
--- a/app/view/twig/nav/_secondary-menuoptions.twig
+++ b/app/view/twig/nav/_secondary-menuoptions.twig
@@ -9,4 +9,4 @@
     ]) %}
 {% endfor %}
 
-{{ nav.submenu('briefcase', __('Extensions'), sub) }}
+{{ nav.submenu('briefcase', __('Extensions'), sub, (page_nav == 'Settings/Extensions')) }}


### PR DESCRIPTION
Extensions can add a navigation-item by calling `$this->addMenuOption` and display their extensions' views under a specified route.
Not sure if this is the most elegant way to proceed, but this patch enables extension-authors to to mark "Extensions" as active in the backend navigation

```
{% extends "_base/_page-nav.twig" %}
{% block page_nav 'Settings/Extensions' %}
```
