### PR TITLE
exclude the tests directory from the code coverage reports

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,12 +21,7 @@
     </testsuites>
     <filter>
         <whitelist>
-            <directory>./tests</directory>
             <directory>./src</directory>
-            <exclude>
-                <directory>./test</directory>
-                <directory>./vendor</directory>
-            </exclude>
         </whitelist>
     </filter>
     <logging>


### PR DESCRIPTION
This should get rid of the tests directory from the code coverage report.