### PR TITLE
Feature - allow ResourceManager getPath to return a relative path based on a known base

### DIFF
--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -141,12 +141,37 @@ class ResourceManager
         if (array_key_exists($name . "path", $this->paths)) {
             return $this->paths[$name . "path"]->string();
         }
+        
+        if (strpos($name, '/') !== false) {
+            return $this->constructRelativePath($name);
+        }
 
         if (! array_key_exists($name, $this->paths)) {
             throw new \InvalidArgumentException("Requested path $name is not available", 1);
         }
 
         return $this->paths[$name];
+    }
+    
+    /**
+     * Takes a known path with relative additional atoms and returns a new path
+     * for instance constructRelativePath('public/images/example')
+     *
+     * @return AbsoluteUnixPath Object
+     **/
+    public function constructRelativePath($name)
+    {
+        list($firstAtom) = explode('/', $name);
+        
+        if (! array_key_exists($firstAtom, $this->paths)) {
+            throw new \InvalidArgumentException("Requested path $name is not available", 1);
+        }
+        
+        $parts = explode('/', $name);
+        array_shift($parts);
+        
+        return $this->paths[$firstAtom]->joinAtomSequence($parts)->string();
+                
     }
 
     public function setUrl($name, $value)

--- a/tests/Configuration/ResourceManagerTest.php
+++ b/tests/Configuration/ResourceManagerTest.php
@@ -68,6 +68,7 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
         $config->getPath($path);
     }
 
+
     public function exceptionGetPathProvider()
     {
         return array(
@@ -93,6 +94,20 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Path::fromString(TEST_ROOT), $config->getPath('root'));
         $this->assertEquals(Path::fromString(TEST_ROOT . '/app'), $config->getPath('app'));
         $this->assertEquals(Path::fromString(TEST_ROOT . '/files'), $config->getPath('files'));
+    }
+    
+    public function testRelativePathCreation()
+    {
+        $config = new ResourceManager(
+            new \Pimple(
+                array(
+                    'rootpath' => TEST_ROOT,
+                    'pathmanager' => new PlatformFileSystemPathFactory()
+                )
+            )
+        );
+        
+        $this->assertEquals(TEST_ROOT.'/app/cache/test', $config->getPath('cache/test'));
     }
 
     public function testDefaultUrls()


### PR DESCRIPTION
As discussed in #2140 