### PR TITLE
Check for 'paging' in array. Fixes #2474

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1931,8 +1931,6 @@ class Storage
                     $totalResults = $countRow['count'];
                 }
 
-                dump($decoded['parameters']);
-
                 if (isset($decoded['parameters']['paging']) && $decoded['parameters']['paging'] == true) {
                     $offset = ($decoded['parameters']['page'] - 1) * $decoded['parameters']['limit'];
                 } else {

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1931,7 +1931,9 @@ class Storage
                     $totalResults = $countRow['count'];
                 }
 
-                if ($decoded['parameters']['paging']) {
+                dump($decoded['parameters']);
+
+                if (isset($decoded['parameters']['paging']) && $decoded['parameters']['paging'] == true) {
                     $offset = ($decoded['parameters']['page'] - 1) * $decoded['parameters']['limit'];
                 } else {
                     $offset = null;


### PR DESCRIPTION
It ought to be 'paging', but it needed better checks. 

For an example, see:

```
        <h4>1 latest, without paging:</h4>
        {% setcontent records = "entries/latest/1" printquery %}

        <h4>6 latest, with paging:</h4>
        {% setcontent records = "entries/latest/6" allowpaging printquery %}
```

output: 

![screen_shot_2015-01-15_at_17_52_28](https://cloud.githubusercontent.com/assets/1833361/5762109/1a370654-9ce0-11e4-9762-ecc43a56a656.png)
