### PR TITLE
Fixes select field type, with values from another content type. 

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -37,57 +37,33 @@
 
 {#=== FIELDSET =======================================================================================================#}
 
-{% if option.multiple %}
+<fieldset class="multiselect">
 
-    <fieldset class="multiselect">
+    <label class="col-sm-3 control-label">{{ (option.info) ? macro.infopop(labelkey, option.info) : labelkey }}</label>
+    <div class="col-sm-9">
+        <select{{ macro.attr(attr_select) }}>
+            {% for id, value in values %}
 
-        <label class="col-sm-3 control-label">{{ (option.info) ? macro.infopop(labelkey, option.info) : labelkey }}</label>
-        <div class="col-sm-9">
-            <select{{ macro.attr(attr_select) }}>
-                {% for id, value in values %}
+                {% set is_array = (value is iterable and (value | length) > 1) %}
+                {% set attr_opt = {
+                    value:     id,
+                    selected:  (id in currentsel) or (is_array ? (value[0] in currentsel) : (value in currentsel)),
+                } %}
 
-                    {% set is_array = (value is iterable and (value | length) > 1) %}
-                    {% set attr_opt = {
-                        value:     id,
-                        selected:  (id in currentsel) or (is_array ? (value[0] in currentsel) : (value in currentsel)),
-                    } %}
+                <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[0:]|join(' / ') : value }}</option>
+            {% endfor %}
+        </select>
 
-                    <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[0:]|join(' / ') : value }}</option>
-                {% endfor %}
-            </select>
-
-            <div>{# TODO: move onclick-events to JS #}
-                <a href="#" class="btn btn-default btn-xs" onclick="jQuery('#{{ key }} option').prop('selected', true); return false;">
-                    <i class="fa fa-fw fa-check-square-o"></i>{{ __("Select all") }}
-                </a>
-                <a href="#" class="btn btn-default btn-xs" onclick="jQuery('#{{ key }} option').prop('selected', false); return false;">
-                    <i class="fa fa-fw fa-square-o"></i>{{ __("Select none") }}
-                </a>
-            </div>
+        {% if option.multiple %}
+        <div>{# TODO: move onclick-events to JS #}
+            <a href="#" class="btn btn-default btn-xs" onclick="jQuery('#{{ key }} option').prop('selected', true); return false;">
+                <i class="fa fa-fw fa-check-square-o"></i>{{ __("Select all") }}
+            </a>
+            <a href="#" class="btn btn-default btn-xs" onclick="jQuery('#{{ key }} option').prop('selected', false); return false;">
+                <i class="fa fa-fw fa-square-o"></i>{{ __("Select none") }}
+            </a>
         </div>
+        {% endif %}
+    </div>
 
-    </fieldset>
-
-{% else %}
-
-    <fieldset class="select">
-
-        <label class="col-sm-3 control-label">{{ (option.info) ? macro.infopop(labelkey, option.info) : labelkey }}</label>
-        <div class="col-sm-9">
-            <select{{ macro.attr(attr_select) }}>
-                {% for id, value in values %}
-
-                    {% set is_array = (value is iterable and (value | length) > 1) %}
-                    {% set attr_opt = {
-                        value:     id,
-                        selected:  (id in currentsel) or (is_array ? (value[0] in currentsel) : (value in currentsel)),
-                    } %}
-
-                    <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[0:]|join(' / ') : value }}</option>
-                {% endfor %}
-            </select>
-        </div>
-
-    </fieldset>
-
-{% endif %}
+</fieldset>

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -19,7 +19,13 @@
         {% set lookupfield = lookupfield|split(',') %}
     {% endif %}
     {% setcontent lookups = lookuptype order lookupfield nohydrate %}
