### PR TITLE
Add Per Content Permissions with default set to ROLE_ANONYMOUS

### DIFF
--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -39,7 +39,7 @@ class Frontend
                 $contenttypeslug = (string) $content;
                 $contentid = null;
             }
-            if (!$app['users']->isAllowed('frontend', $contenttypeslug, $contentid)) {
+            if (!$app['users']->isAllowed('frontend', $contenttypeslug, $contentid, $content)) {
                 $app->abort(403, 'Not allowed.');
             }
         }

--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -36,6 +36,14 @@ class Permissions
      */
     const ROLE_OWNER = 'owner';
 
+    /**
+     * A special role that is used to tag the viewers of a resource when some
+     * field is defined in database for some contenttype
+     * granting possibility to set percontent permissions in addtion
+     * of per contenttype permissions.
+     */
+    const ROLE_VIEWERS = 'viewers';
+
     private $app;
 
     // per-request permission cache
@@ -168,33 +176,112 @@ class Permissions
      * @param  string $contenttype
      * @return bool   TRUE if granted, FALSE if not.
      */
-    public function checkPermission($roleNames, $permissionName, $contenttype = null)
+    public function checkPermission($roleNames, $permissionName, $contenttype = null, $contentid = null, $content = null, $user = null)
     {
+        // ROLE_ROOT has always access to everything
         $roleNames = array_unique($roleNames);
         if (in_array(Permissions::ROLE_ROOT, $roleNames)) {
                 $this->audit(
                     "Granting '$permissionName' " .
                     ($contenttype ? "for $contenttype " : "") .
-                    "to root user"
+                    ($contenttype ? "for contenttype: $contenttype " : "") .
+                    ($contenttype ? "with id: $contentid " : "") .
+                    "to root user with username: '".$user['username']."'"
                 );
 
                 return true;
         }
-        foreach ($roleNames as $roleName) {
-            if ($this->checkRolePermission($roleName, $permissionName, $contenttype)) {
-                $this->audit(
-                    "Granting '$permissionName' " .
-                    ($contenttype ? "for $contenttype " : "") .
-                    "based on role $roleName"
-                );
+        if(isset($contenttype)) {
+            /*
+                We want to know who can access to that content or list of contents from same content type.
+                First we retrieve permissions from config according to:
+                  - $permissionName which could be frontend or more complex $what string
+                  - $contenttype: 'pages', 'entries', 'showcases' by default plus all manually added in contenttypes.yml
+                  - $contentid should be the id to reference the content. Could be the slug sometimes or never, no idea.
+                Then if $user is a valid connected user
+                  we check if its own roles grant him access to this content type or specific content 
+                  or if he is owner as users have always access to all contents they own.
+                  return true for granted or false for refused
+                else we check if this content is granted to ROLE_ANONYMOUS
+                  return true for granted or false for refused
+            */
+            $contentRoles = array_unique($this->getRolesByContentTypePermission($permissionName, $contenttype, $contentid, $content));
 
-                return true;
+            if(isset($user)) {
+                // to have access our user must belong to one role which is also in content roles.
+                foreach($contentRoles as $contentRole) {
+                    if(in_array($contentRole, $user['roles'])) {
+                        $grantingRoles[] = $contentRole;
+                    }
+                }
+
+                // or user has to be owner of the content:
+                if(intval($content->values['ownerid'])
+                && intval($content->values['ownerid']) === intval($user['id'])
+                ) {
+                    $grantingRoles[] = Permissions::ROLE_OWNER;
+                }
+
+                // user have access if $grantingRoles exists
+                if(is_array($grantingRoles)) {
+                    $this->audit(
+                        "Granting '$permissionName' " .
+                        ($contenttype ? "for $contenttype " : "") .
+                        ($contenttype ? "with id: $contentid " : "") .
+                        "based on role '".implode(', ', $grantingRoles)."' " .
+                        "to user with username: '".$user['username']."' " .
+                        "when content roles were: '".implode(', ', $contentRoles)."'"
+                    );
+                    return true;
+                }
+
+                // or if content is granted for ROLE_ANONYMOUS
+                // this could have been managed by next case but logging would have been complex.
+                if(in_array(Permissions::ROLE_ANONYMOUS, $contentRoles)) {
+                    $this->audit(
+                        "Granting '$permissionName' " .
+                        ($contenttype ? "for $contenttype " : "") .
+                        ($contenttype ? "with id: $contentid " : "") .
+                        "based on role Permissions::ROLE_ANONYMOUS " .
+                        "to user with username: '".$user['username']."' " .
+                        "when content roles were: '".implode(', ', $contentRoles)."'"
+                    );
+                    return true;
+                }
+            } else {
+                if(in_array(Permissions::ROLE_ANONYMOUS, $contentRoles)) {
+                    $this->audit(
+                        "Granting '$permissionName' " .
+                        ($contenttype ? "for $contenttype " : "") .
+                        ($contenttype ? "with id: $contentid " : "") .
+                        "based on role Permissions::ROLE_ANONYMOUS " .
+                        "to not connected user."
+                    );
+                    return true;
+                }
+            }
+        } else {
+
+        // keeping usual check if no contenttype given
+            foreach ($roleNames as $roleName) {
+                if ($this->checkRolePermission($roleName, $permissionName, $contenttype, $contentid, $content)) {
+                    $this->audit(
+                        "Granting '$permissionName' " .
+                        ($contenttype ? "for $contenttype " : "") .
+                        "based on role $roleName"
+                    );
+
+                    return true;
+                }
             }
         }
+
         $this->audit(
             "Denying '$permissionName' " .
             ($contenttype ? "for $contenttype" : "") .
-            "; available roles: " . implode(', ', $roleNames)
+            ($contenttype ? " with id: $contentid" : "") .
+            "; user roles were: " . implode(', ', $roleNames) .
+            ($contenttype ? " and content roles were: " . implode(', ', $contentRoles) : "")
         );
 
         return false;
@@ -204,12 +291,12 @@ class Permissions
      * Checks whether the specified $roleName grants permission $permissionName
      * for the $contenttype in question (NULL for global permissions).
      */
-    private function checkRolePermission($roleName, $permissionName, $contenttype = null)
+    private function checkRolePermission($roleName, $permissionName, $contenttype = null, $contentid = null, $content = null)
     {
         if ($contenttype === null) {
             return $this->checkRoleGlobalPermission($roleName, $permissionName);
         } else {
-            return $this->checkRoleContentTypePermission($roleName, $permissionName, $contenttype);
+            return $this->checkRoleContentTypePermission($roleName, $permissionName, $contenttype, $contentid, $content);
         }
     }
 
@@ -225,7 +312,7 @@ class Permissions
         return in_array($roleName, $roles);
     }
 
-    private function checkRoleContentTypePermission($roleName, $permissionName, $contenttype)
+    private function checkRoleContentTypePermission($roleName, $permissionName, $contenttype, $contentid = null, $content = null)
     {
         $roles = $this->getRolesByContentTypePermission($permissionName, $contenttype);
 
@@ -253,7 +340,7 @@ class Permissions
      * specified content type. Sort of a reverse lookup on the permission
      * check.
      */
-    public function getRolesByContentTypePermission($permissionName, $contenttype)
+    public function getRolesByContentTypePermission($permissionName, $contenttype, $contentid = null, $content = null)
     {
         // Here's how it works:
         // - if a permission is granted through 'contenttype-all', it is effectively granted
@@ -265,6 +352,31 @@ class Permissions
             $overrideRoles = array();
         }
         $contenttypeRoles = $this->app['config']->get("permissions/contenttypes/$contenttype/$permissionName");
+        /**
+         * Only for frontend. For now at least.
+         * If ROLE_VIEWERS is set there is two cases:
+         * - $contentid is set -> we get viewers field content
+         * - $contentid is not set -> we replace 'viewers' with 'anonymous' in $contenttypeRoles
+         * to grant access to list pages (ex: http://your.site.tld/pages)
+         */
+        if(strval($permissionName) == 'frontend' && is_array($contenttypeRoles) && in_array(self::ROLE_VIEWERS, $contenttypeRoles)) {
+            if(isset($contentid) || $content instanceof \Bolt\Content) {
+                // we add roles from current $content to $contenttypeRoles
+                $contenttypeRoles = $this->getRolesByContentPermission($permissionName, $contenttype, $contentid, $contenttypeRoles, $content);
+            } else {
+                // if not called from isProtected() we force ROLE_ANYNOMOUS in place of ROLE_VIEWERS
+                if(strval($content) != 'no_ROLE_ANONYMOUS') {
+                    // force anonymous for content types content (ie when accessing /pages/ or /entries/
+                    // In that case content filtering will be performed during lists creation.
+                    $contenttypeRoles = array_replace($contenttypeRoles,
+                                            array_fill_keys(
+                                                array_keys($contenttypeRoles, self::ROLE_VIEWERS),
+                                                self::ROLE_ANONYMOUS
+                                            )
+                                        );
+                }
+            }
+        }
         if (!is_array($contenttypeRoles)) {
             $contenttypeRoles = $this->app['config']->get("permissions/contenttype-default/$permissionName");
         }
@@ -294,6 +406,8 @@ class Permissions
             $userRoles = array();
         }
         $userRoles[] = Permissions::ROLE_ANONYMOUS;
+
+        $userRoles = array_unique($userRoles);
 
         return $userRoles;
     }
@@ -337,7 +451,7 @@ class Permissions
      *                             specifiy the content item.
      * @return bool   TRUE if the permission is granted, FALSE if denied.
      */
-    public function isAllowed($what, $user, $contenttype = null, $contentid = null)
+    public function isAllowed($what, $user, $contenttype = null, $contentid = null, $content = null)
     {
         // $contenttype must be a string, not an array.
         if (is_array($contenttype)) {
@@ -361,7 +475,14 @@ class Permissions
             $this->app['cache']->save($cacheKey, json_encode($rule));
         }
         $userRoles = $this->getEffectiveRolesForUser($user);
-        $isAllowed = $this->isAllowedRule($rule, $user, $userRoles, $contenttype, $contentid);
+
+        if(!isset($contentid)) {
+          $what = explode(':', $what);
+          if(isset($what[3])) {
+              $contentid = $what[3];
+          }
+        }
+        $isAllowed = $this->isAllowedRule($rule, $user, $userRoles, $contenttype, $contentid, $content);
 
         // Cache for the current request
         $this->rqcache[$rqCacheKey] = $isAllowed;
@@ -369,7 +490,7 @@ class Permissions
         return $isAllowed;
     }
 
-    private function isAllowedRule($rule, $user, $userRoles, $contenttype, $contentid)
+    private function isAllowedRule($rule, $user, $userRoles, $contenttype, $contentid, $content)
     {
         switch ($rule['type']) {
             case PermissionParser::P_TRUE:
@@ -377,10 +498,10 @@ class Permissions
             case PermissionParser::P_FALSE:
                 return false;
             case PermissionParser::P_SIMPLE:
-                return $this->isAllowedSingle($rule['value'], $user, $userRoles, $contenttype, $contentid);
+                return $this->isAllowedSingle($rule['value'], $user, $userRoles, $contenttype, $contentid, $content);
             case PermissionParser::P_OR:
                 foreach ($rule['value'] as $subrule) {
-                    if ($this->isAllowedRule($subrule, $user, $userRoles, $contenttype, $contentid)) {
+                    if ($this->isAllowedRule($subrule, $user, $userRoles, $contenttype, $contentid, $content)) {
                         return true;
                     }
                 }
@@ -388,7 +509,7 @@ class Permissions
                 return false;
             case PermissionParser::P_AND:
                 foreach ($rule['value'] as $subrule) {
-                    if (!$this->isAllowedRule($subrule, $user, $userRoles, $contenttype, $contentid)) {
+                    if (!$this->isAllowedRule($subrule, $user, $userRoles, $contenttype, $contentid, $content)) {
                         return false;
                     }
                 }
@@ -399,7 +520,7 @@ class Permissions
         }
     }
 
-    private function isAllowedSingle($what, $user, $userRoles, $contenttype = null, $contentid = null)
+    private function isAllowedSingle($what, $user, $userRoles, $contenttype = null, $contentid = null, $content = null)
     {
         if ($contenttype) {
             $parts = array(
@@ -456,22 +577,6 @@ class Permissions
                 if (empty($permission)) {
                     $permission = 'view';
                 }
-                // Handle special case for owner.
-                // It's a bit unfortunate that we have to fetch the content
-                // item for this, but since we're in the back-end, we probably
-                // won't see a lot of traffic here, so it's probably
-                // forgivable.
-                if (!empty($contentid)) {
-                    // $contenttype must be a string, not an array.
-                    if (is_array($contenttype)) {
-                        $contenttype = $contenttype['slug'];
-                    }
-                    $content = $this->app['storage']->getContent("$contenttype/$contentid", array('hydrate' => false));
-                    if (intval($content['ownerid']) &&
-                        (intval($content['ownerid']) === intval($user['id']))) {
-                        $userRoles[] = Permissions::ROLE_OWNER;
-                    }
-                }
                 break;
 
             case 'editcontent':
@@ -494,7 +599,7 @@ class Permissions
                 break;
         }
 
-        return $this->checkPermission($userRoles, $permission, $contenttype);
+        return $this->checkPermission($userRoles, $permission, $contenttype, $contentid, $content, $user);
     }
 
     /**
@@ -538,6 +643,58 @@ class Permissions
             return true;
         }
 
-        return $this->isAllowed($perm, $user, $contenttype, $contentid);
+        return $this->isAllowed($perm, $user, $contenttype, $contentid, $content);
+    }
+
+    /**
+     * Addition for per content permissions
+     */
+
+    // for it's called only once without $content.
+    public function isProtected($permissionName, $contenttype, $content = null)
+    {
+        // small tweak to avoid getRolesByContentTypePermission() to replace ROLE_VIEWERS by ROLE_ANONYMOUS
+        $content = 'no_ROLE_ANONYMOUS';
+        $effectiveRoles = $this->getRolesByContentTypePermission($permissionName, $contenttype, null, $content);
+        if($this->app['config']->get('general/frontend_permission_checks')
+        && is_array($effectiveRoles)
+        && in_array(self::ROLE_VIEWERS, $effectiveRoles)
+        ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // For now this function is launched only if $permissionName == 'frontend'.
+    public function getRolesByContentPermission($permissionName, $content, $contenttype, $contentid, $contenttypeRoles)
+    {
+        // should be always set but...
+        if(isset($contentid) || $content instanceof \Bolt\Content) {
+            // using returnsingle in getContent() to avoid addition of filter in WHERE clause.
+            if(!$content instanceof \Bolt\Content)
+                $content = $this->app['storage']->getContent($contenttype.'/'.$contentid, array('hydrate' => false, 'returnsingle' => true));
+
+            // if $content[self::ROLE_VIEWERS] is null we set it to self::ROLE_ANONYMOUS.
+            // This to avoid the need to change the whole in case user set self::ROLE_VIEWERS on an already filed database
+            if(!isset($content[self::ROLE_VIEWERS])) $content[self::ROLE_VIEWERS] = self::ROLE_ANONYMOUS;
+
+            // we clean and explode 'viewers' field in an array
+            $content[self::ROLE_VIEWERS] = str_replace(" ", "", $content[self::ROLE_VIEWERS]);
+            $contentRoles = explode(",", $content[self::ROLE_VIEWERS]);
+
+            // remove 'ROLE_VIEWERS' keyword from permissions. We don't want user defined role named 'ROLE_VIEWERS'
+            foreach($contenttypeRoles as $contenttypeRole) {
+                if($contenttypeRole != Permissions::ROLE_VIEWERS)
+                    $tmpRoles[] = $contenttypeRole;
+            }
+
+            // merging $contentRoles which roles declared on content level and
+            // $tmpRoles which is roles declared on content type level minus 'ROLE_VIEWERS'
+            if(is_array($tmpRoles))
+                $contentRoles = array_unique(array_merge($contentRoles, $tmpRoles));
+        }
+
+        return $contentRoles;
     }
 }

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1896,6 +1896,30 @@ class Storage
         $total_results = false;
         $results = false;
         foreach ($decoded['queries'] as $query) {
+            // Perform actual query
+            /*
+              Only for Frontend and in case "viewers" permission is set for that content type
+            */
+            $contenttype = $this->getContenttypeFromQuery($query);
+            if($this->app['permissions']->isProtected($this->app['config']->getWhichEnd(), $contenttype)) {
+
+                // Get user roles
+                $user = $this->app['users']->getCurrentUser();
+                $effectiveUserRoles = $this->app['permissions']->getEffectiveRolesForUser($user);
+
+                // Create the filter to take user roles in account
+                if((isset($decoded['return_single']) || isset($decoded['parameters']['limit']))
+                && !in_array(permissions::ROLE_ROOT, $effectiveUserRoles))
+                    $filter = $this->getPerContentPermissionsFilter($user, $effectiveUserRoles);
+
+                // modify $query['where'] to include the filter
+                $where = str_replace('WHERE', '', $query['where']);
+                if((str_replace(' ', '', $where) != '') && (isset($filter))) {
+                    $where = 'WHERE ('.$filter.') AND '.$where;
+                    $query['where'] = $where;
+                }
+            }
+
             $statement = sprintf(
                 'SELECT %s.* %s %s %s',
                 $query['tablename'],
@@ -2989,5 +3013,54 @@ class Storage
     public function isEmptyPager()
     {
         return (count(static::$pager) === 0);
+    }
+
+    public function getContenttypeFromQuery($query)
+    {
+        return str_replace('FROM '.$this->prefix, '', $query['from']);
+    }
+
+    // $effectiveUserRoles all roles user belongs to
+    public function getPerContentPermissionsFilter($user, $effectiveUserRoles)
+    {
+        // ROLE_VIEWERS field can contain spaces and roles are separated by commas ','
+        // roles can be as numerous as users want to...
+        // example: " (viewers REGEXP '^([a-zA-Z]* *, *)* *(anonymous|admin) *(, *[a-zA-Z]* *)* *$') "
+        // once concatenated in $query['where']:
+        // WHERE  (viewers 
+        //    REGEXP '^([a-zA-Z]* *, *)* *(anonymous|admin) *(, *[a-zA-Z]* *)* *$') 
+        //    OR `viewers` IS NULL OR `viewers` = '' 
+        //    OR `id` = '$users['id']'
+        //    AND (`bolt_pages`.`id` = '1' AND `bolt_pages`.`status` = 'published')
+        $regexpBegin = ' ('.strval(permissions::ROLE_VIEWERS).' REGEXP \'^([a-zA-Z]* *, *)* *(';
+        $regexpEnd = ') *(, *[a-zA-Z]* *)* *$\') OR `viewers` IS NULL OR `viewers` = \'\'';
+
+        // The filter will be inserted between WHERE keyword and initial search condition
+        // so we must not put OR keyword at begining of it
+        if(isset($effectiveUserRoles)) {
+            // several
+            if(is_array($effectiveUserRoles)) {
+                foreach($effectiveUserRoles as $role) {
+                    if(isset($roleRegexp)) $roleRegexp = $roleRegexp.'|'.$role;
+                    else $roleRegexp = $role;
+                }
+            } else {
+                // just one, not sure that's possible, to be checked in 
+                $roleRegexp = $effectiveUserRoles;
+            }
+            $sqlclause = $regexpBegin.$roleRegexp.$regexpEnd;
+
+            // manage ownership
+            if(isset($user['id'])) {
+                $sqlclause = $sqlclause . ' OR `ownerid` = \''.$user['id'].'\' ';
+            }
+
+            return $sqlclause;
+        } else {
+            // NOTE: Can't be: $effectiveUserRoles should at least contain "anonymous"
+            throw new \Exception('In "\\Bolt\\Storage->getPerContentPermissionsFilter($user, $effectiveUserRoles)" "$effectiveUserRoles" is NULL when it should contain at least "anynomous".');
+        }
+
+        return false;
     }
 }

--- a/src/Users.php
+++ b/src/Users.php
@@ -945,11 +945,11 @@ class Users
      * @param  string $what The desired permission, as elaborated upon above.
      * @return bool   TRUE if the permission is granted, FALSE if denied.
      */
-    public function isAllowed($what, $contenttype = null, $contentid = null)
+    public function isAllowed($what, $contenttype = null, $contentid = null, $content = null)
     {
         $user = $this->currentuser;
 
-        return $this->app['permissions']->isAllowed($what, $user, $contenttype, $contentid);
+        return $this->app['permissions']->isAllowed($what, $user, $contenttype, $contentid, $content);
     }
 
     public function isContentStatusTransitionAllowed($fromStatus, $toStatus, $contenttype, $contentid = null)


### PR DESCRIPTION
This patch is to add permissions set at content level in addition to those set at content type level.

The idea to start that change came from there: https://github.com/bolt/bolt/issues/1263 where almost all needed tool to proceed were prepared. In that thread tobias2k warned about ACLs using terms "bloat" and "creepy" as ACLs are quickly complex.

To limit the complexity inside Bolt's code it was decided to use a user defined select field added to each content types you want to protect. This select will contain all groups of roles you want to be able to set up on these content type's contents.

A new role keyword is defined: "viewers". This role keyword is used in permissions.yml to protect some content types.
Ex: 
<pre>    pages:
        frontend: [ viewers ]</pre>

Then in contenttypes.yml the select is created:
Ex: this is an extract of "pages" content type declaration with addition of "viewers" select field
<pre>        template:
            type: templateselect
            filter: '*.twig'
        viewers:
            type: select
            default: anonymous
            values: [ anonymous, everyone, owner, 'admin, editor' ]
    taxonomy: [ chapters ]</pre>

Here each content of this content type would be grant-able to:
- role "anonymous": all users, a public content.
- role "everyone": only connected users
- role "owner": only owner could see the content in frontend
- roles "admin" or "editor": you would need to belong to admin OR editor to access that content.

So here was the way to extract from Bolt  a part of permissions complexity.

As most complexity is pushed on user side now the point - IMHO - would be to help users using this system. The code modification is meant to that purpose.
This modification applies only on frontend content - or at least is meant to apply only there - and it applies in two ways:
- the checkPermission() function in Permissions.php check also per content permissions when needed to add all roles contained in database field "viewers" in available roles array then these available roles are compared to current user's roles
- the executeGetContentQueries() in Storage.php is also modified to add a SQL filter when retrieving multiple contents. This filter avoid breaking limit parameter sent to requests.

So once the patch is added to the code user would need to:
- modify some content type in contenttypes.yml to add "viewers" select.
- modify this content type permissions in permissions.yml to add this internal "viewers" role to "frontend"
- set to "true" flag "frontend_permission_checks" in config.yml
And contents will be filtered.

At this point Bolt will complain the database must be updated, if user do it Bolt will add an empty "viewers" field to this content type table structure. To avoid the whole site becomes unavailable in frontend as no "viewers" roles are defined in our empty field the default behaviour is to consider the content as public and so granted to ROLE_ANONYMOUS in case "viewers" is empty.

How listing views work:

Considering the modified content type is still "pages" with "frontend: [ 'viewers' ]" in permissions.yml.

For now all fallback behaviour (I was able to see) are set to give anonymous access to contents. The two cases are:
- listing pages (ex: /pages)
- empty "viewers" field

When a user access to /pages with "frontend: [ 'viewers' ]" in permissions.yml as there is no database item for that listing page there is no "viewers" field that why the fallback.
When twigs are building this page they call getContent() or record() which would call getContent() which finally launch executeGetContentQueries().

executeGetContentQueries() receives $decoded array which contains all we need to know if this query or list of queries are to retrieve one or more item.

When executeGetContentQueries() tries to retrieve a list of items the SQL filter is applied which returns only database items according to user's roles including ownership.

According to Permissions::isProtected() function this filter applies only if these 3 parameters are defined, if one is missing, no filter, no per content permissions:
- viewed page is in frontend 
- "frontend_permission_checks: true" in config.yml
- "frontend: [ 'viewers' ]" in permissions.yml
So it is easily disabled.

But it is also quiet easily applied. Bolt simplify lot of things letting us doing complex stuffs as if we were good in creating web site. This is to simplify per content filtering.

This version moves added arguments at end of functions declaration. Thanks to GDmac.