### PR TITLE
Selectively disallow snippets

### DIFF
--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -253,7 +253,7 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
     public function before(Request $request, \Bolt\Application $app)
     {
         
-        // This disallows extensions from adding any extra snippets to the 
+        // This disallows extensions from adding any extra snippets to the output
         if ($request->get("_route") !== 'extend') {
             $app['htmlsnippets'] = false;
         }


### PR DESCRIPTION
This hopefully fixes #2073 and other related problems. There were occasions where extensions were adding html to output from ajax requests. This opts the extend controller out of this functionality.
