### PR TITLE
Show view button in sidebar when it disappears from navbar

### DIFF
--- a/app/view/twig/nav/_secondary.twig
+++ b/app/view/twig/nav/_secondary.twig
@@ -6,7 +6,6 @@
         {# Omnisearch: one here for "extra small", the other in the header-navbar #}
         {% include 'nav/_secondary-search.twig' %}
 
-
         {# Dashboard #}
         {{ nav.link('dashboard', __('Dashboard'), 'dashboard', (page_nav == 'Dashboard')) }}
 


### PR DESCRIPTION
Should fix #1864 and show view site in sidebar beneath dashboard button when it gets hidden on width adjustment/small screens
