### PR TITLE
Changed visibility of the frontend permission check so derived classes can keep using this.

### DIFF
--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -29,7 +29,7 @@ class Frontend
      * @param Silex\Application    $app     The application/container
      * @param \Bolt\Content|string $content The content to check
      */
-    private static function checkFrontendPermission(Silex\Application $app, $content)
+    protected static function checkFrontendPermission(Silex\Application $app, $content)
     {
         if ($app['config']->get('general/frontend_permission_checks')) {
             if ($content instanceof \Bolt\Content) {


### PR DESCRIPTION
I'm using my own controller, but I still want to use the frontend permission check.
Currently you're forced to copy the whole function to your own controller, this PR solves that by changing the visibility to protected.

I think the impact will be minimal, but I'm not sure.