### PR TITLE
Refactor constructor into initialize method

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -45,13 +45,19 @@ class Config
     public function __construct(Application $app)
     {
         $this->app = $app;
+        $this->fields = new Field\Manager();
 
+        $this->initialize();
+    }
+
+    protected function initialize()
+    {
         if (!$this->loadCache()) {
             $this->getConfig();
             $this->saveCache();
 
             // if we have to reload the config, we will also want to make sure the DB integrity is checked.
-            Database\IntegrityChecker::invalidate($app);
+            Database\IntegrityChecker::invalidate($this->app);
         } else {
 
             // In this case the cache is loaded, but because the path of the theme
@@ -63,7 +69,6 @@ class Config
 
         $this->setTwigPath();
         $this->setCKPath();
-        $this->fields = new Field\Manager();
     }
 
     /**


### PR DESCRIPTION
Generally it's better not to do logic in constructor.  This allows others to override initialize() to change caching/loading config behavior without having to recreate the constructor.