### PR TITLE
Update queries for slaves

### DIFF
--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -241,7 +241,10 @@ class Async implements ControllerProviderInterface
         $table .= 'taxonomy';
 
         $results = $app['db']->fetchAll(
-            "SELECT DISTINCT $table.slug from $table where taxonomytype = ? order by slug ASC",
+            "SELECT DISTINCT $table.slug
+            FROM $table
+            WHERE taxonomytype = ?
+            ORDER BY slug ASC",
             array($taxonomytype)
         );
 
@@ -254,7 +257,12 @@ class Async implements ControllerProviderInterface
         $table .= 'taxonomy';
 
         $results = $app['db']->fetchAll(
-            "SELECT slug, COUNT(slug) as count from $table where taxonomytype = ? GROUP BY slug ORDER BY count DESC LIMIT ?",
+            "SELECT slug, COUNT(slug) AS count
+            FROM $table
+            WHERE taxonomytype = ?
+            GROUP BY slug
+            ORDER BY count DESC
+            LIMIT ?",
             array(
                 $taxonomytype,
                 $request->query->getInt('limit', 20),

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -240,33 +240,26 @@ class Async implements ControllerProviderInterface
         $table = $app['config']->get('general/database/prefix', "bolt_");
         $table .= 'taxonomy';
 
-        $query = sprintf(
-            'SELECT DISTINCT %s.slug from %s where taxonomytype = ? order by slug ASC;',
-            $table,
-            $table
+        $results = $app['db']->fetchAll(
+            "SELECT DISTINCT $table.slug from $table where taxonomytype = ? order by slug ASC",
+            array($taxonomytype)
         );
-        $query = $app['db']->executeQuery($query, array($taxonomytype));
-
-        $results = $query->fetchAll();
 
         return $app->json($results);
     }
 
-    public function populartags(Silex\Application $app, $taxonomytype)
+    public function populartags(Silex\Application $app, Request $request, $taxonomytype)
     {
         $table = $app['config']->get('general/database/prefix', "bolt_");
         $table .= 'taxonomy';
 
-        $limit = $app['request']->get('limit', 20);
-
-        $query = sprintf(
-            'SELECT slug, COUNT(slug) as count from  %s where taxonomytype = ? GROUP BY  slug ORDER BY count DESC LIMIT %s',
-            $table,
-            intval($limit)
+        $results = $app['db']->fetchAll(
+            "SELECT slug, COUNT(slug) as count from $table where taxonomytype = ? GROUP BY slug ORDER BY count DESC LIMIT ?",
+            array(
+                $taxonomytype,
+                $request->query->getInt('limit', 20),
+            )
         );
-        $query = $app['db']->executeQuery($query, array($taxonomytype));
-
-        $results = $query->fetchAll();
 
         usort(
             $results,


### PR DESCRIPTION
Replaced prepare() queries with executeQuery() since that supports read slaves. 
Replaced prepare() with query() on write queries because why do 3 method calls when you can do one?
Cleaned up tag queries in Async Controller as well.

Should some of those queries be on multiple lines? Like:
```sql
SELECT id 
FROM $tablename 
WHERE status = 'published' 
    and datedepublish <= :now 
    and datedepublish > '1900-01-01 00:00:01'
    and datechanged < datedepublish
```