### PR TITLE
Bolt\Storage, Bolt\Events\StorageEvents and Bolt\Content surgery

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -99,6 +99,100 @@ class Content implements \ArrayAccess
         );
     }
 
+    /**
+     * Return a content obejcts values
+     *
+     * @param  boolean $json Set to TRUE to return JSON encoded values for arrays
+     * @return array
+     */
+    public function getValues($json = false)
+    {
+        // Prevent 'slug may not be NULL'
+        if (!isset($this->values['slug'])) {
+            $this->values['slug'] = '';
+        }
+
+        // Return raw values
+        if ($json === false) {
+            return $this->values;
+        }
+
+        $contenttype = $this->contenttype;
+        $newvalue = $this->values;
+
+        // add the fields for this contenttype,
+        foreach ($contenttype['fields'] as $field => $property) {
+            switch ($property['type']) {
+
+                // Set the slug, while we're at it
+                case 'slug':
+                    if (!empty($property['uses']) && empty($this->values[$field])) {
+                        $uses = '';
+                        foreach ($property['uses'] as $usesField) {
+                            $uses .= $this->values[$usesField] . ' ';
+                        }
+                        $newvalue[$field] = String::slug($uses);
+                    } elseif (!empty($this->values[$field])) {
+                        $newvalue[$field] = String::slug($this->values[$field]);
+                    } elseif (empty($this->values[$field]) && $this->values['id']) {
+                        $newvalue[$field] = $this->values['id'];
+                    }
+                    break;
+
+                case 'video':
+                    foreach (array('html', 'responsive') as $subkey) {
+                        if (!empty($this->values[$field][$subkey])) {
+                            $this->values[$field][$subkey] = (string) $this->values[$field][$subkey];
+                        }
+                    }
+                    if (!empty($this->values[$field]['url'])) {
+                        $newvalue[$field] = json_encode($this->values[$field]);
+                    } else {
+                        $newvalue[$field] = '';
+                    }
+                    break;
+
+                case 'geolocation':
+                    if (!empty($this->values[$field]['latitude']) && !empty($this->values[$field]['longitude'])) {
+                        $newvalue[$field] = json_encode($this->values[$field]);
+                    } else {
+                        $newvalue[$field] = '';
+                    }
+                    break;
+
+                case 'image':
+                    if (!empty($this->values[$field]['file'])) {
+                        $newvalue[$field] = json_encode($this->values[$field]);
+                    } else {
+                        $newvalue[$field] = '';
+                    }
+                    break;
+
+                case 'imagelist':
+                case 'filelist':
+                    if (is_array($this->values[$field])) {
+                        $newvalue[$field] = json_encode($this->values[$field]);
+                    } elseif (!empty($this->values[$field]) && strlen($this->values[$field]) < 3) {
+                        // Don't store '[]'
+                        $newvalue[$field] = '';
+                    }
+                    break;
+
+                case 'integer':
+                    $newvalue[$field] = round($this->values[$field]);
+                    break;
+
+                case 'select':
+                    if (is_array($this->values[$field])) {
+                        $newvalue[$field] = json_encode($this->values[$field]);
+                    }
+                    break;
+            }
+        }
+
+        return $newvalue;
+    }
+
     public function setValues(array $values)
     {
         // Since Bolt 1.4, we use 'ownerid' instead of 'username' in the DB tables. If we get an array that has an

--- a/src/Events/StorageEvent.php
+++ b/src/Events/StorageEvent.php
@@ -76,7 +76,7 @@ class StorageEvent extends GenericEvent
      */
     public function getContent()
     {
-        return $this->content;
+        return $this->getSubject();
     }
 
     /**
@@ -91,29 +91,5 @@ class StorageEvent extends GenericEvent
         if ($this->hasArgument('create')) {
             return $this->getArgument('create');
         }
-    }
-
-    /**
-     * Set the content type and id
-     *
-     * @param string  $contentType
-     * @param integer $id
-     */
-    private function setContentTypeAndId($contentType, $id)
-    {
-        $this->contentType = $contentType;
-        $this->id = $id;
-    }
-
-    /**
-     * Set the content
-     *
-     * @param Content $content
-     */
-    private function setContent(Content $content)
-    {
-        $this->content = $content;
-
-        $this->setContentTypeAndId($content->contenttype['slug'], $content->id);
     }
 }

