### PR TITLE
Fix for array to string error in setFromPost()

### DIFF
--- a/app/src/Bolt/Content.php
+++ b/app/src/Bolt/Content.php
@@ -257,7 +257,7 @@ class Content implements \ArrayAccess
         // to do this.
         if (isset($values['ownerid'])) {
             if ($this['ownerid'] != $values['ownerid']) {
-                if (!$this->app['users']->isAllowed("contenttype:$contenttype:change-ownership:{$this->id}")) {
+                if (!$this->app['users']->isAllowed("contenttype:{$contenttype['slug']}:change-ownership:{$this->id}")) {
                     throw new \Exception("Changing ownership is not allowed.");
                 }
                 $this['ownerid'] = intval($values['ownerid']);


### PR DESCRIPTION
I am not sure if this belongs in the:
- How-the-Hell-Has-This-Not-Been-Hit-Before Department
- Life-on-the-Bleeding-Edge Department
- Only-Found-at-Six-AM-Bug Department

To produce this, you need to get a TRUE from `if ($this['ownerid'] != $values['ownerid'])`, which is easy to simulate if you set an `ownerid` to `NULL` in the database and then edit said record from the backend.

Totally normal behaviour... right?
