### PR TITLE
Use correct protocol for Flysystem repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 
     "repositories": [{
         "type": "vcs",
-        "url": "http://github.com/rossriley/flysystem"
+        "url": "https://github.com/rossriley/flysystem"
     }],
 
     "require": {


### PR DESCRIPTION
This is apparently why composer installs are getting the upstream Flystream instead of Ross'
