### PR TITLE
force json response to send text/plain header

### DIFF
--- a/src/Controllers/Upload.php
+++ b/src/Controllers/Upload.php
@@ -103,8 +103,7 @@ class Upload implements ControllerProviderInterface, ServiceProviderInterface
                             );
                         }
                     }
-
-                    return new JsonResponse($result);
+                    return new JsonResponse($result, 200, array('Content-Type' => 'text/plain'));
                 } else {
                     list($namespace, $prefix) = $parser($handler);
                 }
@@ -114,7 +113,11 @@ class Upload implements ControllerProviderInterface, ServiceProviderInterface
                 $namespace = $app['upload.namespace'];
             }
 
-            return new JsonResponse($controller->uploadFile($app, $request, $namespace));
+            return new JsonResponse(
+                $controller->uploadFile($app, $request, $namespace),
+                200,
+                array('Content-Type' => 'text/plain')
+            );
         };
         $ctr->match('/{namespace}', $func)
             ->value('namespace', 'files')


### PR DESCRIPTION
Fixes #2194. Change the content type of JsonResponse to text/plain which then triggers the complete event in IE9.

Change seems to have no adverse effect on other browsers which seem to interpret json normally.
