### PR TITLE
"Fix" arrays in type:select fields.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -404,6 +404,17 @@ class Config
                 }
             }
 
+            // If field is a "Select" type, make sure the array is a "hash" (as opposed to a "map")
+            // For example: [ 'yes', 'no' ] => { 'yes': 'yes', 'no': 'no' }
+            // The reason that we do this, is because if you set values to ['blue', 'green'], that is
+            // what you'd expect to see in the database. Not '0' and '1', which is what would happen,
+            // if we didn't "correct" it here. 
+            // @see used hack: http://stackoverflow.com/questions/173400/how-to-check-if-php-array-is-associative-or-sequential
+            if ($field['type'] == 'select' && is_array($field['values']) && 
+                array_values($field['values']) === $field['values'] ) {
+                $field['values'] = array_combine($field['values'], $field['values']);
+            }
+            
             // If the field has a 'group', make sure it's added to the 'groups' array, so we can turn
             // them into tabs while rendering. This also makes sure that once you started with a group,
             // all others have a group too.


### PR DESCRIPTION
In a `type: select` field, the current situation is that the YML parser does not distinguish between hashes and map typ arays. 
The reason that we would want to do this, is because if you set values to ['blue', 'green'], that is what you'd expect to see in the database, normally. Not '0' and '1', which is what would happen, if we didn't "correct" it here. 

I'm fully aware that this solution is conceptualy wrong. However before it was actually _broken_, it just wasn't very apparent. So, now we choose: "Wrong and fixed" or "correct and broken". ^_^