### PR TITLE
Fix for #1733

### DIFF
--- a/app/src/Bolt/Controllers/Backend.php
+++ b/app/src/Bolt/Controllers/Backend.php
@@ -784,7 +784,22 @@ class Backend implements ControllerProviderInterface
 
                         // Get our record after POST_SAVE hooks are dealt with and return the JSON
                         $content = $app['storage']->getContent($contenttype['slug'], array('id' => $id, 'returnsingle' => true));
-                        return new JsonResponse($content->values);
+
+                        foreach ($content->values as $key => $value)
+                        {
+                            // Some values are returned as \Twig_Markup and JSON can't deal with that
+                            if (is_array($value)) {
+                                foreach ($value as $subkey => $subvalue) {
+                                    if (gettype($subvalue) == 'object' && get_class($subvalue) == 'Twig_Markup') {
+                                        $val[$key][$subkey] = $subvalue->__toString();
+                                    }
+                                }
+                            } else {
+                                $val[$key] = $value;
+                            }
+                        }
+
+                        return new JsonResponse($val);
                     }
                 }
 


### PR DESCRIPTION
Ensure content values that are returned from getContent() that contain \Twig_Markup objects have __toString() called before conversion to JSON.

Tested on all fields defined in kitchensink contenttype.

Fixes #1733
