### PR TITLE
Also post record.id via preview functionality.

### DIFF
--- a/app/view/twig/editcontent/_meta.twig
+++ b/app/view/twig/editcontent/_meta.twig
@@ -15,6 +15,7 @@
 {% set attr_id = {
     class:     'form-control narrow',
     id:        'id',
+    name:      'id',
     readonly:  true,
     type:      'text',
     value:     context.content.id,


### PR DESCRIPTION
@bobdenotter, not sure if it was intended to NOT post ID. I believe by default the ID is retrieved via the URL. If this is not the _correct_ way to fix this, I could manually add it via JavaScript.
