### PR TITLE
Moved Nut commands to a service provider

### DIFF
--- a/app/nut
+++ b/app/nut
@@ -5,24 +5,7 @@ use Symfony\Component\Console\Application;
 
 $app = require_once __DIR__ . '/load.php';
 
-/** @var Application $application retrieve the Console Application from the Bolt application in the bootstrap */
-$application = $app['console'];
-
-$application->add(new Bolt\Nut\CronRunner($app));
-$application->add(new Bolt\Nut\CacheClear($app));
-$application->add(new Bolt\Nut\Info($app));
-$application->add(new Bolt\Nut\LogTrim($app));
-$application->add(new Bolt\Nut\LogClear($app));
-$application->add(new Bolt\Nut\DatabaseCheck($app));
-$application->add(new Bolt\Nut\DatabaseRepair($app));
-$application->add(new Bolt\Nut\TestRunner($app));
-$application->add(new Bolt\Nut\ConfigGet($app));
-$application->add(new Bolt\Nut\ConfigSet($app));
-$application->add(new Bolt\Nut\Extensions($app));
-$application->add(new Bolt\Nut\ExtensionsEnable($app));
-$application->add(new Bolt\Nut\ExtensionsDisable($app));
-$application->add(new Bolt\Nut\UserAdd($app));
-$application->add(new Bolt\Nut\UserRoleAdd($app));
-$application->add(new Bolt\Nut\UserRoleRemove($app));
+/** @var Application $application retrieve the Nut Console Application from the Bolt application in the bootstrap */
+$application = $app['nut'];
 
 $application->run();

--- a/src/Application.php
+++ b/src/Application.php
@@ -7,7 +7,6 @@ use Bolt\Library as Lib;
 use RandomLib;
 use SecurityLib;
 use Silex;
-use Symfony\Component\Console\Application as ConsoleApplication;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -96,9 +95,6 @@ class Application extends Silex\Application
 
         // Initialize the Database Providers.
         $this->initDatabase();
-
-        // Initialize the Console Application for Nut
-        $this->initConsoleApplication();
 
         // Initialize the rest of the Providers.
         $this->initProviders();
@@ -291,7 +287,9 @@ class Application extends Silex\Application
             ->register(new Controllers\Upload())
             ->register(new Controllers\Extend())
             ->register(new Provider\FilesystemProvider())
-            ->register(new Thumbs\ThumbnailProvider());
+            ->register(new Thumbs\ThumbnailProvider())
+            ->register(new Provider\NutServiceProvider())
+        ;
 
         $this['paths'] = $this['resources']->getPaths();
 
@@ -354,22 +352,6 @@ class Application extends Silex\Application
 
         // Mount the 'frontend' controllers, ar defined in our Routing.yml
         $this->mount('', new Controllers\Routing());
-    }
-
-    /**
-     * Initializes the Console Application that is responsible for CLI interactions.
-     */
-    public function initConsoleApplication()
-    {
-        $this['console'] = $this->share(
-            function (Application $app) {
-                $console = new ConsoleApplication();
-                $console->setName('Bolt console tool - Nut');
-                $console->setVersion($app->getVersion());
-
-                return $console;
-            }
-        );
     }
 
     public function beforeHandler(Request $request)

--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -577,6 +577,13 @@ abstract class BaseExtension implements ExtensionInterface
      */
     public function addConsoleCommand(Command $command)
     {
-        $this->app['console']->add($command);
+        $this->app['nut.commands'] = $this->app->share(
+            $this->app->extend('nut.commands',
+                function($commands) use ($command) {
+                    $commands[] = $command;
+                    return $commands;
+                }
+            )
+        );
     }
 }

--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -5,6 +5,7 @@ use Bolt\Extensions\ExtensionInterface;
 use Bolt\Extensions\TwigProxy;
 use Bolt\Library as Lib;
 use Bolt\Helpers\Arr;
+use Bolt\Provider\NutServiceProvider;
 use Symfony\Component\Console\Command\Command;
 use Composer\Json\JsonFile;
 use utilphp\util;
@@ -577,13 +578,6 @@ abstract class BaseExtension implements ExtensionInterface
      */
     public function addConsoleCommand(Command $command)
     {
-        $this->app['nut.commands'] = $this->app->share(
-            $this->app->extend('nut.commands',
-                function($commands) use ($command) {
-                    $commands[] = $command;
-                    return $commands;
-                }
-            )
-        );
+        NutServiceProvider::addCommand($this->app, $command);
     }
 }

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -1,0 +1,62 @@
+<?php
+namespace Bolt\Provider;
+
+use Bolt\Nut;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\Console\Application as ConsoleApplication;
+
+class NutServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        $app['nut'] = $app->share(
+            function($app) {
+                $console = new ConsoleApplication();
+
+                $console->setName('Bolt console tool - Nut');
+                if ($app instanceof \Bolt\Application) {
+                    $console->setVersion($app->getVersion());
+                }
+
+                $console->addCommands($app['nut.commands']);
+
+                return $console;
+            }
+        );
+
+        $app['nut.commands'] = $app->share(
+            function($app) {
+                return array(
+                    new Nut\CronRunner($app),
+                    new Nut\CacheClear($app),
+                    new Nut\Info($app),
+                    new Nut\LogTrim($app),
+                    new Nut\LogClear($app),
+                    new Nut\DatabaseCheck($app),
+                    new Nut\DatabaseRepair($app),
+                    new Nut\TestRunner($app),
+                    new Nut\ConfigGet($app),
+                    new Nut\ConfigSet($app),
+                    new Nut\Extensions($app),
+                    new Nut\ExtensionsEnable($app),
+                    new Nut\ExtensionsDisable($app),
+                    new Nut\UserAdd($app),
+                    new Nut\UserRoleAdd($app),
+                    new Nut\UserRoleRemove($app),
+                );
+            }
+        );
+
+        // Maintain backwards compatibility
+        $app['console'] = $app->share(
+            function($app) {
+                return $app['nut'];
+            }
+        );
+    }
+
+    public function boot(Application $app)
+    {
+    }
+}

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -64,7 +64,8 @@ class NutServiceProvider implements ServiceProviderInterface
     public static function addCommand(Application $app, Command $command)
     {
         $app['nut.commands'] = $app->share(
-            $app->extend('nut.commands',
+            $app->extend(
+                'nut.commands',
                 function($commands) use ($command) {
                     $commands[] = $command;
                     return $commands;

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -5,6 +5,7 @@ use Bolt\Nut;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\Command\Command;
 
 class NutServiceProvider implements ServiceProviderInterface
 {
@@ -58,5 +59,17 @@ class NutServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
+    }
+
+    public static function addCommand(Application $app, Command $command)
+    {
+        $app['nut.commands'] = $app->share(
+            $app->extend('nut.commands',
+                function($commands) use ($command) {
+                    $commands[] = $command;
+                    return $commands;
+                }
+            )
+        );
     }
 }


### PR DESCRIPTION
Those who want to modify their Bolt install mostly likely need to create their own `nut` file which has their own bootstrap. 
The problem is they then have to add all the nut commands manually. 
What happens when these are removed/changed or others are added?

Moving these commands to a service provider fixes that.