### PR TITLE
Change priorities of taxonomy templates

### DIFF
--- a/src/TemplateChooser.php
+++ b/src/TemplateChooser.php
@@ -129,19 +129,20 @@ class TemplateChooser
      */
     public function taxonomy($taxonomyslug)
     {
-        // Set the template based on the (optional) setting in taxonomy.yml,
-        // or fall back to default listing template
-        if ($this->app['config']->get('taxonomy/' . $taxonomyslug . '/listing_template')) {
-            $template = $this->app['config']->get('taxonomy/' . $taxonomyslug . '/listing_template');
-        } else {
-            $template = $this->app['config']->get('general/listing_template');
-        }
-        $chosen = 'taxonomy';
+        // First candidate: Global config.yml
+        $template = $this->app['config']->get('general/listing_template');
+        $chosen = 'taxonomy config';
 
         // Second candidate: Theme-specific config.yml file.
         if ($this->app['config']->get('theme/listing_template')) {
             $template = $this->app['config']->get('theme/listing_template');
             $chosen = 'taxonomy config in theme';
+        }
+
+        // Third candidate: defined specifically in the taxonomy
+        if ($this->app['config']->get('taxonomy/' . $taxonomyslug . '/listing_template')) {
+            $template = $this->app['config']->get('taxonomy/' . $taxonomyslug . '/listing_template');
+            $chosen = 'taxonomy';
         }
 
         $this->app['log']->setValue('templatechosen', $this->app['config']->get('general/theme') . "/$template ($chosen)");


### PR DESCRIPTION
For everything except taxonomies, the template priority is something like:

    global config < theme config < specific type config

Taxonomies go

    global config < specific type config < theme config

This is unexpected behaviour, and it makes it impossible to specify a custom taxonomy template if you have a listing template specified in your theme (which is pretty common). On top of that, the function's code for choosing taxonomy was slightly inconsistent with all of the other template choosing functions.

Anyway, it was a simple fix. This PR changes the priorities to the expected behaviour.