### PR TITLE
Extend's Composer Implementation for v2.1

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -270,7 +270,6 @@ hash_strength: 10
 extensions:
   site: 'https://extensions.bolt.cm/'
   stability: stable
-  use_http: false
 
 # Enforce SSL: if set, all but the front-end pages will enforce an SSL
 # connection (and redirect to HTTPS if you attempt to visit the backend over

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -214,6 +214,7 @@ module.exports = function(grunt) {
                     Stack: true,                // src/obj-stack.js
                     site: true,                 // src/extend.js/extend.twig
                     baseurl: true,              // src/extend.js/extend.twig
+                    rootpath: true,             // src/extend.js/extend.twig
                     // Bolt global functions
                     bindFileUpload: true,       // src/bindfileuploads.js
                     bindGeolocation: true,      // src/geolocation.js

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -101,14 +101,16 @@ var BoltExtender = Object.extend(Object, {
                     
                     // Add an install button
                     target.append(bolt.data.extend.packages.install_new.subst({
-                        '%PACKAGE%': ext.name}));
+                        '%PACKAGE%': ext.name,
+                        '%VERSION%': ext.version}));
                 }
                 for (e in data.updates) {
                     ext = data.updates[e];
                     
                     // Add an update button
                     target.append(bolt.data.extend.packages.install_update.subst({
-                        '%PACKAGE%': ext.name}));
+                        '%PACKAGE%': ext.name,
+                        '%VERSION%': ext.version}));
                 }
                 active_console.hide();
                 controller.find('.update-list').show();

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -101,14 +101,14 @@ var BoltExtender = Object.extend(Object, {
                     
                     // Add an install button
                     target.append(bolt.data.extend.packages.install_new.subst({
-                        '%PACKAGE%': ext}));
+                        '%PACKAGE%': ext.name}));
                 }
                 for (e in data.updates) {
                     ext = data.updates[e];
                     
                     // Add an update button
                     target.append(bolt.data.extend.packages.install_update.subst({
-                        '%PACKAGE%': ext}));
+                        '%PACKAGE%': ext.name}));
                 }
                 active_console.hide();
                 controller.find('.update-list').show();

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -240,7 +240,7 @@ var BoltExtender = Object.extend(Object, {
                 i = 0;
 
                 // Authors array
-                if (ext.authors.length > 0) {
+                if (ext.authors && ext.authors.length > 0) {
                     var authorsArray = ext.authors;
                     for (i = 0; i < authorsArray.length; i++) {
                         authors += conf.author.subst({'%AUTHOR%': authorsArray[i].name});
@@ -248,7 +248,7 @@ var BoltExtender = Object.extend(Object, {
                 }
 
                 // Keyword array
-                if (ext.keywords.length > 0) {
+                if (ext.keywords && ext.keywords.length > 0) {
                     var keywordsArray = ext.keywords;
                     for (i = 0; i < keywordsArray.length; i++) {
                         keywords += conf.keyword.subst({'%KEYWORD%': keywordsArray[i]});

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -208,6 +208,11 @@ var BoltExtender = Object.extend(Object, {
             var target = jQuery(this).find('.installed-list');
 
             jQuery.get(baseurl + 'installed', function (data) {
+                if (typeof data !== 'object') {
+                    active_console.html('Malformed JSON response. Ensure no debugging or other code is being added to the response');
+                    return;
+                }
+
                 target.show();
                 var html = '',
                     pack = data.installed.concat(data.pending).concat(data.local);

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -472,7 +472,7 @@ var BoltExtender = Object.extend(Object, {
         jQuery.get( jQuery(e.target).data('readme') )
         .done(function(data) {
             bootbox.dialog({
-                message: data
+                message: data ? data : 'Readme is empty.'
             });
             controller.updateLog();
         })

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -98,16 +98,17 @@ var BoltExtender = Object.extend(Object, {
                 var e, ext;
                 for (e in data.installs) {
                     ext = data.installs[e];
-                    target.append('<tr data-package="' + ext + '"><td class="ext-list"><strong class="title">' +
-                        ext + '</strong></td><td> ' +
-                        '<a data-request="update-package" class="btn btn-sm btn-warning" data-package="' + ext + '">' +
-                        'Install New Package</a></td></tr>');
+                    
+                    // Add an install button
+                    target.append(bolt.data.extend.packages.install_new.subst({
+                        '%PACKAGE%': ext}));
                 }
                 for (e in data.updates) {
                     ext = data.updates[e];
-                    target.append("<tr data-package='" + ext + "'><td class='ext-list'><strong class='title'>" + ext +
-                        "</strong></td><td> <a data-request='update-package' class='btn btn-sm btn-tertiary' " +
-                        "data-package='" + ext + "'>Install Package Update</a></td></tr>");
+                    
+                    // Add an update button
+                    target.append(bolt.data.extend.packages.install_update.subst({
+                        '%PACKAGE%': ext}));
                 }
                 active_console.hide();
                 controller.find('.update-list').show();
@@ -255,6 +256,7 @@ var BoltExtender = Object.extend(Object, {
                     }
                 }
 
+                // Generate the HTML for a package item
                 html += conf.item.subst({
                     '%TITLE%': ext.title ? ext.title : ext.name,
                     '%NAME%': ext.name,
@@ -327,15 +329,14 @@ var BoltExtender = Object.extend(Object, {
             version = packages[v];
             aclass = version.buildStatus === 'approved' ? ' label-success' : '';
 
-            tpl += '<tr>' +
-                    '<td>' + version.name + '</td>' +
-                    '<td>' + version.version + '</td>' +
-                    '<td><span class="label label-default' + aclass + '">' + version.buildStatus + '</span></td>' +
-                    '<td><div class="btn-group"><a href="#" data-request="install-package" class="btn btn-primary ' +
-                    'btn-sm" data-package="' + version.name + '" data-version="' + version.version + '">' +
-                    '<i class="icon-gears"></i> Install This Version</a></div></td>' +
-                '</tr>';
+            // Add a row and replace macro values
+            tpl += bolt.data.extend.packages.versions.subst({
+                '%NAME%': version.name,
+                '%VERSION%': version.version,
+                '%CLASS%%': aclass,
+                '%BUILDSTATUS%': version.buildStatus});
         }
+
         return tpl;
     },
 

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -130,12 +130,15 @@ var BoltExtender = Object.extend(Object, {
         active_console = target;
         active_console.html(controller.messages.runningUpdate);
         controller.updateLog();
+
         jQuery.get(baseurl + 'update', function(data) {
             target.html(data);
             setTimeout(function(){
                 controller.find('.update-container').hide();
             }, 7000);
+            
             controller.updateLog();
+            controller.checkInstalled();
         })
         .fail(function(data) {
             active_console.html(controller.formatErrorLog(data));
@@ -183,7 +186,9 @@ var BoltExtender = Object.extend(Object, {
             delay(function () {
                 controller.find('.update-container').hide();
             }, 7000);
+
             controller.updateLog();
+            controller.checkInstalled();
         })
         .fail(function(data) {
             active_console.html(controller.formatErrorLog(data));

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -92,6 +92,7 @@ var BoltExtender = Object.extend(Object, {
         target = controller.find('.update-list-items');
         active_console = controller.find('.update-output');
         active_console.html(controller.messages.updating);
+
         jQuery.get(baseurl + 'check', function(data) {
             if (data.updates.length > 0 || data.installs.length > 0) {
                 var e, ext;
@@ -114,6 +115,10 @@ var BoltExtender = Object.extend(Object, {
                 active_console.html(controller.messages.updated);
             }
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
     },
 
@@ -131,6 +136,10 @@ var BoltExtender = Object.extend(Object, {
                 controller.find('.update-container').hide();
             }, 7000);
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
     },
 
@@ -152,6 +161,10 @@ var BoltExtender = Object.extend(Object, {
             }
             controller.checkInstalled();
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
 
         e.preventDefault();
@@ -164,13 +177,19 @@ var BoltExtender = Object.extend(Object, {
         var target = controller.find('.update-output');
         active_console = target;
         active_console.html(controller.messages.installAll);
+
         jQuery.get(baseurl + 'installAll', function (data) {
             target.html(data);
             delay(function () {
                 controller.find('.update-container').hide();
             }, 7000);
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
+
         e.stopPropagation();
         e.preventDefault();
     },
@@ -181,13 +200,14 @@ var BoltExtender = Object.extend(Object, {
         controller.find('.installed-container').each(function(){
             active_console = controller.find('.installed-container .console');
             var target = jQuery(this).find('.installed-list');
+
             jQuery.get(baseurl + 'installed', function (data) {
                 target.show();
                 var html = '',
                     pack = data.installed.concat(data.pending).concat(data.local);
 
                 target.find('.installed-list-items').html('');
-//                active_console.html(data.length + ' installed extension(s).');
+                active_console.html(pack.length + ' installed extension(s).');
                 controller.find('.installed-container .console').hide();
 
                 html += controller.renderPackage(pack);
@@ -195,20 +215,25 @@ var BoltExtender = Object.extend(Object, {
                 target.find('.installed-list-items').append(html);
 
                 controller.updateLog();
+            })
+            .fail(function(data) {
+                active_console.html(controller.formatErrorLog(data));
+                controller.extensionFailedInstall(data);
             });
         });
     },
     
     renderPackage: function (data) {
+        var html = '';
+        
         if (data.length > 0) {
-            html = '';
             for (var e in data) {
                 var ext = data[e],
                 conf = bolt.data.extend.packages,
                 authors = '',
                 keywords = '',
                 i = 0;
-                
+
                 // Authors array
                 if (ext.authors.length > 0) {
                     var authorsArray = ext.authors;
@@ -279,6 +304,10 @@ var BoltExtender = Object.extend(Object, {
             controller.find('#installModal .loader').hide();
 
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
 
         e.preventDefault();
@@ -348,6 +377,10 @@ var BoltExtender = Object.extend(Object, {
                 controller.themePostInstall(data);
             }
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
     },
 
@@ -381,6 +414,7 @@ var BoltExtender = Object.extend(Object, {
         var trigger = jQuery(e.target);
         var theme = trigger.data('theme');
         var themename  = controller.find('#theme-name').val();
+
         jQuery.get(
             baseurl+'generateTheme',
             {'theme': theme, 'name': themename}
@@ -389,7 +423,12 @@ var BoltExtender = Object.extend(Object, {
             controller.find('.theme-generate-response').html('<p>' + data + '</p>').show();
             controller.find('.theme-generation-container').hide();
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
+
         e.preventDefault();
     },
 
@@ -403,6 +442,7 @@ var BoltExtender = Object.extend(Object, {
             var t = controller.find('.installed-container .console').html(controller.messages.copying);
             t.show();
             active_console = t;
+
             jQuery.get(
                 baseurl + 'generateTheme',
                 {'theme': theme, 'name': themename}
@@ -412,6 +452,10 @@ var BoltExtender = Object.extend(Object, {
                 delay(function () {
                     t.hide();
                 }, 5000);
+            })
+            .fail(function(data) {
+                active_console.html(controller.formatErrorLog(data));
+                controller.extensionFailedInstall(data);
             });
         }
         e.preventDefault();
@@ -426,6 +470,10 @@ var BoltExtender = Object.extend(Object, {
                 message: data
             });
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
 
         e.preventDefault();
@@ -443,6 +491,7 @@ var BoltExtender = Object.extend(Object, {
 
         t.show();
         active_console = t;
+
         jQuery.get(
             jQuery(e.target).attr('href')
         )
@@ -453,6 +502,10 @@ var BoltExtender = Object.extend(Object, {
                 active_console.hide();
             }, 2000);
             controller.updateLog();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
         });
 
         e.preventDefault();

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -263,9 +263,10 @@ var BoltExtender = Object.extend(Object, {
                     '%VERSION%': ext.version,
                     '%AUTHORS%': authors,
                     '%TYPE%': ext.type,
+                    '%AVAILABLE%': conf.avail_button.subst({'%NAME%': ext.name}),
                     '%README%': ext.readme ? conf.readme_button.subst({'%README%': ext.readme}) : '',
                     '%CONFIG%': ext.config ? conf.config_button.subst({'%CONFIG%': ext.config}) : '',
-                    '%THEME%': (ext.type == 'bolt-theme') ? conf.theme_button : '',
+                    '%THEME%': ext.type == 'bolt-theme' ? conf.theme_button : '',
                     '%BASEURL%': baseurl,
                     '%DESCRIPTION%': ext.descrip,
                     '%KEYWORDS%': keywords});
@@ -288,6 +289,15 @@ var BoltExtender = Object.extend(Object, {
         if (packagename) {
             ext = packagename;
         }
+        
+        controller.installInfo(ext);
+
+        e.preventDefault();
+    },
+    
+    installInfo: function (ext) {
+        var controller = this;
+
         active_console = false;
         jQuery.get(baseurl + 'installInfo?package=' + ext, function(data) {
 
@@ -306,7 +316,6 @@ var BoltExtender = Object.extend(Object, {
                     .append(controller.buildVersionTable(stablepacks));
             }
 
-
             controller.find('.install-version-container').show();
             controller.find('#installModal .loader').hide();
 
@@ -316,8 +325,6 @@ var BoltExtender = Object.extend(Object, {
             active_console.html(controller.formatErrorLog(data));
             controller.extensionFailedInstall(data);
         });
-
-        e.preventDefault();
     },
 
     buildVersionTable: function (packages) {
@@ -484,6 +491,22 @@ var BoltExtender = Object.extend(Object, {
 
         e.preventDefault();
     },
+    
+    packageAvailable: function (e) {
+        var controller = this;
+
+        jQuery.get( baseurl + 'installInfo?package=' + jQuery(e.target).data('available') )
+        .done(function(data) {
+            controller.installInfo(jQuery(e.target).data('available'));
+            e.preventDefault();
+        })
+        .fail(function(data) {
+            active_console.html(controller.formatErrorLog(data));
+            controller.extensionFailedInstall(data);
+        });
+
+        e.preventDefault();
+    },
 
     uninstall: function (e) {
         var controller = this,
@@ -599,7 +622,6 @@ var BoltExtender = Object.extend(Object, {
     events: {
         change: function (e, t) {
             var controller = e.data;
-
         },
 
         click: function (e, t) {
@@ -615,9 +637,10 @@ var BoltExtender = Object.extend(Object, {
                 case "prefill-package"   : controller.prefill(e.originalEvent); break;
                 case "install-run"       : controller.installRun(e.originalEvent); break;
                 case "generate-theme"    : controller.generateTheme(e.originalEvent); break;
+                case "package-available" : controller.packageAvailable(e.originalEvent); break;
+                case "package-config"    : controller.packageConfig(e.originalEvent); break;
                 case "package-copy"      : controller.copyTheme(e.originalEvent); break;
                 case "package-readme"    : controller.packageReadme(e.originalEvent); break;
-                case "package-config"    : controller.packageConfig(e.originalEvent); break;
                 case "clear-log"         : controller.clearLog(e.originalEvent); break;
             }
         }

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -102,7 +102,8 @@ var BoltExtender = Object.extend(Object, {
                     // Add an install button
                     target.append(bolt.data.extend.packages.install_new.subst({
                         '%PACKAGE%': ext.name,
-                        '%VERSION%': ext.version}));
+                        '%VERSION%': ext.version,
+                        '%PRETTYVERSION%': ext.prettyversion}));
                 }
                 for (e in data.updates) {
                     ext = data.updates[e];
@@ -110,7 +111,8 @@ var BoltExtender = Object.extend(Object, {
                     // Add an update button
                     target.append(bolt.data.extend.packages.install_update.subst({
                         '%PACKAGE%': ext.name,
-                        '%VERSION%': ext.version}));
+                        '%VERSION%': ext.version,
+                        '%PRETTYVERSION%': ext.prettyversion}));
                 }
                 active_console.hide();
                 controller.find('.update-list').show();

--- a/app/view/lib/bolt/extend.js
+++ b/app/view/lib/bolt/extend.js
@@ -209,7 +209,7 @@ var BoltExtender = Object.extend(Object, {
 
             jQuery.get(baseurl + 'installed', function (data) {
                 if (typeof data !== 'object') {
-                    active_console.html('Malformed JSON response. Ensure no debugging or other code is being added to the response');
+                    active_console.html(controller.messages.badJson);
                     return;
                 }
 

--- a/app/view/twig/extend/_package.twig
+++ b/app/view/twig/extend/_package.twig
@@ -14,6 +14,9 @@
             <div class="actions pull-right">
                 <div class="btn-group">
 
+                    {# Available #}
+                    %AVAILABLE%
+
                     {# Readme #}
                     %README%
 
@@ -66,7 +69,12 @@
 
 {% set package_theme_button %}
     <a data-request="package-copy" data-theme="%NAME%" class="btn btn-sm btn-tertiary" href="#">
-    <i class="fa fa-copy fa-fw"></i> {{ __('Copy to theme folder') }}</a>&nbsp;
+        <i class="fa fa-copy fa-fw"></i> {{ __('Copy to theme folder') }}</a>&nbsp;
+{% endset %}
+
+{% set package_available_button %}
+    <a data-request="package-available" data-available="%NAME%" data-toggle="modal" data-target="#installModal" class='btn btn-sm btn-primary' href="#">
+        <i class='fa fa-list fa-fw'></i> {{ __('Versions') }}</a>&nbsp;
 {% endset %}
 
 {% set package_versions %}
@@ -109,6 +117,7 @@
                             'readme_button':  package_readme_button|trim|preg_replace('/>\\s+</', '><'),
                             'config_button':  package_config_button|trim|preg_replace('/>\\s+</', '><'),
                             'theme_button':   package_theme_button|trim|preg_replace('/>\\s+</', '><'),
+                            'avail_button':   package_available_button|trim|preg_replace('/>\\s+</', '><'),
                             'install_new':    package_install_new|trim|preg_replace('/>\\s+</', '><'),
                             'install_update': package_install_update|trim|preg_replace('/>\\s+</', '><'),
                             'error':          package_error|trim|preg_replace('/>\\s+</', '><')

--- a/app/view/twig/extend/_package.twig
+++ b/app/view/twig/extend/_package.twig
@@ -92,6 +92,7 @@
 {% set package_install_new %}
     <tr data-package="%PACKAGE%">
         <td class="ext-list"><strong class="title">%PACKAGE%</strong></td>
+        <td class="ext-list">%PRETTYVERSION%</td>
         <td><a data-request="update-package" class="btn btn-sm btn-warning" data-package="%PACKAGE%" data-version="%VERSION%">{{ __('Install Package') }}</a></td>
     </tr>
 {% endset %}
@@ -99,6 +100,7 @@
 {% set package_install_update %}
     <tr data-package="%PACKAGE%">
         <td class="ext-list"><strong class="title">%PACKAGE%</strong></td>
+        <td class="ext-list">%PRETTYVERSION%</td>
         <td><a data-request="update-package" class="btn btn-sm btn-tertiary" data-package="%PACKAGE%" data-version="%VERSION%">{{ __('Update Package') }}</a></td>
     </tr>
 {% endset %}

--- a/app/view/twig/extend/_package.twig
+++ b/app/view/twig/extend/_package.twig
@@ -12,10 +12,10 @@
         <div class="panel-body">
             {# Action buttons #}
             <div class="actions pull-right">
-                <div class="btn-group">
+                {# Available #}
+                %AVAILABLE%
 
-                    {# Available #}
-                    %AVAILABLE%
+                <div class="btn-group">
 
                     {# Readme #}
                     %README%

--- a/app/view/twig/extend/_package.twig
+++ b/app/view/twig/extend/_package.twig
@@ -92,14 +92,14 @@
 {% set package_install_new %}
     <tr data-package="%PACKAGE%">
         <td class="ext-list"><strong class="title">%PACKAGE%</strong></td>
-        <td><a data-request="update-package" class="btn btn-sm btn-warning" data-package="%PACKAGE%">{{ __('Install New Package') }}</a></td>
+        <td><a data-request="update-package" class="btn btn-sm btn-warning" data-package="%PACKAGE%" data-version="%VERSION%">{{ __('Install Package') }}</a></td>
     </tr>
 {% endset %}
 
 {% set package_install_update %}
     <tr data-package="%PACKAGE%">
         <td class="ext-list"><strong class="title">%PACKAGE%</strong></td>
-        <td><a data-request="update-package" class="btn btn-sm btn-tertiary" data-package="%PACKAGE%">{{ __('Install Package Update') }}</a></td>
+        <td><a data-request="update-package" class="btn btn-sm btn-tertiary" data-package="%PACKAGE%" data-version="%VERSION%">{{ __('Update Package') }}</a></td>
     </tr>
 {% endset %}
 

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -174,6 +174,7 @@
 
         jQuery(document).ready(function($) {
             var boltExt = new BoltExtender();
+            boltExt.setMessage('badJson', '{{ __('Malformed JSON response. Ensure no debugging or other code is being added to the response') }}' );
             boltExt.setMessage('extError', '{{ __('Bolt Extension could not be found. Please check at %site% to ensure correct name.')|replace({'%site%': site}) }}' );
             boltExt.setMessage('removing', '{{ __('Preparing to remove package …') }}');
             boltExt.setMessage('updating', '{{ __('Searching for available updates …') }}');

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -186,7 +186,7 @@
             boltExt.setMessage('copying', '{{ __('Copying theme assets …') }}');
             boltExt.setMessage('runningUpdate', '{{ __('Running update …') }}');
             boltExt.setMessage('confirmRemove', '{{ __('Please confirm that you want to remove this extension?') }}');
-            boltExt.setMessage('nothtingInstalled', '{{ __('No Bolt Extensions installed.) }}');
+            boltExt.setMessage('nothtingInstalled', '{{ __('No Bolt Extensions installed.') }}');
             boltExt.setPath('extensionsconfigpath', '{{ paths.extensionsconfigpath }}');
             boltExt.setPath('extensionspath', '{{ paths.extensionspath }}');
         });

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -52,6 +52,7 @@
                         <thead>
                             <tr>
                                 <th>{{ __('Extension') }}</th>
+                                <th>{{ __('Version') }}</th>
                                 <th>{{ __('Actions') }}</th>
                             </tr>
                         </thead>

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -175,19 +175,19 @@
         jQuery(document).ready(function($) {
             var boltExt = new BoltExtender();
             boltExt.setMessage('badJson', '{{ __('Malformed JSON response. Ensure no debugging or other code is being added to the response') }}' );
+            boltExt.setMessage('confirmRemove', '{{ __('Please confirm that you want to remove this extension?') }}');
+            boltExt.setMessage('copying', '{{ __('Copying theme assets …') }}');
             boltExt.setMessage('extError', '{{ __('Bolt Extension could not be found. Please check at %site% to ensure correct name.')|replace({'%site%': site}) }}' );
-            boltExt.setMessage('removing', '{{ __('Preparing to remove package …') }}');
-            boltExt.setMessage('updating', '{{ __('Searching for available updates …') }}');
-            boltExt.setMessage('updated', '{{ __('Everything is up to date!') }}');
-            boltExt.setMessage('installing', '{{ __('Preparing to install package …') }}');
             boltExt.setMessage('installAll', '{{ __('Running install of all packages …') }}');
+            boltExt.setMessage('installing', '{{ __('Preparing to install package …') }}');
             boltExt.setMessage('noStable', '{{ __('No Stable Versions Available') }}');
             boltExt.setMessage('noTest', '{{ __('No Test Versions Available') }}');
-            boltExt.setMessage('overwrite', '{{ __('This will overwrite any existing files! Are you sure?') }}');
-            boltExt.setMessage('copying', '{{ __('Copying theme assets …') }}');
-            boltExt.setMessage('runningUpdate', '{{ __('Running update …') }}');
-            boltExt.setMessage('confirmRemove', '{{ __('Please confirm that you want to remove this extension?') }}');
             boltExt.setMessage('nothtingInstalled', '{{ __('No Bolt Extensions installed.') }}');
+            boltExt.setMessage('overwrite', '{{ __('This will overwrite any existing files! Are you sure?') }}');
+            boltExt.setMessage('removing', '{{ __('Preparing to remove package …') }}');
+            boltExt.setMessage('runningUpdate', '{{ __('Running update …') }}');
+            boltExt.setMessage('updating', '{{ __('Searching for available updates …') }}');
+            boltExt.setMessage('updated', '{{ __('Everything is up to date!') }}');
             boltExt.setPath('extensionsconfigpath', '{{ paths.extensionsconfigpath }}');
             boltExt.setPath('extensionspath', '{{ paths.extensionspath }}');
         });

--- a/src/Composer/Action/BoltExtendJson.php
+++ b/src/Composer/Action/BoltExtendJson.php
@@ -10,7 +10,7 @@ use Silex\Application;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class InitJson
+class BoltExtendJson
 {
     /**
      * @var array

--- a/src/Composer/Action/BoltExtendJson.php
+++ b/src/Composer/Action/BoltExtendJson.php
@@ -50,8 +50,11 @@ class BoltExtendJson
 
     /**
      * Set up Composer JSON file
+     *
+     * @param  Silex\Application $app
+     * @return string
      */
-    public function setupJson(Silex\Application $app)
+    public function updateJson(Silex\Application $app)
     {
         if (!is_file($this->options['composerjson'])) {
             $this->initJson($this->options['composerjson']);

--- a/src/Composer/Action/BoltExtendJson.php
+++ b/src/Composer/Action/BoltExtendJson.php
@@ -10,7 +10,7 @@ use Silex\Application;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class BoltExtendJson
+final class BoltExtendJson
 {
     /**
      * @var array

--- a/src/Composer/Action/BoltExtendJson.php
+++ b/src/Composer/Action/BoltExtendJson.php
@@ -51,10 +51,10 @@ final class BoltExtendJson
     /**
      * Set up Composer JSON file
      *
-     * @param  Silex\Application $app
+     * @param  \Silex\Application $app
      * @return string
      */
-    public function updateJson(Silex\Application $app)
+    public function updateJson(\Silex\Application $app)
     {
         if (!is_file($this->options['composerjson'])) {
             $this->initJson($this->options['composerjson']);

--- a/src/Composer/Action/CheckPackage.php
+++ b/src/Composer/Action/CheckPackage.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Bolt\Composer\Action;
+
+use Composer\Factory;
+use Composer\Json\JsonFile;
+use Silex\Application;
+
+/**
+ * Checks for installable, or upgradeable packages
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class CheckPackage
+{
+    /**
+     * @var Silex\Application
+     */
+    private $app;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var Composer\IO\IOInterface
+     */
+    private $io;
+
+    /**
+     * @var Composer\Composer
+     */
+    private $composer;
+
+    /**
+     * @param $options  array
+     */
+    public function __construct(Application $app, \Composer\IO\IOInterface $io, \Composer\Composer $composer, array $options)
+    {
+        $this->app      = $app;
+        $this->options  = $options;
+        $this->io       = $io;
+        $this->composer = $composer;
+    }
+
+    /**
+     *
+     * @return array
+     */
+    public function execute()
+    {
+        $packages = array('update' => array(), 'install' => array());
+
+        // Get known installed packages
+        $rootpack = $this->app['extend.manager']->showPackage('installed');
+
+        // Get the packages that a set as "required" in the JSON file
+        $file = new JsonFile($this->options['composerjson']);
+        $json = $file->read();
+        $jsonpack = $json['require'];
+
+        if (!empty($jsonpack)) {
+            // Find the packages that are NOT part of the root install yet and mark
+            // them as pending installs
+            foreach ($jsonpack as $package => $packageInfo) {
+                if (!array_key_exists($package, $rootpack)) {
+                    $remote = $this->app['extend.manager']->factory->findBestVersionForPackage($package);
+
+                    // If a 'best' version is found, and there is a version mismatch then
+                    // propose as an update. Making the assumption that Composer isn't
+                    // going to offer us an older version.
+                    if (is_array($remote)) {
+                        $packages['install'][$package] = $remote;
+                    } else {
+                        $packages['install'][$package] = array('error' => 'No valid package found.');
+                    }
+                }
+            }
+        }
+
+        foreach ($rootpack as $package => $data) {
+            $remote = $this->app['extend.manager']->factory->findBestVersionForPackage($package);
+
+            // If a 'best' version is found, and there is a version mismatch then
+            // propose as an update. Making the assumption that Composer isn't
+            // going to offer us an older version.
+            if (is_array($remote) && ($remote['package']->getVersion() != $data['package']->getVersion())) {
+                $packages['update'][$package] = $remote;
+            }
+        }
+
+        return array('updates' => $packages['update'], 'installs' => $packages['installs']);
+    }
+}

--- a/src/Composer/Action/CheckPackage.php
+++ b/src/Composer/Action/CheckPackage.php
@@ -72,9 +72,7 @@ final class CheckPackage
                     // propose as an update. Making the assumption that Composer isn't
                     // going to offer us an older version.
                     if (is_array($remote)) {
-                        $packages['installs'][] = array('name' => $package, 'version' => $remote['version']);
-                    } else {
-                        $packages['installs'][] = array('name' => $package, 'version' => null);
+                        $packages['installs'][] = $remote;
                     }
                 }
             }
@@ -88,9 +86,7 @@ final class CheckPackage
             // propose as an update. Making the assumption that Composer isn't
             // going to offer us an older version.
             if (is_array($remote) && ($remote['package']->getVersion() != $data['package']->getVersion())) {
-                $packages['updates'][] = array('name' => $package, 'version' => $remote['version']);
-            } else {
-                $packages['updates'][] = array('name' => $package, 'version' => null);
+                $packages['updates'][] = $remote;
             }
         }
 

--- a/src/Composer/Action/DumpAutoload.php
+++ b/src/Composer/Action/DumpAutoload.php
@@ -7,7 +7,7 @@ namespace Bolt\Composer\Action;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class DumpAutoload
+final class DumpAutoload
 {
     /**
      * @var array

--- a/src/Composer/Action/DumpAutoload.php
+++ b/src/Composer/Action/DumpAutoload.php
@@ -2,6 +2,11 @@
 
 namespace Bolt\Composer\Action;
 
+/**
+ * Composer autoloader creation class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class DumpAutoload
 {
     /**

--- a/src/Composer/Action/DumpAutoload.php
+++ b/src/Composer/Action/DumpAutoload.php
@@ -24,7 +24,7 @@ class DumpAutoload
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct($io, $composer, $options)
+    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/DumpAutoload.php
+++ b/src/Composer/Action/DumpAutoload.php
@@ -15,7 +15,7 @@ final class DumpAutoload
     private $options;
 
     /**
-     * @var Composer\IO\BufferIO
+     * @var Composer\IO\IOInterface
      */
     private $io;
 
@@ -25,11 +25,11 @@ final class DumpAutoload
     private $composer;
 
     /**
-     * @param $io       Composer\IO\BufferIO
+     * @param $io       Composer\IO\IOInterface
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    public function __construct(\Composer\IO\IOInterface $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/InitJson.php
+++ b/src/Composer/Action/InitJson.php
@@ -4,6 +4,11 @@ namespace Bolt\Composer\Action;
 
 use Composer\Json\JsonFile;
 
+/**
+ * Initialise Composer JSON file class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class InitJson
 {
     /**

--- a/src/Composer/Action/InitJson.php
+++ b/src/Composer/Action/InitJson.php
@@ -26,7 +26,7 @@ class InitJson
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct($io, $composer, $options)
+    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/InitJson.php
+++ b/src/Composer/Action/InitJson.php
@@ -17,16 +17,6 @@ class InitJson
     private $options;
 
     /**
-     * @var Composer\IO\BufferIO
-     */
-    private $io;
-
-    /**
-     * @var Composer\Composer
-     */
-    private $composer;
-
-    /**
      * @param $options  array
      */
     public function __construct(array $options)

--- a/src/Composer/Action/InitJson.php
+++ b/src/Composer/Action/InitJson.php
@@ -3,6 +3,7 @@
 namespace Bolt\Composer\Action;
 
 use Composer\Json\JsonFile;
+use Silex\Application;
 
 /**
  * Initialise Composer JSON file class
@@ -31,7 +32,70 @@ class InitJson
      */
     public function execute($file, array $data = array())
     {
-        $file = new JsonFile($file);
-        $file->write($data);
+        $jsonFile = new JsonFile($file);
+        $jsonFile->write($data);
+    }
+
+    /**
+     * Set up Composer JSON file
+     */
+    public function setupJson(Silex\Application $app)
+    {
+        if (!is_file($this->options['composerjson'])) {
+            $this->initJson($this->options['composerjson']);
+        }
+
+        $jsonFile = new JsonFile($this->options['composerjson']);
+        if ($jsonFile->exists()) {
+            $json = $jsonorig = $jsonFile->read();
+        } else {
+            // Error
+            $this->messages[] = Trans::__(
+                "The Bolt extensions file '%composerjson%' isn't readable.",
+                array('%composerjson%' => $this->options['composerjson'])
+            );
+
+            $app['extend.writeable'] = false;
+            $app['extend.online'] = false;
+
+            return;
+        }
+
+        $pathToWeb = $app['resources']->findRelativePath($app['resources']->getPath('extensions'), $app['resources']->getPath('web'));
+
+        // Enforce standard settings
+        $json['repositories']['packagist'] = false;
+        $json['repositories']['bolt'] = array(
+            'type' => 'composer',
+            'url' => $app['extend.site'] . 'satis/'
+        );
+        $json['minimum-stability'] = $app['config']->get('general/extensions/stability', 'stable');
+        $json['prefer-stable'] = true;
+        $json['config'] = array(
+            'discard-changes' => true,
+            'preferred-install' => 'dist'
+        );
+        $json['provide']['bolt/bolt'] = $app['bolt_version'];
+        $json['scripts'] = array(
+            'post-package-install' => "Bolt\\Composer\\ExtensionInstaller::handle",
+            'post-package-update' => "Bolt\\Composer\\ExtensionInstaller::handle"
+        );
+        $json['extra'] = array('bolt-web-path' => $pathToWeb);
+        $json['autoload'] = array('files' => array('installer.php'));
+
+        // Write out the file, but only if it's actually changed, and if it's writable.
+        if ($json != $jsonorig) {
+            try {
+                umask(0000);
+                $jsonFile->write($json);
+            } catch (Exception $e) {
+                $this->messages[] = Trans::__(
+                    'The Bolt extensions Repo at %repository% is currently unavailable. Check your connection and try again shortly.',
+                    array('%repository%' => $app['extend.site'])
+                );
+            }
+        }
+
+        return $json;
     }
 }

--- a/src/Composer/Action/InitJson.php
+++ b/src/Composer/Action/InitJson.php
@@ -26,11 +26,23 @@ class InitJson
     }
 
     /**
+     * Convenience function to generalise the library
      *
      * @param string $file
      * @param array  $data
      */
     public function execute($file, array $data = array())
+    {
+        $this->initJson($file, $data);
+    }
+
+    /**
+     * Initialise a JSON file at given location with optional data input
+     *
+     * @param string $file
+     * @param array  $data
+     */
+    public function initJson($file, array $data = array())
     {
         $jsonFile = new JsonFile($file);
         $jsonFile->write($data);

--- a/src/Composer/Action/InitJson.php
+++ b/src/Composer/Action/InitJson.php
@@ -27,15 +27,11 @@ class InitJson
     private $composer;
 
     /**
-     * @param $io       Composer\IO\BufferIO
-     * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    public function __construct(array $options)
     {
         $this->options = $options;
-        $this->io = $io;
-        $this->composer = $composer;
     }
 
     /**

--- a/src/Composer/Action/InstallPackage.php
+++ b/src/Composer/Action/InstallPackage.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Bolt\Composer\Action;
+
+use Composer\Installer;
+
+class InstallPackage
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var Composer\IO\BufferIO
+     */
+    private $io;
+
+    /**
+     * @var Composer\Composer
+     */
+    private $composer;
+
+    /**
+     * @param $io       Composer\IO\BufferIO
+     * @param $composer Composer\Composer
+     * @param $options  array
+     */
+    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    {
+        $this->options = $options;
+        $this->io = $io;
+        $this->composer = $composer;
+    }
+
+    /**
+     * Install packages
+     *
+     * @return integer 0 on success or a positive error code on failure
+     */
+    public function execute()
+    {
+        $install = Installer::create($this->io, $this->composer);
+        $config = $this->composer->getConfig();
+        $optimize = $config->get('optimize-autoloader');
+
+        $preferSource = false;
+        $preferDist = true;
+
+        switch ($config->get('preferred-install')) {
+            case 'source':
+                $preferSource = true;
+                break;
+            case 'dist':
+                $preferDist = true;
+                break;
+            case 'auto':
+            default:
+                // noop
+                break;
+        }
+
+        if ($config->get('prefer-source') || $config->get('prefer-dist')) {
+            $preferSource = $config->get('prefer-source');
+            $preferDist = $config->get('prefer-dist');
+        }
+
+        /* @todo: Enable setDumpAutoloader() for changes in Composer 1.0.0-alpha10 */
+        $install
+            ->setDryRun($this->options['dry-run'])
+            ->setVerbose($this->options['verbose'])
+            ->setPreferSource($preferSource)
+            ->setPreferDist($preferDist)
+            ->setDevMode(!$this->options['no-dev'])
+//            ->setDumpAutoloader(!$this->options['no-autoloader'])
+            ->setRunScripts(!$this->options['no-scripts'])
+            ->setOptimizeAutoloader($optimize)
+            ->setIgnorePlatformRequirements($this->options['ignore-platform-reqs'])
+            ->setUpdate(true)
+        ;
+
+        return $install->run();
+    }
+}

--- a/src/Composer/Action/InstallPackage.php
+++ b/src/Composer/Action/InstallPackage.php
@@ -4,6 +4,11 @@ namespace Bolt\Composer\Action;
 
 use Composer\Installer;
 
+/**
+ * Composer package install class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class InstallPackage
 {
     /**

--- a/src/Composer/Action/InstallPackage.php
+++ b/src/Composer/Action/InstallPackage.php
@@ -17,7 +17,7 @@ final class InstallPackage
     private $options;
 
     /**
-     * @var Composer\IO\BufferIO
+     * @var Composer\IO\IOInterface
      */
     private $io;
 
@@ -27,11 +27,11 @@ final class InstallPackage
     private $composer;
 
     /**
-     * @param $io       Composer\IO\BufferIO
+     * @param $io       Composer\IO\IOInterface
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    public function __construct(\Composer\IO\IOInterface $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/InstallPackage.php
+++ b/src/Composer/Action/InstallPackage.php
@@ -9,7 +9,7 @@ use Composer\Installer;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class InstallPackage
+final class InstallPackage
 {
     /**
      * @var array

--- a/src/Composer/Action/RemovePackage.php
+++ b/src/Composer/Action/RemovePackage.php
@@ -36,7 +36,7 @@ class RemovePackage
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(Application $app, $io, $composer, $options)
+    public function __construct(Application $app, \Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
     {
         $this->app = $app;
         $this->options = $options;

--- a/src/Composer/Action/RemovePackage.php
+++ b/src/Composer/Action/RemovePackage.php
@@ -3,7 +3,6 @@
 namespace Bolt\Composer\Action;
 
 use Composer\Config\JsonConfigSource;
-use Composer\Factory;
 use Composer\Installer;
 use Composer\Json\JsonFile;
 use Silex\Application;

--- a/src/Composer/Action/RemovePackage.php
+++ b/src/Composer/Action/RemovePackage.php
@@ -8,6 +8,11 @@ use Composer\Installer;
 use Composer\Json\JsonFile;
 use Silex\Application;
 
+/**
+ * Composer remove package class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class RemovePackage
 {
     /**

--- a/src/Composer/Action/RemovePackage.php
+++ b/src/Composer/Action/RemovePackage.php
@@ -25,7 +25,7 @@ final class RemovePackage
     private $options;
 
     /**
-     * @var Composer\IO\BufferIO
+     * @var Composer\IO\IOInterface
      */
     private $io;
 
@@ -36,11 +36,11 @@ final class RemovePackage
 
     /**
      * @param $app      Silex\Application
-     * @param $io       Composer\IO\BufferIO
+     * @param $io       Composer\IO\IOInterface
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(Application $app, \Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    public function __construct(Application $app, \Composer\IO\IOInterface $io, \Composer\Composer $composer, array $options)
     {
         $this->app = $app;
         $this->options = $options;

--- a/src/Composer/Action/RemovePackage.php
+++ b/src/Composer/Action/RemovePackage.php
@@ -12,7 +12,7 @@ use Silex\Application;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class RemovePackage
+final class RemovePackage
 {
     /**
      * @var Silex\Application

--- a/src/Composer/Action/RequirePackage.php
+++ b/src/Composer/Action/RequirePackage.php
@@ -95,7 +95,7 @@ class RequirePackage
         $packages = $this->formatRequirements($packages);
         $sortPackages = $this->options['sortpackages'];
 
-        // validate requirements format
+        // Validate requirements format
         $versionParser = new VersionParser();
         foreach ($packages as $constraint) {
             $versionParser->parseConstraints($constraint);
@@ -149,6 +149,11 @@ class RequirePackage
         return $status;
     }
 
+    /**
+     *
+     * @param  array $packages
+     * @return array
+     */
     protected function formatRequirements(array $packages)
     {
         $requires = array();
@@ -160,6 +165,12 @@ class RequirePackage
         return $requires;
     }
 
+    /**
+     * Parses a name/version pairs and returns an array of pairs
+     *
+     * @param  array   $packages a set of package/version pairs separated by ":", "=" or " "
+     * @return array[] array of arrays containing a name and (if provided) a version
+     */
     protected function normalizeRequirements(array $packages)
     {
         $parser = new VersionParser();
@@ -167,6 +178,17 @@ class RequirePackage
         return $parser->parseNameVersionPairs($packages);
     }
 
+    /**
+     * Cleanly update a Composer JSON file
+     *
+     * @param  \Composer\Json\JsonFile $json
+     * @param  array                   $base
+     * @param  array                   $new
+     * @param  string                  $requireKey
+     * @param  string                  $removeKey
+     * @param  boolean                 $sortPackages
+     * @return boolean
+     */
     private function updateFileCleanly($json, array $base, array $new, $requireKey, $removeKey, $sortPackages)
     {
         $contents = file_get_contents($json->getPath());

--- a/src/Composer/Action/RequirePackage.php
+++ b/src/Composer/Action/RequirePackage.php
@@ -39,7 +39,7 @@ class RequirePackage
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(Application $app, $io, $composer, $options)
+    public function __construct(Application $app, \Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
     {
         $this->app = $app;
         $this->options = $options;

--- a/src/Composer/Action/RequirePackage.php
+++ b/src/Composer/Action/RequirePackage.php
@@ -2,7 +2,6 @@
 
 namespace Bolt\Composer\Action;
 
-use Composer\Factory;
 use Composer\Installer;
 use Composer\Json\JsonFile;
 use Composer\Json\JsonManipulator;

--- a/src/Composer/Action/RequirePackage.php
+++ b/src/Composer/Action/RequirePackage.php
@@ -28,7 +28,7 @@ final class RequirePackage
     private $options;
 
     /**
-     * @var Composer\IO\BufferIO
+     * @var Composer\IO\IOInterface
      */
     private $io;
 
@@ -39,11 +39,11 @@ final class RequirePackage
 
     /**
      * @param $app      Silex\Application
-     * @param $io       Composer\IO\BufferIO
+     * @param $io       Composer\IO\IOInterface
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(Application $app, \Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    public function __construct(Application $app, \Composer\IO\IOInterface $io, \Composer\Composer $composer, array $options)
     {
         $this->app = $app;
         $this->options = $options;

--- a/src/Composer/Action/RequirePackage.php
+++ b/src/Composer/Action/RequirePackage.php
@@ -15,7 +15,7 @@ use Silex\Application;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class RequirePackage
+final class RequirePackage
 {
     /**
      * @var Silex\Application

--- a/src/Composer/Action/RequirePackage.php
+++ b/src/Composer/Action/RequirePackage.php
@@ -11,6 +11,11 @@ use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
 use Silex\Application;
 
+/**
+ * Composer require package class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class RequirePackage
 {
     /**

--- a/src/Composer/Action/SearchPackage.php
+++ b/src/Composer/Action/SearchPackage.php
@@ -12,7 +12,7 @@ use Composer\Repository\RepositoryInterface;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class SearchPackage
+final class SearchPackage
 {
     /**
      * @var array

--- a/src/Composer/Action/SearchPackage.php
+++ b/src/Composer/Action/SearchPackage.php
@@ -29,7 +29,7 @@ class SearchPackage
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct($io, $composer, $options)
+    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/SearchPackage.php
+++ b/src/Composer/Action/SearchPackage.php
@@ -7,6 +7,11 @@ use Composer\Repository\CompositeRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryInterface;
 
+/**
+ * Composer search package class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class SearchPackage
 {
     /**

--- a/src/Composer/Action/SearchPackage.php
+++ b/src/Composer/Action/SearchPackage.php
@@ -20,7 +20,7 @@ final class SearchPackage
     private $options;
 
     /**
-     * @var Composer\IO\BufferIO
+     * @var Composer\IO\IOInterface
      */
     private $io;
 
@@ -30,11 +30,11 @@ final class SearchPackage
     private $composer;
 
     /**
-     * @param $io       Composer\IO\BufferIO
+     * @param $io       Composer\IO\IOInterface
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    public function __construct(\Composer\IO\IOInterface $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/ShowPackage.php
+++ b/src/Composer/Action/ShowPackage.php
@@ -13,6 +13,11 @@ use Composer\Repository\ComposerRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryInterface;
 
+/**
+ * Composer show package class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class ShowPackage
 {
     /**

--- a/src/Composer/Action/ShowPackage.php
+++ b/src/Composer/Action/ShowPackage.php
@@ -35,7 +35,7 @@ class ShowPackage
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct($io, $composer, $options)
+    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/ShowPackage.php
+++ b/src/Composer/Action/ShowPackage.php
@@ -48,10 +48,10 @@ final class ShowPackage
     }
 
     /**
-     * @param string $target  Repository target, either: 'self', 'platform', 'installed' or 'available'
-     * @param string $package Package name to show
-     * @param string $version Package version to show
-     * @return array Array of Composer packages
+     * @param  string $target  Repository target, either: 'self', 'platform', 'installed' or 'available'
+     * @param  string $package Package name to show
+     * @param  string $version Package version to show
+     * @return array  Array of Composer packages
      */
     public function execute($type, $package = '', $version = '')
     {

--- a/src/Composer/Action/ShowPackage.php
+++ b/src/Composer/Action/ShowPackage.php
@@ -179,9 +179,12 @@ final class ShowPackage
             $matchedPackage = $pool->literalToPackage($prefered[0]);
         }
 
-        return array($matchedPackage->getName() => array(
-            'package'  => $matchedPackage,
-            'versions' => $versions
-        ));
+        // If we have package result, return them
+        if ($matchedPackage) {
+            return array($matchedPackage->getName() => array(
+                'package'  => $matchedPackage,
+                'versions' => $versions
+            ));
+        }
     }
 }

--- a/src/Composer/Action/ShowPackage.php
+++ b/src/Composer/Action/ShowPackage.php
@@ -18,7 +18,7 @@ use Composer\Repository\RepositoryInterface;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ShowPackage
+final class ShowPackage
 {
     /**
      * @var array

--- a/src/Composer/Action/ShowPackage.php
+++ b/src/Composer/Action/ShowPackage.php
@@ -51,6 +51,7 @@ class ShowPackage
      * @param string $target  Repository target, either: 'self', 'platform', 'installed' or 'available'
      * @param string $package Package name to show
      * @param string $version Package version to show
+     * @return array Array of Composer packages
      */
     public function execute($type, $package = '', $version = '')
     {

--- a/src/Composer/Action/ShowPackage.php
+++ b/src/Composer/Action/ShowPackage.php
@@ -26,7 +26,7 @@ final class ShowPackage
     private $options;
 
     /**
-     * @var Composer\IO\BufferIO
+     * @var Composer\IO\IOInterface
      */
     private $io;
 
@@ -36,11 +36,11 @@ final class ShowPackage
     private $composer;
 
     /**
-     * @param $io       Composer\IO\BufferIO
+     * @param $io       Composer\IO\IOInterface
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    public function __construct(\Composer\IO\IOInterface $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -77,20 +77,20 @@ class UpdatePackage
          * for changes in Composer 1.0.0-alpha10
          */
         $install
-            ->setDryRun($this->options['dryrun'])
-            ->setVerbose($this->options['verbose'])
+            ->setDryRun($options['dryrun'])
+            ->setVerbose($options['verbose'])
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
-            ->setDevMode(!$this->options['nodev'])
-//            ->setDumpAutoloader(!$this->options['noautoloader'])
-            ->setRunScripts(!$this->options['noscripts'])
+            ->setDevMode(!$options['nodev'])
+//            ->setDumpAutoloader(!$options['noautoloader'])
+            ->setRunScripts(!$options['noscripts'])
             ->setOptimizeAutoloader($optimize)
             ->setUpdate(true)
             ->setUpdateWhitelist($packages)
-            ->setWhitelistDependencies($this->options['withdependencies'])
-            ->setIgnorePlatformRequirements($this->options['ignoreplatformreqs'])
-//            ->setPreferStable($this->options['preferstable'])
-//            ->setPreferLowest($this->options['preferlowest'])
+            ->setWhitelistDependencies($options['withdependencies'])
+            ->setIgnorePlatformRequirements($options['ignoreplatformreqs'])
+//            ->setPreferStable($options['preferstable'])
+//            ->setPreferLowest($options['preferlowest'])
             ->disablePlugins();
         ;
 

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -26,7 +26,7 @@ class UpdatePackage
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct($io, $composer, $options)
+    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Composer\Action;
 
+use Bolt\Helpers\Arr;
 use Composer\Installer;
 
 /**
@@ -42,10 +43,16 @@ class UpdatePackage
      * Update packages
      *
      * @param  $packages array Indexed array of package names to remove
+     * @param  $options  array [Optional] changed option set
      * @return integer 0 on success or a positive error code on failure
      */
-    public function execute(array $packages = array())
+    public function execute(array $packages = array(), array $options = null)
     {
+        // Handle passed in options
+        if (!is_null($options)) {
+            $options = Arr::mergeRecursiveDistinct($this->options, $options);
+        }
+
         $install = Installer::create($this->io, $this->composer);
         $config = $this->composer->getConfig();
         $optimize = $config->get('optimize-autoloader');

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -60,21 +60,25 @@ class UpdatePackage
                 break;
         }
 
+        /*
+         * @todo: Enable setDumpAutoloader(), setPreferStable() and setPreferLowest()
+         * for changes in Composer 1.0.0-alpha10
+         */
         $install
             ->setDryRun($this->options['dryrun'])
             ->setVerbose($this->options['verbose'])
             ->setPreferSource($preferSource)
             ->setPreferDist($preferDist)
             ->setDevMode(!$this->options['nodev'])
-            ->setDumpAutoloader(!$this->options['noautoloader'])
+//            ->setDumpAutoloader(!$this->options['noautoloader'])
             ->setRunScripts(!$this->options['noscripts'])
             ->setOptimizeAutoloader($optimize)
             ->setUpdate(true)
             ->setUpdateWhitelist($packages)
             ->setWhitelistDependencies($this->options['withdependencies'])
             ->setIgnorePlatformRequirements($this->options['ignoreplatformreqs'])
-            ->setPreferStable($this->options['preferstable'])
-            ->setPreferLowest($this->options['preferlowest'])
+//            ->setPreferStable($this->options['preferstable'])
+//            ->setPreferLowest($this->options['preferlowest'])
             ->disablePlugins();
         ;
 

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -10,7 +10,7 @@ use Composer\Installer;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class UpdatePackage
+final class UpdatePackage
 {
     /**
      * @var array

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -45,8 +45,8 @@ class UpdatePackage
         $config = $this->composer->getConfig();
         $optimize = $config->get('optimize-autoloader');
 
-        $preferSource = true; // Forces installation from package sources when possible, including VCS information.
-        $preferDist = false;
+        $preferSource = false; // Forces installation from package sources when possible, including VCS information.
+        $preferDist = true;
 
         switch ($config->get('preferred-install')) {
             case 'source':

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -18,7 +18,7 @@ final class UpdatePackage
     private $options;
 
     /**
-     * @var Composer\IO\BufferIO
+     * @var Composer\IO\IOInterface
      */
     private $io;
 
@@ -28,11 +28,11 @@ final class UpdatePackage
     private $composer;
 
     /**
-     * @param $io       Composer\IO\BufferIO
+     * @param $io       Composer\IO\IOInterface
      * @param $composer Composer\Composer
      * @param $options  array
      */
-    public function __construct(\Composer\IO\BufferIO $io, \Composer\Composer $composer, array $options)
+    public function __construct(\Composer\IO\IOInterface $io, \Composer\Composer $composer, array $options)
     {
         $this->options = $options;
         $this->io = $io;

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -57,8 +57,9 @@ class UpdatePackage
         $config = $this->composer->getConfig();
         $optimize = $config->get('optimize-autoloader');
 
+        // Set preferred install method
         $preferSource = false; // Forces installation from package sources when possible, including VCS information.
-        $preferDist = true;
+        $preferDist = false;
 
         switch ($config->get('preferred-install')) {
             case 'source':

--- a/src/Composer/Action/UpdatePackage.php
+++ b/src/Composer/Action/UpdatePackage.php
@@ -4,6 +4,11 @@ namespace Bolt\Composer\Action;
 
 use Composer\Installer;
 
+/**
+ * Composer update package class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class UpdatePackage
 {
     /**

--- a/src/Composer/ExtensionInstaller.php
+++ b/src/Composer/ExtensionInstaller.php
@@ -6,7 +6,7 @@ class ExtensionInstaller
     public static function handle($event)
     {
         try {
-            $installedPackage = $event->getOperation()->getPackage();
+            $installedPackage = $event->getComposer()->getPackage();
         } catch (\Exception $e) {
             return;
         }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Bolt\Composer;
+
+use Bolt\Library as Lib;
+use Bolt\Translation\Translator as Trans;
+use Composer\Factory;
+use Composer\IO\BufferIO;
+use Composer\Json\JsonFile;
+use Guzzle\Http\Client as GuzzleClient;
+use Guzzle\Http\Exception\RequestException;
+use Guzzle\Http\Exception\CurlException;
+use Silex\Application;
+
+class Factory
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @var Composer\IO\BufferIO
+     */
+    private $io;
+
+    /**
+     * @var Composer\Composer
+     */
+    private $composer;
+
+    /**
+     * @var Silex\Application
+     */
+    private $app;
+
+    /**
+     * @var boolean
+     */
+    private $downgradeSsl = false;
+
+    /**
+     * @var array
+     */
+    public $messages = array();
+
+    /**
+     *
+     * @param Application          $app
+     * @param Composer\Composer    $composer
+     * @param Composer\IO\BufferIO $io
+     * @param array                $options
+     */
+    public function __construct(Application $app, Composer\Composer $composer, Composer\IO\BufferIO $io, array $options)
+    {
+        $this->app = $app;
+        $this->composer = $composer;
+        $this->io = $io;
+    }
+
+    /**
+     * Get a Composer object
+     *
+     * @return Composer\Composer
+     */
+    public function getComposer()
+    {
+        if (!$this->composer) {
+            // Set working directory
+            chdir($this->options['basedir']);
+
+            // Use the factory to get a new Composer object
+            $this->composer = \Composer\Factory::create($this->io, $this->options['composerjson'], true);
+
+            if ($this->downgradeSsl) {
+                $this->allowSslDowngrade(true);
+            }
+        }
+
+        return $this->composer;
+    }
+
+    /**
+     * Get a new Composer object
+     *
+     * @return Bolt\Composer\Factory
+     */
+    public function resetComposer()
+    {
+        $this->composer = null;
+
+        return $this;
+    }
+
+    /**
+     * Return the output from the last IO
+     *
+     * @return array
+     */
+    public function getOutput()
+    {
+        return $this->io->getOutput();
+    }
+
+}

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -5,6 +5,7 @@ namespace Bolt\Composer;
 use Bolt\Library as Lib;
 use Bolt\Translation\Translator as Trans;
 use Composer\Composer;
+use Composer\IO\BufferIO;
 use Composer\IO\IOInterface;
 use Composer\Json\JsonFile;
 use Guzzle\Http\Client as GuzzleClient;
@@ -12,7 +13,7 @@ use Guzzle\Http\Exception\RequestException;
 use Guzzle\Http\Exception\CurlException;
 use Silex\Application;
 
-class Factory extends PackageManager
+final class Factory extends PackageManager
 {
     /**
      * @var array
@@ -35,14 +36,14 @@ class Factory extends PackageManager
     private $app;
 
     /**
-     * @var boolean
-     */
-    private $downgradeSsl = false;
-
-    /**
      * @var array
      */
     public $messages = array();
+
+    /**
+     * @var boolean
+     */
+    protected $downgradeSsl;
 
     /**
      * @param Silx\Application        $app
@@ -51,9 +52,13 @@ class Factory extends PackageManager
     public function __construct(Application $app, array $options)
     {
         $this->app = $app;
+        $this->options = $options;
 
         // Create the Composer and IOInterface objects
         $this->composer = $this->getComposer();
+
+        //parent::$io = $this->io;
+        //parent::$composer = $this->composer;
     }
 
     /**
@@ -70,7 +75,7 @@ class Factory extends PackageManager
             // Use the factory to get a new Composer object
             $this->composer = \Composer\Factory::create($this->getIO(), $this->options['composerjson'], true);
 
-            if (parent::$downgradeSsl) {
+            if ($this->downgradeSsl) {
                 $this->allowSslDowngrade(true);
             }
         }
@@ -83,7 +88,7 @@ class Factory extends PackageManager
      *
      * @return Composer\IO\IOInterface
      */
-    public function getIO()
+    protected function getIO()
     {
         if (!$this->io) {
             $this->io = new BufferIO();
@@ -97,11 +102,11 @@ class Factory extends PackageManager
      *
      * @return Bolt\Composer\Factory
      */
-    public function resetComposer()
+    protected function resetComposer()
     {
         $this->composer = null;
 
-        return $this;
+        return $this->getComposer();
     }
 
     /**

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -36,14 +36,14 @@ final class Factory extends PackageManager
     private $app;
 
     /**
+     * @var boolean
+     */
+    protected $downgradeSsl = false;
+
+    /**
      * @var array
      */
     public $messages = array();
-
-    /**
-     * @var boolean
-     */
-    protected $downgradeSsl;
 
     /**
      * @param Silx\Application        $app
@@ -53,12 +53,6 @@ final class Factory extends PackageManager
     {
         $this->app = $app;
         $this->options = $options;
-
-        // Create the Composer and IOInterface objects
-        $this->composer = $this->getComposer();
-
-        //parent::$io = $this->io;
-        //parent::$composer = $this->composer;
     }
 
     /**

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -152,10 +152,11 @@ final class Factory extends PackageManager
         }
 
         return array(
-            'name'       => $name,
-            'version'    => $package->getVersion(),
-            'package'    => $package,
-            'requirever' => $versionSelector->findRecommendedRequireVersion($package)
+            'name'          => $name,
+            'version'       => $package->getVersion(),
+            'prettyversion' => $package->getPrettyVersion(),
+            'package'       => $package,
+            'requirever'    => $versionSelector->findRecommendedRequireVersion($package)
         );
     }
 

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -4,15 +4,15 @@ namespace Bolt\Composer;
 
 use Bolt\Library as Lib;
 use Bolt\Translation\Translator as Trans;
-use Composer\Factory;
-use Composer\IO\BufferIO;
+use Composer\Composer;
+use Composer\IO\IOInterface;
 use Composer\Json\JsonFile;
 use Guzzle\Http\Client as GuzzleClient;
 use Guzzle\Http\Exception\RequestException;
 use Guzzle\Http\Exception\CurlException;
 use Silex\Application;
 
-class Factory
+class Factory extends PackageManager
 {
     /**
      * @var array
@@ -45,17 +45,15 @@ class Factory
     public $messages = array();
 
     /**
-     *
-     * @param Application          $app
-     * @param Composer\Composer    $composer
-     * @param Composer\IO\BufferIO $io
-     * @param array                $options
+     * @param Silx\Application        $app
+     * @param array                   $options
      */
-    public function __construct(Application $app, Composer\Composer $composer, Composer\IO\BufferIO $io, array $options)
+    public function __construct(Application $app, array $options)
     {
         $this->app = $app;
-        $this->composer = $composer;
-        $this->io = $io;
+
+        // Create the Composer and IOInterface objects
+        $this->composer = $this->getComposer();
     }
 
     /**
@@ -70,7 +68,7 @@ class Factory
             chdir($this->options['basedir']);
 
             // Use the factory to get a new Composer object
-            $this->composer = \Composer\Factory::create($this->io, $this->options['composerjson'], true);
+            $this->composer = \Composer\Factory::create($this->getIO(), $this->options['composerjson'], true);
 
             if ($this->downgradeSsl) {
                 $this->allowSslDowngrade(true);
@@ -78,6 +76,20 @@ class Factory
         }
 
         return $this->composer;
+    }
+
+    /**
+     * Get the IOInterface object
+     *
+     * @return Composer\IO\IOInterface
+     */
+    public function getIO()
+    {
+        if (!$this->io) {
+            $this->io = new BufferIO();
+        }
+
+        return $this->io;
     }
 
     /**
@@ -101,5 +113,4 @@ class Factory
     {
         return $this->io->getOutput();
     }
-
 }

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -138,7 +138,7 @@ final class Factory extends PackageManager
      * This returns a version with the ~ operator prefixed when possible.
      *
      * @param  string                    $name
-     * @return string
+     * @return array
      * @throws \InvalidArgumentException
      */
     public function findBestVersionForPackage($name)
@@ -152,6 +152,8 @@ final class Factory extends PackageManager
         }
 
         return array(
+            'name'       => $name,
+            'version'    => $package->getVersion(),
             'package'    => $package,
             'requirever' => $versionSelector->findRecommendedRequireVersion($package)
         );

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -82,7 +82,7 @@ final class Factory extends PackageManager
      *
      * @return Composer\IO\IOInterface
      */
-    protected function getIO()
+    public function getIO()
     {
         if (!$this->io) {
             $this->io = new BufferIO();

--- a/src/Composer/Factory.php
+++ b/src/Composer/Factory.php
@@ -70,7 +70,7 @@ class Factory extends PackageManager
             // Use the factory to get a new Composer object
             $this->composer = \Composer\Factory::create($this->getIO(), $this->options['composerjson'], true);
 
-            if ($this->downgradeSsl) {
+            if (parent::$downgradeSsl) {
                 $this->allowSslDowngrade(true);
             }
         }
@@ -112,5 +112,22 @@ class Factory extends PackageManager
     public function getOutput()
     {
         return $this->io->getOutput();
+    }
+
+    /**
+     * Set repos to allow HTTP instead of HTTPS
+     *
+     * @param boolean $choice
+     */
+    private function allowSslDowngrade($choice)
+    {
+        $repos = $this->composer->getRepositoryManager()->getRepositories();
+
+        foreach ($repos as $repo) {
+            $reflection = new \ReflectionClass($repo);
+            $allowSslDowngrade = $reflection->getProperty('allowSslDowngrade');
+            $allowSslDowngrade->setAccessible($choice);
+            $allowSslDowngrade->setValue($repo, $choice);
+        }
     }
 }

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -353,6 +353,12 @@ class PackageManager
         return $pack;
     }
 
+    /**
+     * Return the URI for a package's readme
+     *
+     * @param  string $name
+     * @return string
+     */
     private function linkReadMe($name)
     {
         $paths = $this->app['resources']->getPaths();
@@ -369,6 +375,12 @@ class PackageManager
         }
     }
 
+    /**
+     * Return the URI for a package's config file edit window
+     *
+     * @param  string $name
+     * @return string
+     */
     private function linkConfig($name)
     {
         $paths = $this->app['resources']->getPaths();

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -113,6 +113,16 @@ class PackageManager
     }
 
     /**
+     * Return/create our Factory object
+     *
+     * @return Factory
+     */
+    public function getFactory()
+    {
+        return $this->factory;
+    }
+
+    /**
      * If the extension project area is writable, ensure the JSON is up-to-date
      * and test connection to the extension server.
      *
@@ -145,6 +155,9 @@ class PackageManager
 
             // Create the Composer object
             $this->composer = $this->getComposer();
+
+            // Create our Factory
+            $this->factory = new Factory($this->app, $this->composer, $this->io, $this->options);
         }
     }
 
@@ -159,7 +172,7 @@ class PackageManager
         chdir($this->options['basedir']);
 
         // Use the factory to get a new Composer object
-        $this->composer = Factory::create($this->io, $this->options['composerjson'], true);
+        $this->composer = \Composer\Factory::create($this->io, $this->options['composerjson'], true);
 
         if ($this->downgradeSsl) {
             $this->allowSslDowngrade(true);

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -431,7 +431,7 @@ class PackageManager
      */
     private function updateJson()
     {
-        $initjson = new BoltExtendJson($this->io, $this->composer, $this->options);
+        $initjson = new BoltExtendJson($this->options);
         $this->json = $initjson->updateJson($this->app);
     }
 

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -364,19 +364,6 @@ class PackageManager
     }
 
     /**
-     *
-     * @return array
-     */
-    private function readComposerPackages()
-    {
-        //
-        $jsonFile = new JsonFile($this->options['composerjson']);
-        if ($jsonFile->exists()) {
-            $json = $jsonorig = $jsonFile->read();
-        }
-    }
-
-    /**
      * Format a Composer API package array suitable for AJAX response
      *
      * @param  array $packages

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -13,7 +13,6 @@ use Bolt\Composer\Action\ShowPackage;
 use Bolt\Composer\Action\UpdatePackage;
 use Bolt\Library as Lib;
 use Bolt\Translation\Translator as Trans;
-use Composer\Factory;
 use Composer\IO\BufferIO;
 use Composer\Json\JsonFile;
 use Guzzle\Http\Client as GuzzleClient;
@@ -86,7 +85,7 @@ class PackageManager
     /**
      * @var boolean
      */
-    private $downgradeSsl = false;
+    protected $downgradeSsl = false;
 
     /**
      * @var array
@@ -162,17 +161,7 @@ class PackageManager
      */
     public function getComposer()
     {
-        // Set working directory
-        chdir($this->options['basedir']);
-
-        // Use the factory to get a new Composer object
-        $this->composer = \Composer\Factory::create($this->io, $this->options['composerjson'], true);
-
-        if ($this->downgradeSsl) {
-            $this->allowSslDowngrade(true);
-        }
-
-        return $this->composer;
+        return $this->factory->getComposer();
     }
 
     /**
@@ -182,7 +171,7 @@ class PackageManager
      */
     public function getOutput()
     {
-        return $this->io->getOutput();
+        return $this->io->factory->getOutput();
     }
 
     /**

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -587,5 +587,7 @@ class PackageManager
 
             'optimizeautoloader'    => true,     // optimize-autoloader - Optimizes PSR0 and PSR4 packages to be loaded with classmaps too, good for production.
         );
+
+        return $this->options;
     }
 }

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -484,7 +484,7 @@ class PackageManager
 
             return $response->getStatusCode();
         } catch (CurlException $e) {
-            if ($e->getErrorNo() == 60){
+            if ($e->getErrorNo() == 60) {
                 // Eariler versions of libcurl support only SSL, whereas we require TLS.
                 // In this case, downgrade our composer to use HTTP
                 $this->downgradeSsl = true;

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -126,21 +126,16 @@ class PackageManager
     }
 
     /**
-     * Get the Composer object
+     * Get a new Composer object
      *
      * @return Composer\Composer
      */
     public function getComposer()
     {
         // Use the factory to get a new Composer object
-        $composer = Factory::create($this->io, $this->options['composerjson'], true);
-        $repos = $composer->getRepositoryManager()->getRepositories();
+        $this->composer = Factory::create($this->io, $this->options['composerjson'], true);
 
-        if ($this->app['config']->get('general/extensions/use_http', false)) {
-            $this->allowSslDowngrade($repos);
-        }
-
-        return $composer;
+        return $this->composer;
     }
 
     /**
@@ -506,15 +501,17 @@ class PackageManager
     /**
      * Set repos to allow HTTP instead of HTTPS
      *
-     * @param array $repos
+     * @param boolean $choice
      */
-    private function allowSslDowngrade(array $repos)
+    private function allowSslDowngrade($choice)
     {
+        $repos = $this->composer->getRepositoryManager()->getRepositories();
+
         foreach ($repos as $repo) {
             $reflection = new \ReflectionClass($repo);
             $allowSslDowngrade = $reflection->getProperty('allowSslDowngrade');
-            $allowSslDowngrade->setAccessible(true);
-            $allowSslDowngrade->setValue($repo, true);
+            $allowSslDowngrade->setAccessible($choice);
+            $allowSslDowngrade->setValue($repo, $choice);
         }
     }
 

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -150,14 +150,8 @@ class PackageManager
         }
 
         if ($this->app['extend.online']) {
-            // Create the IO
-            $this->io = new BufferIO();
-
-            // Create the Composer object
-            $this->composer = $this->getComposer();
-
             // Create our Factory
-            $this->factory = new Factory($this->app, $this->composer, $this->io, $this->options);
+            $this->factory = new Factory($this->app, $this->options);
         }
     }
 

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -4,6 +4,7 @@ namespace Bolt\Composer;
 
 use Bolt\Composer\Action\DumpAutoload;
 use Bolt\Composer\Action\InitJson;
+use Bolt\Composer\Action\InstallPackage;
 use Bolt\Composer\Action\RemovePackage;
 use Bolt\Composer\Action\RequirePackage;
 use Bolt\Composer\Action\SearchPackage;
@@ -162,6 +163,21 @@ class PackageManager
         }
 
         $this->dumpautoload->execute();
+    }
+
+    /**
+     * Install configured packages
+     *
+     * @return integer 0 on success or a positive error code on failure
+     */
+    public function installPackages()
+    {
+        if (!$this->install) {
+            $this->install = new InstallPackage($this->io, $this->composer, $this->options);
+        }
+
+        // 0 on success or a positive error code on failure
+        return $this->install->execute();
     }
 
     /**

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -83,11 +83,6 @@ class PackageManager
     private $app;
 
     /**
-     * @var boolean
-     */
-    protected $downgradeSsl = false;
-
-    /**
      * @var array
      */
     public $messages = array();
@@ -470,7 +465,7 @@ class PackageManager
             if ($e->getErrorNo() == 60) {
                 // Eariler versions of libcurl support only SSL, whereas we require TLS.
                 // In this case, downgrade our composer to use HTTP
-                $this->downgradeSsl = true;
+                $this->factory->downgradeSsl = true;
 
                 $this->messages[] = Trans::__("cURL library doesn't support TLS. Downgrading to HTTP.");
 

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -503,23 +503,6 @@ class PackageManager
     }
 
     /**
-     * Set repos to allow HTTP instead of HTTPS
-     *
-     * @param boolean $choice
-     */
-    private function allowSslDowngrade($choice)
-    {
-        $repos = $this->composer->getRepositoryManager()->getRepositories();
-
-        foreach ($repos as $repo) {
-            $reflection = new \ReflectionClass($repo);
-            $allowSslDowngrade = $reflection->getProperty('allowSslDowngrade');
-            $allowSslDowngrade->setAccessible($choice);
-            $allowSslDowngrade->setValue($repo, $choice);
-        }
-    }
-
-    /**
      * Set the default options
      */
     private function getOptions()

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -187,7 +187,7 @@ class PackageManager
     public function checkPackage()
     {
         if (!$this->check) {
-            $this->check = new CheckPackage($this->getIO(), $this->getComposer(), $this->options);
+            $this->check = new CheckPackage($this->app, $this->getIO(), $this->getComposer(), $this->options);
         }
 
         return $this->check->execute();

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -3,6 +3,7 @@
 namespace Bolt\Composer;
 
 use Bolt\Composer\Action\BoltExtendJson;
+use Bolt\Composer\Action\CheckPackage;
 use Bolt\Composer\Action\DumpAutoload;
 use Bolt\Composer\Action\InstallPackage;
 use Bolt\Composer\Action\RemovePackage;
@@ -36,6 +37,11 @@ class PackageManager
      * @var Composer\Composer
      */
     private $composer;
+
+    /**
+     * @var Bolt\Composer\Action\CheckPackage
+     */
+    private $check;
 
     /**
      * @var Bolt\Composer\Action\DumpAutoload
@@ -170,6 +176,20 @@ class PackageManager
     public function getOutput()
     {
         return $this->io->getOutput();
+    }
+
+    /**
+     * Check for packages that need to be installed or updated
+     *
+     * @return array
+     */
+    public function checkPackage()
+    {
+        if (!$this->check) {
+            $this->check = new CheckPackage($this->io, $this->composer, $this->options);
+        }
+
+        return $this->check->execute();
     }
 
     /**

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -356,14 +356,17 @@ class PackageManager
     private function linkReadMe($name)
     {
         $paths = $this->app['resources']->getPaths();
+        $base = $paths['extensionspath'] . '/vendor/' . $name;
 
-        if (is_readable($paths['extensionspath'] . '/vendor/' . $name . '/README.md')) {
+        if (is_readable($base . '/README.md')) {
             $readme = $name . '/README.md';
-        } elseif (is_readable($paths['extensionspath'] . '/vendor/' . $name . '/readme.md')) {
+        } elseif (is_readable($base . '/readme.md')) {
             $readme = $name . '/readme.md';
         }
 
-        return $paths['async'] . 'readme/' . $readme;
+        if ($readme) {
+            return $paths['async'] . 'readme/' . $readme;
+        }
     }
 
     private function linkConfig($name)

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -268,7 +268,7 @@ class PackageManager
     public function initJson($file, array $data = array())
     {
         if (!$this->initJson) {
-            $this->initJson = new InitJson($this->io, $this->composer, $this->options);
+            $this->initJson = new InitJson($this->options);
         }
 
         $this->initJson->execute($file, $data);

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -126,9 +126,6 @@ class PackageManager
         }
 
         if ($app['extend.online']) {
-            // Set working directory
-            chdir($this->options['basedir']);
-
             // Create the IO
             $this->io = new BufferIO();
 
@@ -144,6 +141,9 @@ class PackageManager
      */
     public function getComposer()
     {
+        // Set working directory
+        chdir($this->options['basedir']);
+
         // Use the factory to get a new Composer object
         $this->composer = Factory::create($this->io, $this->options['composerjson'], true);
 

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -160,13 +160,23 @@ class PackageManager
     }
 
     /**
+     * Get a new IO object
+     *
+     * @return Composer\Composer
+     */
+    public function getIO()
+    {
+        return $this->factory->getIO();
+    }
+
+    /**
      * Return the output from the last IO
      *
      * @return array
      */
     public function getOutput()
     {
-        return $this->io->factory->getOutput();
+        return $this->getIO()->factory->getOutput();
     }
 
     /**
@@ -177,7 +187,7 @@ class PackageManager
     public function checkPackage()
     {
         if (!$this->check) {
-            $this->check = new CheckPackage($this->io, $this->composer, $this->options);
+            $this->check = new CheckPackage($this->getIO(), $this->getComposer(), $this->options);
         }
 
         return $this->check->execute();
@@ -189,7 +199,7 @@ class PackageManager
     public function dumpautoload()
     {
         if (!$this->dumpautoload) {
-            $this->dumpautoload = new DumpAutoload($this->io, $this->composer, $this->options);
+            $this->dumpautoload = new DumpAutoload($this->getIO(), $this->getComposer(), $this->options);
         }
 
         $this->dumpautoload->execute();
@@ -203,7 +213,7 @@ class PackageManager
     public function installPackages()
     {
         if (!$this->install) {
-            $this->install = new InstallPackage($this->io, $this->composer, $this->options);
+            $this->install = new InstallPackage($this->getIO(), $this->getComposer(), $this->options);
         }
 
         // 0 on success or a positive error code on failure
@@ -219,7 +229,7 @@ class PackageManager
     public function removePackage(array $packages)
     {
         if (!$this->remove) {
-            $this->remove = new RemovePackage($this->app, $this->io, $this->composer, $this->options);
+            $this->remove = new RemovePackage($this->app, $this->getIO(), $this->getComposer(), $this->options);
         }
 
         // 0 on success or a positive error code on failure
@@ -236,7 +246,7 @@ class PackageManager
     public function requirePackage(array $packages)
     {
         if (!$this->require) {
-            $this->require = new RequirePackage($this->app, $this->io, $this->composer, $this->options);
+            $this->require = new RequirePackage($this->app, $this->getIO(), $this->getComposer(), $this->options);
         }
 
         // 0 on success or a positive error code on failure
@@ -252,7 +262,7 @@ class PackageManager
     public function searchPackage(array $packages)
     {
         if (!$this->search) {
-            $this->search = new SearchPackage($this->io, $this->composer, $this->options);
+            $this->search = new SearchPackage($this->getIO(), $this->getComposer(), $this->options);
         }
 
         return $this->search->execute($packages);
@@ -267,7 +277,7 @@ class PackageManager
     public function showPackage($target, $package = '', $version = '')
     {
         if (!$this->show) {
-            $this->show = new ShowPackage($this->io, $this->composer, $this->options);
+            $this->show = new ShowPackage($this->getIO(), $this->getComposer(), $this->options);
         }
 
         return $this->show->execute($target, $package, $version);
@@ -282,7 +292,7 @@ class PackageManager
     public function updatePackage(array $packages)
     {
         if (!$this->update) {
-            $this->update = new UpdatePackage($this->io, $this->composer, $this->options);
+            $this->update = new UpdatePackage($this->getIO(), $this->getComposer(), $this->options);
         }
 
         // 0 on success or a positive error code on failure

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -308,7 +308,6 @@ class PackageManager
         }
 
         // Local packages @todo
-
         return $packages;
     }
 
@@ -331,7 +330,8 @@ class PackageManager
      * @param  array $packages
      * @return array
      */
-    public function formatPackageResponse(array $packages) {
+    public function formatPackageResponse(array $packages)
+    {
         $pack = array();
 
         foreach ($packages as $package) {
@@ -380,6 +380,7 @@ class PackageManager
         $configfilepath = $paths['extensionsconfig'] . '/' . $configfilename;
         if (is_readable($configfilepath)) {
             $configfilename = 'extensions/' . $configfilename;
+
             return Lib::path('fileedit', array('namespace' => 'config', 'file' => $configfilename));
         }
     }

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -508,7 +508,6 @@ class PackageManager
                 // Eariler versions of libcurl support only SSL, whereas we require TLS.
                 // In this case, downgrade our composer to use HTTP
                 $this->downgradeSsl = true;
-                $this->allowSslDowngrade(true);
 
                 $this->messages[] = Trans::__("cURL library doesn't support TLS. Downgrading to HTTP.");
 

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -96,19 +96,27 @@ class PackageManager
     {
         $this->app = $app;
 
-        // Get default options
-        $this->getOptions();
-
         // Set composer environment variables
         putenv('COMPOSER_HOME=' . $this->app['resources']->getPath('cache') . '/composer');
 
-        /*
-         * If the extension project area is writable, ensure the JSON is up-to-date
-         * and test connection to the extension server.
-         *
-         * If all is OK, set $app['extend.online'] to TRUE
-         */
-        if ($app['extend.writeable']) {
+        // Get default options
+        $this->getOptions();
+
+        // Set up
+        $this->setup();
+    }
+
+    /**
+     * If the extension project area is writable, ensure the JSON is up-to-date
+     * and test connection to the extension server.
+     *
+     * $app['extend.writeable'] is originally set in Extend::register()
+     *
+     * If all is OK, set $app['extend.online'] to TRUE
+     */
+    private function setup()
+    {
+        if ($this->app['extend.writeable']) {
             // Copy/update installer helper
             $this->copyInstaller();
 
@@ -119,13 +127,13 @@ class PackageManager
             $response = $this->ping($this->app['extend.site'], 'ping', true);
             $httpOk = array(200, 301, 302);
             if (in_array($response, $httpOk)) {
-                $app['extend.online'] = true;
+                $this->app['extend.online'] = true;
             } else {
                 $this->messages[] = $this->app['extend.site'] . ' is unreachable.';
             }
         }
 
-        if ($app['extend.online']) {
+        if ($this->app['extend.online']) {
             // Create the IO
             $this->io = new BufferIO();
 
@@ -255,9 +263,9 @@ class PackageManager
     }
 
     /**
-     * Remove packages from the root install
+     * Update packages in the root install
      *
-     * @param $packages array Indexed array of package names to remove
+     * @param  $packages array Indexed array of package names to update
      * @return integer 0 on success or a positive error code on failure
      */
     public function updatePackage(array $packages)

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -176,7 +176,7 @@ class PackageManager
      */
     public function getOutput()
     {
-        return $this->getIO()->factory->getOutput();
+        return $this->factory->getIO()->getOutput();
     }
 
     /**

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -120,8 +120,8 @@ class PackageManager
             // Copy/update installer helper
             $this->copyInstaller();
 
-            // Do required JSON set up
-            $this->setupJson();
+            // Do required JSON update/set up
+            $this->updateJson();
 
             // Ping the extensions server to confirm connection
             $response = $this->ping($this->app['extend.site'], 'ping', true);
@@ -429,10 +429,10 @@ class PackageManager
     /**
      * Set up Composer JSON file
      */
-    private function setupJson()
+    private function updateJson()
     {
         $initjson = new BoltExtendJson($this->io, $this->composer, $this->options);
-        $this->json = $initjson->setupJson($this->app);
+        $this->json = $initjson->updateJson($this->app);
     }
 
     /**

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -2,8 +2,8 @@
 
 namespace Bolt\Composer;
 
+use Bolt\Composer\Action\BoltExtendJson;
 use Bolt\Composer\Action\DumpAutoload;
-use Bolt\Composer\Action\InitJson;
 use Bolt\Composer\Action\InstallPackage;
 use Bolt\Composer\Action\RemovePackage;
 use Bolt\Composer\Action\RequirePackage;
@@ -43,7 +43,7 @@ class PackageManager
     private $dumpautoload;
 
     /**
-     * @var Bolt\Composer\Action\InitJson
+     * @var Bolt\Composer\Action\BoltExtendJson
      */
     private $initJson;
 
@@ -281,13 +281,13 @@ class PackageManager
     /**
      * Initialise a new JSON file
      *
-     * @param string $file
-     * @param array  $data
+     * @param string $file File to initialise
+     * @param array  $data Data to be added as JSON paramter/value pairs
      */
     public function initJson($file, array $data = array())
     {
         if (!$this->initJson) {
-            $this->initJson = new InitJson($this->options);
+            $this->initJson = new BoltExtendJson($this->options);
         }
 
         $this->initJson->execute($file, $data);
@@ -431,7 +431,7 @@ class PackageManager
      */
     private function setupJson()
     {
-        $initjson = new InitJson($this->io, $this->composer, $this->options);
+        $initjson = new BoltExtendJson($this->io, $this->composer, $this->options);
         $this->json = $initjson->setupJson($this->app);
     }
 

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -102,6 +102,12 @@ class PackageManager
         // Set composer environment variables
         putenv('COMPOSER_HOME=' . $this->app['resources']->getPath('cache') . '/composer');
 
+        /*
+         * If the extension project area is writable, ensure the JSON is up-to-date
+         * and test connection to the extension server.
+         *
+         * If all is OK, set $app['extend.online'] to TRUE
+         */
         if ($app['extend.writeable']) {
             // Copy/update installer helper
             $this->copyInstaller();

--- a/src/Configuration/LowlevelException.php
+++ b/src/Configuration/LowlevelException.php
@@ -93,6 +93,11 @@ EOM;
         // Get last error, if any
         $error = error_get_last();
 
+        // Let Whoops handle AJAX requested fatal errors
+        if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest') {
+            return;
+        }
+
         if (($error['type'] == E_ERROR || $error['type'] == E_PARSE)) {
             $html = self::$html;
 

--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -166,7 +166,7 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
         $package = $request->get('package') ?: array();
 
         try {
-            $response = $app['extend.manager']->updatePackage($package);
+            $response = $app['extend.manager']->updatePackage(array($package));
         } catch (Exception $e) {
             throw new \Exception($e->getMessage(), $e->getCode(), $e->getPrevious());
         }

--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -218,7 +218,13 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
 
     public function installAll(Silex\Application $app, Request $request)
     {
-        return new Response($app['extend.manager']->installPackages());
+        $response = $app['extend.manager']->installPackages();
+
+        if ($response === 0) {
+            return new Response($app['extend.manager']->getOutput());
+        } else {
+            throw new BoltComposerException($app['extend.manager']->getOutput(), $response);
+        }
     }
 
     public function generateTheme(Silex\Application $app, Request $request)

--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -163,11 +163,16 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
 
     public function update(Silex\Application $app, Request $request)
     {
-        $package = $request->get('package');
+        $package = $request->get('package') ?: [];
 
-        $response = Response($app['extend.manager']->update($package));
+        try {
+            $response = $app['extend.manager']->updatePackage($package);
+        } catch (Exception $e) {
+            throw new \Exception($e->getMessage(), $e->getCode(), $e->getPrevious());
+        }
+
         if ($response === 0) {
-            return new Response($app['extend.manager']->getOutput());
+            return new JsonResponse($app['extend.manager']->getOutput());
         } else {
             throw new BoltComposerException($app['extend.manager']->getOutput(), $response);
         }

--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -163,7 +163,7 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
 
     public function update(Silex\Application $app, Request $request)
     {
-        $package = $request->get('package') ?: [];
+        $package = $request->get('package') ?: array();
 
         try {
             $response = $app['extend.manager']->updatePackage($package);

--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -157,7 +157,7 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
 
     public function check(Silex\Application $app, Request $request)
     {
-        return new JsonResponse($app['extend.manager']->check());
+        return new JsonResponse($app['extend.manager']->checkPackage());
 
     }
 

--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -218,7 +218,7 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
 
     public function installAll(Silex\Application $app, Request $request)
     {
-        return new Response($app['extend.manager']->installAll());
+        return new Response($app['extend.manager']->installPackages());
     }
 
     public function generateTheme(Silex\Application $app, Request $request)

--- a/src/Nut/Extensions.php
+++ b/src/Nut/Extensions.php
@@ -16,12 +16,11 @@ class Extensions extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $result = $this->app['extend.manager']->installed();
-        $json = $result->getContent();
-
+        $installed = $this->app['extend.manager']->showPackage('installed');
         $rows = array();
-        foreach (json_decode($json) as $ext) {
-            $rows[] = array($ext->name, $ext->version, $ext->type, $ext->descrip);
+
+        foreach ($installed as $ext) {
+            $rows[] = array($ext['package']->getPrettyName(), $ext['package']->getPrettyVersion(), $ext['package']->getType(), $ext['package']->getDescription());
         }
 
         $table = $this->getHelper('table');

--- a/src/Nut/ExtensionsDisable.php
+++ b/src/Nut/ExtensionsDisable.php
@@ -20,7 +20,7 @@ class ExtensionsDisable extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $name = $input->getArgument('name');
-        $result = $this->app['extend.manager']->uninstall($name);
+        $result = $this->app['extend.manager']->removePackage(array($name));
         $output->writeln('<info>' . $result . '</info>', OutputInterface::OUTPUT_PLAIN);
     }
 }

--- a/src/Nut/ExtensionsEnable.php
+++ b/src/Nut/ExtensionsEnable.php
@@ -24,7 +24,7 @@ class ExtensionsEnable extends BaseCommand
         $name = $input->getArgument('name');
         $version = $input->getArgument('version');
 
-        $result = $this->app['extend.manager']->install($name, $version);
+        $result = $this->app['extend.manager']->requirePackage(array('name' => $name, 'version' => $version));
 
         $output->writeln("<info>[Done]</info> ");
         $output->writeln($result, OutputInterface::OUTPUT_PLAIN);


### PR DESCRIPTION
"And...  In the blue corner, weighing in at 146 commits..."
![daffey-boxing-small](https://cloud.githubusercontent.com/assets/1427081/5813352/1ad6b072-a074-11e4-8b64-7fa7006cb1d0.jpg)

So here is, a canary merge branch, branched fresh off my feature branch. A big thank you goes out to @rossriley for figuring so much of this out in the first place.

### New/Changed
* LOTS!
* Using the Composer API more directly, rather than proxying through console commands
* Each implemented `Composer\Command` has a corresponding `Bolt\Composer\Action` class that closely mimics how the `Composer\Command` classes individually interface `Composer\Installer`
* Actions currently implemented:
  - BoltExtendJson
  - CheckPackage
  - DumpAutoload
  - InstallPackage
  - RemovePackage
  - RequirePackage
  - SearchPackage
  - ShowPackage
  - UpdatePackage
* `Bolt\Composer\Action` classes are all declared `final`, for now. Our implementation of these classes is likely to change over time and as such, not valid as part of a 'public API'
* All jQuery `.get()` requests are now matched with a `.fail()` handler to report on Composer/Whoops errors and display feedback to end user
* Refactored `Bolt\Composer\CommandRunner` into `PackageManager` and `Factory` classes
* Most (eventually all) JSON calls use `Bolt\Composer\Action\` libraries
* Error handling all around, especially with a focus on AJAX requests
* Lots of work on a consistent AJAX response for available queries.  Composer itself is where this gets tricky, they really haven't gotten their heads/code into the idea that `Output\Console` is not how 100% of the library's user base want to (randomly) deal with things...
* Exceptions can now throw a BoltComposerException class
* Version button!  Everyone wants a version button these days, all the cool kids have one! 
  - Will display the installer dialogue for that package
  - Allow you to upgrade/downgrade on the spot
* cURL SSL/TLS certificate errors will now automatically downgrade the connection to HTTP 
  - See #2283
* Uses the full set of Composer JSON database files to compile package information, therefore we can list extensions that are installed as a dependency and manage those in the front end too
* JavaScript created HTML has mostly been moved to Twig generated Javascript variables
* UI strings are now translated in PHP and stored in a JavaScript object

**NOTE:** The old log has not been removed, just non-functional.  Will be fixed soon, but you will still get 500 errors on AJAX requests in your console log.

### Reviews/Tracking
* Feature tracking branch (PR against) `https://github.com/GawainLynch/bolt.git feature/composer-api`
* Feed back on unclear code would be very much appreciated
* PRs welcome
* Bolt's Composer installs have not been well tested
