### PR TITLE
R.I.P. Library::fixPath() 

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -14,49 +14,6 @@ use Bolt\Translation\Translator;
 class Library
 {
     /**
-     * Cleans up/fixes a relative paths.
-     *
-     * As an example '/site/pivotx/../index.php' becomes '/site/index.php'.
-     * In addition (non-leading) double slashes are removed.
-     *
-     * @param  string $path
-     * @param  bool   $nodoubleleadingslashes
-     * @return string
-     */
-    public static function fixPath($path, $nodoubleleadingslashes = true)
-    {
-        $path = str_replace("\\", "/", rtrim($path, '/'));
-
-        // Handle double leading slash (that shouldn't be removed).
-        if (!$nodoubleleadingslashes && (strpos($path, '//') === 0)) {
-            $lead = '//';
-            $path = substr($path, 2);
-        } else {
-            $lead = '';
-        }
-
-        $patharray = explode('/', preg_replace('#/+#', '/', $path));
-        $newPath = array();
-
-        foreach ($patharray as $item) {
-            if ($item == '..') {
-                // remove the previous element
-                @array_pop($newPath);
-            } elseif ($item == 'http:') {
-                // Don't break for URLs with http:// scheme
-                $newPath[] = 'http:/';
-            } elseif ($item == 'https:') {
-                // Don't break for URLs with https:// scheme
-                $newPath[] = 'https:/';
-            } elseif (($item != '.')) {
-                $newPath[] = $item;
-            }
-        }
-
-        return $lead . implode('/', $newPath);
-    }
-
-    /**
      * Format a filesize like '10.3 kb' or '2.5 mb'
      *
      * @param  integer $size

--- a/src/Library.php
+++ b/src/Library.php
@@ -292,8 +292,6 @@ class Library
      */
     public static function saveSerialize($filename, &$data)
     {
-        $filename = self::fixPath($filename);
-
         $serString = '<?php /* bolt */ die(); ?>json:' . json_encode($data);
 
         // disallow user to interrupt

--- a/src/Library.php
+++ b/src/Library.php
@@ -231,8 +231,6 @@ class Library
      */
     public static function loadSerialize($filename, $silent = false)
     {
-        $filename = self::fixPath($filename);
-
         if (! is_readable($filename)) {
 
             if ($silent) {

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -1231,8 +1231,8 @@ class TwigExtension extends \Twig_Extension
                 $item['record'] = $content;
 
             } else {
-                // we assume the user links to this on purpose.
-                $item['link'] = Lib::fixPath($this->app['paths']['root'] . $item['path']);
+                // The user has probably put a 'link' in the 'path' key, set it for them
+                $item['link'] = $item['path'];
             }
 
         }

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -2,13 +2,14 @@
 
 namespace Bolt;
 
-use Silex;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\Glob;
 use Bolt\Library as Lib;
 use Bolt\Helpers\String;
 use Bolt\Helpers\Html;
 use Bolt\Translation\Translator as Trans;
+use Silex;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\Glob;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
  * The class for Bolt' Twig tags, functions and filters.
@@ -1210,31 +1211,50 @@ class TwigExtension extends \Twig_Extension
             $add = empty($item['add']) ? '' : $item['add'];
 
             $item['link'] = Lib::path($item['route'], $param, $add);
-        } elseif (isset($item['path'])) {
-            // if the item is like 'content/1', get that content.
-            if (preg_match('#^([a-z0-9_-]+)/([a-z0-9_-]+)$#i', $item['path'])) {
-                $content = $this->app['storage']->getContent($item['path']);
-            }
-
-            if ($content instanceof \Bolt\Content) {
-                // We have content.
-                if (empty($item['label'])) {
-                    $item['label'] = !empty($content->values['title']) ? $content->values['title'] : "";
-                }
-                if (empty($item['title'])) {
-                    $item['title'] = !empty($content->values['subtitle']) ? $content->values['subtitle'] : "";
-                }
-                if (is_object($content)) {
-                    $item['link'] = $content->link();
-                }
-
-                $item['record'] = $content;
-
-            } else {
-                // The user has probably put a 'link' in the 'path' key, set it for them
+        } elseif (isset($item['path']) && !isset($item['link'])) {
+            if (preg_match('#^(https?://|//)#i', $item['path'])) {
+                // We have a mistakenly placed URL, allow it but log it.
                 $item['link'] = $item['path'];
-            }
+                $this->app['logger.system']->addError(Trans::__('Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!', array('%PATH%' => $item['path'])), array('event' => 'config'));
+            } else {
+                // Get a copy of the path minus trainling/leading slash
+                $path = ltrim(rtrim($item['path'], '/'), '/');
 
+                // Pre-set our link in case the match() throws an exception
+                $item['link'] = '/' . $path;
+
+                try {
+                    // See if we have a 'content/id' or 'content/slug' path
+                    if (preg_match('#^([a-z0-9_-]+)/([a-z0-9_-]+)$#i', $path)) {
+
+                        // Determine if the provided path first matches any routes
+                        // that we have, this will catch any valid configured
+                        // contenttype slug and record combination, or throw a
+                        // ResourceNotFoundException exception otherwise
+                        $this->app['url_matcher']->match('/' . $path);
+
+                        // If we found a valid routing match then we're still here,
+                        // attempt to retrive the actual record.
+                        $content = $this->app['storage']->getContent($path);
+                        if ($content instanceof \Bolt\Content) {
+
+                            if (empty($item['label'])) {
+                                $item['label'] = !empty($content->values['title']) ? $content->values['title'] : "";
+                            }
+
+                            if (empty($item['title'])) {
+                                $item['title'] = !empty($content->values['subtitle']) ? $content->values['subtitle'] : "";
+                            }
+
+                            $item['link'] = $content->link();
+                        }
+                    } else {
+                        $item['link'] = '/' . $path;
+                    }
+                } catch (ResourceNotFoundException $e) {
+                    $this->app['logger.system']->addError(Trans::__('Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.', array('%PATH%' => $item['path'])), array('event' => 'config'));
+                }
+            }
         }
 
         return $item;

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -1216,7 +1216,7 @@ class TwigExtension extends \Twig_Extension
                 $content = $this->app['storage']->getContent($item['path']);
             }
 
-            if (!empty($content) && is_object($content) && get_class($content) == 'Bolt\Content') {
+            if ($content instanceof \Bolt\Content) {
                 // We have content.
                 if (empty($item['label'])) {
                     $item['label'] = !empty($content->values['title']) ? $content->values['title'] : "";

--- a/tests/Library/BoltLibraryTest.php
+++ b/tests/Library/BoltLibraryTest.php
@@ -13,31 +13,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class BoltLibraryTest extends BoltUnitTest
 {
-
-    public function testFixPath()
-    {
-        $windowsPath = "A:\My\File";
-        $fix = Library::fixPath($windowsPath);
-        $this->assertEquals("A:/My/File", $fix);
-
-        $protocolPath = "//path/to\image.jpg";
-        $fix = Library::fixPath($protocolPath, false);
-        $this->assertEquals("//path/to/image.jpg", $fix);
-
-        $relative = "/path/to/nested/nested/../../image.jpg";
-        $fix = Library::fixPath($relative);
-        $this->assertEquals("/path/to/image.jpg", $fix);
-
-        $relativeUrl = "http://path/to/nested/nested/../../image.jpg";
-        $fix = Library::fixPath($relativeUrl, false);
-        $this->assertEquals("http://path/to/image.jpg", $fix);
-
-        $relativeSecureUrl = "https://path/to/nested/nested/../../image.jpg";
-        $fix = Library::fixPath($relativeSecureUrl, false);
-        $this->assertEquals("https://path/to/image.jpg", $fix);
-
-    }
-
     public function testFormatFilesize()
     {
         $b = 300;


### PR DESCRIPTION
Library::fixPath() had only three remaining users:
* `Library::loadSerialize()`
* `Library::saveSerialize()`
* `TwigExtension::menuHelper()`

Both `loadSerialize() and `saveSerialize()` are only called from `Bolt\Config` and the paths are constructed fine.

`TwigExtension::menuHelper()` was a bit of fun, it now handles menu `path:` keys a lot better (I hope).

The following permutations all work:
* `{contenttype}`
* `{contenttype}/`
* `/{contenttype}`
* `/{contenttype}/`
* `{contenttype}/{id|slug}`
* `/{contenttype}/{id|slug}`

Also if someone (mis)configures `path:` with any of the following, they will create working links, but get an error logged in the system log:
* `http://`
* `https://`
* `//`

**NOTE:** If none of these match, `menuHelper()` will just assume that whatever the string given in `path` is a relative site URI.