### PR TITLE
Allow extensions to declare safe for user content.

### DIFF
--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -268,7 +268,7 @@ class Extensions
             try {
                 foreach ($extension->getTwigExtensions() as $extension) {
                     $this->app['twig']->addExtension($extension);
-                    if (!empty($info['allow_in_user_content'])) {
+                    if (is_callable($extension, 'isSafe') && $extension->isSafe() === true) {
                         $this->app['safe_twig']->addExtension($extension);
                     }
                 }


### PR DESCRIPTION
added a method check on the extension class to handle the old allow_in_user_content setting that was no longer implemented
