### PR TITLE
Enable JsonResponseHandler for Whoops! to send JSON formatted errors for AJAX requests

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -424,7 +424,9 @@ class Application extends Silex\Application
                 $this->register(new WhoopsServiceProvider());
 
                 // Add a special handler to deal with AJAX requests
-                $this['whoops']->pushHandler(new JsonResponseHandler);
+                if ($this['config']->getWhichEnd() == 'async') {
+                    $this['whoops']->pushHandler(new JsonResponseHandler());
+                }
             }
 
             $this->register(new Silex\Provider\ServiceControllerServiceProvider());

--- a/src/Application.php
+++ b/src/Application.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Stopwatch;
+use Whoops\Handler\JsonResponseHandler;
 use Whoops\Provider\Silex\WhoopsServiceProvider;
 use Bolt\Provider\PathServiceProvider;
 
@@ -421,6 +422,9 @@ class Application extends Silex\Application
             // Register Whoops, to handle errors for logged in users only.
             if ($this['config']->get('general/debug_enable_whoops')) {
                 $this->register(new WhoopsServiceProvider());
+
+                // Add a special handler to deal with AJAX requests
+                $this['whoops']->pushHandler(new JsonResponseHandler);
             }
 
             $this->register(new Silex\Provider\ServiceControllerServiceProvider());


### PR DESCRIPTION
An example of what is given in error generating AJAX requests now:
```
{
	"error" : {
		"type" : "UnexpectedBeerException",
		"message" : "Expected more beer in request. Unable to continue!",
		"file" : "src/Application.php",
		"line" : 123
	}
}
```

**NOTE** This attaches to the Whoops! service provider, so will only be sent in the cases where a HTML Whoops! otherwise would.

### Changelog
- Whoops now sends errors to AJAX callers in JSON format