### PR TITLE
Database Clusters

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -132,10 +132,9 @@ class Application extends Silex\Application
                 'db.options' => $this['config']->getDBOptions()
             )
         );
+        $this->register(new Database\InitListener());
 
         $this->checkDatabaseConnection();
-
-        $this->tweakDatabaseDefaults();
 
         $this->register(
             new Silex\Provider\HttpCacheServiceProvider(),
@@ -164,27 +163,6 @@ class Application extends Silex\Application
                 database <code>" . $db->getDatabase() . "</code> exists, and the configured user has access to it.";
             }
             throw new LowlevelException($error);
-        }
-    }
-
-    protected function tweakDatabaseDefaults()
-    {
-        /** @var \Doctrine\DBAL\Connection $db */
-        $db = $this['db'];
-        $driver = $db->getDriver()->getName();
-
-        if ($driver == 'pdo_sqlite') {
-            $db->query('PRAGMA synchronous = OFF');
-        } elseif ($driver == 'pdo_mysql') {
-            /**
-             * @link https://groups.google.com/forum/?fromgroups=#!topic/silex-php/AR3lpouqsgs
-             */
-            $db->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
-
-            // set utf8 on names and connection as all tables has this charset
-            $db->executeQuery("SET NAMES 'utf8';");
-            $db->executeQuery("SET CHARACTER_SET_CONNECTION = 'utf8';");
-            $db->executeQuery("SET CHARACTER SET utf8;");
         }
     }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -4,8 +4,6 @@ namespace Bolt;
 
 use Bolt\Configuration\LowlevelException;
 use Bolt\Library as Lib;
-use Doctrine\DBAL\Event\ConnectionEventArgs;
-use Doctrine\DBAL\Events;
 use RandomLib;
 use SecurityLib;
 use Silex;

--- a/src/Config.php
+++ b/src/Config.php
@@ -822,56 +822,8 @@ class Config
             $dboptions['charset'] = isset($configdb['charset']) ? $configdb['charset'] : 'utf8';
         }
 
