### PR TITLE
Compete & remove obsolete @todo tasks

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -294,8 +294,6 @@ class Application extends Silex\Application
                 return new Stopwatch\Stopwatch();
             }
         );
-
-        // @todo: make a provider for the Random generator..
     }
 
     public function initExtensions()

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -703,13 +703,6 @@ class Async implements ControllerProviderInterface
         // Start the 'stopwatch' for the profiler.
         $app['stopwatch']->start('bolt.async.before');
 
-        // Only set which endpoint it is, if it's not already set. Which it is, in cases like
-        // when it's embedded on a page using {{ render() }}
-        // @todo Is this still needed?
-        if (empty($app['end'])) {
-            $app['end'] = "asynchronous";
-        }
-
         // If there's no active session, don't do anything..
         if (!$app['users']->isValidSession()) {
             $app->abort(404, "You must be logged in to use this.");

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -354,7 +354,6 @@ class Backend implements ControllerProviderInterface
             // This is easy:
             $title = Trans::__('All content types');
             $logEntries = $app['logger.manager.change']->getChangelog($options);
-            // @todo: Unused in template. Leave it in for now
             $itemcount = $app['logger.manager.change']->countChangelog($options);
         } else {
             // We have a content type, and possibly a contentid.
@@ -365,7 +364,6 @@ class Backend implements ControllerProviderInterface
             }
             // Getting a slice of data and the total count
             $logEntries = $app['logger.manager.change']->getChangelogByContentType($contenttype, $options);
-            // @todo: Unused in template. Leave it in for now
             $itemcount = $app['logger.manager.change']->countChangelogByContentType($contenttype, $options);
 
             // The page title we're sending to the template depends on a few

--- a/src/Nut/ConfigSet.php
+++ b/src/Nut/ConfigSet.php
@@ -16,8 +16,8 @@ class ConfigSet extends BaseCommand
             ->setDescription('Set a value in config.yml.')
             ->addArgument('key', InputArgument::REQUIRED, 'The key you wish to get.')
             ->addArgument('value', InputArgument::REQUIRED, 'The value you wish to set it to.')
-            ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, "Specify config file to use");
-
+            ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'Specify config file to use')
+            ->addOption('backup', 'b', InputOption::VALUE_NONE, 'Make a backup of the config file');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -25,14 +25,20 @@ class ConfigSet extends BaseCommand
         $key = $input->getArgument('key');
         $value = $input->getArgument('value');
 
+        if ($input->getOption('backup')) {
+            $backup = true;
+        } else {
+            $backup = false;
+        }
+
         if ($input->getOption('file')) {
             $file = $input->getOption('file');
         } else {
-            $file = $this->app['resources']->getPath('config') . "/config.yml";
+            $file = $this->app['resources']->getPath('config') . '/config.yml';
         }
 
         $yaml = new \Bolt\YamlUpdater($file);
-        $result = $yaml->change($key, $value);
+        $result = $yaml->change($key, $value, $backup);
 
         if ($result) {
             $result = sprintf("New value for <info>%s: %s</info> was successful. File updated.", $key, $value);

--- a/src/YamlUpdater.php
+++ b/src/YamlUpdater.php
@@ -186,7 +186,7 @@ class YamlUpdater
     {
         $this->filesystem = new FileSystem();
 
-        if (!$this->valid()) {
+        if (!$this->verify()) {
             return false;
         }
 
@@ -198,7 +198,7 @@ class YamlUpdater
         // Attempt to write out a temporary copy of the new YAML file
         $tmpfile = $this->filename . '.tmp';
         try {
-            $this->filesystem->dump($tmpfile, $this->yaml);
+            $this->filesystem->dumpFile($tmpfile, $this->yaml);
         } catch (IOExceptionInterface $e) {
             return false;
         }
@@ -210,6 +210,8 @@ class YamlUpdater
         } catch (IOExceptionInterface $e) {
             return false;
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
* Compete & remove obsolete @todo tasks
* Implemented YAML verification and optional backup of target file in YamlUpdater
* Make config file backup and option for nut config:set

### Changelog
Added: nut config:set now has an optional --backup parameter that creates a backup of the target config file
