### PR TITLE
[RFC] Indeterminate config values

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1067,11 +1067,4 @@ class Config
 
         return $merged;
     }
-
-    /**
-     * @deprecated Will be removed in Bolt 3.0
-     */
-    public function setCKPath()
-    {
-    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -67,8 +67,6 @@ class Config
             $this->checkValidCache();
 
         }
-
-        $this->setCKPath();
     }
 
     /**
@@ -890,28 +888,6 @@ class Config
         return $twigpath;
     }
 
-    /**
-     * Will be made protected in Bolt 3.0
-     */
-    public function setCKPath()
-    {
-        $app = $this->app['resources']->getUrl('app');
-
-        // Make sure the paths for CKeditor config are always set correctly..
-        $this->set(
-            'general/wysiwyg/ck/contentsCss',
-            array(
-                $app . 'view/css/ckeditor-contents.css',
-                $app . 'view/css/ckeditor.css'
-            )
-        );
-        $this->set('general/wysiwyg/filebrowser/browseUrl', $this->app['resources']->getUrl('async') . 'filebrowser/');
-        $this->set(
-            'general/wysiwyg/filebrowser/imageBrowseUrl',
-            $this->app['resources']->getUrl('bolt') . 'files/files/'
-        );
-    }
-
     protected function loadCache()
     {
         $dir = $this->app['resources']->getPath('config');
@@ -1090,5 +1066,12 @@ class Config
         }
 
         return $merged;
+    }
+
+    /**
+     * @deprecated Will be removed in Bolt 3.0
+     */
+    public function setCKPath()
+    {
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -168,13 +168,30 @@ class Config
             $part = & $part[$key];
         }
 
-        if ($value instanceof Type\ResolvableInterface) {
-            return $value->resolve($this->app);
-        } elseif ($value !== null) {
-            return $value;
+        if ($value === null) {
+            return $default;
+        }
+        return $this->resolveValue($value);
+    }
+
+    /**
+     * Ensure all values are resolved, by walking the data recursively.
+     *
+     * @param mixed $data
+     * @return mixed
+     */
+    protected function resolveValue($data)
+    {
+        if ($data instanceof Type\ResolvableInterface) {
+            return $data->resolve($this->app);
+        } elseif (!is_array($data)) {
+            return $data;
+        }
+        foreach ($data as $key => $value) {
+            $data[$key] = $this->resolveValue($value);
         }
 
-        return $default;
+        return $data;
     }
 
     /**

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -341,7 +341,6 @@ class ResourceManager
 
         $branding = ltrim($this->app['config']->get('general/branding/path') . '/', '/');
         $this->setUrl("bolt", $this->getUrl('root') . $branding);
-        $this->app['config']->setCkPath();
         $this->verifyDb();
     }
 

--- a/src/Configuration/Type/Path.php
+++ b/src/Configuration/Type/Path.php
@@ -1,0 +1,43 @@
+<?php
+namespace Bolt\Configuration\Type;
+
+use Silex\Application;
+
+/**
+ * This class represents a place holder for a filesystem path
+ */
+class Path implements ResolvableInterface
+{
+    /** @var string */
+    protected $path;
+
+    /**
+     * @param string $path
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Resolves the path from {@see ResourceManager::getPath}
+     *
+     * @param Application $app
+     *
+     * @return string
+     */
+    public function resolve(Application $app)
+    {
+        return $app['resources']->getPath($this->path);
+    }
+
+    /**
+     * Update the path place holder.
+     *
+     * @param string $path
+     */
+    public function update($path)
+    {
+        $this->path = $path;
+    }
+}

--- a/src/Configuration/Type/ResolvableInterface.php
+++ b/src/Configuration/Type/ResolvableInterface.php
@@ -1,0 +1,26 @@
+<?php
+namespace Bolt\Configuration\Type;
+
+use Silex\Application;
+
+/**
+ * An interface to define how "place holder" objects can be resolved to their actual values
+ */
+interface ResolvableInterface
+{
+    /**
+     * Resolves the value and returns it
+     *
+     * @param Application $app
+     *
+     * @return mixed
+     */
+    public function resolve(Application $app);
+
+    /**
+     * Updates the place holder value
+     *
+     * @param mixed $value
+     */
+    public function update($value);
+}

--- a/src/Configuration/Type/Url.php
+++ b/src/Configuration/Type/Url.php
@@ -1,0 +1,55 @@
+<?php
+namespace Bolt\Configuration\Type;
+
+use Silex\Application;
+
+/**
+ * This class represents a place holder for a url
+ */
+class Url implements ResolvableInterface
+{
+    /** @var string ResourceManager path value */
+    protected $prefix;
+
+    /** @var string The path to append to the prefix value or absolute path */
+    protected $path;
+
+    /**
+     * @param string $prefix
+     * @param string $path
+     */
+    public function __construct($prefix, $path)
+    {
+        $this->prefix = $prefix;
+        $this->path = $path;
+    }
+
+    /**
+     * Resolves the prefix from {@see ResourceManager::getUrl} and appends the path.
+     * If prefix is false, the path is assumed absolute.
+     *
+     * @param Application $app
+     *
+     * @return string
+     */
+    public function resolve(Application $app)
+    {
+        if ($this->prefix === false) {
+            return $this->path;
+        }
+        return $app['resources']->getUrl($this->prefix) . $this->path;
+    }
+
+    /**
+     * Updates the url place holder. If no prefix is specified
+     * the new path is assumed to be absolute.
+     *
+     * @param string      $path
+     * @param string|bool $prefix
+     */
+    public function update($path, $prefix = false)
+    {
+        $this->path = $path;
+        $this->prefix = $prefix;
+    }
+}


### PR DESCRIPTION
### Problem
Values can be based on other values, which can change. After changing a value, the dependent value(s) have to be re-set to account for this change. 
An example of this are the url paths for ckeditor (I think modifying them in the actual config file is broken right now....which defeats the purpose of having them in a config in the first place).

### Solution
Determine the value at the latest possible moment. 
I created an interface, `ResolvableInterface`, for place-holder-like objects. These objects hold the variables necessary to _resolve_ the actual value when the time comes.

When the value is accessed via `Config::get` the value is _resolved_ at that point (uncached). 
The values can also be _updated_ via `Config::set` or the actual yaml files when parsing.

Any value that is resolvable should be defined as such in `Config::getDefaults`.

----
I created two implentations, `Url` and `Path`, which reference values related to `ResourceManager::getPath/Url`. 
Although currently only `Url` is used, because the only use case for `Path` may break BC (thumbnail images).

----

There is a minor performance implication as values are _re-resolved_ for each call. Also, when pulling an array of values, iteration is needed to verify all values have been _resolved_.

Thoughts? Comments? This is awesome/mehh...over-engineered?