### PR TITLE
Dashboard (listing) styles fix #1985

### DIFF
--- a/app/view/sass/modules/_bootstrapcustom.scss
+++ b/app/view/sass/modules/_bootstrapcustom.scss
@@ -20,6 +20,7 @@
   padding: 4px 7px;
 }
 
+.btn-group > a.btn-sm,
 .btn-group > a.btn-xs {
     font-weight: normal;
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/app/view/sass/modules/_dashboard.scss
+++ b/app/view/sass/modules/_dashboard.scss
@@ -21,13 +21,22 @@
 .dashboardlisting tbody {
     border-top: 0px !important;
 }
+.dashboardlisting th,
+.dashboardlisting td {
+  border-bottom: 1px solid $table-border-color;
+  font-size: 13px;
+  line-height: $line-height-base;
+  vertical-align: top;
+  padding: 8px;
+}
 
 .dashboardlisting th {
     background-color: #F2F2F2 !important;
     text-align: left;
     font-weight: bold;
     color: #888;
-    padding: 3px 5px;
+    padding-top: 5px;
+    padding-bottom: 5px;
     border-bottom: 1px solid #E7E7E7;
 }
 
@@ -78,30 +87,24 @@
     filter: grayscale(0.6) blur(1px);
 }
 
-.dashboardlisting td {
-    border-bottom: 1px solid $table-border-color;
-    font-size: 13px;
-}
-
 .dashboardlisting td.id,
 .dashboardlisting td.username,
 .dashboardlisting td.actions,
 .dashboardlisting td.listthumb  {
     white-space: nowrap;
     color: #666;
-    padding: 12px 2px;
+    padding: 8px;
 }
-
 .dashboardlisting td.username {
     text-align: left;
 }
 
 .dashboardlisting td.listthumb {
-    padding: 9px 2px 2px;
+    padding: 4px 2px 2px;
 }
 
 .dashboardlisting td.check {
-    padding-top: 10px;
+    /* padding-top: 10px; */
 }
 
 .dashboardlisting td.listthumb img {
@@ -127,9 +130,10 @@
 }
 
 .dashboardlisting td.excerpt span {
-    height: 40px;
-    padding-top: 3px;
+    max-height: 40px;
+    /* padding-top: 3px; */
     display: block;
+    line-height: $line-height-base;
     color: #777;
     overflow: hidden;
     word-wrap:break-word;
@@ -137,7 +141,7 @@
 }
 
 .dashboardlisting td.excerpt.large span {
-    height: 54px;
+    max-height: 54px;
 }
 
 @media (max-width: 767px) {

--- a/app/view/twig/overview/overview.twig
+++ b/app/view/twig/overview/overview.twig
@@ -21,7 +21,7 @@
 
             {% include '_sub/_messages.twig' %}
 
-            {{ list(context.contenttype, context.contenttype, context.multiplecontent, 'table table-striped') }}
+            {{ list(context.contenttype, context.contenttype, context.multiplecontent, 'table-striped') }}
             
         </div>
 

--- a/app/view/twig/users/_userlist.twig
+++ b/app/view/twig/users/_userlist.twig
@@ -1,4 +1,4 @@
-<table class='table table-striped dashboardlisting'>
+<table class='table-striped dashboardlisting userlist'>
     <thead>
         <tr>
             <th>#</th>
@@ -19,7 +19,7 @@
                     {% if user.enabled == 0 %}</s>{% endif %}
                 </td>
 
-                <td>
+                <td class="username">
                     {% if user.enabled == 0 %}<s>{% endif %}
                     <strong>{{ user.displayname }}</strong> ({{ user.username}})
                     {% if user.enabled == 0 %}</s>{% endif %}


### PR DESCRIPTION
- bootstrap class=table has to much css weight on children,
  removed table class and added base-styles to
  dashboardlisting th/td.
- button btn-sm used wrong font
- excerpt height converted to max-height to...
- td vertical-align top
- set some (base) line-heights on td
