### PR TITLE
Renamed BaseExtensionInterface to IsExtension

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -1,11 +1,11 @@
 <?php
 namespace Bolt;
 
-use Bolt\Extensions\BaseExtensionInterface;
+use Bolt\Extensions\IsExtension;
 use Symfony\Component\Console\Command\Command;
 use Composer\Json\JsonFile;
 
-abstract class BaseExtension extends \Twig_Extension implements BaseExtensionInterface
+abstract class BaseExtension extends \Twig_Extension implements IsExtension
 {
     protected $app;
     protected $basepath;

--- a/app/src/Bolt/Extensions.php
+++ b/app/src/Bolt/Extensions.php
@@ -4,7 +4,7 @@ namespace Bolt;
 
 use Bolt;
 use Bolt\Extensions\Snippets\Location as SnippetLocation;
-use Bolt\Extensions\BaseExtensionInterface;
+use Bolt\Extensions\IsExtension;
 use Bolt\Configuration\LowlevelException;
 
 class Extensions
@@ -185,10 +185,10 @@ class Extensions
     /**
      * Extension register method. Allows any extension to register itself onto the enabled stack.
      *
-     * @param BaseExtensionInterface $extension
+     * @param IsExtension $extension
      * @return void
      */
-    public function register(BaseExtensionInterface $extension)
+    public function register(IsExtension $extension)
     {
         $name = $extension->getName();
         $this->app['extensions.' . $name] = $extension;
@@ -226,7 +226,7 @@ class Extensions
         }
     }
 
-    protected function initializeExtension(BaseExtensionInterface $extension)
+    protected function initializeExtension(IsExtension $extension)
     {
         $name = $extension->getName();
         try {

--- a/app/src/Bolt/Extensions/IsExtension.php
+++ b/app/src/Bolt/Extensions/IsExtension.php
@@ -4,7 +4,7 @@ namespace Bolt\Extensions;
 
 use Bolt\Application;
 
-interface BaseExtensionInterface
+interface IsExtension
 {
     public function __construct(Application $app);
     public function initialize();


### PR DESCRIPTION
Making this a pull request, because I'm totally open for discussion here.

My reasoning is that in the name "BaseExtensionInterface", the "Base" part is a lie (it's an interface, not a base-anything), and the "Interface" part is an implementation detail, and mentioning it in the identifier name is redundant (we're not writing `$foobarVariable`, `SomethingClass` or `$instanceOfSomethingClassFoo->methodBar($argumentBaz)` either, after all...).

I went with `IsExtension`, because:
- Interfaces are conceptually _predicates_, not nouns, so they should take the grammatical form of a noun-less sentence fragment or an adjective (typically "-able" stuff like "Foobarable"), not a proper noun.
- `CanBeUsedAsAnExtension` is... uhm... no.
- I couldn't come up with a valid adjective - `Extensionable` is not a word, `Extensible` or `Extendable` or any such have the roles reversed and are thus wrong.
- `Extension` is the class name for individual extensions already; `class Extension implements \Bolt\Extensions\Extension` looks confusing to me.

Further; if we do change the name at all, I guess it's best to do it _right now_, certainly not after the 2.0 release.

Discuss.