-        switch ($dboptions['driver']) {
-            case 'pdo_mysql':
-                $dboptions['port'] = isset($configdb['port']) ? $configdb['port'] : '3306';
-                $dboptions['reservedwords'] = explode(
-                    ',',
-                    'accessible,add,all,alter,analyze,and,as,asc,asensitive,before,between,' .
-                    'bigint,binary,blob,both,by,call,cascade,case,change,char,character,check,collate,column,condition,constraint,' .
-                    'continue,convert,create,cross,current_date,current_time,current_timestamp,current_user,cursor,database,databases,' .
-                    'day_hour,day_microsecond,day_minute,day_second,dec,decimal,declare,default,delayed,delete,desc,describe,' .
-                    'deterministic,distinct,distinctrow,div,double,drop,dual,each,else,elseif,enclosed,escaped,exists,exit,explain,' .
-                    'false,fetch,float,float4,float8,for,force,foreign,from,fulltext,get,grant,group,having,high_priority,hour_microsecond,' .
-                    'hour_minute,hour_second,if,ignore,in,index,infile,inner,inout,insensitive,insert,int,int1,int2,int3,int4,int8,' .
-                    'integer,interval,into,io_after_gtids,io_before_gtids,is,iterate,join,key,keys,kill,leading,leave,left,like,limit,' .
-                    'linear,lines,load,localtime,localtimestamp,lock,long,longblob,longtext,loop,low_priority,master_bind,' .
-                    'master_ssl_verify_server_cert,match,maxvalue,mediumblob,mediumint,mediumtext,middleint,minute_microsecond,' .
-                    'minute_second,mod,modifies,natural,nonblocking,not,no_write_to_binlog,null,numeric,on,optimize,option,optionally,' .
-                    'or,order,out,outer,outfile,partition,precision,primary,procedure,purge,range,read,reads,read_write,real,references,' .
-                    'regexp,release,rename,repeat,replace,require,resignal,restrict,return,revoke,right,rlike,schema,schemas,' .
-                    'second_microsecond,select,sensitive,separator,set,show,signal,smallint,spatial,specific,sql,sqlexception,sqlstate,' .
-                    'sqlwarning,sql_big_result,sql_calc_found_rows,sql_small_result,ssl,starting,straight_join,table,terminated,then,' .
-                    'tinyblob,tinyint,tinytext,to,trailing,trigger,true,undo,union,unique,unlock,unsigned,update,usage,use,using,utc_date,' .
-                    'utc_time,utc_timestamp,values,varbinary,varchar,varcharacter,varying,when,where,while,with,write,xor,year_month,' .
-                    'zerofill,nonblocking'
-                );
-                break;
-            case 'pdo_sqlite':
-                $dboptions['reservedwords'] = explode(
-                    ',',
-                    'abort,action,add,after,all,alter,analyze,and,as,asc,attach,autoincrement,' .
-                    'before,begin,between,by,cascade,case,cast,check,collate,column,commit,conflict,constraint,create,cross,current_date,' .
-                    'current_time,current_timestamp,database,default,deferrable,deferred,delete,desc,detach,distinct,drop,each,else,end,' .
-                    'escape,except,exclusive,exists,explain,fail,for,foreign,from,full,glob,group,having,if,ignore,immediate,in,index,' .
-                    'indexed,initially,inner,insert,instead,intersect,into,is,isnull,join,key,left,like,limit,match,natural,no,not,' .
-                    'notnull,null,of,offset,on,or,order,outer,plan,pragma,primary,query,raise,references,regexp,reindex,release,rename,' .
-                    'replace,restrict,right,rollback'
-                );
-                break;
-            case 'pdo_pgsql':
-                $dboptions['port'] = isset($configdb['port']) ? $configdb['port'] : '5432';
-                $dboptions['reservedwords'] = explode(
-                    ',',
-                    'all,analyse,analyze,and,any,as,asc,authorization,between,bigint,binary,bit,' .
-                    'boolean,both,case,cast,char,character,check,coalesce,collate,column,constraint,convert,create,cross,current_date,' .
-                    'current_time,current_timestamp,current_user,dec,decimal,default,deferrable,desc,distinct,do,else,end,except,exists,' .
-                    'extract,float,for,foreign,freeze,from,full,grant,group,having,ilike,in,initially,inner,int,integer,intersect,interval,' .
-                    'into,is,isnull,join,leading,left,like,limit,localtime,localtimestamp,natural,nchar,new,none,not,notnull,null,nullif,' .
-                    'numeric,off,offset,old,on,only,or,order,outer,overlaps,overlay,placing,position,primary,real,references,right,row,' .
-                    'select,session_user,setof,similar,smallint,some,substring,table,then,time,timestamp,to,trailing,treat,trim,union,' .
-                    'unique,user,using,varchar,verbose,when,where,false,true'
-                );
+        if (isset($configdb['port'])) {
+            $dboptions['port'] = $configdb['port'];
         }
 
         return $dboptions;

--- a/src/Config.php
+++ b/src/Config.php
@@ -799,10 +799,9 @@ class Config
             'host' => 'localhost',
         );
         $master = $this->parseConnectionParams($config, $defaults);
+        $options = array_merge($options, $master);
 
-        // If there are no slaves, merge the master connection into the dboptions and return
         if (!isset($config['slaves']) || empty($config['slaves'])) {
-            $options = array_merge($options, $master);
             return $options;
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -828,11 +828,10 @@ class Config
             $basename .= '.db';
         }
 
-        $path = isset($config['path']) ? $config['path'] : null;
+        $path = isset($config['path']) ? $config['path'] : $this->resources->getPath('database');
         if (substr($path, 0, 1) !== '/') {
             $path = $this->resources->getPath('root') . '/' . $path;
         }
-        $path = realpath($path) ?: $this->resources->getPath('database');
 
         return array(
             'driver'         => 'pdo_sqlite',

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -245,9 +245,7 @@ class Async implements ControllerProviderInterface
             $table,
             $table
         );
-        $query = $app['db']->executeQuery($query, array($taxonomytype));
-
-        $results = $query->fetchAll();
+        $results = $app['db']->fetchAll($query, array($taxonomytype));
 
         return $app->json($results);
     }