--- a/src/Events/StorageEvent.php
+++ b/src/Events/StorageEvent.php
@@ -18,24 +18,14 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 class StorageEvent extends GenericEvent
 {
     /**
-     * The id
+     * @var Bolt\Content
      */
-    private $id = null;
+    private $subject;
 
     /**
-     * The content type
+     * @var array
      */
-    private $contentType = null;
-
-    /**
-     * The content to act upon
-     */
-    private $content = null;
-
-    /**
-     * Record create/update flag
-     */
-    private $create = null;
+    private $arguments;
 
     /**
      * Instantiate generic Storage Event
@@ -50,27 +40,27 @@ class StorageEvent extends GenericEvent
     }
 
     /**
-     * Return the id
+     * Return the record id
      *
      * @return integer
      */
     public function getId()
     {
-        return $this->id;
+        return $this->getSubject()->id;
     }
 
     /**
-     * Return the content type
+     * Return the record contenttype
      *
      * @return string
      */
     public function getContentType()
     {
-        return $this->contentType;
+        return $this->getSubject()->contenttype['slug'];
     }
 
     /**
-     * Return the content (if any)
+     * Return the content object
      *
      * @return Bolt\Content
      */

--- a/src/Events/StorageEvent.php
+++ b/src/Events/StorageEvent.php
@@ -88,7 +88,9 @@ class StorageEvent extends GenericEvent
      */
     public function isCreate()
     {
-        return $this->create;
+        if ($this->hasArgument('create')) {
+            return $this->getArgument('create');
+        }
     }
 
     /**

--- a/src/Events/StorageEvent.php
+++ b/src/Events/StorageEvent.php
@@ -3,7 +3,7 @@ namespace Bolt\Events;
 
 use Bolt;
 use Bolt\Content;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Our specific Event instance for Storage Events
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\Event;
  * For preDelete and postDelete the content won't be available, but the
  * $this->getId() and $this->getContentType() will be set.
  */
-class StorageEvent extends Event
+class StorageEvent extends GenericEvent
 {
     /**
      * The id

--- a/src/Events/StorageEvent.php
+++ b/src/Events/StorageEvent.php
@@ -40,17 +40,13 @@ class StorageEvent extends GenericEvent
     /**
      * Instantiate generic Storage Event
      *
-     * @param mixed $in The content or (contenttype,id) combination
+     * @param Bolt\Content $subject   A Content object that is being saved or deleted
+     * @param array        $arguments Arguments to store in the event.
      */
-    public function __construct($in = null, $create = null)
+    public function __construct(Content $subject = null, array $arguments = array())
     {
-        if ($in instanceof \Bolt\Content) {
-            $this->setContent($in);
-        } elseif (is_array($in)) {
-            $this->setContentTypeAndId($in[0], $in[1]);
-        }
-
-        $this->create = $create;
+        $this->subject = $subject;
+        $this->arguments = $arguments;
     }
 
     /**

--- a/src/Events/StorageEvent.php
+++ b/src/Events/StorageEvent.php
@@ -6,14 +6,35 @@ use Bolt\Content;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
- * Our specific Event instance for Storage Events
+ * Event instance for Storage events
  *
- * For preSave and postSave you may assume you can directly access the
- * content using $this->getContent(). The id will be available in a
- * postSave but is not guarenteerd for a preSave (since it could be
- * new).
- * For preDelete and postDelete the content won't be available, but the
- * $this->getId() and $this->getContentType() will be set.
+ * PRE_SAVE (preSave)
+ * - Available:
+ *   - Content obejct
+ * - Notes:
+ *   - Do not call saveContent()
+ *
+ * POST_SAVE (postSave)
+ * - Available:
+ *   - Content obejct
+ *   - ID
+ * - Notes:
+ *   - Safe to call saveContent()
+ *
+ * PRE_DELETE (preDelete)
+ * - Available:
+ *   - Content obejct
+ *   - ID
+ * - Notes:
+ *   - Do not call saveContent()
+ *
+ * POST_DELETE (postDelete)
+ * - Available:
+ *   - Content obejct
+ *   - ID
+ * - Notes:
+ *   - Do not call saveContent()
+ *   - Database record will no longer exist
  */
 class StorageEvent extends GenericEvent
 {

--- a/src/Events/StorageEvent.php
+++ b/src/Events/StorageEvent.php
@@ -41,12 +41,12 @@ class StorageEvent extends GenericEvent
     /**
      * @var Bolt\Content
      */
-    private $subject;
+    protected $subject;
 
     /**
      * @var array
      */
-    private $arguments;
+    protected $arguments;
 
     /**
      * Instantiate generic Storage Event

--- a/src/Exception/StorageException.php
+++ b/src/Exception/StorageException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bolt\Exception;
+
+use \Exception;
+
+/**
+ * Exceptions in Bolt\Storage 
+ */
+class StorageException extends Exception
+{
+}
+

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -310,6 +310,12 @@ class Storage
         );
     }
 
+    /**
+     * Save a record
+     *
+     * @param Bolt\Content $content
+     * @param string        $comment
+     */
     public function saveContent(\Bolt\Content $content, $comment = null)
     {
         $contenttype = $content->contenttype;
@@ -459,6 +465,12 @@ class Storage
         return $id;
     }
 
+    /**
+     * Delete a record
+     *
+     * @param string  $contenttype
+     * @param integer $id
+     */
     public function deleteContent($contenttype, $id)
     {
         if (empty($contenttype)) {

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -824,6 +824,7 @@ class Storage
 
     public function searchContentType($contenttypename, array $parameters = array(), &$pager = array())
     {
+        $where = array();
         $tablename = $this->getTablename($contenttypename);
 
         $contenttype = $this->app['config']->get('contenttypes/' . $contenttypename);

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -334,15 +334,10 @@ class Storage
             $create = false;
         }
 
+        // Dispatch pre-save event
         if (! $this->inDispatcher && $this->app['dispatcher']->hasListeners(StorageEvents::PRE_SAVE)) {
-            // Block dispatcher loops
-            $this->inDispatcher = true;
-
             $event = new StorageEvent($content, array('contenttype' => $contenttype, 'create' => $create));
             $this->app['dispatcher']->dispatch(StorageEvents::PRE_SAVE, $event);
-
-            // Re-enable the dispather
-            $this->inDispatcher = false;
         }
 
         if (!isset($fieldvalues['slug'])) {
@@ -451,6 +446,7 @@ class Storage
         $this->updateTaxonomy($contenttype, $id, $content->taxonomy);
         $this->updateRelation($contenttype, $id, $content->relation);
 
+        // Dispatch post-save event
         if (!$this->inDispatcher && $this->app['dispatcher']->hasListeners(StorageEvents::POST_SAVE)) {
             // Block loops
             $this->inDispatcher = true;

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -2,16 +2,17 @@
 
 namespace Bolt;
 
-use Doctrine\DBAL\DBALException;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Bolt;
 use Bolt\Events\StorageEvent;
 use Bolt\Events\StorageEvents;
+use Bolt\Exception\StorageException;
 use Bolt\Helpers\Arr;
 use Bolt\Helpers\String;
 use Bolt\Helpers\Html;
 use Bolt\Translation\Translator as Trans;
 use Doctrine\DBAL\Connection as DoctrineConn;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Symfony\Component\HttpFoundation\Request;
 
 class Storage
@@ -322,9 +323,8 @@ class Storage
         $fieldvalues = $content->values;
 
         if (empty($contenttype)) {
-            echo 'Contenttype is required.';
-
-            return false;
+            $this->app['logger.system']->addError('Contenttype is required for' . __FUNCTION__, array('event' => 'exception'));
+            throw new StorageException('Contenttype is required for ' . __FUNCTION__);
         }
 
         // Test to see if this is a new record, or an update
@@ -474,9 +474,8 @@ class Storage
     public function deleteContent($contenttype, $id)
     {
         if (empty($contenttype)) {
-            echo "Contenttype is required.";
-
-            return false;
+            $this->app['logger.system']->addError('Contenttype is required for' . __FUNCTION__, array('event' => 'exception'));
+            throw new StorageException('Contenttype is required for ' . __FUNCTION__);
         }
 
         // Make sure $contenttype is a 'slug'
@@ -500,9 +499,9 @@ class Storage
 
         // Make sure relations and taxonomies are deleted as well.
         if ($res) {
-            $this->app['db']->delete($this->prefix . "relations", array('from_contenttype' => $contenttype, 'from_id' => $id));
-            $this->app['db']->delete($this->prefix . "relations", array('to_contenttype' => $contenttype, 'to_id' => $id));
-            $this->app['db']->delete($this->prefix . "taxonomy", array('contenttype' => $contenttype, 'content_id' => $id));
+            $this->app['db']->delete($this->prefix . 'relations', array('from_contenttype' => $contenttype, 'from_id' => $id));
+            $this->app['db']->delete($this->prefix . 'relations', array('to_contenttype' => $contenttype, 'to_id' => $id));
+            $this->app['db']->delete($this->prefix . 'taxonomy', array('contenttype' => $contenttype, 'content_id' => $id));
         }
 
         // Dispatch post-delete event

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -350,18 +350,18 @@ class Storage
             $create = false;
         }
 
-        // Dispatch pre-save event
-        if (! $this->inDispatcher && $this->app['dispatcher']->hasListeners(StorageEvents::PRE_SAVE)) {
-            $event = new StorageEvent($content, array('contenttype' => $contenttype, 'create' => $create));
-            $this->app['dispatcher']->dispatch(StorageEvents::PRE_SAVE, $event);
-        }
-
         // We need to verify if the slug is unique. If not, we update it.
         $getId = $create ? null : $fieldvalues['id'];
         $fieldvalues['slug'] = $this->getUri($fieldvalues['slug'], $getId, $contenttype['slug'], false, false);
 
         // Update the content object
         $content->setValues($fieldvalues);
+
+        // Dispatch pre-save event
+        if (! $this->inDispatcher && $this->app['dispatcher']->hasListeners(StorageEvents::PRE_SAVE)) {
+            $event = new StorageEvent($content, array('contenttype' => $contenttype, 'create' => $create));
+            $this->app['dispatcher']->dispatch(StorageEvents::PRE_SAVE, $event);
+        }
 
         // Decide whether to insert a new record, or update an existing one.
         if ($create) {

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -339,7 +339,7 @@ class Storage
         $fieldvalues = $content->values;
 
         if (empty($contenttype)) {
-            $this->app['logger.system']->addError('Contenttype is required for' . __FUNCTION__, array('event' => 'exception'));
+            $this->app['logger.system']->addError('Contenttype is required for ' . __FUNCTION__, array('event' => 'exception'));
             throw new StorageException('Contenttype is required for ' . __FUNCTION__);
         }
 

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -17,6 +17,15 @@ class ContentTest extends BoltUnitTest
     public function testgetValues()
     {
         $app = $this->getApp();
+        $content = new Content($app, 'pages');
+
+        $content->setValue('title', 'Test Page');
+        $content->setValue('image', array('file' => 'image1.jpg', 'title' => 'Test image'));
+
+        $values = $content->getValues(true);
+
+        $this->assertEquals('Test Page', $values['title']);
+        $this->assertEquals('{"file":"image1.jpg","title":"Test image"}', $values['image']);
     }
 
     public function testsetValues()

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -1,0 +1,149 @@
+<?php
+namespace Bolt\tests\Content;
+
+use Bolt\Tests\BoltUnitTest;
+use Bolt\Content;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class to test src/Storage.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ContentTest extends BoltUnitTest
+{
+
+    public function testgetValues()
+    {
+        $app = $this->getApp();
+    }
+
+    public function testsetValues()
+    {
+    }
+
+    public function testsetValue()
+    {
+    }
+
+    public function testsetFromPost()
+    {
+    }
+
+    public function testsetContenttype()
+    {
+    }
+
+    public function testsetTaxonomy()
+    {
+    }
+
+    public function testsortTaxonomy()
+    {
+    }
+
+    public function testsetRelation()
+    {
+    }
+
+    public function testgetTaxonomyType()
+    {
+    }
+
+    public function testsetGroup()
+    {
+    }
+
+    public function testgetDecodedValue()
+    {
+    }
+
+    public function testpreParse()
+    {
+    }
+
+    public function testgetTemplateContext()
+    {
+    }
+
+    public function testget()
+    {
+    }
+
+    public function testgetTitle()
+    {
+    }
+
+    public function testgetTitleColumnName()
+    {
+    }
+
+    public function testgetImage()
+    {
+    }
+
+    public function testgetReference()
+    {
+    }
+
+    public function testeditlink()
+    {
+    }
+
+    public function testlink()
+    {
+    }
+
+    public function testprevious()
+    {
+    }
+
+    public function testnext()
+    {
+    }
+
+    public function testrelated()
+    {
+    }
+
+    public function testfieldinfo()
+    {
+    }
+
+    public function testfieldtype()
+    {
+    }
+
+    public function testexcerpt()
+    {
+    }
+
+    public function testrss_safe()
+    {
+    }
+
+    public function testweighSearchResult()
+    {
+    }
+
+    public function testgetSearchResultWeight()
+    {
+    }
+
+    public function testoffsetExists()
+    {
+    }
+
+    public function testoffsetGet()
+    {
+    }
+
+    public function testoffsetSet()
+    {
+    }
+
+    public function testoffsetUnset()
+    {
+    }
+}

--- a/tests/Events/StorageEventTest.php
+++ b/tests/Events/StorageEventTest.php
@@ -9,7 +9,6 @@ use Bolt\Events\StorageEvent;
  * Class to test src/Events/StorageEvent.
  *
  * @author Ross Riley <riley.ross@gmail.com>
- *
  */
 class StorageEventTest extends BoltUnitTest
 {
@@ -18,6 +17,7 @@ class StorageEventTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $content = new Content($app);
+
         $event = new StorageEvent($content);
         $this->assertEquals(null, $event->isCreate());
         $this->assertEquals($content, $event->getContent());
@@ -28,8 +28,10 @@ class StorageEventTest extends BoltUnitTest
     public function testSetupWithRecord()
     {
         $app = $this->getApp();
-        $event = new StorageEvent(array('test', 5));
+        $content = new Content($app, 'pages');
+        $content->setValue('id', 5);
+        $event = new StorageEvent($content);
         $this->assertEquals(5, $event->getId());
-        $this->assertEquals('test', $event->getContentType());
+        $this->assertEquals('pages', $event->getContentType());
     }
 }

--- a/tests/Storage/StorageTest.php
+++ b/tests/Storage/StorageTest.php
@@ -5,6 +5,7 @@ use Bolt\Tests\BoltUnitTest;
 use Bolt\Storage;
 use Bolt\Content;
 use Bolt\Events\StorageEvents;
+use Bolt\Exception\StorageException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -56,7 +57,7 @@ class StorageTest extends BoltUnitTest
 
         // Test missing contenttype handled
         $content = new Content($app);
-        $this->expectOutputString('Contenttype is required.');
+        $this->setExpectedException('Bolt\Exception\StorageException', 'Contenttype is required for saveContent');
         $this->assertFalse($storage->saveContent($content));
 
         // Test dispatcher is called pre-save and post-save
@@ -85,7 +86,7 @@ class StorageTest extends BoltUnitTest
         $storage = new Storage($app);
 
         // Test delete fails on missing params
-        $this->expectOutputString('Contenttype is required.');
+        $this->setExpectedException('Bolt\Exception\StorageException', 'Contenttype is required for deleteContent');
         $this->assertFalse($storage->deleteContent('', 999));
 
         $content = $storage->getContent('showcases/1');


### PR DESCRIPTION
So, you know when you start looking at a bug like #2484 and you think, "how hard can this be?", and 6 hours later you've fixed the problem... and several others along the way?

* StorageEvent refactored and now extends GenericEvent
* Move content related functionality out of Storage::saveContent() into Content (still needs larger refactor)
* Refactored insertContent() and updateContent()
* Bunch of docblock and type hinting
* saveContent() heavily refactored in the process...  Down from 101 lines to 53
* StorageEvents::PRE_SAVE no longer cares about event loops as Content object data can be modified before the database commit
* Fixes #2484 

### Changelog
Fixed: StorageEvents::PRE_SAVE now allows proper on-the-fly modification of data (see #2484) 