### PR TITLE
Allow ckeditor config override via contenttype HTML

### DIFF
--- a/app/view/js/bolt.js
+++ b/app/view/js/bolt.js
@@ -485,6 +485,14 @@ CKEDITOR.editorConfig = function( config ) {
         }
     }
 
+    /* Parse override settings from field in contenttypes.yml */
+    var custom = $('[name='+this.name+']').data('ckconfig');
+    for (var key in custom){
+        if (custom.hasOwnProperty(key)) {
+             config[key] = custom[key];
+        }
+    }
+
 };
 
 

--- a/app/view/twig/editcontent/fields/_html.twig
+++ b/app/view/twig/editcontent/fields/_html.twig
@@ -5,7 +5,8 @@
     height:    field.height|default(''),
     label:     field.label|default(''),
     required:  field.required|default(false),
-    info:      field.info|default('')
+    info:      field.info|default(''),
+    ckconfig:  field.ckconfig|json_encode|raw|default('{}')
 }%}
 
 {#=== INIT ===========================================================================================================#}
@@ -20,10 +21,9 @@
 {#=== FIELDSET =======================================================================================================#}
 
 <fieldset class="html">
-
     <div class="col-sm-12">
         <label class="control-label">{{ (option.info) ? macro.infopop(labelkey, option.info) : labelkey }}</label>
-        <textarea{{ macro.attr(attr_html) }}>{{ context.content.get(key)|default('') }}</textarea>
+        <textarea{{ macro.attr(attr_html) }} data-ckconfig="{{ option.ckconfig }}">{{ context.content.get(key)|default('') }}</textarea>
     </div>
 
 </fieldset>


### PR DESCRIPTION
Settings are added as json to the data-ckconfig attribute of the textarea 
and are used as override inside bolt.js. see also #1233 

```
// Example under "Showcases" contenttype
        html:
            type: html
            height: 333px
            ckconfig:
                height: 300
                # contentsCss: ["directory/aa", "/directory/bb"]
                autoGrow_minHeight: 300
                autoGrow_maxHeight: 900
```