--- a/src/Database/InitListener.php
+++ b/src/Database/InitListener.php
@@ -16,8 +16,10 @@ class InitListener implements ServiceProviderInterface, EventSubscriber
             $app->extend(
                 'dbs.event_manager',
                 function($managers) use ($self) {
-                    foreach ($managers as $name => $manager) {
+                    /** @var \Pimple $managers */
+                    foreach ($managers->keys() as $name) {
                         /** @var \Doctrine\Common\EventManager $manager */
+                        $manager = $managers[$name];
                         $manager->addEventSubscriber($self);
                     }
                     return $managers;

--- a/src/Database/InitListener.php
+++ b/src/Database/InitListener.php
@@ -1,0 +1,57 @@
+<?php
+namespace Bolt\Database;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Event\ConnectionEventArgs;
+use Doctrine\DBAL\Events;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+
+class InitListener implements ServiceProviderInterface, EventSubscriber
+{
+    public function register(Application $app)
+    {
+        $self = $this;
+        $app['dbs.event_manager'] = $app->share(
+            $app->extend(
+                'dbs.event_manager',
+                function($managers) use ($self) {
+                    foreach ($managers as $name => $manager) {
+                        /** @var \Doctrine\Common\EventManager $manager */
+                        $manager->addEventSubscriber($self);
+                    }
+                    return $managers;
+                }
+            )
+        );
+    }
+
+    public function postConnect(ConnectionEventArgs $args)
+    {
+        $db = $args->getConnection();
+        $driver = $args->getDriver()->getName();
+
+        if ($driver == 'pdo_sqlite') {
+            $db->query('PRAGMA synchronous = OFF');
+        } elseif ($driver == 'pdo_mysql') {
+            /**
+             * @link https://groups.google.com/forum/?fromgroups=#!topic/silex-php/AR3lpouqsgs
+             */
+            $db->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+
+            // set utf8 on names and connection as all tables has this charset
+            $db->executeQuery('SET NAMES utf8');
+            $db->executeQuery('SET CHARACTER_SET_CONNECTION = utf8');
+            $db->executeQuery('SET CHARACTER SET utf8');
+        }
+    }
+
+    public function getSubscribedEvents()
+    {
+        return array(Events::postConnect);
+    }
+
+    public function boot(Application $app)
+    {
+    }
+}

--- a/src/Field/Manager.php
+++ b/src/Field/Manager.php
@@ -11,6 +11,9 @@ namespace Bolt\Field;
 class Manager
 {
 
+    /**
+     * @var FieldInterface[]
+     */
     protected $fields = array();
 
     protected $defaults = array(
@@ -40,6 +43,10 @@ class Manager
         return $this->fields;
     }
 
+    /**
+     * @param string $name
+     * @return FieldInterface|false
+     */
     public function getField($name)
     {
         if ($this->has($name)) {

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1347,17 +1347,21 @@ class Storage
         try {
 
             // Check if there are any records that need publishing..
-            $query = "SELECT id FROM $tablename WHERE status = 'timed' and datepublish < :now";
-            $stmt = $this->db->prepare($query);
-            $stmt->bindValue("now", $now);
-            $stmt->execute();
+            $stmt = $this->db->executeQuery(
+                "SELECT id FROM $tablename WHERE status = 'timed' and datepublish < :now",
+                array(
+                    'now' => $now,
+                )
+            );
 
             // If there's a result, we need to set these to 'publish'..
             if ($stmt->fetch() !== false) {
-                $query = "UPDATE $tablename SET status = 'published', datechanged = :now  WHERE status = 'timed' and datepublish < :now";
-                $stmt = $this->db->prepare($query);
-                $stmt->bindValue("now", $now);
-                $stmt->execute();
+                $this->db->query(
+                    "UPDATE $tablename SET status = 'published', datechanged = :now  WHERE status = 'timed' and datepublish < :now",
+                    array(
+                        "now" => $now,
+                    )
+                );
             }
 
         } catch (\Doctrine\DBAL\DBALException $e) {
@@ -1386,17 +1390,21 @@ class Storage
         try {
 
             // Check if there are any records that need depublishing..
-            $query = "SELECT id FROM $tablename WHERE status = 'published' and datedepublish <= :now and datedepublish > '1900-01-01 00:00:01' and datechanged < datedepublish";
-            $stmt = $this->db->prepare($query);
-            $stmt->bindValue("now", $now);
-            $stmt->execute();
+            $stmt = $this->db->executeQuery(
+                "SELECT id FROM $tablename WHERE status = 'published' and datedepublish <= :now and datedepublish > '1900-01-01 00:00:01' and datechanged < datedepublish",
+                array(
+                    'now' => $now,
+                )
+            );
 
             // If there's a result, we need to set these to 'held'..
             if ($stmt->fetch() !== false) {
-                $query = "UPDATE $tablename SET status = 'held', datechanged = :now WHERE status = 'published' and datedepublish <= :now and datedepublish > '1900-01-01 00:00:01' and datechanged < datedepublish";
-                $stmt = $this->db->prepare($query);
-                $stmt->bindValue("now", $now);
-                $stmt->execute();
+                $this->db->query(
+                    "UPDATE $tablename SET status = 'held', datechanged = :now WHERE status = 'published' and datedepublish <= :now and datedepublish > '1900-01-01 00:00:01' and datechanged < datedepublish",
+                    array(
+                        "now" => $now,
+                    )
+                );
             }
 
         } catch (\Doctrine\DBAL\DBALException $e) {

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1199,7 +1199,7 @@ class Storage
         // Order, with a special case for 'RANDOM'.
         if (!empty($parameters['order'])) {
             if ($parameters['order'] == "RANDOM") {
-                $dboptions = $this->app['config']->getDBOptions();
+                $dboptions = $this->db->getParams();
                 $queryparams .= sprintf(' ORDER BY %s', $dboptions['randomfunction']);
             } else {
                 $order = $this->getEscapedSortorder($parameters['order'], false);
@@ -1619,7 +1619,7 @@ class Storage
         } else {
             $parOrder = String::makeSafe($orderValue);
             if ($parOrder == 'RANDOM') {
-                $dboptions = $this->app['config']->getDBOptions();
+                $dboptions = $this->db->getParams();
                 $order = $dboptions['randomfunction'];
             } elseif ($this->isValidColumn($parOrder, $contenttype, true)) {
                 $order = $this->getEscapedSortorder($parOrder, false);
@@ -2931,17 +2931,16 @@ class Storage
         }
 
         // See if the table exists.
-        $dboptions = $this->app['config']->getDBOptions();
-        if ($dboptions['driver'] == 'pdo_sqlite') {
+        $driver = $this->db->getDriver()->getName();
+        $databasename = $this->db->getDatabase();
+        if ($driver == 'pdo_sqlite') {
             // For SQLite:
             $query = "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='$name';";
-        } elseif ($dboptions['driver'] == 'pdo_pgsql') {
+        } elseif ($driver == 'pdo_pgsql') {
             // For Postgres
-            $databasename = $this->app['config']->get('general/database/databasename');
             $query = "SELECT count(*) FROM information_schema.tables WHERE table_catalog = '$databasename' AND table_name = '$name';";
         } else {
             // For MySQL
-            $databasename = $this->app['config']->get('general/database/databasename');
             $query = "SELECT count(*) FROM information_schema.tables WHERE table_schema = '$databasename' AND table_name = '$name';";
         }
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -16,6 +16,7 @@ class Users
     const ADMIN = 4;
     const DEVELOPER = 6;
 
+    /** @var \Doctrine\DBAL\Connection */
     public $db;
     public $config;
     public $usertable;
@@ -285,7 +286,7 @@ class Users
         try {
             // Check if there's already a token stored for this name / IP combo.
             $query = sprintf('SELECT id FROM %s WHERE username=? AND ip=? AND useragent=?', $this->authtokentable);
-            $query = $this->app['db']->getDatabasePlatform()->modifyLimitQuery($query, 1);
+            $query = $this->db->getDatabasePlatform()->modifyLimitQuery($query, 1);
             $row = $this->db->executeQuery($query, array($token['username'], $token['ip'], $token['useragent']), array(\PDO::PARAM_STR))->fetch();
 
             // Update or insert the row..
@@ -357,7 +358,7 @@ class Users
     private function deleteExpiredSessions()
     {
         try {
-            $stmt = $this->db->prepare(sprintf('DELETE FROM %s WHERE validity < :now"', $this->authtokentable));
+            $stmt = $this->db->prepare(sprintf('DELETE FROM %s WHERE validity < :now', $this->authtokentable));
             $stmt->bindValue("now", date("Y-m-d H:i:s"));
             $stmt->execute();
         } catch (\Doctrine\DBAL\DBALException $e) {
@@ -397,7 +398,7 @@ class Users
 
         // for once we don't use getUser(), because we need the password.
         $query = sprintf('SELECT * FROM %s WHERE username=?', $this->usertable);
-        $query = $this->app['db']->getDatabasePlatform()->modifyLimitQuery($query, 1);
+        $query = $this->db->getDatabasePlatform()->modifyLimitQuery($query, 1);
         $user = $this->db->executeQuery($query, array($userslug), array(\PDO::PARAM_STR))->fetch();
 
         if (empty($user)) {
@@ -490,7 +491,7 @@ class Users
         // Check if there's already a token stored for this token / IP combo.
         try {
             $query = sprintf('SELECT * FROM %s WHERE token=? AND ip=? AND useragent=?', $this->authtokentable);
-            $query = $this->app['db']->getDatabasePlatform()->modifyLimitQuery($query, 1);
+            $query = $this->db->getDatabasePlatform()->modifyLimitQuery($query, 1);
             $row = $this->db->executeQuery($query, array($authtoken, $remoteip, $browser), array(\PDO::PARAM_STR))->fetch();
         } catch (\Doctrine\DBAL\DBALException $e) {
             // Oops. User will get a warning on the dashboard about tables that need to be repaired.
@@ -621,7 +622,7 @@ class Users
 
         // Let's see if the token is valid, and it's been requested within two hours...
         $query = sprintf('SELECT * FROM %s WHERE shadowtoken = ? AND shadowvalidity > ?', $this->usertable);
-        $query = $this->app['db']->getDatabasePlatform()->modifyLimitQuery($query, 1);
+        $query = $this->db->getDatabasePlatform()->modifyLimitQuery($query, 1);
         $user = $this->db->executeQuery($query, array($token, $now), array(\PDO::PARAM_STR))->fetch();
 
         if (!empty($user)) {


### PR DESCRIPTION
### This allows database clusters to be used in multi-server deployments!

### Notable changes:
- Refactored database initialization queries to `Database\InitListener` which is called automatically for _EVERY_ connection
- Using DBAL's `connect` method to check for valid connection, which is defined by the driver.
- Using DBAL's reserved keywords list, fixes #2507 
- Getting driver name and other options from actual connection instead of config options.
- Changed `prepare` calls to `executeQuery` (see Caveats)
- Config changes:
  - Updated `Config::getDBOptions` to parse slave connections (see example below)
  - Config does not assume database port. If it is left out, the driver's default is used.
  - Other [driver specific options](http://doctrine-dbal.readthedocs.org/en/latest/reference/configuration.html#connection-details) are now allowed
- Refactors to use `app` less, which hinders type hinting amongst other things.
- Added more type hinting to methods and variables.

### Caveats
- Only `fetch*` and `executeQuery` can take advantage of the slave connection.   
  Once the master connection used, it will always be picked over the slave (to avoid data inconsistency issues).  
  Because of this, `prepare` can not be used for read queries.  
- Bolt's `Log` class currently writes to the database (breaking slave connections).   
  Left alone because #693 #2524 is almost ready. 
- Branch depends on #2527 

### Config Example
```yaml
database:
  host: db.bolt.com
  # dbname or databasename works
  dbname: bolt
  # user or username works
  user: root
  password: admin
  slaves:
    # Options not specified default to master options
    - host: slave2.db.bolt.com
      user: read_only_user
    # Here's a shortcut if only the host is different 
    - slave.db.bolt.com
    # Slaves can be named as well
    eu: eu.db.bolt.com
    us: us.db.bolt.com
```