### PR TITLE
Fixed #2278. Method getContent can return single object, which will be omitted

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -926,12 +926,18 @@ class Content implements \ArrayAccess
             $where = array('id' => implode(" || ", $ids));
             $dummy = false;
 
-            $temp_records = $this->app['storage']->getContent($contenttype, $params, $dummy, $where);
+            $temp_result = $this->app['storage']->getContent($contenttype, $params, $dummy, $where);
 
-            if (!empty($temp_records) && is_array($temp_records)) {
-                $records = array_merge($records, $temp_records);
+            if (empty($temp_result)) {
+                continue; // Go ahead if content not found.
             }
-
+            
+            // Variable $temp_result can be an array of object.
+            if (is_array($temp_result)) {
+                $records = array_merge($records, $temp_result);
+            } else {
+                $records[] = $temp_result;
+            }
         }
 
         return $records;


### PR DESCRIPTION
More informations in #2278.
