### PR TITLE
Makes filters work for templateselect fields.

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -693,11 +693,16 @@ class TwigExtension extends \Twig_Extension
             return null;
         }
 
+        $name = '/^[a-zA-Z0-9]\V+\.twig$/';
+        if ($filter) {
+            $name = $filter;
+        }
+
         $finder = new Finder();
         $finder->files()
                ->in($this->app['paths']['themepath'])
                ->depth('== 0')
-               ->name('/^[a-zA-Z0-9]\V+\.twig$/')
+               ->name($name)
                ->sortByName();
 
         $files = array();


### PR DESCRIPTION
Hm, can't find anything about `filter` in the docs but it's there by default in `contenttypes.yml` as `*.twig`. This is quite a useful feature to have. E.g. use `filter: invoice*.twig` to only select invoice templates. Not sure about its security implications though.