### PR TITLE
Revert back to using span instead of button for now

### DIFF
--- a/app/view/twig/_macro/_macro.twig
+++ b/app/view/twig/_macro/_macro.twig
@@ -216,11 +216,11 @@
     <div class="button-wrap fileselectbuttongroup">
 
         {# Button: Upload #}
-        <button type="button" class="btn btn-secondary fileinput-button">
+        <span type="button" class="btn btn-secondary fileinput-button">
             <i class="fa fa-upload"></i>
             <span>{{ (type == 'image') ? __('Upload image') : __('Upload file') }}</span>
             <input{{ attr(attr_upload) }}>
-        </button>
+        </span>
 
         {# Button: Select from Server #}
         <button type="button" class="btn btn-tertiary" data-target="#selectModal-{{ key }}" href="{{ href }}" data-toggle="modal">


### PR DESCRIPTION
Doesn't seem to be working in Firefox. Perhaps a bug in jquery.fileupload-ui.js which could be solved to update to a newer version of it.

So for now we revert it and have a look into this in the future.
