### PR TITLE
Refactor DB config parsing

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -144,7 +144,7 @@ class Application extends Silex\Application
         $this->register(
             new Silex\Provider\DoctrineServiceProvider(),
             array(
-                'db.options' => $this['config']->getDBOptions()
+                'db.options' => $this['config']->get('general/database')
             )
         );
         $this->register(new Database\InitListener());

--- a/src/Config.php
+++ b/src/Config.php
@@ -735,7 +735,7 @@ class Config
     {
         return array(
             'database'                    => array(
-                'driver'         => 'mysql',
+                'driver'         => 'sqlite',
                 'host'           => 'localhost',
                 'slaves'         => array(),
                 'dbname'         => 'bolt',

--- a/src/Config.php
+++ b/src/Config.php
@@ -7,6 +7,8 @@ use Bolt\Library as Lib;
 use Bolt\Helpers\Arr;
 use Bolt\Helpers\String;
 use Bolt\Translation\Translator as Trans;
+use Eloquent\Pathogen\PathInterface;
+use Eloquent\Pathogen\RelativePathInterface;
 use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Yaml;
@@ -594,7 +596,15 @@ class Config
     protected function getDefaults()
     {
         return array(
-            'database'                    => array('prefix' => 'bolt_'),
+            'database'                    => array(
+                'driver'         => 'mysql',
+                'host'           => 'localhost',
+                'slaves'         => array(),
+                'dbname'         => 'bolt',
+                'prefix'         => 'bolt_',
+                'charset'        => 'utf8',
+                'randomfunction' => '',
+            ),
             'sitename'                    => 'Default Bolt site',
             'homepage'                    => 'page/*',
             'homepage_template'           => 'index.twig',
@@ -812,69 +822,143 @@ class Config
      *
      * @return array
      */
-
     public function getDBOptions()
     {
-        $configdb = $this->data['general']['database'];
+        $options = $this->data['general']['database'];
 
-        if (isset($configdb['driver']) && in_array($configdb['driver'], array('pdo_sqlite', 'sqlite'))) {
-            $basename = isset($configdb['databasename']) ? basename($configdb['databasename']) : 'bolt';
-            if (Lib::getExtension($basename) != 'db') {
-                $basename .= '.db';
-            }
+        // Parse master connection parameters
+        $master = $this->parseConnectionParams($options);
+        // Merge master connection into options
+        $options = array_replace($options, $master);
 
-            if (isset($configdb["path"])) {
-                $configpaths = $this->app['resources']->getPaths();
-                if (substr($configdb['path'], 0, 1) !== "/") {
-                    $configdb['path'] = $configpaths["rootpath"] . '/' . $configdb['path'];
-                }
-            }
+        // Add platform specific random functions
+        $driver = String::replaceFirst('pdo_', '', $options['driver']);
+        if ($driver === 'sqlite') {
+            $options['driver'] = 'pdo_sqlite';
+            $options['randomfunction'] = 'RANDOM()';
+        } elseif (in_array($driver, array('mysql', 'mysqli'))) {
+            $options['driver'] = 'pdo_mysql';
+            $options['randomfunction'] = 'RAND()';
+        } elseif (in_array($driver, array('pgsql', 'postgres', 'postgresql'))) {
+            $options['driver'] = 'pdo_pgsql';
+            $options['randomfunction'] = 'RANDOM()';
+        }
 
-            $dboptions = array(
-                'driver' => 'pdo_sqlite',
-                'path' => isset($configdb['path']) ? realpath($configdb['path']) . '/' . $basename : $this->app['resources']->getPath('database') . '/' . $basename,
-                'randomfunction' => 'RANDOM()',
-                'memory' => isset($configdb['memory']) ? true : false
-            );
+        // Parse SQLite separately since it has to figure out database path
+        if ($driver === 'sqlite') {
+            return $this->getSqliteOptions($options);
+        }
+
+        // If no slaves return with single connection
+        if (empty($options['slaves'])) {
+            return $options;
+        }
+
+        // Specify we want a master slave connection
+        $options['wrapperClass'] = '\Doctrine\DBAL\Connections\MasterSlaveConnection';
+
+        // Add master connection where MasterSlaveConnection looks for it.
+        $options['master'] = $master;
+
+        // Parse each slave connection parameters
+        foreach ($options['slaves'] as $name => $slave) {
+            $options['slaves'][$name] = $this->parseConnectionParams($slave, $master);
+        }
+
+        return $options;
+    }
+
+    /**
+     * Parses path and
+     *
+     * @param array $config
+     * @return array
+     */
+    protected function getSqliteOptions($config)
+    {
+        if (isset($config['memory']) && $config['memory']) {
+            // If in-memory, no need to parse paths
+            return $config;
         } else {
-            // Assume we configured it correctly. Yeehaa!
-
-            if (empty($configdb['password'])) {
-                $configdb['password'] = '';
-            }
-
-            $driver = (isset($configdb['driver']) ? $configdb['driver'] : 'pdo_mysql');
-            $randomfunction = '';
-            if (in_array($driver, array('mysql', 'mysqli'))) {
-                $driver = 'pdo_mysql';
-                $randomfunction = 'RAND()';
-            }
-            if (in_array($driver, array('postgres', 'postgresql'))) {
-                $driver = 'pdo_pgsql';
-                $randomfunction = 'RANDOM()';
-            }
-
-            $dboptions = array(
-                'driver'         => $driver,
-                'host'           => (isset($configdb['host']) ? $configdb['host'] : 'localhost'),
-                'dbname'         => $configdb['databasename'],
-                'user'           => $configdb['username'],
-                'password'       => $configdb['password'],
-                'randomfunction' => $randomfunction
-            );
-
-            $dboptions['charset'] = isset($configdb['charset']) ? $configdb['charset'] : 'utf8';
+            // Prevent SQLite driver from trying to use in-memory connection
+            unset($config['memory']);
         }
 
-        switch ($dboptions['driver']) {
-            case 'pdo_mysql':
-                $dboptions['port'] = isset($configdb['port']) ? $configdb['port'] : '3306';
-                break;
-            case 'pdo_pgsql':
-                $dboptions['port'] = isset($configdb['port']) ? $configdb['port'] : '5432';
+        // Get path from config or use database path
+        if (isset($config['path'])) {
+            $path = $this->app['pathmanager']->create($config['path']);
+            // If path is relative, resolve against root path
+            if ($path instanceof RelativePathInterface) {
+                $path = $path->resolveAgainst($this->app['resources']->getPathObject('root'));
+            }
+        } else {
+            $path = $this->app['resources']->getPathObject('database');
         }
 
-        return $dboptions;
+        // If path has filename with extension, use that
+        if ($path->hasExtension()) {
+            $config['path'] = $path->string();
+            return $config;
+        }
+
+        // Use database name for filename
+        /** @var PathInterface $filename */
+        $filename = $this->app['pathmanager']->create(basename($config['dbname']));
+        if (!$filename->hasExtension()) {
+            $filename = $filename->joinExtensions('db');
+        }
+
+        // Join filename with database path
+        $config['path'] = $path->joinAtoms($filename)->string();
+
+        return $config;
+    }
+
+    /**
+     * Parses params to valid connection parameters.
+     *
+     * Defaults are merged into the params.
+     * Bolt keys are converted to Doctrine keys.
+     * Invalid keys are filtered out.
+     *
+     * @param array|string $params
+     * @param array $defaults
+     * @return array
+     */
+    protected function parseConnectionParams($params, $defaults = array())
+    {
+        // Handle host shortcut
+        if (is_string($params)) {
+            $params = array('host' => $params);
+        }
+
+        // Convert keys from Bolt
+        $replacements = array(
+            'databasename' => 'dbname',
+            'username' => 'user',
+        );
+        foreach ($replacements as $old => $new) {
+            if (isset($params[$old])) {
+                $params[$new] = $params[$old];
+                unset($params[$old]);
+            }
+        }
+
+        // Merge in defaults
+        $params = array_replace($defaults, $params);
+
+        // Filter out invalid keys
+        $validKeys = array(
+            'user', 'password', 'host', 'port', 'dbname', 'charset', // common
+            'path', 'memory', // sqlite
+            'unix_socket', 'driverOptions', // mysql
+            'sslmode', // postgres
+            'servicename', 'service', 'pooled', 'instancename', 'server', // oracle
+            'persistent', // sqlanywhere
+        );
+        $params = array_intersect_key($params, array_flip($validKeys));
+
+        return $params;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -496,6 +496,7 @@ class Config
     {
         if (isset($config['memory']) && $config['memory']) {
             // If in-memory, no need to parse paths
+            unset($config['path']);
             return $config;
         } else {
             // Prevent SQLite driver from trying to use in-memory connection

--- a/src/Config.php
+++ b/src/Config.php
@@ -246,6 +246,8 @@ class Config
         // Make sure Bolt's mount point is OK:
         $general['branding']['path'] = '/' . String::makeSafe($general['branding']['path']);
 
+        $general['database'] = $this->parseDatabase($general['database']);
+
         return $general;
     }
 
@@ -818,14 +820,17 @@ class Config
 
 
     /**
-     * Get an associative array with the correct options for the chosen database type.
+     * @deprecated Use get('general/database') instead
      *
      * @return array
      */
     public function getDBOptions()
     {
-        $options = $this->data['general']['database'];
+        return $this->get('general/database');
+    }
 
+    protected function parseDatabase($options)
+    {
         // Parse master connection parameters
         $master = $this->parseConnectionParams($options);
         // Merge master connection into options
@@ -846,7 +851,7 @@ class Config
 
         // Parse SQLite separately since it has to figure out database path
         if ($driver === 'sqlite') {
-            return $this->getSqliteOptions($options);
+            return $this->parseSqliteOptions($options);
         }
 
         // If no slaves return with single connection
@@ -868,13 +873,7 @@ class Config
         return $options;
     }
 
-    /**
-     * Parses path and
-     *
-     * @param array $config
-     * @return array
-     */
-    protected function getSqliteOptions($config)
+    protected function parseSqliteOptions($config)
     {
         if (isset($config['memory']) && $config['memory']) {
             // If in-memory, no need to parse paths

--- a/src/Config.php
+++ b/src/Config.php
@@ -445,6 +445,11 @@ class Config
 
     protected function parseDatabase($options)
     {
+        // Make sure prefix ends with underscore
+        if (substr($options['prefix'], strlen($options['prefix']) - 1) !== '_') {
+            $options['prefix'] .= '_';
+        }
+
         // Parse master connection parameters
         $master = $this->parseConnectionParams($options);
         // Merge master connection into options

--- a/src/Configuration/LowLevelDatabaseException.php
+++ b/src/Configuration/LowLevelDatabaseException.php
@@ -1,0 +1,69 @@
+<?php
+namespace Bolt\Configuration;
+
+class LowLevelDatabaseException extends LowlevelException
+{
+    public static function missingParameter($parameter)
+    {
+        return new static("There is no <code>$parameter</code> set for your database.");
+    }
+
+    public static function missingDriver($name, $driver)
+    {
+        return new static(
+            sprintf("%s was selected as the database type, " .
+                "but the driver does not exist or is not loaded. " .
+                "Please install the %s driver.",
+                $name,
+                $driver
+            )
+        );
+    }
+
+    public static function unsupportedDriver($driver)
+    {
+        return new static($driver . ' was selected as the database type, but it is not supported.');
+    }
+
+    public static function unsecure()
+    {
+        return new static(
+            "There is no <code>password</code> set for the database connection, and you're using user 'root'.<br/> " .
+            "That must surely be a mistake, right? " .
+            "Bolt will stubbornly refuse to run until you've set a password for 'root'."
+        );
+    }
+
+    public static function unwritableFile($path)
+    {
+        return static::invalidPath('file', $path, 'is not writable');
+    }
+
+    public static function unwritableFolder($path)
+    {
+        return static::invalidPath('folder', $path, 'is not writable');
+    }
+
+    public static function nonexistantFile($path)
+    {
+        return static::invalidPath('file', $path, 'does not exist');
+    }
+
+    public static function nonexistantFolder($path)
+    {
+        return static::invalidPath('folder', $path, 'does not exist');
+    }
+
+    protected static function invalidPath($type, $path, $error)
+    {
+        return new static(
+            sprintf(
+                "The database %s <code>%s</code> %s. " .
+                "Make sure it's present and writable to the user that the webserver is using.",
+                $type,
+                $path,
+                $error
+            )
+        );
+    }
+}

--- a/src/Configuration/LowlevelChecks.php
+++ b/src/Configuration/LowlevelChecks.php
@@ -169,72 +169,59 @@ class LowlevelChecks
     public function doDatabaseCheck()
     {
         $cfg = $this->config->app['config']->get('general/database');
-        if (!isset($cfg['driver'])) {
+        $driver = $cfg['driver'];
+
+        if ($driver == 'pdo_sqlite') {
+            $this->doDatabaseSqliteCheck($cfg);
             return;
         }
 
-        if ($cfg['driver'] == 'mysql' || $cfg['driver'] == 'postgres' || $cfg['driver'] == 'postgresql') {
-            if (empty($cfg['password']) && ($cfg['username'] == "root")) {
-                throw new LowlevelException(
-                    "There is no <code>password</code> set for the database connection, and you're using user 'root'." .
-                    "<br>That must surely be a mistake, right? Bolt will stubbornly refuse to run until you've set a password for 'root'."
-                );
-            }
-            if (empty($cfg['databasename'])) {
-                throw new LowlevelException("There is no <code>databasename</code> set for your database.");
-            }
-            if (empty($cfg['username'])) {
-                throw new LowlevelException("There is no <code>username</code> set for your database.");
-            }
+        if (!in_array($driver, array('pdo_mysql', 'pdo_pgsql'))) {
+            throw LowLevelDatabaseException::unsupportedDriver($driver);
         }
 
-        if ($cfg['driver'] == 'mysql') {
-            if (!$this->mysqlLoaded) {
-                throw new LowlevelException("MySQL was selected as the database type, but the driver does not exist or is not loaded. Please install the pdo_mysql driver.");
-            }
-
-            return;
-        } elseif ($cfg['driver'] == 'postgres' || $cfg['driver'] == 'postgresql') {
-            if (!$this->postgresLoaded) {
-                throw new LowlevelException("Postgres was selected as the database type, but the driver does not exist or is not loaded. Please install the pdo_pgsql driver.");
-            }
-
-            return;
-        } elseif ($cfg['driver'] == 'sqlite') {
-            if (!$this->sqliteLoaded) {
-                throw new LowlevelException("SQLite was selected as the database type, but the driver does not exist or is not loaded. Please install the pdo_sqlite driver.");
-            }
-        } else {
-            throw new LowlevelException('The selected database type is not supported.');
+        if ($driver == 'pdo_mysql' && !$this->mysqlLoaded) {
+            throw LowLevelDatabaseException::missingDriver('MySQL', 'pdo_mysql');
+        } elseif ($driver == 'pdo_pgsql' && !$this->postgresLoaded) {
+            throw LowLevelDatabaseException::missingDriver('PostgreSQL', 'pdo_pgsql');
         }
 
+        if (empty($cfg['dbname'])) {
+            throw LowLevelDatabaseException::missingParameter('databasename');
+        }
+        if (empty($cfg['user'])) {
+            throw LowLevelDatabaseException::missingParameter('username');
+        }
+        if (empty($cfg['password']) && ($cfg['user'] === 'root')) {
+            throw LowLevelDatabaseException::unsecure();
+        }
+    }
+
+    protected function doDatabaseSqliteCheck($config)
+    {
+        if (!$this->sqliteLoaded) {
+            throw LowLevelDatabaseException::missingDriver('SQLite', 'pdo_sqlite');
+        }
+
+        // If in-memory connection, skip path checks
         if (isset($cfg['memory']) && $cfg['memory'] === true) {
             return;
         }
 
-        $filename = isset($cfg['databasename']) ? basename($cfg['databasename']) : 'bolt';
-        if (Lib::getExtension($filename) != 'db') {
-            $filename .= '.db';
+        // If the file is present, make sure it is writable
+        $file = $config['path'];
+        if (file_exists($file) && !is_writable($file)) {
+            throw LowLevelDatabaseException::unwritableFile($file);
         }
-        
-        // Check if the app/database folder and .db file are present and writable
-        if (!is_writable($this->config->getPath('database'))) {
-            throw new LowlevelException(
-                'The folder <code>' .
-                $this->config->getPath('database') .
-                "</code> doesn't exist or it is not writable. Make sure it's " .
-                "present and writable to the user that the webserver is using."
-            );
+
+        // If the file isn't present, make sure the directory
+        // exists and is writable so the file can be created
+        $dir = dirname($file);
+        if (!file_exists($dir)) {
+            throw LowLevelDatabaseException::nonexistantFolder($dir);
         }
-        
-        // If the .db file is present, make sure it is writable
-        if (file_exists($this->config->getPath('database') . '/' . $filename) && !is_writable($this->config->getPath('database') . '/' . $filename)) {
-            throw new LowlevelException(
-                "The database file <code>app/database/" .
-                htmlspecialchars($filename, ENT_QUOTES) .
-                "</code> isn't writable. Make sure it's " .
-                "present and writable to the user that the webserver is using. If the file doesn't exist, make sure the folder is writable and Bolt will create the file."
-            );
+        if (!is_writable($dir)) {
+            throw LowLevelDatabaseException::unwritableFolder($dir);
         }
     }
 

--- a/src/Configuration/LowlevelChecks.php
+++ b/src/Configuration/LowlevelChecks.php
@@ -1,13 +1,10 @@
 <?php
 namespace Bolt\Configuration;
 
-use Bolt\Library as Lib;
-
 /**
  * A class to perform several 'low level' checks. Since we're doing it (by design)
  * _before_ the autoloader gets initialized, we can't use autoloading.
  */
-
 class LowlevelChecks
 {
     public $config;
@@ -37,11 +34,8 @@ class LowlevelChecks
     public $sqliteLoaded;
 
     /**
-     * The constructor requires a resource manager object to perform checks against.
-     * This should ideally be typehinted to Bolt\Configuration\ResourceManager
-     *
-     * @return void
-     **/
+     * @param ResourceManager $config
+     */
     public function __construct($config = null)
     {
         $this->config = $config;
@@ -204,14 +198,17 @@ class LowlevelChecks
         }
 
         // If in-memory connection, skip path checks
-        if (isset($cfg['memory']) && $cfg['memory'] === true) {
+        if (isset($config['memory']) && $config['memory'] === true) {
             return;
         }
 
         // If the file is present, make sure it is writable
         $file = $config['path'];
-        if (file_exists($file) && !is_writable($file)) {
-            throw LowLevelDatabaseException::unwritableFile($file);
+        if (file_exists($file)) {
+            if (!is_writable($file)) {
+                throw LowLevelDatabaseException::unwritableFile($file);
+            }
+            return;
         }
 
         // If the file isn't present, make sure the directory

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -104,7 +104,7 @@ class Async implements ControllerProviderInterface
 
             $app['logger.system']->addInfo("Fetching from remote server: $source", array('event' => 'news'));
 
-            $driver = $app['config']->get('general/database/driver', 'sqlite');
+            $driver = $app['db']->getDatabasePlatform()->getName();
 
             $url = sprintf(
                 '%s?v=%s&p=%s&db=%s&name=%s',

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -48,11 +48,6 @@ class Storage
 
         $this->prefix = $app['config']->get('general/database/prefix', "bolt_");
 
-        // Make sure prefix ends in '_'. Prefixes without '_' are lame..
-        if ($this->prefix[strlen($this->prefix) - 1] != "_") {
-            $this->prefix .= "_";
-        }
-
         $this->tables = array();
     }
 

--- a/tests/BoltUnitTest.php
+++ b/tests/BoltUnitTest.php
@@ -54,8 +54,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
             array(
                 'driver' => 'pdo_sqlite',
                 'user' => 'test',
-                'memory' => true,
-                'path' => false
+                'path' => TEST_ROOT . '/bolt.db'
             )
         );
         $bolt['session'] = $sessionMock;

--- a/tests/BoltUnitTest.php
+++ b/tests/BoltUnitTest.php
@@ -52,8 +52,8 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
         $bolt['config']->set(
             'general/database',
             array(
-                'driver' => 'sqlite',
-                'username' => 'test',
+                'driver' => 'pdo_sqlite',
+                'user' => 'test',
                 'memory' => true,
                 'path' => false
             )

--- a/tests/Configuration/Mock/Config.php
+++ b/tests/Configuration/Mock/Config.php
@@ -11,10 +11,10 @@ class Config
 {
 
     public $db1 = array(
-        'driver'=>'mysql',
-        'username'=>'test',
-        'password'=>'test' ,
-        'databasename'=> 'test'
+        'driver'   => 'pdo_mysql',
+        'user'     => 'test',
+        'password' => 'test',
+        'dbname'   => 'test'
     );
 
     public $value;
@@ -27,20 +27,20 @@ class Config
     public function mockRoot()
     {
         $this->value = $this->db1;
-        $this->value['username'] = 'root';
+        $this->value['user'] = 'root';
         $this->value['password'] = '';
     }
 
     public function mockEmptyDb()
     {
         $this->value = $this->db1;
-        $this->value['databasename'] = false;
+        $this->value['dbname'] = false;
     }
 
     public function mockEmptyUser()
     {
         $this->value = $this->db1;
-        $this->value['username'] = false;
+        $this->value['user'] = false;
     }
 
     public function mockMysql()
@@ -51,31 +51,26 @@ class Config
     public function mockPostgres()
     {
         $this->value = $this->db1;
-        $this->value['driver'] = "postgres";
+        $this->value['driver'] = "pdo_pgsql";
     }
 
     public function mockSqlite()
     {
         $this->value = $this->db1;
-        $this->value['driver'] = "sqlite";
+        $this->value['driver'] = "pdo_sqlite";
+        $this->value['path'] = "test/bolt.db";
     }
 
-    public function mockBadDb()
+    public function mockUnsupportedPlatform()
     {
         $this->value = $this->db1;
         $this->value['driver'] = "mongodb";
     }
 
-    public function mockNoDriver()
-    {
-        $this->value = $this->db1;
-        unset($this->value['driver']);
-    }
-
     public function mockSqliteMem()
     {
         $this->value = $this->db1;
-        $this->value['driver'] = "sqlite";
+        $this->value['driver'] = "pdo_sqlite";
         $this->value['memory'] = true;
     }
 

--- a/tests/Controller/BackendTest.php
+++ b/tests/Controller/BackendTest.php
@@ -45,7 +45,7 @@ class BackendTest extends BoltUnitTest
         $app = $this->getApp();
         $this->allowLogin($app);
         $check = $this->getMock('Bolt\Database\IntegrityChecker', array('checkTablesIntegrity'), array($app));
-        $check->expects($this->once())
+        $check->expects($this->atLeastOnce())
             ->method('checkTablesIntegrity')
             ->will($this->returnValue(array('message', 'hint')));
 

--- a/tests/Library/BoltLibraryTest.php
+++ b/tests/Library/BoltLibraryTest.php
@@ -145,7 +145,7 @@ class BoltLibraryTest extends BoltUnitTest
         $app = $this->getApp();
         $this->expectOutputRegex("/Redirecting to/i");
         $redirect = Library::simpleredirect("/test", false);
-        $this->assertEquals( array( 'location: /test' ), xdebug_get_headers() );
+        $this->assertContains('location: /test', xdebug_get_headers());
     }
 
     /**
@@ -156,7 +156,7 @@ class BoltLibraryTest extends BoltUnitTest
         $app = $this->getApp();
         $this->expectOutputRegex("/Redirecting to/i");
         $redirect = Library::simpleredirect("", false);
-        $this->assertEquals( array( 'location: /' ), xdebug_get_headers() );
+        $this->assertContains('location: /', xdebug_get_headers());
     }
 
     /**

--- a/tests/Storage/StorageTest.php
+++ b/tests/Storage/StorageTest.php
@@ -15,14 +15,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class StorageTest extends BoltUnitTest
 {
-    public function testSetup()
-    {
-        $app = $this->getApp();
-        $app['config']->set('general/database/prefix', "bolt");
-        $storage = new Storage($app);
-        $this->assertEquals('bolt_', \PHPUnit_Framework_Assert::readAttribute($storage, 'prefix'));
-    }
-
     public function testGetContentObject()
     {
         $app = $this->getApp();


### PR DESCRIPTION
Depends on #2601.

- Cleans up the parsing methods and makes them more readable
- Adds master / slave connections
- Allows standard Doctrine configuration, while maintaining BC
- Uses pathogen for SQLite paths

See Config changes in #2530.