### PR TITLE
Use string for BOLT_PROJECT_ROOT_DIR

### DIFF
--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -283,7 +283,7 @@ class ResourceManager
             define('BOLT_COMPOSER_INSTALLED', false);
         }
         if (! defined("BOLT_PROJECT_ROOT_DIR")) {
-            define('BOLT_PROJECT_ROOT_DIR', $this->root);
+            define('BOLT_PROJECT_ROOT_DIR', $this->getPath('root'));
         }
         if (! defined('BOLT_WEB_DIR')) {
             define('BOLT_WEB_DIR', $this->getPath('web'));


### PR DESCRIPTION
Should also fix the HHVM `Constants may only evaluate to scalar values` failures on Travis
