### PR TITLE
fixes nav links in admin dashboard when accessed over https

### DIFF
--- a/app/view/twig/nav/_secondary-extensions.twig
+++ b/app/view/twig/nav/_secondary-extensions.twig
@@ -8,13 +8,13 @@
         {
             icon: 'fa:cubes',
             label: __('View/install Extensions'),
-            link: url('extend', {}),
+            link: path('extend', {}),
             isallowed: 'extensions'
         },
         {
             icon: 'fa:cog',
             label: __('Configure Extensions'),
-            link: url('files', {'namespace': 'config', 'path': 'extensions'}),
+            link: path('files', {'namespace': 'config', 'path': 'extensions'}),
             isallowed: 'extensions:config'
         }
     ]) %}

--- a/app/view/twig/nav/_secondary-filemanagement.twig
+++ b/app/view/twig/nav/_secondary-filemanagement.twig
@@ -2,12 +2,12 @@
     {
         icon: 'fa:folder-open-o',
         label: __('Uploaded files'),
-        link: url('files', {'namespace': 'files', 'path': ''}),
+        link: path('files', {'namespace': 'files', 'path': ''}),
         isallowed: 'files:uploads'
     }, {
         icon: 'fa:desktop',
         label: __('View/edit Templates'),
-        link: url('files', {'namespace': 'theme', 'path': ''}),
+        link: path('files', {'namespace': 'theme', 'path': ''}),
         isallowed: 'files:theme'
     }
 ] %}


### PR DESCRIPTION
when you use the nav links it attempts to load extensions and file-managment pages using http