### PR TITLE
Remove xdebug.max_nesting_level from Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ before_script:
   - chmod 777 tests/Nut/resources/
   - mkdir -p app/cache
   - chmod 777 app/cache
-  - echo 'xdebug.max_nesting_level = 2000' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 after_script:
   - ./vendor/bin/ocular code-coverage:upload --format=php-clover coverage.xml


### PR DESCRIPTION
After #2647 Travis no longer requires `xdebug.max_nesting_level = 2000` to pass.  This also makes HHVM tests run again...  For what that is worth.