### PR TITLE
Gruntfile reorganisation

### DIFF
--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -216,62 +216,63 @@ module.exports = function(grunt) {
         },
 
         jshint: {
-            options: {
-                browser: true,          // Defines globals exposed by modern browsers
-                curly: true,            // Always put curly braces around blocks
-                devel: true,            // Defines globals that are usually used for logging/debugging
-                immed: true,            // Prohibits the use of immediate function invocations without parentheses
-                indent: 4,              // Tab width
-                latedef: true,          // Prohibits the use of a variable before it was defined
-                maxlen: 120,            // Maximum length of a line
-                noarg: true,            // Prohibits the use of arguments.caller and arguments.callee
-                nonbsp: true,           // Warns about "non-breaking whitespace" characters
-                singleGroups: true,     // Prohibits the use of the grouping operator for single-expression statements
-                undef: true,            // Prohibits the use of undeclared variables
-                globals: {
-                    // Bolt
-                    bolt: true,                 // src/console.js
-                    FilelistHolder: true,       // src/upload-files.js
-                    Files: true,                // src/obj-files.js
-                    Folders: true,              // src/obj-folders.js
-                    init: true,                 // src/init.js
-                    Moments: true,              // src/obj-moments.js
-                    Navpopups: true,            // src/obj-navpopups.js
-                    Sidebar: true,              // src/obj-sidebar.js
-                    Stack: true,                // src/obj-stack.js
-                    site: true,                 // src/extend.js/extend.twig
-                    baseurl: true,              // src/extend.js/extend.twig
-                    rootpath: true,             // src/extend.js/extend.twig
-                    // Bolt global functions
-                    bindFileUpload: true,       // src/bindfileuploads.js
-                    bindGeolocation: true,      // src/geolocation.js
-                    bindVideoEmbed: true,       // src/video-embed.js
-                    getSelectedItems: true,     // src/fnc-helpers.js
-                    makeUri: true,              // src/make-uri-slug.js
-                    makeUriAjax: true,          // src/make-uri-slug.js
-                    stopMakeUri: true,          // src/make-uri-slug.js
-                    updateLatestActivity: true, // src/activity.js
-                    validateContent: true,      // src/fnc-helpers.js
-                    // Vendor
-                    $: true,                    // jQuery
-                    _: true,                    // underscore.js
-                    Backbone: true,             // backbone.min.js
-                    bootbox: true,              // bootbox.min.js
-                    CKEDITOR: true,             // ckeditor.js
-                    CodeMirror: true,           // ckeditor.js
-                    google: true,               // Google
-                    jQuery: true,               // jQuery
-                    moment: true,               // moment.min.js
-                    UAParser: true              // ua-parser.min.js
-                }
-            },
-            src: ['lib/bolt/*.js']
+            bolt_js: {
+                options: {
+                    browser: true,      // Defines globals exposed by modern browsers
+                    curly: true,        // Always put curly braces around blocks
+                    devel: true,        // Defines globals that are usually used for logging/debugging
+                    immed: true,        // Prohibits the use of immediate function invocations without parentheses
+                    indent: 4,          // Tab width
+                    latedef: true,      // Prohibits the use of a variable before it was defined
+                    maxlen: 120,        // Maximum length of a line
+                    noarg: true,        // Prohibits the use of arguments.caller and arguments.callee
+                    nonbsp: true,       // Warns about "non-breaking whitespace" characters
+                    singleGroups: true, // Prohibits the use of the grouping operator for single-expression statements
+                    undef: true,        // Prohibits the use of undeclared variables
+                    globals: {
+                        // Bolt
+                        bolt: true,                 // src/console.js
+                        FilelistHolder: true,       // src/upload-files.js
+                        Files: true,                // src/obj-files.js
+                        Folders: true,              // src/obj-folders.js
+                        init: true,                 // src/init.js
+                        Moments: true,              // src/obj-moments.js
+                        Navpopups: true,            // src/obj-navpopups.js
+                        Sidebar: true,              // src/obj-sidebar.js
+                        Stack: true,                // src/obj-stack.js
+                        site: true,                 // src/extend.js/extend.twig
+                        baseurl: true,              // src/extend.js/extend.twig
+                        rootpath: true,             // src/extend.js/extend.twig
+                        // Bolt global functions
+                        bindFileUpload: true,       // src/bindfileuploads.js
+                        bindGeolocation: true,      // src/geolocation.js
+                        bindVideoEmbed: true,       // src/video-embed.js
+                        getSelectedItems: true,     // src/fnc-helpers.js
+                        makeUri: true,              // src/make-uri-slug.js
+                        makeUriAjax: true,          // src/make-uri-slug.js
+                        stopMakeUri: true,          // src/make-uri-slug.js
+                        updateLatestActivity: true, // src/activity.js
+                        validateContent: true,      // src/fnc-helpers.js
+                        // Vendor
+                        $: true,                    // jQuery
+                        _: true,                    // underscore.js
+                        Backbone: true,             // backbone.min.js
+                        bootbox: true,              // bootbox.min.js
+                        CKEDITOR: true,             // ckeditor.js
+                        CodeMirror: true,           // ckeditor.js
+                        google: true,               // Google
+                        jQuery: true,               // jQuery
+                        moment: true,               // moment.min.js
+                        UAParser: true              // ua-parser.min.js
+                    }
+                },
+                src: ['lib/bolt/*.js']
+            }
         }
