### PR TITLE
groupby for relations

### DIFF
--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -43,16 +43,25 @@
                         <select name="relation[{{ relcontenttype }}][]" id="relation-{{ relcontenttype }}" class="wide" style="width: 100%;" data-placeholder="{{ __('(none)') }}">
                             <option value="0">{{ __('(none)') }}</option>
                     {% endif %}
+
+                        {% set groupby = relation.groupby|default(false) %}
+                        {% set optgroup = '' %}
                         {% for item in listcontent(relcontenttype, relation, context.content) %}
                             {% if relcontenttype == app.request.get('relation') and item.id == app.request.get('relationid') %}
                                 {% set selectedbyrelation = true %}
                             {% else %}
                                 {% set selectedbyrelation = false %}
                             {% endif %}
+                            {% if groupby and optgroup != item[groupby] %}
+                                {% if optgroup != '' %}</optgroup>{% endif %}
+                                {% set optgroup = item[groupby] %}
+                                <optgroup label="{{ optgroup }}">
+                            {% endif %}
                             <option value="{{ item.id }}"{% if item.selected or selectedbyrelation %} selected{% endif %}>
                                 {{ format|twig({'item': item}) }}
                             </option>
                         {% endfor %}
+                        {% if optgroup != '' %}</optgroup>{% endif %}
 
                     </select>
 
@@ -61,6 +70,9 @@
                             $('#relation-{{ relcontenttype }}').select2({
                                 placeholder: "{{ __('(none)') }}",
                                 allowClear: true
+                                {% if groupby %}, formatSelection: function (item) {
+                                    return $(item.element).parent().attr('label') + ': ' + item.text;
+                                }{% endif %}
                             });
                         });
                     </script>


### PR DESCRIPTION
had to add this urgent _bugfix_ as it could save us from #1555 or just bring us world peace ;-)

Usage:

```
    relations:
        entries:
            multiple: false
            groupby: title
            order: title
```

Todo: add ordering for multiple colums `order: [title, name]`, even better add sorting by the groupby column first automatic when set.
