### PR TITLE
[RFC] Enabling Extension Dependencies from Packagist

### DIFF
--- a/src/Composer/Action/BoltExtendJson.php
+++ b/src/Composer/Action/BoltExtendJson.php
@@ -103,7 +103,7 @@ final class BoltExtendJson
         );
         $json['provide']['bolt/bolt'] = $app['bolt_version'];             
         foreach($this->options['rootdependencies'] as $corePackage) {
-            $json['provide'][$corePackage] = "*";
+            $json['replace'][$corePackage] = "*";
         }
         $json['scripts'] = array(
             'post-package-install' => "Bolt\\Composer\\ExtensionInstaller::handle",

--- a/src/Composer/Action/BoltExtendJson.php
+++ b/src/Composer/Action/BoltExtendJson.php
@@ -25,6 +25,14 @@ final class BoltExtendJson
     {
         $this->options = $options;
     }
+    
+    /**
+     * @return $options  array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
 
     /**
      * Convenience function to generalise the library
@@ -80,7 +88,9 @@ final class BoltExtendJson
         $pathToWeb = $app['resources']->findRelativePath($app['resources']->getPath('extensions'), $app['resources']->getPath('web'));
 
         // Enforce standard settings
-        $json['repositories']['packagist'] = false;
+        if( isset($json['repositories']['packagist'])) {
+            unset($json['repositories']['packagist']);
+        }
         $json['repositories']['bolt'] = array(
             'type' => 'composer',
             'url' => $app['extend.site'] . 'satis/'
@@ -91,7 +101,10 @@ final class BoltExtendJson
             'discard-changes' => true,
             'preferred-install' => 'dist'
         );
-        $json['provide']['bolt/bolt'] = $app['bolt_version'];
+        $json['provide']['bolt/bolt'] = $app['bolt_version'];             
+        foreach($this->options['rootdependencies'] as $corePackage) {
+            $json['provide'][$corePackage] = "*";
+        }
         $json['scripts'] = array(
             'post-package-install' => "Bolt\\Composer\\ExtensionInstaller::handle",
             'post-package-update' => "Bolt\\Composer\\ExtensionInstaller::handle"

--- a/src/Composer/Action/BoltExtendJson.php
+++ b/src/Composer/Action/BoltExtendJson.php
@@ -88,9 +88,7 @@ final class BoltExtendJson
         $pathToWeb = $app['resources']->findRelativePath($app['resources']->getPath('extensions'), $app['resources']->getPath('web'));
 
         // Enforce standard settings
-        if( isset($json['repositories']['packagist'])) {
-            unset($json['repositories']['packagist']);
-        }
+        $json['repositories']['packagist'] = false;
         $json['repositories']['bolt'] = array(
             'type' => 'composer',
             'url' => $app['extend.site'] . 'satis/'

--- a/tests/Composer/Action/BoltExtendJsonTest.php
+++ b/tests/Composer/Action/BoltExtendJsonTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace Bolt\Tests\Composer\Action;
+
+use Bolt\Tests\BoltUnitTest;
+use Bolt\Composer\Action\BoltExtendJson;
+
+/**
+ * Class to test src/Composer/Action/BoltExtendJson.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ *
+ */
+class BoltExtendJsonTest extends BoltUnitTest
+{
+
+    public function setup()
+    {
+        
+    }
+
+    public function tearDown()
+    {
+        
+    }
+
+    public function testConstructWithOptions()
+    {
+        $options = array('name'=>'test');
+        $action = new BoltExtendJson($options);
+        $this->assertSame($options, $action->getOptions());
+        
+    }
+
+    
+    
+}

--- a/tests/Composer/PackageManagerTest.php
+++ b/tests/Composer/PackageManagerTest.php
@@ -2,10 +2,10 @@
 namespace Bolt\Tests\Composer;
 
 use Bolt\Tests\BoltUnitTest;
-use Bolt\Composer\CommandRunner;
+use Bolt\Composer\PackageManager;
 
 /**
- * Class to test src/Composer/CommandRunner.
+ * Class to test src/Composer/PackageManager.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  *
@@ -16,5 +16,14 @@ class PackageManagerTest extends BoltUnitTest
     public function testConstruct()
     {
 
+    }
+    
+    public function testGetRootDependencies()
+    {
+        $app = $this->getApp();
+        $manager = new PackageManager($app);
+        $dependencies = $manager->getRootDependencies($app);
+
+        $this->assertTrue(is_array($dependencies));
     }
 }


### PR DESCRIPTION
As discussed here is an implementation that allows extensions (and their dependencies) to require packages from Packagist as well as the Bolt extensions repo.

To protect the core Bolt app we automatically mark as satisfied all of the core dependency graph, so should a package be part of this then the extension has to use the version installed and will be unable to replace it.

Potential Drawbacks to Consider
1. Speed: Parsing the packagist database is significantly slower than just our own repo, installing extensions will take a few seconds longer and possibly more as the dependency tree gets larger.

2. Clashes in future versions: For example, the scenario where a popular extension requires a package that in the future we want to include in core. We currently don't overwrite any existing composer requires, but we may have to consider that in the future.

3. Version nuances. There will be an increased onus on extension developers to ensure the extension works with the Bolt version of the package as this is upgraded. An extension that requires x/x: ~2.7 will be ignored when Bolt upgrades to 3.0 of x/x independently of the extension. 

### Possible Improvements:

1. We could make extension developers opt in to Packagist dependencies by specifying 
    "packagist": true

in the extra section of the extension composer.json.

The potential advantage of this is that we can do a scan of required extensions and leave Packagist disabled if none require it.

