### PR TITLE
Rename: BaseExtensionInterface -> ExtensionInterface

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -1,11 +1,11 @@
 <?php
 namespace Bolt;
 
-use Bolt\Extensions\BaseExtensionInterface;
+use Bolt\Extensions\ExtensionInterface;
 use Symfony\Component\Console\Command\Command;
 use Composer\Json\JsonFile;
 
-abstract class BaseExtension extends \Twig_Extension implements BaseExtensionInterface
+abstract class BaseExtension extends \Twig_Extension implements ExtensionInterface
 {
     protected $app;
     protected $basepath;

--- a/app/src/Bolt/Extensions.php
+++ b/app/src/Bolt/Extensions.php
@@ -4,7 +4,7 @@ namespace Bolt;
 
 use Bolt;
 use Bolt\Extensions\Snippets\Location as SnippetLocation;
-use Bolt\Extensions\BaseExtensionInterface;
+use Bolt\Extensions\ExtensionInterface;
 use Bolt\Configuration\LowlevelException;
 
 class Extensions
@@ -185,10 +185,10 @@ class Extensions
     /**
      * Extension register method. Allows any extension to register itself onto the enabled stack.
      *
-     * @param BaseExtensionInterface $extension
+     * @param ExtensionInterface $extension
      * @return void
      */
-    public function register(BaseExtensionInterface $extension)
+    public function register(ExtensionInterface $extension)
     {
         $name = $extension->getName();
         $this->app['extensions.' . $name] = $extension;
@@ -226,7 +226,7 @@ class Extensions
         }
     }
 
-    protected function initializeExtension(BaseExtensionInterface $extension)
+    protected function initializeExtension(ExtensionInterface $extension)
     {
         $name = $extension->getName();
         try {

--- a/app/src/Bolt/Extensions/ExtensionInterface.php
+++ b/app/src/Bolt/Extensions/ExtensionInterface.php
@@ -4,7 +4,7 @@ namespace Bolt\Extensions;
 
 use Bolt\Application;
 
-interface BaseExtensionInterface
+interface ExtensionInterface
 {
     public function __construct(Application $app);
     public function initialize();


### PR DESCRIPTION
As per public "voting"; `ExtensionInterface` it is.
