### PR TITLE
update gruntfile for magnfic popup

### DIFF
--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function(grunt) {
                     'lib/underscore-1.7.0/underscore-min.js',                       //  16 kb
                     'lib/backbone/backbone-min.js',                                 //  20 kb
                     'lib/bootstrap-sass.generated/bootstrap.min.js',                //   2 kb
-                    'lib/magnific-popup-0.9.9/magnific-popup.min.js',               //  21 kb
+                    'lib/magnific-popup/magnific-popup.min.js',               //  21 kb
                     'lib/select2-3.5.1/select2.min.js',                             //  66 kb
                     'node_modules/moment/min/moment.min.js',                        //  35 kb
                     'lib/bootbox-4.3.0/bootbox.min.js',                             //   9 kb

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function(grunt) {
                     'lib/underscore-1.7.0/underscore-min.js',                       //  16 kb
                     'lib/backbone/backbone-min.js',                                 //  20 kb
                     'lib/bootstrap-sass.generated/bootstrap.min.js',                //   2 kb
-                    'lib/magnific-popup/magnific-popup.min.js',               //  21 kb
+                    'lib/magnific-popup-1.0.0/magnific-popup.min.js',               //  21 kb
                     'lib/select2-3.5.1/select2.min.js',                             //  66 kb
                     'node_modules/moment/min/moment.min.js',                        //  35 kb
                     'lib/bootbox-4.3.0/bootbox.min.js',                             //   9 kb
@@ -110,7 +110,7 @@ module.exports = function(grunt) {
                 files: {
                     'css/lib.css': [
                         'lib/jquery-ui-1.10.3/jquery-ui.custom.min.css',      // 20 kb
-                        'lib/magnific-popup-0.9.9/magnific-popup.css',        //  9 kb
+                        'lib/magnific-popup-1.0.0/magnific-popup.css',        //  9 kb
                         'lib/select2-3.5.1/select2.css',                      // 19 kb
                         'lib/jquery-fileupload-5.26/jquery-fileupload-ui.css' //  2 kb
                     ]


### PR DESCRIPTION
I forgot to commit the updated gruntfile when I updated magnific popup to 1.0.0.  

Also removed version number from the directory to make future manual updates easier (if not using a package manager like Bower or NPM ) 