### PR TITLE
Use 'web' instead of 'root' as the base for Thumbs, because thumbs might...

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -72,7 +72,7 @@ class Cache extends FilesystemCache
 
         // Clear the thumbs folder.
         $app = ResourceManager::getApp();
-        $this->clearCacheHelper($app['resources']->getPath('root') . '/thumbs', '', $result);
+        $this->clearCacheHelper($app['resources']->getPath('web') . '/thumbs', '', $result);
 
         return $result;
     }


### PR DESCRIPTION
... not be in root.

Thanks, @rossriley. See #2512