### PR TITLE
Multiline messages - like stacktrace - should be converted to html

### DIFF
--- a/src/Configuration/LowlevelException.php
+++ b/src/Configuration/LowlevelException.php
@@ -69,6 +69,7 @@ EOM;
         $info = self::$info;
 
         $output = str_replace('%error_title%', 'Bolt - Fatal Error', $html);
+        $message = nl2br($message);
         $output = str_replace('%error%', $message, $output);
         $output = str_replace('%info%', $info, $output);
 
@@ -135,6 +136,7 @@ EOM;
                 $message = $errorblock;
             }
 
+            $message = nl2br($message);
             $html = str_replace('%error%', $message, $html);
             echo str_replace($app['resources']->getPath('rootpath'), '', $html);
         }


### PR DESCRIPTION
![selection_004](https://cloud.githubusercontent.com/assets/761149/4845270/eab23e32-6042-11e4-9bde-1212850e99f4.jpg)
vs
![selection_005](https://cloud.githubusercontent.com/assets/761149/4845264/d9637862-6042-11e4-8dd5-426ed054e8e2.jpg)
