### PR TITLE
only catch errors if they are in an extension

### DIFF
--- a/app/src/Bolt/Extensions.php
+++ b/app/src/Bolt/Extensions.php
@@ -165,7 +165,8 @@ class Extensions
         ob_start(
             function ($buffer) use ($current) {
                 $error = error_get_last();
-                if ($error['type'] == E_ERROR || $error['type'] == E_PARSE) {
+                $isExtensionError = strpos($error['file'], $this->app['resources']->getPath('extensions'));
+                if (($error['type'] == E_ERROR || $error['type'] == E_PARSE) && false !== $isExtensionError) {
                     $html = LowlevelException::$html;
                     $message = '<code>'.$error['message']."<br>File ".$error['file']."<br>Line: ".$error['line'].'</code><br><br>';
                     $message .= $this->app['translator']->trans('There is a fatal error in one of the extensions loaded on your Bolt Installation.');


### PR DESCRIPTION
This should hopefully improve problems discussed in: https://github.com/bolt/bolt/issues/1661

This now only catches parse and fatal errors that are inside an extension, others in core of bolt etc will fall through to default behaviour.
