### PR TITLE
Fixes #1670. Add function that gets all assets added by extensions.

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -278,6 +278,16 @@ abstract class BaseExtension extends \Twig_Extension implements BaseExtensionInt
     }
 
     /**
+     * Returns a list of all css and js assets that are added via extensions.
+     *
+     * @return array
+     */
+    public function getAssets()
+    {
+        return $this->app['extensions']->getAssets();
+    }
+
+    /**
      * Add a javascript file to the rendered HTML.
      *
      * @param string $filename

--- a/app/src/Bolt/Extensions.php
+++ b/app/src/Bolt/Extensions.php
@@ -85,6 +85,13 @@ class Extensions
      * @var array
      */
     public $composer;
+    /**
+     * Contains a list of all css and js assets added through addCss and
+     * addJavascript functions.
+     *
+     * @var array
+     */
+    private $assets;
 
 
     public function __construct(Application $app)
@@ -98,6 +105,11 @@ class Extensions
         } else {
             $this->addjquery = false;
         }
+
+        $this->assets = array(
+            'css' => array(),
+            'js'  => array()
+        );
     }
 
     /**
@@ -255,6 +267,16 @@ class Extensions
     }
 
     /**
+     * Returns a list of all css and js assets that are added via extensions.
+     *
+     * @return array
+     */
+    public function getAssets()
+    {
+        return $this->assets;
+    }
+
+    /**
      * Add a particular CSS file to the output. This will be inserted before the
      * other css files.
      *
@@ -264,6 +286,7 @@ class Extensions
     public function addCss($filename, $late = false)
     {
         $html = sprintf('<link rel="stylesheet" href="%s" media="screen">', $filename);
+        $this->assets['css'][] = $filename;
 
         if ($late) {
             $this->insertSnippet(SnippetLocation::END_OF_BODY, $html);
@@ -281,6 +304,7 @@ class Extensions
     public function addJavascript($filename, $late = false)
     {
         $html = sprintf('<script src="%s"></script>', $filename);
+        $this->assets['js'][] = $filename;
 
         if ($late) {
             $this->insertSnippet(SnippetLocation::END_OF_BODY, $html);


### PR DESCRIPTION
See #1670.
All extensions can use `getAssets` for a list of all assets added by extensions. E.g. in your extension, 

```
$assets = $this->getAssets();
$assets['js']; // all js files
$assets['css']; // all css files
\Dumper::dump($assets);
```

You can also access it via the global `{{ app.extensions.assets }}` in twig templates, which is a pretty nice addition.
