### PR TITLE
[RFC] allow null dates for content

### DIFF
--- a/src/Database/IntegrityChecker.php
+++ b/src/Database/IntegrityChecker.php
@@ -550,7 +550,7 @@ class IntegrityChecker
             $myTable->addIndex(array('datecreated'));
             $myTable->addColumn("datechanged", "datetime");
             $myTable->addIndex(array('datechanged'));
-            $myTable->addColumn("datepublish", "datetime");
+            $myTable->addColumn("datepublish", "datetime", array("notnull" => false, 'default'=>null));
             $myTable->addIndex(array('datepublish'));
             $myTable->addColumn("datedepublish", "datetime", array("default" => "1900-01-01 00:00:00"));
             $myTable->addIndex(array('datedepublish'));


### PR DESCRIPTION
This can be left as a post 2.0 PR since it will probably have some repercussions across the codebase.

Take the following code:
    $content = $storage->getContentObject('pages');
    $storage->saveContent($content, 'pages');

It will currently fail on a not null datepublish constraint. Not setting a publish date should be an option since this is only required if you want timed publishing. The one below for depublish should also be changed to null by default but if everyone agrees on using null for date defaults then we can make the changes required across the rest of the codebase and push onto this PR branch.

thoughts?
