### PR TITLE
Cleanup of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,16 @@
 
     "require": {
         "bolt/dumper": "~2.0",
+        "bolt/pathogen": "~0.6",
         "bolt/thumbs": "~2.0",
         "brandonwamboldt/utilphp": "~1.0",
-        "composer/composer": "1.0.*@dev",
+        "composer/composer": "dev-master",
         "doctrine/dbal": "2.5.1",
         "erusev/parsedown-extra": "~0.2",
         "filp/whoops": "~1.1",
         "guzzle/guzzle": "~3.9",
         "hautelook/phpass": "~0.3",
-        "ircmaxell/random-lib": "dev-master",
+        "ircmaxell/random-lib": "~1.1",
         "jbroadway/urlify": "~1.0",
         "rossriley/flysystem53": "~0.5",
         "php": ">=5.3.3",
@@ -32,12 +33,11 @@
         "symfony/translation": "~2.6",
         "symfony/twig-bridge": "~2.6",
         "symfony/validator": "~2.6",
-        "symfony/var-dumper": "~2.6",        
+        "symfony/var-dumper": "~2.6",
         "symfony/web-profiler-bundle": "~2.6",
         "symfony/yaml": "~2.6",
         "tdammers/htmlmaid": "~0.7",
-        "twig/twig": "~1.16",
-        "bolt/pathogen": "~0.6"
+        "twig/twig": "~1.16"
     },
     "require-dev": {
         "lstrojny/phpunit-function-mocker": "dev-master@dev",


### PR DESCRIPTION
- Put `bolt/pathogen` in alphabetical order
- Use tagged version for `ircmaxell/random-lib`
- Use `dev-master` for `composer/composer`. We don't see that there will be an actual 1.0.0 release anytime soon, so we might as well use the latest. 