### PR TITLE
Extensions / ComandRunnder bugfix

### DIFF
--- a/src/Composer/CommandRunner.php
+++ b/src/Composer/CommandRunner.php
@@ -197,7 +197,7 @@ class CommandRunner
         // @see https://github.com/composer/composer/issues/2146#issuecomment-35478940
         putenv("DYLD_LIBRARY_PATH=''");
 
-        $command .= ' -d ' . $this->basedir . ' -n --no-ansi';
+        $command .= ' -d "' . $this->basedir . '" -n --no-ansi';
         $this->writeLog('command', $command);
 
         // Create an InputInterface object to pass to Composer


### PR DESCRIPTION
CommandRunner breaks when bolt is installed in a directory containing spaces, e.g. `/Users/bacbos/bolt rocks/`
(not that anyone would name his virtual hosts directory with spaces... :neutral_face: )