-    {% set values = lookups|selectfield(lookupfield) %}
+    {% set values = lookups|selectfield(lookupfield, option.multiple) %}
+{% endif %}
+
+{# get the current selection. Either a single value, or an array. #}
+{% set currentsel = context.content.get(key)|default(null) %}
+{% if currentsel is not iterable %}
+    {% set currentsel = [ currentsel ] %}
 {% endif %}
 
 {% set attr_select = {
@@ -38,15 +44,15 @@
         <label class="col-sm-3 control-label">{{ (option.info) ? macro.infopop(labelkey, option.info) : labelkey }}</label>
         <div class="col-sm-9">
             <select{{ macro.attr(attr_select) }}>
-                {% for value in values %}
+                {% for id, value in values %}
 
                     {% set is_array = (value is iterable and (value | length) > 1) %}
                     {% set attr_opt = {
-                        value:     (is_array ? value[0] : value),
-                        selected:  (is_array ? (value[0] in context.content.get(key)) : (value in context.content.get(key))),
+                        value:     id,
+                        selected:  (id in currentsel) or (is_array ? (value[0] in currentsel) : (value in currentsel)),
                     } %}
 
-                    <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[1] : value }}</option>
+                    <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[0:]|join(' / ') : value }}</option>
                 {% endfor %}
             </select>
 
@@ -69,15 +75,15 @@
         <label class="col-sm-3 control-label">{{ (option.info) ? macro.infopop(labelkey, option.info) : labelkey }}</label>
         <div class="col-sm-9">
             <select{{ macro.attr(attr_select) }}>
-                {% for value in values %}
+                {% for id, value in values %}
 
                     {% set is_array = (value is iterable and (value | length) > 1) %}
                     {% set attr_opt = {
-                        value:     (is_array ? value[0] : value),
-                        selected:  (context.content.get(key) == (is_array ? value[0] : value)),
+                        value:     id,
+                        selected:  (id in currentsel) or (is_array ? (value[0] in currentsel) : (value in currentsel)),
                     } %}
 
-                    <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[1] : value }}</option>
+                    <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[0:]|join(' / ') : value }}</option>
                 {% endfor %}
             </select>
         </div>

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -23,9 +23,9 @@
 {% endif %}
 
 {# get the current selection. Either a single value, or an array. #}
-{% set currentsel = context.content.get(key)|default(null) %}
-{% if currentsel is not iterable %}
-    {% set currentsel = [ currentsel ] %}
+{% set selection = context.content.get(key)|default(null) %}
+{% if selection is not iterable %}
+    {% set selection = [ selection ] %}
 {% endif %}
 
 {% set attr_select = {
@@ -47,7 +47,7 @@
                 {% set is_array = (value is iterable and (value | length) > 1) %}
                 {% set attr_opt = {
                     value:     id,
-                    selected:  (id in currentsel) or (is_array ? (value[0] in currentsel) : (value in currentsel)),
+                    selected:  (id in selection) or (is_array ? (value[0] in selection) : (value in selection)),
                 } %}
 
                 <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[0:]|join(' / ') : value }}</option>

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -47,7 +47,7 @@
                 {% set is_array = (value is iterable and (value | length) > 1) %}
                 {% set attr_opt = {
                     value:     id,
-                    selected:  (id in selection) or (is_array ? (value[0] in selection) : (value in selection)),
+                    selected:  id in selection or (is_array ? value[0] : value) in selection,
                 } %}
 
                 <option{{ macro.attr(attr_opt) }}>{{ is_array ? value[0:]|join(' / ') : value }}</option>

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -1384,9 +1384,13 @@ class TwigExtension extends \Twig_Extension
      *                          fields, to return from each record
      * @return array
      */
-    public function selectField($content, $fieldname)
+    public function selectField($content, $fieldname, $startempty = false)
     {
-        $retval = array('');
+        if ($startempty) {
+            $retval = array();
+        } else {
+            $retval = array('');
+        }
         foreach ($content as $c) {
             if (is_array($fieldname)) {
                 $row = array();
@@ -1397,10 +1401,10 @@ class TwigExtension extends \Twig_Extension
                         $row[] = null;
                     }
                 }
-                $retval[] = $row;
+                $retval[ $c->values['id'] ] = $row;
             } else {
                 if (isset($c->values[$fieldname])) {
-                    $retval[] = $c->values[$fieldname];
+                    $retval[ $c->values['id'] ] = $c->values[$fieldname];
                 }
             }
         }


### PR DESCRIPTION
Fixes #2437.

As an added benefit, this change makes sure that you don't lose the current settings if you later decide to set or remove `multiple: true` on your field, because we always check for values in an array. 

Also, if anyone has a suggestion for a better name than `currentsel`, i'm all ears! 