### PR TITLE
Refactor Config::getWhichEnd() to work with PHP CLI Server and use Symfony Req Object

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -7,6 +7,7 @@ use Bolt\Library as Lib;
 use Bolt\Helpers\Arr;
 use Bolt\Helpers\String;
 use Bolt\Translation\Translator as Trans;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Yaml;
 use Symfony\Component\Yaml\Parser;
 
@@ -880,49 +881,55 @@ class Config
     /**
      * Utility function to determine which 'end' we're using right now. Can be either "frontend", "backend", "async" or "cli".
      *
-     * NOTE: We retain the $_SERVER global here as this method can get called very early and the Request object might not exist yet
-     * 
+     * NOTE: If the Request object has not been intialized by Silex yet,
+     * we create a local version based on the request globals.
+     *
      * @param  string $mountpoint
      * @return string
      */
     public function getWhichEnd($mountpoint = '')
     {
+        // Get a request object
+        // Will throw RuntimeException if not initialized by Silex yet, in which case
+        // we create our own
+        try {
+            $reqObj = $this->app['request'];
+        }
+        catch (\RuntimeException $e) {
+
+            // Return CLI if request not already exist and we're on the CLI
+            if (php_sapi_name() == 'cli') {
+                $this->app['end'] = 'cli';
+                return 'cli';
+            }
+
+            $reqObj = Request::createFromGlobals();
+        }
+
+        // Ensure the request path always includes a left slash
+        $reqPath = '/' . ltrim($reqObj->getPathInfo(), '/');
+
+        // Default mountpoint is branding path (defaults to 'bolt' unless changed in config)
         if (empty($mountpoint)) {
             $mountpoint = $this->get('general/branding/path');
         }
 
-        if (empty($_SERVER['REQUEST_URI'])) {
-            // We're probably in CLI mode.
-            $this->app['end'] = 'cli';
-
-            return 'cli';
-        }
-
-        // Set scriptname, take care of odd '/./' in the SCRIPT_NAME, which lightspeed does.
-        $scriptname = str_replace('/./', '/', $_SERVER['SCRIPT_NAME']);
-
-        // Get the script's filename, but _without_ REQUEST_URI. We need to str_replace the slashes, because of a
-        // weird quirk in dirname on windows: http://nl1.php.net/dirname#refsect1-function.dirname-notes
-        $scriptdirname = '#' . str_replace("\\", "/", dirname($scriptname));
-        $scripturi = str_replace($scriptdirname, '', '#' . $_SERVER['REQUEST_URI']);
-        // make sure it starts with '/', like our mountpoint.
-        if (empty($scripturi) || ($scripturi[0] != '/')) {
-            $scripturi = '/' . $scripturi;
-        }
-
-        // If the request URI is '/bolt' or '/async' (or starts with '/bolt/' etc.), assume backend or async.
+        // Ensure left slash on mountpoint
         $mountpoint = '/' . ltrim($mountpoint, '/');
-        if ((isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest')
-            || $scripturi === '/async' || strpos($scripturi, '/async/') === 0) {
+
+        // If path begins with '/async' or is AJAX request, is 'async'
+        if (strpos($reqObj->getPathInfo(), '/async') === 0 OR $reqObj->isXmlHttpRequest()) {
             $end = 'async';
-        } elseif ($scripturi === $mountpoint || strpos($scripturi, $mountpoint . '/') === 0) {
+        }
+        // Or.. if req path starts with mountpoint, is backend
+        elseif (strpos($reqPath, $mountpoint) === 0) {
             $end = 'backend';
-        } else {
+        }
+        else { // Else assume frontend
             $end = 'frontend';
         }
 
         $this->app['end'] = $end;
-
         return $end;
     }
 


### PR DESCRIPTION
The `Config::getWhichEnd()` method relies some custom logic that uses the `$_SERVER` superglobal to determine which 'end' of the application is being used.  I propose instead using the Symfony `Request` object, since it does a better job of determining path information for various environments.

If the `$app['request']` hasn't been initialized yet, we can create a local copy of the Symfony `Request` object using `createFromGlobals()`.  This will ensure that the `getWhichEnd()` uses the same HTTP interpretation logic that the routing does.

This benefits of this pull request include:

- simplifies the code in the `getWhichEnd()` method, and
- fixes an issue where certain pages in the admin section throw "missing Twig template" errors; specifically pages where the URI ends with a file extension (e.g. `/bolt/file/edit/app/config/contenttypes.yml`).  This error occurs when using the PHP built-in webserver