### PR TITLE
Allow template directory

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -677,7 +677,7 @@ class Config
 
     public function getTwigPath()
     {
-        $themepath = $this->app['resources']->getPath("theme");
+        $themepath = $this->app['resources']->getPath("templatespath");
         $end = $this->getWhichEnd($this->get('general/branding/path'));
 
         if ($end == 'frontend' && file_exists($themepath)) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -689,7 +689,8 @@ class Config
         // If the template path doesn't exist, flash error on the dashboard.
         if (!file_exists($themepath)) {
             $relativethemepath = basename($this->get('general/theme'));
-            if (isset($this->app['config']->get('theme')['template_directory'])) {
+            $theme = $this->app['config']->get('theme');
+            if (isset($theme['template_directory'])) {
                 $relativethemepath .= '/' . $this->app['config']->get('theme/template_directory');
             }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -688,7 +688,12 @@ class Config
 
         // If the template path doesn't exist, flash error on the dashboard.
         if (!file_exists($themepath)) {
-            $error = "Template folder 'theme/" . basename($this->get('general/theme')) . "' does not exist, or is not writable.";
+            $relativethemepath = basename($this->get('general/theme'));
+            if (isset($this->app['config']->get('theme')['template_directory'])) {
+                $relativethemepath .= '/' . $this->app['config']->get('theme/template_directory');
+            }
+
+            $error = "Template folder 'theme/" . $relativethemepath . "' does not exist, or is not writable.";
             $this->app['session']->getFlashBag()->set('error', $error);
         }
 

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -276,6 +276,13 @@ class ResourceManager
     public function postInitialize()
     {
         $this->setThemePath($this->app['config']->get("general"));
+
+        if (isset($this->app['config']->get('theme')['template_directory'])) {
+            $this->setPath('templatespath', $this->getPath('theme') . '/' . $this->app['config']->get('theme/template_directory'));
+        } else {
+            $this->setPath('templatespath', $this->getPath('theme'));
+        }
+
         $branding = ltrim($this->app['config']->get('general/branding/path') . '/', '/');
         $this->setUrl("bolt", $this->getUrl('root') . $branding);
         $this->app['config']->setCkPath();

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -276,7 +276,8 @@ class ResourceManager
     {
         $this->setThemePath($this->app['config']->get("general"));
 
-        if (isset($this->app['config']->get('theme')['template_directory'])) {
+        $theme = $this->app['config']->get('theme');
+        if (isset($theme['template_directory'])) {
             $this->setPath('templatespath', $this->getPath('theme') . '/' . $this->app['config']->get('theme/template_directory'));
         } else {
             $this->setPath('templatespath', $this->getPath('theme'));

--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -158,7 +158,7 @@ class Frontend
         $template = $app['templatechooser']->record($content);
 
         // Fallback: If file is not OK, show an error page
-        $filename = $app['paths']['themepath'] . "/" . $template;
+        $filename = $app['paths']['templatespath'] . "/" . $template;
         if (!file_exists($filename) || !is_readable($filename)) {
             $error = sprintf(
                 "No template for '%s' defined. Tried to use '%s/%s'.",
@@ -208,7 +208,7 @@ class Frontend
         $template = $app['templatechooser']->record($content);
 
         // Fallback: If file is not OK, show an error page
-        $filename = $app['paths']['themepath'] . "/" . $template;
+        $filename = $app['paths']['templatespath'] . "/" . $template;
         if (!file_exists($filename) || !is_readable($filename)) {
             $error = sprintf(
                 "No template for '%s' defined. Tried to use '%s/%s'.",
@@ -258,7 +258,7 @@ class Frontend
         $template = $app['templatechooser']->listing($contenttype);
 
         // Fallback: If file is not OK, show an error page
-        $filename = $app['paths']['themepath'] . "/" . $template;
+        $filename = $app['paths']['templatespath'] . "/" . $template;
         if (!file_exists($filename) || !is_readable($filename)) {
             $error = sprintf(
                 "No template for '%s'-listing defined. Tried to use '%s/%s'.",
@@ -316,7 +316,7 @@ class Frontend
         $template = $app['templatechooser']->taxonomy($taxonomyslug);
 
         // Fallback: If file is not OK, show an error page
-        $filename = $app['paths']['themepath'] . "/" . $template;
+        $filename = $app['paths']['templatespath'] . "/" . $template;
         if (!file_exists($filename) || !is_readable($filename)) {
             $error = sprintf(
                 "No template for '%s'-listing defined. Tried to use '%s/%s'.",

--- a/src/TemplateChooser.php
+++ b/src/TemplateChooser.php
@@ -60,7 +60,7 @@ class TemplateChooser
 
         // Third candidate: a template with the same filename as the name of
         // the contenttype.
-        $templatefile = $this->app['paths']['themepath'] . '/' . $record->contenttype['singular_slug'] . '.twig';
+        $templatefile = $this->app['paths']['templatespath'] . '/' . $record->contenttype['singular_slug'] . '.twig';
         if (is_readable($templatefile)) {
             $template = $record->contenttype['singular_slug'] . ".twig";
             $chosen = 'singular_slug';
@@ -68,7 +68,7 @@ class TemplateChooser
 
         // Fourth candidate: defined specificaly in the contenttype.
         if (isset($record->contenttype['record_template'])) {
-            $templatefile = $this->app['paths']['themepath'] . '/' . $record->contenttype['record_template'];
+            $templatefile = $this->app['paths']['templatespath'] . '/' . $record->contenttype['record_template'];
             if (file_exists($templatefile)) {
                 $template = $record->contenttype['record_template'];
                 $chosen = 'contenttype';
@@ -106,7 +106,7 @@ class TemplateChooser
 
         // Third candidate: a template with the same filename as the name of
         // the contenttype.
-        $filename = $this->app['paths']['themepath'] . '/' . $contenttype['slug'] . '.twig';
+        $filename = $this->app['paths']['templatespath'] . '/' . $contenttype['slug'] . '.twig';
         if (file_exists($filename) && is_readable($filename)) {
                 $template = $contenttype['slug'] . '.twig';
                 $chosen = 'slug';

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -4,6 +4,7 @@ namespace Bolt;
 
 use Silex;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\Glob;
 use Bolt\Library as Lib;
 use Bolt\Helpers\String;
 use Bolt\Helpers\Html;
@@ -717,21 +718,23 @@ class TwigExtension extends \Twig_Extension
             return null;
         }
 
-        $name = '/^[a-zA-Z0-9]\V+\.twig$/';
         if ($filter) {
-            $name = $filter;
+            $name = Glob::toRegex($filter, false, false);
+        } else {
+            $name = '/^[a-zA-Z0-9]\V+\.twig$/';
         }
+
+        //$dir = $this->app['paths']['templatespath'] . ($in ? '/' . $in : '');
 
         $finder = new Finder();
         $finder->files()
                ->in($this->app['paths']['templatespath'])
-               ->depth('== 0')
-               ->name($name)
+               ->path($name)
                ->sortByName();
 
         $files = array();
         foreach ($finder as $file) {
-            $name = $file->getFilename();
+            $name = $file->getRelativePathname();
             $files[$name] = $name;
         }
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -729,6 +729,7 @@ class TwigExtension extends \Twig_Extension
         $finder = new Finder();
         $finder->files()
                ->in($this->app['paths']['templatespath'])
+               ->notname('/^_/')
                ->path($name)
                ->sortByName();
 

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -724,7 +724,7 @@ class TwigExtension extends \Twig_Extension
 
         $finder = new Finder();
         $finder->files()
-               ->in($this->app['paths']['themepath'])
+               ->in($this->app['paths']['templatespath'])
                ->depth('== 0')
                ->name($name)
                ->sortByName();


### PR DESCRIPTION
Fixes #2445

If you specify `template_directory` in your theme's `config.yml`, all related template activities will be relative to that directory (which is relative to the theme directory).

It adds `templatespath` to the paths object, and I *think* I managed to change all of the correct instances of `themepath`. This should be checked by someone who knows their stuff.