### PR TITLE
Add a missing default() for context.contenttype.description

### DIFF
--- a/app/view/twig/overview/_panel-actions_overview.twig
+++ b/app/view/twig/overview/_panel-actions_overview.twig
@@ -32,7 +32,7 @@
         <li>{{ __("Default status") }}: {{ context.contenttype.default_status|default('published') }}</li>
         <li>{{ __("Listing template") }}: <code>{{ context.contenttype.listing_template|default( app.config.get('general/listing_template') ) }}</code></li>
         <li>{{ __("Detail template") }}: <code>{{ context.contenttype.record_template|default( app.config.get('general/record_template') ) }}</code></li>
-        {% if context.contenttype.taxonomy is iterable %}
+        {% if context.contenttype.taxonomy|default('') is iterable %}
             <li>{{ __("Taxonomy") }}: {{ context.contenttype.taxonomy|join(', ') }}</li>
         {% endif %}
         {% if context.contenttype.relations|default('') is iterable %}


### PR DESCRIPTION
The first rule of BoltClub:  Don't talk about defaults for Twig variables when beer is involved :beers: 
