### PR TITLE
[RFCish] Symfony Filesystem service

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -352,6 +352,7 @@ class Application extends Silex\Application
             ->register(new Thumbs\ThumbnailProvider())
             ->register(new Provider\NutServiceProvider())
             ->register(new Provider\GuzzleServiceProvider())
+            ->register(new Provider\SymfonyFilesystemServiceProvider())
             ->register(new SlugifyServiceProvider());
 
         $this['paths'] = $this['resources']->getPaths();

--- a/src/Content.php
+++ b/src/Content.php
@@ -2,12 +2,11 @@
 
 namespace Bolt;
 
-use Silex;
-use Symfony\Component\Filesystem\Filesystem;
 use Bolt\Library as Lib;
 use Bolt\Helpers\String;
 use Bolt\Helpers\Input;
 use Bolt\Helpers\Html;
+use Silex;
 
 class Content implements \ArrayAccess
 {
@@ -418,10 +417,9 @@ class Content implements \ArrayAccess
                 }
 
                 $fieldname  = substr($key, 11);
-                $fileSystem = new Filesystem();
 
                 // Make sure the folder exists.
-                $fileSystem->mkdir(dirname($filename));
+                $this->app['symfony.filesystem']->mkdir(dirname($filename));
 
                 // Check if we don't have doubles.
                 if (is_file($filename)) {

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -7,11 +7,9 @@ use Bolt\Translation\Translator as Trans;
 use Guzzle\Http\Exception\RequestException;
 use Silex;
 use Silex\ControllerProviderInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Filesystem\Exception\IOException;
 
 class Async implements ControllerProviderInterface
 {
@@ -507,14 +505,10 @@ class Async implements ControllerProviderInterface
                       . DIRECTORY_SEPARATOR
                       . $newName;
 
-        $fileSystemHelper = new Filesystem();
-
         try {
-            $fileSystemHelper->rename($oldPath, $newPath, false /* Don't rename if target exists already! */);
+            $this->app['symfony.filesystem']->rename($oldPath, $newPath, false /* Don't rename if target exists already! */);
         } catch (IOException $exception) {
-
             /* Thrown if target already exists or renaming failed. */
-
             return false;
         }
 
@@ -598,18 +592,14 @@ class Async implements ControllerProviderInterface
                       . $parentPath
                       . $newName;
 
-        $fileSystemHelper = new Filesystem();
-
         try {
-            $fileSystemHelper->rename(
+            $this->app['symfony.filesystem']->rename(
                 $oldPath,
                 $newPath,
                 false /* Don't rename if target exists already! */
             );
         } catch (IOException $exception) {
-
             /* Thrown if target already exists or renaming failed. */
-
             return false;
         }
 

--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -2,20 +2,18 @@
 
 namespace Bolt\Controllers;
 
+use Bolt\Composer\PackageManager;
+use Bolt\Exception\PackageManagerException;
+use Bolt\Extensions\ExtensionsInfoService;
+use Bolt\Library as Lib;
+use Bolt\Translation\Translator as Trans;
 use Silex;
 use Silex\ControllerProviderInterface;
 use Silex\ServiceProviderInterface;
-
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Filesystem\Filesystem;
 
-use Bolt\Composer\PackageManager;
-use Bolt\Exception\PackageManagerException;
-use Bolt\Library as Lib;
-use Bolt\Translation\Translator as Trans;
-use Bolt\Extensions\ExtensionsInfoService;
 
 class Extend implements ControllerProviderInterface, ServiceProviderInterface
 {
@@ -177,12 +175,11 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
         $destination = $app['resources']->getPath('themebase') . '/' . $newName;
         if (is_dir($source)) {
             try {
-                $filesystem = new Filesystem();
-                $filesystem->mkdir($destination);
-                $filesystem->mirror($source, $destination);
+                $this->app['symfony.filesystem']->mkdir($destination);
+                $this->app['symfony.filesystem']->mirror($source, $destination);
 
                 if (file_exists($destination . "/config.yml.dist")) {
-                    $filesystem->copy($destination . "/config.yml.dist", $destination . "/config.yml");
+                    $this->app['symfony.filesystem']->copy($destination . "/config.yml.dist", $destination . "/config.yml");
                 }
 
                 return new Response(Trans::__('Theme successfully generated. You can now edit it directly from your theme folder.'));

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -8,7 +8,6 @@ use Bolt\Extensions\ExtensionInterface;
 use Bolt\Helpers\String;
 use Bolt\Translation\Translator as Trans;
 use Monolog\Logger;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 class Extensions
@@ -156,8 +155,7 @@ class Extensions
      */
     public function localload($app)
     {
-        $fs = new Filesystem();
-        $flag = $fs->exists($this->basefolder . '/local');
+        $flag = $this->app['symfony.filesystem']->exists($this->basefolder . '/local');
 
         // Check that local exists
         if ($flag) {

--- a/src/Nut/ConfigGet.php
+++ b/src/Nut/ConfigGet.php
@@ -29,7 +29,7 @@ class ConfigGet extends BaseCommand
             $file = $this->app['resources']->getPath('config') . "/config.yml";
         }
 
-        $yaml = new \Bolt\YamlUpdater($file);
+        $yaml = new \Bolt\YamlUpdater($this->app, $file);
         $match = $yaml->get($key);
 
         if (!empty($match)) {

--- a/src/Nut/ConfigSet.php
+++ b/src/Nut/ConfigSet.php
@@ -37,7 +37,7 @@ class ConfigSet extends BaseCommand
             $file = $this->app['resources']->getPath('config') . '/config.yml';
         }
 
-        $yaml = new \Bolt\YamlUpdater($file);
+        $yaml = new \Bolt\YamlUpdater($this->app, $file);
         $result = $yaml->change($key, $value, $backup);
 
         if ($result) {

--- a/src/Provider/SymfonyFilesystemServiceProvider.php
+++ b/src/Provider/SymfonyFilesystemServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bolt\Provider;
+
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Provider for Symfony Filesystem
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class SymfonyFilesystemServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        $app['symfony.filesystem'] = $app->share(
+            function(Application $app) {
+                return new Filesystem();
+        });
+    }
+
+    public function boot(Application $app)
+    {
+    }
+}

--- a/src/YamlUpdater.php
+++ b/src/YamlUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Bolt;
 
+use Bolt\Application;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Yaml\Exception\ParseException;
@@ -15,6 +16,10 @@ use Symfony\Component\Yaml\Parser;
  **/
 class YamlUpdater
 {
+    /**
+     * @var $app Silex\Application
+     */
+    private $app;
 
     /**
      * "File pointer". Basically used as offset for searching.
@@ -42,9 +47,10 @@ class YamlUpdater
     /**
      * Creates an updater for the given file.
      *
-     * @param string  $filename   The file to modify
+     * @param Silex\Application $app
+     * @param string            $filename   The file to modify
      */
-    public function __construct($filename = '')
+    public function __construct(Application $app, $filename = '')
     {
         if (!is_readable($filename)) {
             echo "Can't read $filename\n";
@@ -52,6 +58,7 @@ class YamlUpdater
             return false;
         }
 
+        $this->app = $app;
         $this->filename = $filename;
         $this->file = file($filename);
         $this->lines = count($this->file);

--- a/src/YamlUpdater.php
+++ b/src/YamlUpdater.php
@@ -3,7 +3,6 @@
 namespace Bolt;
 
 use Bolt\Application;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
@@ -185,8 +184,6 @@ class YamlUpdater
      */
     protected function save($makebackup)
     {
-        $this->filesystem = new FileSystem();
-
         if (!$this->verify()) {
             return false;
         }
@@ -199,7 +196,7 @@ class YamlUpdater
         // Attempt to write out a temporary copy of the new YAML file
         $tmpfile = $this->filename . '.tmp';
         try {
-            $this->filesystem->dumpFile($tmpfile, $this->yaml);
+            $this->app['symfony.filesystem']->dumpFile($tmpfile, $this->yaml);
         } catch (IOExceptionInterface $e) {
             return false;
         }
@@ -207,7 +204,7 @@ class YamlUpdater
         // We know the temporary file is readable, we touched the file in verify(),
         // so attempt a final rename
         try {
-            $this->filesystem->rename($tmpfile, $this->filename, true);
+            $this->app['symfony.filesystem']->rename($tmpfile, $this->filename, true);
         } catch (IOExceptionInterface $e) {
             return false;
         }
@@ -230,7 +227,7 @@ class YamlUpdater
         // Attempt to change the modification time on the file to test if it is
         // writeable
         try {
-            $this->filesystem->touch($this->filename);
+            $this->app['symfony.filesystem']->touch($this->filename);
         } catch (IOExceptionInterface $e) {
             return false;
         }
@@ -255,7 +252,7 @@ class YamlUpdater
     protected function backup()
     {
         try {
-            $this->filesystem->copy($this->filename, $this->filename . '.' . date('Ymd-His'), true);
+            $this->app['symfony.filesystem']->copy($this->filename, $this->filename . '.' . date('Ymd-His'), true);
         } catch (IOExceptionInterface $e) {
             return false;
         }


### PR DESCRIPTION
We use `Symfony\Component\Filesystem\Filesystem` in several places, some of them are very early and have to stay that way, and there are more still where we could leverage it.

This implements a service provider and uses it where we currently create a new instance.  Basically this is an opportunity to expand on that with fractional overhead.

**Note for the OCDs:** `$app['symfony.filesystem']` chosen as a name due to `$app['filesystem']` being used as a project specific service provider class...  Suggestions welcome prior to merge...  or after, we're in alpha after all :camel: 