### PR TITLE
We now use the _bind keyword for js init …

### DIFF
--- a/app/view/twig/_macro/_macro.twig
+++ b/app/view/twig/_macro/_macro.twig
@@ -53,8 +53,8 @@
                     style="{{ value|trim }}"
                 {% elseif attrname == 'checked' %}
                     {% if value != false %}checked="checked"{% endif %}
-                {% elseif attrname == 'bind' %}
-                    data-bind="{{ value|json_encode }}"
+                {% elseif attrname == '_bind' %}
+                    data-bind="{{ {bind: value[0]}|merge(value[1]|default({}))|json_encode }}"
                 {% else %}
                     {{ attrname|replace({'_': '-'}) }}="{{ value }}"
                 {% endif %}

--- a/app/view/twig/editcontent/fields/_date.twig
+++ b/app/view/twig/editcontent/fields/_date.twig
@@ -9,7 +9,7 @@
 {#=== INIT ===========================================================================================================#}
 
 {% set attr_date = {
-    bind:   {bind: 'date', id: key},
+    _bind:  ['date', {id: key}],
     class:  option.class~' datepicker',
     id:     key~'-date',
     name:   key~'-dateformatted',

--- a/app/view/twig/editcontent/fields/_datetime.twig
+++ b/app/view/twig/editcontent/fields/_datetime.twig
@@ -9,7 +9,7 @@
 {#=== INIT ===========================================================================================================#}
 
 {% set attr_date = {
-    bind:   {bind: 'datetime', id: key},
+    _bind:  ['datetime', {id: key}],
     class:  option.class~' datepicker',
     id:     key~'-date',
     name:   key~'-dateformatted',

--- a/app/view/twig/editcontent/fields/_slug.twig
+++ b/app/view/twig/editcontent/fields/_slug.twig
@@ -6,8 +6,7 @@
 
 {#=== INIT ===========================================================================================================#}
 
-{% set bind_values = option.uses ? {
-    bind:           'slug',
+{% set bind_values = option.uses ? ['slug', {
     contentId:      context.content.id,
     isEmpty:        (context.content.get(key) == ''),
     key:            key,
@@ -15,10 +14,10 @@
     messageUnlock:  __('Are you sure you wish to unlock the slug? This might break existing links to this record.'),
     slug:           context.content.contenttype.slug,
     uses:           option.uses,
-} : '' %}
+}] : '' %}
 
 {% set attr_slug = {
-    bind:     bind_values,
+    _bind:    bind_values,
     class:    'editslug',
     name_id:  key,
     type:     'text',

--- a/app/view/twig/editcontent/fields/_video.twig
+++ b/app/view/twig/editcontent/fields/_video.twig
@@ -12,13 +12,13 @@
 {% set videotitle = (video.title is defined) ? '"<b>' ~ video.title|trimtext(18)~'</b>" by '~video.authorname|trimtext(18) %}
 
 {% set attr_url = {
-    bind:        {bind: 'video', key: key},
-    class:       'form-control',
-    id:          'video-'~key,
-    name:        key~'[url]',
-    type:        'url',
-    placeholder: __('URL of video on Youtube, Vimeo or other video website') ~ ' …',
-    value:       video.url|default(''),
+    _bind:        ['video', {key: key}],
+    class:        'form-control',
+    id:           'video-'~key,
+    name:         key~'[url]',
+    placeholder:  __('URL of video on Youtube, Vimeo or other video website') ~ ' …',
+    type:         'url',
+    value:        video.url|default(''),
 }%}
 
 {% set attr_width = {

--- a/app/view/twig/editfile/editfile.twig
+++ b/app/view/twig/editfile/editfile.twig
@@ -13,7 +13,7 @@
     {% import '_macro/_macro.twig' as macro %}
 
     {% set attr_text = {
-        bind:      ismobileclient() ? '' : {bind: 'editfile', readonly: context.write_allowed ? false : true},
+        _bind:     ismobileclient() ? '' : ['editfile', {readonly: context.write_allowed ? false : true}],
         class:     'CodeMirror-scroll',
         id:        'form_contents',
         name:      'form[contents]',

--- a/app/view/twig/editlocale/editlocale.twig
+++ b/app/view/twig/editlocale/editlocale.twig
@@ -13,7 +13,7 @@
     {% import '_macro/_macro.twig' as macro %}
 
     {% set attr_text = {
-        bind:      ismobileclient() ? '' : {bind: 'editlocale', readonly: context.write_allowed ? false : true},
+        _bind:     ismobileclient() ? '' : ['editlocale', {readonly: context.write_allowed ? false : true}],
         class:     'CodeMirror-scroll',
         id:        'form_contents',
         name:      'form[contents]',

--- a/app/view/twig/files_ck/_files.twig
+++ b/app/view/twig/files_ck/_files.twig
@@ -1,4 +1,6 @@
-<table class="dashboardlisting" data-bind="{{ {bind: 'ckfileselect'}|json_encode }}">
+{% import '_macro/_macro.twig' as macro %}
+
+<table class="dashboardlisting"{{ macro.attr({_bind: ['ckfileselect']}) }}>
     <thead>
         <tr>
             <th>{{ __('Files') }}</th>

--- a/app/view/twig/users/users.twig
+++ b/app/view/twig/users/users.twig
@@ -11,7 +11,9 @@
 
 {% block page_main %}
 
-    <div class="row" data-bind="{{ {bind: 'users'}|json_encode }}">
+    {% import '_macro/_macro.twig' as macro %}
+
+    <div class="row"{{ macro.attr({_bind: ['users']}) }}>
         <div class="col-md-9">
 
             {% include '_sub/_messages.twig' %}


### PR DESCRIPTION
...  and expect an `array ['function', {values}]` as parameter

(just had the idea  :bulb: that it even could be renamed to `_jsbind` later)
