### PR TITLE
Allow getPath to return PathInterfaces

### DIFF
--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -136,9 +136,9 @@ class ResourceManager
 
         return $path;
     }
-
+    
     /**
-     * Gets a path either as a string or PathInterface.
+     * Gets a path either as a string.
      *
      * Subdirectories are automatically parsed to correct filesystem.
      *
@@ -147,14 +147,33 @@ class ResourceManager
      *     $bar = getPath('root/foo/bar');
      *
      * @param string $name Name of path
-     * @param bool   $asPath Whether to return as string or PathInterface.
-     *                       String by default.
      *
-     * @return AbsolutePathInterface|string
+     * @return string
      *
      * @throws \InvalidArgumentException If path isn't available
      */
-    public function getPath($name, $asPath = false)
+    public function getPath($name)
+    {
+        $path = $this->getPathObject($name);
+        return $path->string();
+    }
+
+    /**
+     * Gets a path as a PathInterface.
+     *
+     * Subdirectories are automatically parsed to correct filesystem.
+     *
+     * For example:
+     *
+     *     $bar = getPath('root/foo/bar');
+     *
+     * @param string $name Name of path
+     *
+     * @return AbsolutePathInterface
+     *
+     * @throws \InvalidArgumentException If path isn't available
+     */
+    public function getPathObject($name)
     {
         if (array_key_exists($name . "path", $this->paths)) {
             $path = $this->paths[$name . "path"];
@@ -165,11 +184,8 @@ class ResourceManager
         } else {
             throw new \InvalidArgumentException("Requested path $name is not available", 1);
         }
-
-        if ($asPath) {
-            return $path;
-        }
-        return $path->string();
+        
+        return $path;
     }
 
     /**

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -138,7 +138,7 @@ class ResourceManager
     }
     
     /**
-     * Gets a path either as a string.
+     * Gets a path as a string.
      *
      * Subdirectories are automatically parsed to correct filesystem.
      *
@@ -154,8 +154,7 @@ class ResourceManager
      */
     public function getPath($name)
     {
-        $path = $this->getPathObject($name);
-        return $path->string();
+        return $this->getPathObject($name)->string();
     }
 
     /**
@@ -184,7 +183,7 @@ class ResourceManager
         } else {
             throw new \InvalidArgumentException("Requested path $name is not available", 1);
         }
-        
+
         return $path;
     }
 
@@ -193,6 +192,7 @@ class ResourceManager
      * for instance constructRelativePath('public/images/example')
      *
      * @param string $name
+     *
      * @return AbsolutePathInterface
      */
     protected function constructRelativePath($name)

--- a/tests/Configuration/ResourceManagerTest.php
+++ b/tests/Configuration/ResourceManagerTest.php
@@ -50,7 +50,7 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider exceptionGetPathProvider
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testExceptionGetPath($path)
     {
@@ -73,6 +73,9 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'FAKE_PATH'
+            ),
+            array(
+                'FAKE_PATH/test'
             )
         );
     }
@@ -88,8 +91,10 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $this->assertEquals(Path::fromString(TEST_ROOT), $config->getPath('root'));
+        $this->assertEquals(Path::fromString(TEST_ROOT), $config->getPath('rootpath'));
         $this->assertEquals(Path::fromString(TEST_ROOT . '/app'), $config->getPath('app'));
         $this->assertEquals(Path::fromString(TEST_ROOT . '/files'), $config->getPath('files'));
+        $this->assertInstanceOf('Eloquent\Pathogen\PathInterface', $config->getPath('root', true));
     }
 
     public function testRelativePathCreation()
@@ -103,7 +108,7 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->assertEquals(TEST_ROOT.'/app/cache/test', $config->getPath('cache/test'));
+        $this->assertEquals(Path::fromString(TEST_ROOT . '/app/cache/test'), $config->getPath('cache/test'));
     }
 
     public function testDefaultUrls()
@@ -126,7 +131,7 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider exceptionGetUrlProvider
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testExceptionGetUrl($url)
     {
@@ -194,7 +199,7 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider exceptionGetRequest
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testExceptionGetRequest($request)
     {

--- a/tests/Configuration/ResourceManagerTest.php
+++ b/tests/Configuration/ResourceManagerTest.php
@@ -94,7 +94,7 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Path::fromString(TEST_ROOT), $config->getPath('rootpath'));
         $this->assertEquals(Path::fromString(TEST_ROOT . '/app'), $config->getPath('app'));
         $this->assertEquals(Path::fromString(TEST_ROOT . '/files'), $config->getPath('files'));
-        $this->assertInstanceOf('Eloquent\Pathogen\PathInterface', $config->getPath('root', true));
+        $this->assertInstanceOf('Eloquent\Pathogen\PathInterface', $config->getPathObject('root'));
     }
 
     public function testRelativePathCreation()


### PR DESCRIPTION
Paths are joined together with "/" hardcoded in several places. This is the first step to allow them to be joined properly.