### PR TITLE
Add a 'ck' parameter (that by default reflects CK's default) 

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -179,6 +179,7 @@ wysiwyg:
   ck:
     allowedContent: true # If set to 'true', any elements and attributes are allowed in Wysiwg Elements
     autoParagraph: true # If set to 'true', any pasted content is wrapped in <p> tags for multiple line-breaks
+    disableNativeSpellChecker: true # If set to 'true' it will stop browsers from underlining spelling mistakes
 
 # by default, mail is sent using PHP's built-in mail function. In general, it's advised to use SMTP for sending mail
 # instead. Uncomment the following lines to use an SMTP server with authentication.


### PR DESCRIPTION
...that indicates to a site admin they can enable browser spell checking.
