### PR TITLE
Symfony styles were not required for codesniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "phpmd/phpmd": "1.5.0",
         "sebastian/phpcpd": "1.4.3",
         "squizlabs/php_codesniffer": "1.5.*",
+        "m6web/symfony2-coding-standard": "dev-master",
         "codeception/codeception": "*"
     },
     "minimum-stability": "beta",


### PR DESCRIPTION
Codesniffer didn't work without that line, that tells me, that nobody ever tried to use it.
