### PR TITLE
Fix for #2457. Remove changed self message when creating first user.

### DIFF
--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1318,16 +1318,16 @@ class Backend implements ControllerProviderInterface
                     $app['session']->getFlashBag()->set('error', Trans::__('page.edit-users.message.saving-user', array('%user%' => $user['displayname'])));
                 }
 
-                // If the current user changed their own login name, the session is effectively 
-                // invalidated. If so, we must redirect to the login page with a flash message.
                 $currentuser = $app['users']->getCurrentUser();
 
-                if (($user['id'] == $currentuser['id']) && ($user['username'] != $currentuser['username'])) {
-                    $app['session']->getFlashBag()->set('error', Trans::__('page.edit-users.message.change-self'));
-                    return Lib::redirect('login');
-                } else if ($firstuser) {
+                if ($firstuser) {
                     // To the dashboard, where 'login' will be triggered..
                     return Lib::redirect('dashboard');
+                } else if (($user['id'] == $currentuser['id']) && ($user['username'] != $currentuser['username'])) {
+                    // If the current user changed their own login name, the session is effectively 
+                    // invalidated. If so, we must redirect to the login page with a flash message.
+                    $app['session']->getFlashBag()->set('error', Trans::__('page.edit-users.message.change-self'));
+                    return Lib::redirect('login');
                 } else {
                     // Return to the 'Edit users' screen.
                     return Lib::redirect('users');

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1324,7 +1324,7 @@ class Backend implements ControllerProviderInterface
                     // To the dashboard, where 'login' will be triggered..
                     return Lib::redirect('dashboard');
                 } else if (($user['id'] == $currentuser['id']) && ($user['username'] != $currentuser['username'])) {
-                    // If the current user changed their own login name, the session is effectively 
+                    // If the current user changed their own login name, the session is effectively
                     // invalidated. If so, we must redirect to the login page with a flash message.
                     $app['session']->getFlashBag()->set('error', Trans::__('page.edit-users.message.change-self'));
                     return Lib::redirect('login');


### PR DESCRIPTION
#2457 - Removes the changed own username message when creating first user.