### PR TITLE
Fix for #2257

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -663,7 +663,7 @@ class TwigExtension extends \Twig_Extension
         $finder->files()
                ->in($this->app['paths']['themepath'])
                ->depth('== 0')
-               ->name('/^[a-zA-Z0-9]\w+\.twig$/')
+               ->name('/^[a-zA-Z0-9]\V+\.twig$/')
                ->sortByName();
 
         $files = array();


### PR DESCRIPTION
When looking for Twig template file names, also include any character that is not a vertical whitespace character.
