### PR TITLE
Allow setting of regex pattern, replacement and case of uploaded file names

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -144,6 +144,15 @@ thumbnails:
   exif_orientation: true
 #  browser_cache_time: 2592000
 
+# Uploaded file handling
+# 
+# You can change the pattern match and replacement on uploaded files and if the 
+# resulting filename should be transformed to lower case.
+#upload:
+#  pattern: '[^A-Za-z0-9\.]+'
+#  replacement: '-'
+#  lowercase: true
+
 # File types that are acceptable for upload in either 'file' fields or through the 'files' screen.
 
 # The following is the default list of file-types that can be uploaded through the 'files' screen.

--- a/src/Controllers/Upload.php
+++ b/src/Controllers/Upload.php
@@ -31,6 +31,19 @@ class Upload implements ControllerProviderInterface, ServiceProviderInterface
                 $uploadHandler->setOverwrite($app['upload.overwrite']);
                 $uploadHandler->addRule('extension', array('allowed' => $allowedExensions));
 
+                $pattern = $app['config']->get('general/upload/pattern', '[^A-Za-z0-9\.]+');
+                $replacement = $app['config']->get('general/upload/replacement', '-');
+                $lowercase = $app['config']->get('general/upload/lowercase', true);
+
+                $uploadHandler->setSanitizerCallback(function($filename) use ($pattern, $replacement, $lowercase) {
+                    if ($lowercase) {
+                        return preg_replace("/$pattern/", $replacement, strtolower($filename));
+                    }
+
+                    return preg_replace("/$pattern/", $replacement, $filename);
+                });
+
+
                 return $uploadHandler;
         };
 


### PR DESCRIPTION
The maintainer of siriusphp/upload added the ability today to provide a sanitisation callback for the upload handler.  This PR adds config options to allow us to use this.

Might be worth thinking about deprecating `accept_file_types:` key and making it part of `upload:`.

Fixes #1249 and #2237