### PR TITLE
Pass a target dir to Wrapper::create() so that composer.phar ends up in our cache

### DIFF
--- a/src/Composer/CommandRunner.php
+++ b/src/Composer/CommandRunner.php
@@ -324,7 +324,7 @@ class CommandRunner
         // Set the error reporting before initializing the wrapper, to suppress them.
         $oldErrorReporting = error_reporting(E_ERROR);
 
-        $this->wrapper = \evidev\composer\Wrapper::create();
+        $this->wrapper = \evidev\composer\Wrapper::create($this->app['resources']->getPath('cache') . '/composer');
 
         // re-set error reporting to the value it should be.
         error_reporting($oldErrorReporting);


### PR DESCRIPTION
Fixes #1935 
