### PR TITLE
Bugfix multiple flash messages

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -358,10 +358,6 @@ class Application extends Silex\Application
             return $response;
         }
 
-        // Sanity checks for doubles in in contenttypes.
-        // unfortunately this has to be done here, because the 'translator' classes need to be initialised.
-        $this['config']->checkConfig();
-
         // Stop the 'stopwatch' for the profiler.
         $this['stopwatch']->stop('bolt.app.before');
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -428,6 +428,17 @@ class Config
                 $field['group'] = $currentGroup;
             }
 
+            // Make sure we have these keys
+            $field = array_replace($field, array(
+                'label' => '',
+                'variant' => '',
+                'default' => '',
+                'pattern' => '',
+            ));
+
+            // Prefix class with "form-control"
+            $field['class'] = 'form-control' . (isset($field['class']) ? ' ' . $field['class'] : '');
+
             $fields[$key] = $field;
         }
 
@@ -632,25 +643,6 @@ class Config
                             return;
                         }
                     }
-                }
-
-                // Make sure we have a 'label', 'class', 'variant' and 'default'.
-                if (!isset($field['label'])) {
-                    $this->set("contenttypes/{$key}/fields/{$fieldname}/label", '');
-                }
-                if (!isset($field['class'])) {
-                    $this->set("contenttypes/{$key}/fields/{$fieldname}/class", 'form-control');
-                } else {
-                    $this->set("contenttypes/{$key}/fields/{$fieldname}/class", 'form-control ' . $field['class']);
-                }
-                if (!isset($field['variant'])) {
-                    $this->set("contenttypes/{$key}/fields/{$fieldname}/variant", '');
-                }
-                if (!isset($field['default'])) {
-                    $this->set("contenttypes/{$key}/fields/{$fieldname}/default", '');
-                }
-                if (!isset($field['pattern'])) {
-                    $this->set("contenttypes/{$key}/fields/{$fieldname}/pattern", '');
                 }
 
                 // Make sure the 'type' is in the list of allowed types

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1668,6 +1668,10 @@ class Backend implements ControllerProviderInterface
 
         $app['debugbar'] = true;
 
+        // Sanity checks for doubles in in contenttypes.
+        // unfortunately this has to be done here, because the 'translator' classes need to be initialised.
+        $app['config']->checkConfig();
+
         // If the users table is present, but there are no users, and we're on /bolt/useredit,
         // we let the user stay, because they need to set up the first user.
         if ($app['integritychecker']->checkUserTableIntegrity() && !$app['users']->getUsers() && $route == 'useredit') {


### PR DESCRIPTION
This is caused by Config::checkConfig being called for ajax requests. Flash bag messages are only removed when the backend twig template pulls them. So every ajax request will add one error, which will build up until they are flushed with a backend twig response.

For example, here's a request list:
1) /bolt -> removes all errors (now 0)
2) /async/latestactivity -> +1 error (now 1)
2) /async/latestactivity -> +1 error (now 2)
3) /bolt -> +1 error (now 3). They are flushed here, so 3 errors are rendered and the list is reset.

I moved `Config::checkConfig` call to only on the `Backend` controller, since this is the only time they will be rendered.

Although the could be rendered on the Frontend as well, should I call be added there as well?