-
     });
 
     require('load-grunt-tasks')(grunt);
 
-    grunt.registerTask('default', ['sass', 'jshint', 'uglify', 'cssmin', 'concat', 'watch']);
+    grunt.registerTask('default', ['sass', 'jshint:bolt_js', 'uglify', 'cssmin', 'concat', 'watch']);
 
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -121,11 +121,11 @@ module.exports = function(grunt) {
         },
 
         cssmin: {
-            lib: {
+            libCss: {
                 options: {
                     compatibility: 'ie8',
-                    relativeTo: './css/',
-                    target: './css/'
+                    relativeTo: 'css/',
+                    target: 'css/'
                 },
                 files: {
                     'css/lib.css': [
@@ -284,6 +284,7 @@ module.exports = function(grunt) {
     ]);
 
     grunt.registerTask('update', [
-        'copy:fonts'        // Copies fonts to view/fonts/
+        'copy:fonts',       // Copies fonts to view/fonts/
+        'cssmin:libCss'     // Builds view/css/lib.css from library css files
     ]);
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -284,18 +284,25 @@ module.exports = function(grunt) {
 
     require('load-grunt-tasks')(grunt);
 
-    /*** DEFAULT TASK:  Creates Bolts own css and js files ***/
+    /*** DEFAULT TASK:  Watches for changes of Bolts own css and js files ***/
     grunt.registerTask(
         'default',
         [
-            'sass',
-            'jshint:boltJs',
-            'uglify:boltJs',
             'watch'
         ]
     );
 
-    /*** UPDATE TASK:  Builds library css/js. Run after one of the externals is updated ***/
+    /*** UPDATE BOLT TASK:  Creates Bolts own css and js files ***/
+    grunt.registerTask(
+        'updateBolt',
+        [
+            'sass',
+            'jshint:boltJs',
+            'uglify:boltJs'
+        ]
+    );
+
+    /*** UPDATE LIB TASK:  Builds library css/js. Run after one of the externals is updated ***/
     grunt.registerTask(
         'updateLib',
         [

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -85,7 +85,7 @@ module.exports = function(grunt) {
         },
 
         copy: {
-            fonts: {
+            installFonts: {
                 files: [{
                     expand: true,
                     flatten: true,
@@ -99,7 +99,7 @@ module.exports = function(grunt) {
         },
 
         concat: {
-            libJs: {
+            installLibJs: {
                 options: {
                     separator: '\n\n'
                 },
@@ -129,7 +129,7 @@ module.exports = function(grunt) {
         },
 
         cssmin: {
-            libCss: {
+            installLibCss: {
                 options: {
                     compatibility: 'ie8',
                     relativeTo: 'css/',
@@ -147,7 +147,7 @@ module.exports = function(grunt) {
         },
 
         uglify: {
-            libJs: {
+            prepareLibJs: {
                 options: {
                     preserveComments: 'some'
                 },
@@ -166,7 +166,7 @@ module.exports = function(grunt) {
                     ]
                 }]
             },
-            localeDatepicker: {
+            installLocaleDatepicker: {
                 options: {
                     preserveComments: 'some'
                 },
@@ -181,7 +181,7 @@ module.exports = function(grunt) {
                     }
                 }]
             },
-            localeMoment: {
+            installLocaleMoment: {
                 options: {
                     preserveComments: 'some'
                 },
@@ -198,7 +198,7 @@ module.exports = function(grunt) {
                     }
                 }]
             },
-            bootstrap: {
+            prepareBootstrapJs: {
                 files: {
                     'lib/bootstrap-sass.generated/bootstrap.min.js': [
                         'node_modules/bootstrap-sass/assets/javascripts/bootstrap/alert.js',
@@ -307,14 +307,14 @@ module.exports = function(grunt) {
         'updateLib',
         [
             // Prepare
-            'uglify:bootstrap',             // Concat bootstrap scripts into one minified file
-            'uglify:libJs',                 // Create minified versions of library scripts that don't have them
+            'uglify:prepareBootstrapJs',        // Concat bootstrap scripts into one minified file
+            'uglify:prepareLibJs',              // Create minified versions of library scripts that don't have them
             // Install
-            'copy:fonts',                   // Copies fonts                       => view/fonts/*
-            'cssmin:libCss',                // Concats and minifies library css   => view/css/lib.css
-            'concat:libJs',                 // Concats minified library scripts   => view/js/lib.min.js
-            'uglify:localeDatepicker',      // Copies minified datepicker locale  => view/js/locale/datepicker/*
-            'uglify:localeMoment'           // Copies minified moment.js locale   => view/js/locale/datepicker/*
+            'copy:installFonts',                // Copies fonts                       => view/fonts/*
+            'cssmin:installLibCss',             // Concats and minifies library css   => view/css/lib.css
+            'concat:installLibJs',              // Concats minified library scripts   => view/js/lib.min.js
+            'uglify:installLocaleDatepicker',   // Copies minified datepicker locale  => view/js/locale/datepicker/*
+            'uglify:installLocaleMoment'        // Copies minified moment.js locale   => view/js/locale/datepicker/*
         ]
     );
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -77,8 +77,7 @@ module.exports = function(grunt) {
         },
 
         copy: {
-            main: {
-                // Includes files within path
+            fonts: {
                 files: [{
                     expand: true,
                     flatten: true,
@@ -285,6 +284,6 @@ module.exports = function(grunt) {
     ]);
 
     grunt.registerTask('update', [
+        'copy:fonts'        // Copies fonts to view/fonts/
     ]);
-
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -276,20 +276,28 @@ module.exports = function(grunt) {
 
     require('load-grunt-tasks')(grunt);
 
-    grunt.registerTask('default', [
-        'sass',
-        'jshint:boltJs',
-        'uglify:boltJs',
-        'watch'
-    ]);
+    grunt.registerTask(
+        'default',
+        [
+            'sass',
+            'jshint:boltJs',
+            'uglify:boltJs',
+            'watch'
+        ]
+    );
 
-    grunt.registerTask('update', [
-        'copy:fonts',               // Copies fonts to view/fonts/
-        'cssmin:libCss',            // Builds view/css/lib.css from library css files
-        'uglify:bootstrap',         // Concat bootstrap scripts into one minified file
-        'uglify:libJs',             // Create minified versions of library scripts that don't have them
-        'concat:libJs',             // Concats minified library scripts to view/js/lib.min.js
-        'uglify:localeDatepicker',  // Copies minified datepicker locale to view/js/locale/datepicker
-        'uglify:localeMoment'       // Copies minified moment.js locale to view/js/locale/datepicker
-    ]);
+    grunt.registerTask(
+        'update',
+        [
+            // Prepare
+            'uglify:bootstrap',             // Concat bootstrap scripts into one minified file
+            'uglify:libJs',                 // Create minified versions of library scripts that don't have them
+            // Install
+            'copy:fonts',                   // Copies fonts                       => view/fonts/*
+            'cssmin:libCss',                // Concats and minifies library css   => view/css/lib.css
+            'concat:libJs',                 // Concats minified library scripts   => view/js/lib.min.js
+            'uglify:localeDatepicker',      // Copies minified datepicker locale  => view/js/locale/datepicker/*
+            'uglify:localeMoment'           // Copies minified moment.js locale   => view/js/locale/datepicker/*
+        ]
+    );
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -51,7 +51,6 @@ module.exports = function(grunt) {
                     'css/bolt.css': 'sass/app.scss'
                 }
             }
-
         },
 
         copy: {

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
         },
 
         sass: {
-            dist: {
+            boltCss: {
                 options: {
                     outputStyle: 'compressed',
                     includePaths: [
@@ -296,7 +296,7 @@ module.exports = function(grunt) {
     grunt.registerTask(
         'updateBolt',
         [
-            'sass',
+            'sass:boltCss',
             'jshint:boltJs',
             'uglify:boltJs'
         ]

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -13,8 +13,7 @@ module.exports = function(grunt) {
             scripts: {
                 files: [
                     'sass/*.scss',
-                    'sass/nav/*.scss',
-                    'sass/modules/*.scss'
+                    'sass/**/*.scss'
                 ],
                 tasks: [
                     'sass'

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
                     'sass'
                 ]
             },
-            js: {
+            bolt_js: {
                 files: [
                     'lib/bolt/*.js'
                 ],

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -41,13 +41,13 @@ module.exports = function(grunt) {
                     'sass'
                 ]
             },
-            bolt_js: {
+            boltJs: {
                 files: [
                     "<%= filesBoltJs %>"
                 ],
                 tasks: [
-                    'jshint:bolt_js',
-                    'uglify:bolt_js'
+                    'jshint:boltJs',
+                    'uglify:boltJs'
                 ]
             }
         },
@@ -205,7 +205,7 @@ module.exports = function(grunt) {
                     ]
                 }
             },
-            bolt_js: {
+            boltJs: {
                 options: {
                     banner: "/**\n" +
                             " * These are Bolt's COMPILED JS files!\n" +
@@ -220,7 +220,7 @@ module.exports = function(grunt) {
         },
 
         jshint: {
-            bolt_js: {
+            boltJs: {
                 options: {
                     browser: true,      // Defines globals exposed by modern browsers
                     curly: true,        // Always put curly braces around blocks
@@ -279,8 +279,8 @@ module.exports = function(grunt) {
 
     grunt.registerTask('default', [
         'sass',
-        'jshint:bolt_js',
-        'uglify:bolt_js',
+        'jshint:boltJs',
+        'uglify:boltJs',
         'cssmin',
         'concat',
         'watch'

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -91,7 +91,7 @@ module.exports = function(grunt) {
         },
 
         concat: {
-            lib: {
+            libJs: {
                 options: {
                     separator: '\n\n'
                 },
@@ -285,6 +285,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask('update', [
         'copy:fonts',       // Copies fonts to view/fonts/
-        'cssmin:libCss'     // Builds view/css/lib.css from library css files
+        'cssmin:libCss',    // Builds view/css/lib.css from library css files
+        'concat:libJs'      // Concats minified library scripts to view/js/lib.min.js
     ]);
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -49,6 +49,14 @@ module.exports = function(grunt) {
                     'jshint:boltJs',
                     'uglify:boltJs'
                 ]
+            },
+            gruntfile: {
+                files: [
+                    'Gruntfile.js'
+                ],
+                options: {
+                    reload: true
+                }
             }
         },
 
@@ -276,6 +284,7 @@ module.exports = function(grunt) {
 
     require('load-grunt-tasks')(grunt);
 
+    /*** DEFAULT TASK:  Creates Bolts own css and js files ***/
     grunt.registerTask(
         'default',
         [
@@ -286,6 +295,7 @@ module.exports = function(grunt) {
         ]
     );
 
+    /*** UPDATE TASK:  Builds library css/js. Run after one of the externals is updated ***/
     grunt.registerTask(
         'update',
         [

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
                 spawn: false,
                 livereload: true
             },
-            scripts: {
+            sass: {
                 files: [
                     'sass/*.scss',
                     'sass/**/*.scss'

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -281,8 +281,6 @@ module.exports = function(grunt) {
         'sass',
         'jshint:boltJs',
         'uglify:boltJs',
-        'cssmin',
-        'concat',
         'watch'
     ]);
 

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -158,7 +158,7 @@ module.exports = function(grunt) {
                     ]
                 }]
             },
-            locale_datepicker: {
+            localeDatepicker: {
                 options: {
                     preserveComments: 'some'
                 },
@@ -284,9 +284,10 @@ module.exports = function(grunt) {
     ]);
 
     grunt.registerTask('update', [
-        'copy:fonts',       // Copies fonts to view/fonts/
-        'cssmin:libCss',    // Builds view/css/lib.css from library css files
-        'uglify:libJs',     // Create minified versions of library scripts that don't have them
-        'concat:libJs'      // Concats minified library scripts to view/js/lib.min.js
+        'copy:fonts',               // Copies fonts to view/fonts/
+        'cssmin:libCss',            // Builds view/css/lib.css from library css files
+        'uglify:libJs',             // Create minified versions of library scripts that don't have them
+        'concat:libJs',             // Concats minified library scripts to view/js/lib.min.js
+        'uglify:localeDatepicker'   // Copies minified datepicker locale to view/js/locale/datepicker
     ]);
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -297,7 +297,7 @@ module.exports = function(grunt) {
 
     /*** UPDATE TASK:  Builds library css/js. Run after one of the externals is updated ***/
     grunt.registerTask(
-        'update',
+        'updateLib',
         [
             // Prepare
             'uglify:bootstrap',             // Concat bootstrap scripts into one minified file

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -139,7 +139,7 @@ module.exports = function(grunt) {
         },
 
         uglify: {
-            lib: {
+            libJs: {
                 options: {
                     preserveComments: 'some'
                 },
@@ -286,6 +286,7 @@ module.exports = function(grunt) {
     grunt.registerTask('update', [
         'copy:fonts',       // Copies fonts to view/fonts/
         'cssmin:libCss',    // Builds view/css/lib.css from library css files
+        'uglify:libJs',     // Create minified versions of library scripts that don't have them
         'concat:libJs'      // Concats minified library scripts to view/js/lib.min.js
     ]);
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
                     'lib/bolt/*.js'
                 ],
                 tasks: [
+                    'jshint:bolt_js',
                     'uglify:bolt'
                 ]
             }

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -284,4 +284,7 @@ module.exports = function(grunt) {
         'watch'
     ]);
 
+    grunt.registerTask('update', [
+    ]);
+
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
                 ],
                 tasks: [
                     'jshint:bolt_js',
-                    'uglify:bolt'
+                    'uglify:bolt_js'
                 ]
             }
         },
@@ -183,7 +183,7 @@ module.exports = function(grunt) {
                     ]
                 }
             },
-            bolt: {
+            bolt_js: {
                 options: {
                     banner: "/**\n" +
                             " * These are Bolt's COMPILED JS files!\n" +
@@ -274,6 +274,6 @@ module.exports = function(grunt) {
 
     require('load-grunt-tasks')(grunt);
 
-    grunt.registerTask('default', ['sass', 'jshint:bolt_js', 'uglify', 'cssmin', 'concat', 'watch']);
+    grunt.registerTask('default', ['sass', 'jshint:bolt_js', 'uglify:bolt_js', 'cssmin', 'concat', 'watch']);
 
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -173,7 +173,7 @@ module.exports = function(grunt) {
                     }
                 }]
             },
-            locale_moment: {
+            localeMoment: {
                 options: {
                     preserveComments: 'some'
                 },
@@ -288,6 +288,7 @@ module.exports = function(grunt) {
         'cssmin:libCss',            // Builds view/css/lib.css from library css files
         'uglify:libJs',             // Create minified versions of library scripts that don't have them
         'concat:libJs',             // Concats minified library scripts to view/js/lib.min.js
-        'uglify:localeDatepicker'   // Copies minified datepicker locale to view/js/locale/datepicker
+        'uglify:localeDatepicker',  // Copies minified datepicker locale to view/js/locale/datepicker
+        'uglify:localeMoment'       // Copies minified moment.js locale to view/js/locale/datepicker
     ]);
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -286,6 +286,7 @@ module.exports = function(grunt) {
     grunt.registerTask('update', [
         'copy:fonts',               // Copies fonts to view/fonts/
         'cssmin:libCss',            // Builds view/css/lib.css from library css files
+        'uglify:bootstrap',         // Concat bootstrap scripts into one minified file
         'uglify:libJs',             // Create minified versions of library scripts that don't have them
         'concat:libJs',             // Concats minified library scripts to view/js/lib.min.js
         'uglify:localeDatepicker',  // Copies minified datepicker locale to view/js/locale/datepicker

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -3,7 +3,29 @@ module.exports = function(grunt) {
 
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
+
         config: grunt.file.readYAML('../config/config.yml'),
+
+        filesBoltJs: [
+            'lib/bolt/console.js',
+            'lib/bolt/fnc-helpers.js',
+            'lib/bolt/activity.js',
+            'lib/bolt/bind-fileupload.js',
+            'lib/bolt/make-uri-slug.js',
+            'lib/bolt/video-embed.js',
+            'lib/bolt/geolocation.js',
+            'lib/bolt/upload-files.js',
+            'lib/bolt/obj-sidebar.js',
+            'lib/bolt/obj-navpopups.js',
+            'lib/bolt/obj-moments.js',
+            'lib/bolt/obj-files.js',
+            'lib/bolt/obj-stack.js',
+            'lib/bolt/obj-folders.js',
+            'lib/bolt/obj-datetime.js',
+            'lib/bolt/extend.js',
+            'lib/bolt/init.js',
+            'lib/bolt/start.js'
+        ],
 
         watch: {
             options: {
@@ -21,7 +43,7 @@ module.exports = function(grunt) {
             },
             bolt_js: {
                 files: [
-                    'lib/bolt/*.js'
+                    "<%= filesBoltJs %>"
                 ],
                 tasks: [
                     'jshint:bolt_js',
@@ -192,26 +214,7 @@ module.exports = function(grunt) {
                     sourceMap: true
                 },
                 files: {
-                    'js/bolt.min.js': [
-                        'lib/bolt/console.js',
-                        'lib/bolt/fnc-helpers.js',
-                        'lib/bolt/activity.js',
-                        'lib/bolt/bind-fileupload.js',
-                        'lib/bolt/make-uri-slug.js',
-                        'lib/bolt/video-embed.js',
-                        'lib/bolt/geolocation.js',
-                        'lib/bolt/upload-files.js',
-                        'lib/bolt/obj-sidebar.js',
-                        'lib/bolt/obj-navpopups.js',
-                        'lib/bolt/obj-moments.js',
-                        'lib/bolt/obj-files.js',
-                        'lib/bolt/obj-stack.js',
-                        'lib/bolt/obj-folders.js',
-                        'lib/bolt/obj-datetime.js',
-                        'lib/bolt/extend.js',
-                        'lib/bolt/init.js',
-                        'lib/bolt/start.js'
-                    ]
+                    'js/bolt.min.js': ["<%= filesBoltJs %>"]
                 }
             }
         },
@@ -267,13 +270,20 @@ module.exports = function(grunt) {
                         UAParser: true              // ua-parser.min.js
                     }
                 },
-                src: ['lib/bolt/*.js']
+                src: ["<%= filesBoltJs %>"]
             }
         }
     });
 
     require('load-grunt-tasks')(grunt);
 
-    grunt.registerTask('default', ['sass', 'jshint:bolt_js', 'uglify:bolt_js', 'cssmin', 'concat', 'watch']);
+    grunt.registerTask('default', [
+        'sass',
+        'jshint:bolt_js',
+        'uglify:bolt_js',
+        'cssmin',
+        'concat',
+        'watch'
+    ]);
 
 };

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -38,7 +38,8 @@ module.exports = function(grunt) {
                     'sass/**/*.scss'
                 ],
                 tasks: [
-                    'sass'
+                    'sass:boltCss',
+                    'eol:boltCss'
                 ]
             },
             boltJs: {
@@ -82,6 +83,21 @@ module.exports = function(grunt) {
                     'css/bolt.css': 'sass/app.scss'
                 }
             }
+        },
+
+        eol: {
+            boltCss: {
+                options: {
+                    eol: 'lf',
+                    replace: true
+                },
+                files: {
+                    src: [
+                        'css/bolt-old-ie.css',
+                        'css/bolt.css'
+                    ]
+                }
+            },
         },
 
         copy: {
@@ -297,6 +313,7 @@ module.exports = function(grunt) {
         'updateBolt',
         [
             'sass:boltCss',
+            'eol:boltCss',
             'jshint:boltJs',
             'uglify:boltJs'
         ]

--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -27,6 +27,9 @@ module.exports = function(grunt) {
             'lib/bolt/start.js'
         ],
 
+        /*
+         * WATCH: Run predefined tasks whenever watched file patterns are added, changed or deleted
+         */
         watch: {
             options: {
                 spawn: false,
@@ -61,6 +64,9 @@ module.exports = function(grunt) {
             }
         },
 
+        /*
+         * SASS: Compile Sass to CSS
+         */
         sass: {
             boltCss: {
                 options: {
@@ -85,6 +91,9 @@ module.exports = function(grunt) {
             }
         },
 
+        /*
+         * EOL: Convert line endings
+         */
         eol: {
             boltCss: {
                 options: {
@@ -100,6 +109,9 @@ module.exports = function(grunt) {
             },
         },
 
+        /*
+         * COPY: Copy files and folders
+         */
         copy: {
             installFonts: {
                 files: [{
@@ -114,6 +126,9 @@ module.exports = function(grunt) {
             }
         },
 
+        /*
+         * CONCAT: Concatenate files
+         */
         concat: {
             installLibJs: {
                 options: {
@@ -144,6 +159,9 @@ module.exports = function(grunt) {
             }
         },
 
+        /*
+         * CSSMIN: Compress CSS files
+         */
         cssmin: {
             installLibCss: {
                 options: {
@@ -162,6 +180,9 @@ module.exports = function(grunt) {
             }
         },
 
+        /*
+         * UGLIFY: Minify files with UglifyJS
+         */
         uglify: {
             prepareLibJs: {
                 options: {
@@ -242,6 +263,9 @@ module.exports = function(grunt) {
             }
         },
 
+        /*
+         * JSHINT: Validates files with JSHint
+         */
         jshint: {
             boltJs: {
                 options: {

--- a/app/view/package.json
+++ b/app/view/package.json
@@ -18,6 +18,7 @@
     "grunt-contrib-cssmin": "^0.11.0",
     "load-grunt-tasks": "^0.6.0",
     "grunt-sass": "~0.17",
+    "grunt-eol": "^0.2.0",
     "node-sass": "~1.2"
   },
   "dependencies": {


### PR DESCRIPTION
- ``default`` task now only watches changes in bolts own js/css so that files are not automatically regenerated when grunt is started
- ``default`` task now also jshints
- ``updateBolt`` task now regenerates bolts own js/css
- ``updateLib`` task now regenerates external library stuff
- In Bolts css for now CRLF is converted to LF (until libsass catches up)
- Tasknames are now more descriptive
- Comments added
- Bolts js files are now in list template
- Gruntfile.js is watched now and reloads config on change

These changes are in preparation of things to come.
Be sure to update npm!