### PR TITLE
Use recursive array merging for getDefaultConfig() in loadConfigFile()

### DIFF
--- a/app/src/Bolt/BaseExtension.php
+++ b/app/src/Bolt/BaseExtension.php
@@ -264,7 +264,7 @@ abstract class BaseExtension extends \Twig_Extension implements ExtensionInterfa
 
         // Don't error on empty config files
         if (is_array($new_config)) {
-            $this->config = array_merge_recursive($this->config, $new_config);
+            $this->config = array_merge_recursive_distinct($this->config, $new_config);
         }
     }
 

--- a/app/src/Bolt/Config.php
+++ b/app/src/Bolt/Config.php
@@ -164,7 +164,7 @@ class Config
         $config = array();
 
         // Read the config
-        $config['general']     = array_merge_recursive(
+        $config['general']     = array_merge_recursive_distinct(
             $this->parseConfigYaml('config.yml'),
             $this->parseConfigYaml('config_local.yml')
         );


### PR DESCRIPTION
If an extension author specifies a default config that uses arrays for subvalues, the entire subvalue array will otherwise get overridden by incorrect/incomplete values.

``` php
$default = array(
    'templates' => array(
        'parent' => 'parent.twig',
        'child' => 'child.twig',
        'navigation' => array(
            'crumbs' => 'crumbs.twig'
)));

$yaml = array(
    'templates' => array(
        'parent' => 'parent.twig',
        'child' => 'child.twig',
        'navigation' => array(
            'mycrumbs' => 'mycrumbs.twig'
)));

var_export(array_merge($default, $yaml));
var_export(array_merge_recursive($default, $yaml));
```

In the above, `array_merge` will make `$default['templates']['navigation']` contain only `array('mycrumbs' => 'mycrumbs.twig')` where the extension's author is checking for config values in `$return_val['templates']['navigation']['crumbs']`
