### PR TITLE
Update Users.php - method: loginAuthtoken

### DIFF
--- a/src/Users.php
+++ b/src/Users.php
@@ -477,11 +477,11 @@ class Users
     public function loginAuthtoken()
     {
         // If there's no cookie, we can't resume a session from the authtoken.
-        if (empty($_COOKIE['bolt_authtoken'])) {
+        if (empty($this->app['request']->cookies->get('bolt_authtoken'))) {
             return false;
         }
 
-        $authtoken = $_COOKIE['bolt_authtoken'];
+        $authtoken = $this->app['request']->cookies->get('bolt_authtoken');
         $remoteip = $this->remoteIP;
         $browser = $_SERVER['HTTP_USER_AGENT'];
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -477,7 +477,7 @@ class Users
     public function loginAuthtoken()
     {
         // If there's no cookie, we can't resume a session from the authtoken.
-        if (empty($this->app['request']->cookies->get('bolt_authtoken'))) {
+        if (is_null($this->app['request']->cookies->get('bolt_authtoken'))) {
             return false;
         }
 


### PR DESCRIPTION
We should not refer directly to $_COOKIE array.

On my configuration (win7, xammp with php  5.5.11) $ _COOKIE ignores cookie in domain ".local". Bolt works on "local" domain.