### PR TITLE
Small clean up for Config::getWhichEnd

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -878,9 +878,10 @@ class Config
     }
 
     /**
-     * Utility function to determine which 'end' we're using right now. Can be either "frontend", "backend", "async" or "cli".
+     * Utility function to determine which 'end' we're using right now.
+     * Can be either "frontend", "backend", "async" or "cli".
      *
-     * NOTE: If the Request object has not been intialized by Silex yet,
+     * NOTE: If the Request object has not been initialized by Silex yet,
      * we create a local version based on the request globals.
      *
      * @param  string $mountpoint
@@ -910,13 +911,10 @@ class Config
         $mountpoint = '/' . ltrim($mountpoint, '/');
 
         if (strpos($request->getPathInfo(), '/async') === 0 || $request->isXmlHttpRequest()) {
-            // If path begins with '/async' or is AJAX request, is 'async'
             $end = 'async';
         } elseif (strpos($request->getPathInfo(), $mountpoint) === 0) {
-            // If request path starts with mountpoint, is backend
             $end = 'backend';
-        } else { 
-            // Else assume frontend
+        } else {
             $end = 'frontend';
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -901,9 +901,6 @@ class Config
             $request = Request::createFromGlobals();
         }
 
-        // Ensure the request path always includes a left slash
-        $reqPath = '/' . ltrim($request->getPathInfo(), '/');
-
         // Default mountpoint is branding path (defaults to 'bolt' unless changed in config)
         if (empty($mountpoint)) {
             $mountpoint = $this->get('general/branding/path');
@@ -915,7 +912,7 @@ class Config
         if (strpos($request->getPathInfo(), '/async') === 0 || $request->isXmlHttpRequest()) {
             // If path begins with '/async' or is AJAX request, is 'async'
             $end = 'async';
-        } elseif (strpos($reqPath, $mountpoint) === 0) {
+        } elseif (strpos($request->getPathInfo(), $mountpoint) === 0) {
             // If request path starts with mountpoint, is backend
             $end = 'backend';
         } else { 


### PR DESCRIPTION
Request::getPathInfo() always starts with a slash