### PR TITLE
Refactor Twig setup

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -265,8 +265,6 @@ class Application extends Silex\Application
 
         $this['paths'] = $this['resources']->getPaths();
 
-        $this['twig']->addGlobal('paths', $this['paths']);
-
         // For some obscure reason, and under suspicious circumstances $app['locale'] might become 'null'.
         // Re-set it here, just to be sure. See https://github.com/bolt/bolt/issues/1405
         $this['locale'] = $currentlocale;
@@ -274,8 +272,6 @@ class Application extends Silex\Application
         // Add the Bolt Twig functions, filters and tags.
         $this['twig']->addExtension(new TwigExtension($this));
         $this['safe_twig']->addExtension(new TwigExtension($this, true));
-
-        $this['twig']->addTokenParser(new SetcontentTokenParser());
 
         // Initialize stopwatch even if debug is not enabled.
         $this['stopwatch'] = $this->share(
@@ -338,38 +334,6 @@ class Application extends Silex\Application
         $this->mount('', new Controllers\Routing());
     }
 
-
-    /**
-     * Add all the global twig variables, like 'user' and 'theme'
-     */
-    private function addTwigGlobals()
-    {
-        $this['twig']->addGlobal('bolt_name', $this['bolt_name']);
-        $this['twig']->addGlobal('bolt_version', $this['bolt_version']);
-
-        $this['twig']->addGlobal('frontend', false);
-        $this['twig']->addGlobal('backend', false);
-        $this['twig']->addGlobal('async', false);
-        $this['twig']->addGlobal($this['config']->getWhichEnd(), true);
-
-        $this['twig']->addGlobal('user', $this['users']->getCurrentUser());
-        $this['twig']->addGlobal('users', $this['users']->getUsers());
-        $this['twig']->addGlobal('config', $this['config']);
-        $this['twig']->addGlobal('theme', $this['config']->get('theme'));
-
-        $this['safe_twig']->addGlobal('bolt_name', $this['bolt_name']);
-        $this['safe_twig']->addGlobal('bolt_version', $this['bolt_version']);
-
-        $this['safe_twig']->addGlobal('frontend', false);
-        $this['safe_twig']->addGlobal('backend', false);
-        $this['safe_twig']->addGlobal('async', false);
-        $this['safe_twig']->addGlobal($this['config']->getWhichEnd(), true);
-
-        $this['safe_twig']->addGlobal('user', $this['users']->getCurrentUser());
-        $this['safe_twig']->addGlobal('theme', $this['config']->get('theme'));
-    }
-
-
     /**
      * Initializes the Console Application that is responsible for CLI interactions.
      */
@@ -390,9 +354,6 @@ class Application extends Silex\Application
     {
         // Start the 'stopwatch' for the profiler.
         $this['stopwatch']->start('bolt.app.before');
-
-        // Set the twig Globals, like 'user' and 'theme'.
-        $this->addTwigGlobals();
 
         if ($response = $this['render']->fetchCachedRequest()) {
             // Stop the 'stopwatch' for the profiler.
@@ -547,9 +508,6 @@ class Application extends Silex\Application
         $end = $this['config']->getWhichEnd();
 
         $trace = $exception->getTrace();
-
-        // Set the twig Globals, like 'user' and 'theme'.
-        $this->addTwigGlobals();
 
         foreach ($trace as $key => $value) {
             if (!empty($value['file']) && strpos($value['file'], '/vendor/') > 0) {

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -187,7 +187,7 @@ class ResourceManager
      * However $this->paths can be either mixed array elements of String or Path
      * getPaths() will convert them string to provide homogeneous type result.
      *
-     * @return array String array of merge
+     * @return string[] array of merged strings
      */
     public function getPaths()
     {

--- a/src/Provider/SafeTwigServiceProvider.php
+++ b/src/Provider/SafeTwigServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Provider;
 
+use Bolt\TwigExtension;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -9,11 +10,18 @@ class SafeTwigServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
+        $app['safe_twig.bolt_extension'] = function($app) {
+            return new TwigExtension($app, true);
+        };
+
         $app['safe_twig'] = $app->share(
-            function () {
+            function ($app) {
                 $loader = new \Twig_Loader_String();
 
-                return new \Twig_Environment($loader);
+                $twig = new \Twig_Environment($loader);
+                $twig->addExtension($app['safe_twig.bolt_extension']);
+
+                return $twig;
             }
         );
     }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -130,8 +130,8 @@ class TwigExtension extends \Twig_Extension
         /** @var Configuration\ResourceManager $resources */
         $resources = $this->app['resources'];
 
-        $configVal = $this->safe ? $config : null;
-        $usersVal = $this->safe ? $users : null;
+        $configVal = $this->safe ? null : $config;
+        $usersVal = $this->safe ? null : $users;
         // structured to allow PHPStorm's SymfonyPlugin to provide code completion
         return array(
             'bolt_name'            => $this->app['bolt_name'],

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -121,6 +121,42 @@ class TwigExtension extends \Twig_Extension
         );
     }
 
+    public function getGlobals()
+    {
+        /** @var Config $config */
+        $config = $this->app['config'];
+        /** @var Users $users */
+        $users = $this->app['users'];
+        /** @var Configuration\ResourceManager $resources */
+        $resources = $this->app['resources'];
+
+        $configVal = $this->safe ? $config : null;
+        $usersVal = $this->safe ? $users : null;
+        // structured to allow PHPStorm's SymfonyPlugin to provide code completion
+        return array(
+            'bolt_name'            => $this->app['bolt_name'],
+            'bolt_version'         => $this->app['bolt_version'],
+            'frontend'             => false,
+            'backend'              => false,
+            'async'                => false,
+            $config->getWhichEnd() => true,
+            'paths'                => $resources->getPaths(),
+            'theme'                => $config->get('theme'),
+            'user'                 => $users->getCurrentUser(),
+            'users'                => $usersVal,
+            'config'               => $configVal,
+        );
+    }
+
+    public function getTokenParsers()
+    {
+        $parsers = array();
+        if (!$this->safe) {
+            $parsers[] = new SetcontentTokenParser();
+        }
+        return $parsers;
+    }
+
     /**
      * Check if a file exists.
      *


### PR DESCRIPTION
The problem I had is twig was getting initialized to add globals and extensions before my customizations were added.

Twig shouldn't be initialized until it is needed, so others can extend it further.
I also moved the globals into the TwigExtension class, which also dries them up. Same with the SetcontentTokenParser.
