### PR TITLE
Fix search_results_records.

### DIFF
--- a/app/src/Bolt/Controllers/Frontend.php
+++ b/app/src/Bolt/Controllers/Frontend.php
@@ -313,7 +313,8 @@ class Frontend
         $q = cleanPostedData($q, false);
 
         // Make paging work
-        $page_size = 10;
+        $config = $app['config'];
+        $page_size = $config->get('general/search_results_records') ?: ($config->get('general/listing_records') ?: 10);
         $page = 1;
         if ($request->query->has('page')) {
             $page = intval($request->get('page'));


### PR DESCRIPTION
Just saw this on one of our client's sites -> can't customize number of records on search page.

Based on fc17164f564ba772ab452194c317dd0a00d33ec3 fix by @rixbeck on Bolt 2. Not sure if we need the whole Bolt/Pager.
