### PR TITLE
The 'Extra' section of Bolt is plural, not possessive.

### DIFF
--- a/app/view/twig/nav/_secondary-extensions.twig
+++ b/app/view/twig/nav/_secondary-extensions.twig
@@ -38,4 +38,4 @@
 
 {% endif %}
 
-{{ nav.submenu('cubes', __("Extra's"), sub, (page_nav == 'Settings/ExtendBolt')) }}
+{{ nav.submenu('cubes', __("Extras"), sub, (page_nav == 'Settings/ExtendBolt')) }}


### PR DESCRIPTION
This will silence the crying kittens...  Oh @rossriley and I as well :wink: 
