### PR TITLE
Use null defaults for dates

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -210,9 +210,9 @@ class Content implements \ArrayAccess
                 // @todo Try better date-parsing, instead of just setting it to
                 // 'now' (or 'the past' for datedepublish)
                 if ($key == 'datedepublish') {
-                    $value = date("1900-01-01 00:00:00");
+                    $value = null;
                 } else {
-                    $value = date("Y-m-d H:i:s");
+                    $value = date('Y-m-d H:i:s');
                 }
             }
         }

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -969,14 +969,14 @@ class Backend implements ControllerProviderInterface
 
         $duplicate = $app['request']->query->get('duplicate');
         if (!empty($duplicate)) {
-            $content->setValue('id', "");
-            $content->setValue('slug', "");
-            $content->setValue('datecreated', "");
-            $content->setValue('datepublish', "");
-            $content->setValue('datedepublish', "1900-01-01 00:00:00"); // Not all DB-engines can handle a date like '0000-00-00'
-            $content->setValue('datechanged', "");
-            $content->setValue('username', "");
-            $content->setValue('ownerid', "");
+            $content->setValue('id', '');
+            $content->setValue('slug', '');
+            $content->setValue('datecreated', '');
+            $content->setValue('datepublish', '');
+            $content->setValue('datedepublish', null);
+            $content->setValue('datechanged', '');
+            $content->setValue('username', '');
+            $content->setValue('ownerid', '');
             $app['session']->getFlashBag()->set('info', Trans::__('contenttypes.generic.duplicated-finalize', array('%contenttype%' => $contenttype['slug'])));
         }
 

--- a/src/Database/IntegrityChecker.php
+++ b/src/Database/IntegrityChecker.php
@@ -409,7 +409,7 @@ class IntegrityChecker
         $authtokenTable->addColumn('lastseen', 'datetime', array('notnull' => false, 'default' => null));
         $authtokenTable->addColumn('ip', 'string', array('length' => 32, 'default' => ''));
         $authtokenTable->addColumn('useragent', 'string', array('length' => 128, 'default' => ''));
-        $authtokenTable->addColumn('validity', array('notnull' => false, 'default' => null));
+        $authtokenTable->addColumn('validity', 'datetime', array('notnull' => false, 'default' => null));
         $tables[] = $authtokenTable;
 
         $usersTable = $schema->createTable($this->prefix . 'users');

--- a/src/Database/IntegrityChecker.php
+++ b/src/Database/IntegrityChecker.php
@@ -419,7 +419,7 @@ class IntegrityChecker
         $usersTable->addIndex(array('username'));
         $usersTable->addColumn('password', 'string', array('length' => 128));
         $usersTable->addColumn('email', 'string', array('length' => 128));
-        $usersTable->addColumn('lastseen', 'datetime');
+        $usersTable->addColumn('lastseen', 'datetime', array('notnull' => false, 'default' => null));
         $usersTable->addColumn('lastip', 'string', array('length' => 32, 'default' => ''));
         $usersTable->addColumn('displayname', 'string', array('length' => 32));
         $usersTable->addColumn('stack', 'string', array('length' => 1024, 'default' => ''));

--- a/src/Database/IntegrityChecker.php
+++ b/src/Database/IntegrityChecker.php
@@ -406,10 +406,10 @@ class IntegrityChecker
         $authtokenTable->addIndex(array('username'));
         $authtokenTable->addColumn('token', 'string', array('length' => 128));
         $authtokenTable->addColumn('salt', 'string', array('length' => 128));
-        $authtokenTable->addColumn('lastseen', 'datetime', array('default' => '1900-01-01 00:00:00'));
+        $authtokenTable->addColumn('lastseen', 'datetime', array('notnull' => false, 'default' => null));
         $authtokenTable->addColumn('ip', 'string', array('length' => 32, 'default' => ''));
         $authtokenTable->addColumn('useragent', 'string', array('length' => 128, 'default' => ''));
-        $authtokenTable->addColumn('validity', 'datetime', array('default' => '1900-01-01 00:00:00'));
+        $authtokenTable->addColumn('validity', array('notnull' => false, 'default' => null));
         $tables[] = $authtokenTable;
 
         $usersTable = $schema->createTable($this->prefix . 'users');
@@ -427,9 +427,9 @@ class IntegrityChecker
         $usersTable->addIndex(array('enabled'));
         $usersTable->addColumn('shadowpassword', 'string', array('length' => 128, 'default' => ''));
         $usersTable->addColumn('shadowtoken', 'string', array('length' => 128, 'default' => ''));
-        $usersTable->addColumn('shadowvalidity', 'datetime', array('default' => '1900-01-01 00:00:00'));
+        $usersTable->addColumn('shadowvalidity', 'datetime', array('notnull' => false, 'default' => null));
         $usersTable->addColumn('failedlogins', 'integer', array('default' => 0));
-        $usersTable->addColumn('throttleduntil', 'datetime', array('default' => '1900-01-01 00:00:00'));
+        $usersTable->addColumn('throttleduntil', 'datetime', array('notnull' => false, 'default' => null));
         $usersTable->addColumn('roles', 'string', array('length' => 1024, 'default' => ''));
         $tables[] = $usersTable;
 
