### PR TITLE
Make grunt options really optional

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -276,7 +276,7 @@ hash_strength: 10
 #  password: pwd
 
 
-# options for when you're working with Grunt. Feel free to ignore these, if you don't use grunt.
+# Options for when you're working with Grunt.
 #grunt:
 #  livereload: false
 #  livereloadport: 35729


### PR DESCRIPTION
I guess it's better to signal that they are optional by commenting them out instead of just saying so.
