### PR TITLE
[WIP] Allow extensions to leverage getDecodedValue

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -536,83 +536,14 @@ class Content implements \ArrayAccess
 
         if (isset($this->values[$name])) {
             $fieldtype = $this->fieldtype($name);
-            $fieldinfo = $this->fieldinfo($name);
-            $allowtwig = !empty($fieldinfo['allowtwig']);
-
-            switch ($fieldtype) {
-                case 'markdown':
-
-                    $value = $this->preParse($this->values[$name], $allowtwig);
-
-                    // Parse the field as Markdown, return HTML
-                    $value = \ParsedownExtra::instance()->text($value);
-
-                    // Sanitize/clean the HTML.
-                    $maid = new \Maid\Maid(
-                        array(
-                            'output-format' => 'html',
-                            'allowed-tags' => array('html', 'head', 'body', 'section', 'div', 'p', 'br', 'hr', 's', 'u', 'strong', 'em', 'i', 'b', 'li', 'ul', 'ol', 'menu', 'blockquote', 'pre', 'code', 'tt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'dd', 'dl', 'dh', 'table', 'tbody', 'thead', 'tfoot', 'th', 'td', 'tr', 'a', 'img'),
-                            'allowed-attribs' => array('id', 'class', 'name', 'value', 'href', 'src')
-                        )
-                    );
-                    $value = $maid->clean($value);
-                    $value = new \Twig_Markup($value, 'UTF-8');
-                    break;
-
-                case 'html':
-                case 'text':
-                case 'textarea':
-
-                    $value = $this->preParse($this->values[$name], $allowtwig);
-                    $value = new \Twig_Markup($value, 'UTF-8');
-
-                    break;
-
-                case 'imagelist':
-                case 'filelist':
-                    if (is_string($this->values[$name])) {
-                        // Parse the field as JSON, return the array
-                        $value = json_decode($this->values[$name]);
-                    } else {
-                        // Already an array, do nothing.
-                        $value = $this->values[$name];
-                    }
-                    break;
-
-                case 'image':
-                    if (is_array($this->values[$name]) && isset($this->values[$name]['file'])) {
-                        $value = $this->values[$name]['file'];
-                    } else {
-                        $value = $this->values[$name];
-                    }
-                    break;
-
-                default:
-                    $value = $this->values[$name];
-                    break;
+            if ($this->app['config']->getFields()->has($fieldtype)) {
+                $value = $this->app['config']->getFields()->getField($fieldtype)->getDecodedValue($this->values[$name], $this->fieldinfo($name));
+            } else {
+                $value = $this->values[$name];
             }
         }
 
         return $value;
-    }
-
-    /**
-     * If passed snippet contains Twig tags, parse the string as Twig, and return the results
-     *
-     * @param  string $snippet
-     * @param $allowtwig
-     * @return string
-     */
-    public function preParse($snippet, $allowtwig)
-    {
-        // Quickly verify that we actually need to parse the snippet!
-        if ($allowtwig && preg_match('/[{][{%#]/', $snippet)) {
-            $snippet = html_entity_decode($snippet, ENT_QUOTES, 'UTF-8');
-
-            return $this->app['safe_render']->render($snippet, $this->getTemplateContext());
-        }
-
-        return $snippet;
     }
 
     public function getTemplateContext()

--- a/src/Field/Base.php
+++ b/src/Field/Base.php
@@ -33,4 +33,84 @@ class Base implements FieldInterface
     {
         return array();
     }
+
+    public function getDecodedValue($value, $fieldinfo)
+    {
+        $returnvalue = $value;
+        $allowtwig = !empty($fieldinfo['allowtwig']);
+
+        switch ($name) {
+            case 'markdown':
+
+                $returnvalue = $this->preParse($value, $allowtwig);
+
+                // Parse the field as Markdown, return HTML
+                $returnvalue = \ParsedownExtra::instance()->text($returnvalue);
+
+                // Sanitize/clean the HTML.
+                $maid = new \Maid\Maid(
+                    array(
+                        'output-format' => 'html',
+                        'allowed-tags' => array('html', 'head', 'body', 'section', 'div', 'p', 'br', 'hr', 's', 'u', 'strong', 'em', 'i', 'b', 'li', 'ul', 'ol', 'menu', 'blockquote', 'pre', 'code', 'tt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'dd', 'dl', 'dh', 'table', 'tbody', 'thead', 'tfoot', 'th', 'td', 'tr', 'a', 'img'),
+                        'allowed-attribs' => array('id', 'class', 'name', 'value', 'href', 'src')
+                    )
+                );
+                $returnvalue = $maid->clean($returnvalue);
+                $returnvalue = new \Twig_Markup($returnvalue, 'UTF-8');
+                break;
+
+            case 'html':
+            case 'text':
+            case 'textarea':
+
+                $returnvalue = $this->preParse($value, $allowtwig);
+                $returnvalue = new \Twig_Markup($returnvalue, 'UTF-8');
+
+                break;
+
+            case 'imagelist':
+            case 'filelist':
+                if (is_string($value)) {
+                    // Parse the field as JSON, return the array
+                    $returnvalue = json_decode($value);
+                } else {
+                    // Already an array, do nothing.
+                    $returnvalue = $value;
+                }
+                break;
+
+            case 'image':
+                if (is_array($value) && isset($value['file'])) {
+                    $returnvalue = $value['file'];
+                } else {
+                    $returnvalue = $value;
+                }
+                break;
+
+            default:
+                $returnvalue = $value;
+                break;
+        }
+
+        return $returnvalue;
+    }
+
+    /**
+     * If passed snippet contains Twig tags, parse the string as Twig, and return the results
+     *
+     * @param  string $snippet
+     * @param $allowtwig
+     * @return string
+     */
+    public function preParse($snippet, $allowtwig)
+    {
+        // Quickly verify that we actually need to parse the snippet!
+        if ($allowtwig && preg_match('/[{][{%#]/', $snippet)) {
+            $snippet = html_entity_decode($snippet, ENT_QUOTES, 'UTF-8');
+
+            return $this->app['safe_render']->render($snippet, $this->getTemplateContext());
+        }
+
+        return $snippet;
+    }
 }

--- a/src/Field/FieldInterface.php
+++ b/src/Field/FieldInterface.php
@@ -37,4 +37,13 @@ interface FieldInterface
      * @return array An array of options
      */
     public function getStorageOptions();
+
+    /**
+     * Manipulates the content before it reaches the template
+     *
+     * @param  mixed $value The original value
+     * @param  mixed $fieldinfo Information about the field
+     * @return mixed The decoded value
+     */
+    public function getDecodedValue($value, $fieldinfo);
 }


### PR DESCRIPTION
Fixes #2591 

I've done what I have described in the issue, but this is a breaking change for all current extensions that create new fieldtypes as I have added a new method to the FieldInterface.

I was wondering if there was any advice as to how I could make this change non-breaking? I don't PHP often so I don't know what is considered black magic - would taking the function out of the interface and then checking if the method exists using [`method_exists`](http://php.net/manual/en/function.method-exists.php) be something worth doing?

This also breaks the excerpt function for some reason, and all html tags have escaped brackets. Trying to get to the bottom of that one.

**Edit**: Part of me also wants to do something similar to the `setValues` function as I think that would allow for pre-saving hooks.