### PR TITLE
BASH/ZSH command completion for Nut

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "siriusphp/upload": "~1.2",
         "silex/silex": "~1.2",
         "silex/web-profiler": "~1.0",
+        "stecman/symfony-console-completion": "~0.4",
         "swiftmailer/swiftmailer": "~5.3",
         "symfony/config": "~2.6",
         "symfony/console": "~2.6",

--- a/src/Nut/NutApplication.php
+++ b/src/Nut/NutApplication.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
+use Symfony\Component\Console\Application as ConsoleApplication;
+
+/**
+ * Nut application
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class NutApplication extends ConsoleApplication
+{
+    /**
+     * Gets the default commands that should always be available.
+     *
+     * @return Command[] An array of default Command instances
+     */
+    protected function getDefaultCommands()
+    {
+        // Get the Symfony defaults
+        $commands = parent::getDefaultCommands();
+
+        return $commands;
+    }
+}

--- a/src/Nut/NutApplication.php
+++ b/src/Nut/NutApplication.php
@@ -22,6 +22,9 @@ class NutApplication extends ConsoleApplication
         // Get the Symfony defaults
         $commands = parent::getDefaultCommands();
 
+        // Add command completion
+        $commands[] = new CompletionCommand();
+
         return $commands;
     }
 }

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -2,6 +2,7 @@
 namespace Bolt\Provider;
 
 use Bolt\Nut;
+use Bolt\Nut\NutApplication;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Console\Application as ConsoleApplication;
@@ -13,7 +14,7 @@ class NutServiceProvider implements ServiceProviderInterface
     {
         $app['nut'] = $app->share(
             function ($app) {
-                $console = new ConsoleApplication();
+                $console = new NutApplication();
 
                 $console->setName('Bolt console tool - Nut');
                 if ($app instanceof \Bolt\Application) {


### PR DESCRIPTION
This is one for the CLI obsessed.

To use, you just add the following to either your `~/.bash_profile` or `~/.zshrc`

``` bash
source <(cd /my/bolt/directory && ./app/nut _completion --generate-hook)
```

**NOTE:** For BASH v3 you will need to instead use:
```bash
cd /my/bolt/directory && ./app/nut _completion --generate-hook | source /dev/stdin
```

Then when you're in `/my/bolt/directory` you can enter `./app/nut` and double tap the TAB key for command completion.

### Changelog
Added: BASH/ZSH command completion for Nut