### PR TITLE
If you sort by a column, it will also sort these 'recent' menu items.

### DIFF
--- a/app/view/twig/nav/_secondary-content.twig
+++ b/app/view/twig/nav/_secondary-content.twig
@@ -20,7 +20,7 @@
         {# Contenttypes, where show_in_menu is set true #}
         {% if contenttype.show_in_menu %}
 
-            {% setcontent records = slug limit 4 nohydrate orderby '-datepublish' %}
+            {% setcontent records = slug limit 4 nohydrate orderby '-datechanged' %}
             {% for record in records %}
                 {% set sub = sub|merge([
                     {


### PR DESCRIPTION
Bolt breaks if you sort using a custom listing in `app/view/twig/custom/`  with a field that doesn't exist in other contenttypes.