@@ -552,7 +552,7 @@ class IntegrityChecker
             $myTable->addIndex(array('datechanged'));
             $myTable->addColumn("datepublish", "datetime", array("notnull" => false, 'default' => null));
             $myTable->addIndex(array('datepublish'));
-            $myTable->addColumn("datedepublish", "datetime", array("default" => "1900-01-01 00:00:00"));
+            $myTable->addColumn("datedepublish", "datetime", array('notnull' => false, 'default' => null));
             $myTable->addIndex(array('datedepublish'));
             $myTable->addColumn("username", "string", array("length" => 32, "default" => "", "notnull" => false)); // We need to keep this around for backward compatibility. For now.
             $myTable->addColumn("ownerid", "integer", array("notnull" => false));

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -146,19 +146,19 @@ class Storage
     private function preFillSingle($key, $contenttype)
     {
         $content = array();
-        $title = "";
+        $title = '';
 
         $content['contenttype'] = $key;
         $content['datecreated'] = date('Y-m-d H:i:s', time() - rand(0, 365 * 24 * 60 * 60));
         $content['datepublish'] = date('Y-m-d H:i:s', time() - rand(0, 365 * 24 * 60 * 60));
-        $content['datedepublish'] = "1900-01-01 00:00:00";
+        $content['datedepublish'] = null;
 
         $username = array_rand($this->app['users']->getUsers());
         $user = $this->app['users']->getUser($username);
 
         $content['ownerid'] = $user['id'];
 
-        $content['status'] = "published";
+        $content['status'] = 'published';
 
         foreach ($contenttype['fields'] as $field => $values) {
 
@@ -170,7 +170,7 @@ class Storage
                     }
                     break;
                 case 'image':
-                    // Get a random image..
+                    // Get a random image
                     if (!empty($this->images)) {
                         $content[$field]['file'] = $this->images[array_rand($this->images)];
                     }
@@ -199,7 +199,7 @@ class Storage
                     $content[$field] = rand(0, 1);
                     break;
                 case 'float':
-                case 'number': // number is deprecated..
+                case 'number': // number is deprecated
                 case 'integer':
                     $content[$field] = rand(-1000, 1000) + (rand(0, 1000) / 1000);
                     break;
@@ -821,7 +821,7 @@ class Storage
 
         if (!empty($oldContent)) {
 
-            // Do the actual update, and log it. 
+            // Do the actual update, and log it.
             $res = $this->app['db']->update($tablename, $content, array('id' => $content['id']));
             if ($res > 0) {
                 $this->logUpdate($contenttype, $content['id'], $content, $oldContent, $comment);
@@ -829,7 +829,7 @@ class Storage
 
         } else {
 
-            // Content didn't exist, so do an insert after all. Log it as an insert.            
+            // Content didn't exist, so do an insert after all. Log it as an insert.
             $res = $this->app['db']->insert($tablename, $content);
             $seq = null;
             if ($this->app['db']->getDatabasePlatform() instanceof PostgreSqlPlatform) {

--- a/src/Users.php
+++ b/src/Users.php
@@ -633,7 +633,7 @@ class Users
                 'password' => $user['shadowpassword'],
                 'shadowpassword' => "",
                 'shadowtoken' => "",
-                'shadowvalidity' => "0000-00-00 00:00:00"
+                'shadowvalidity' => "1900-01-01 00:00:00"
             );
             $this->db->update($this->usertable, $update, array('id' => $user['id']));
 
@@ -659,7 +659,7 @@ class Users
     private function throttleUntil($attempts)
     {
         if ($attempts < 5) {
-            return "0000-00-00 00:00:00";
+            return "1900-01-01 00:00:00";
         } else {
             $wait = pow(($attempts - 4), 2);
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -659,7 +659,7 @@ class Users
     private function throttleUntil($attempts)
     {
         if ($attempts < 5) {
-            return "1900-01-01 00:00:00";
+            return null;
         } else {
             $wait = pow(($attempts - 4), 2);
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -631,9 +631,9 @@ class Users
 
             $update = array(
                 'password' => $user['shadowpassword'],
-                'shadowpassword' => "",
-                'shadowtoken' => "",
-                'shadowvalidity' => "1900-01-01 00:00:00"
+                'shadowpassword' => '',
+                'shadowtoken' => '',
+                'shadowvalidity' => null
             );
             $this->db->update($this->usertable, $update, array('id' => $user['id']));
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -114,7 +114,7 @@ class Users
         $user['username'] = String::slug($user['username']);
 
         if (empty($user['lastseen'])) {
-            $user['lastseen'] = "1900-01-01";
+            $user['lastseen'] = null;
         }
 
         if (empty($user['enabled']) && $user['enabled'] !== 0) {
@@ -122,11 +122,11 @@ class Users
         }
 
         if (empty($user['shadowvalidity'])) {
-            $user['shadowvalidity'] = "1900-01-01";
+            $user['shadowvalidity'] = null;
         }
 
         if (empty($user['throttleduntil'])) {
-            $user['throttleduntil'] = "1900-01-01";
+            $user['throttleduntil'] = null;
         }
 
         if (empty($user['failedlogins'])) {


### PR DESCRIPTION
Fixes #2395 

### Changelog
* Fields that previously used `0000-00-00` and `1900-01-01` now default to using `NULL` instead