### PR TITLE
Enforce SSL Config Change

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -250,15 +250,6 @@ cookies_use_remoteaddr: true
 cookies_use_browseragent: false
 cookies_use_httphost: true
 
-# Set the SECURE flag on session and authentication cookies. This will keep
-# most browsers from transmitting sessions cookies over an unencrypted
-# connection (e.g. when editing the site over HTTPS and at the same time
-# viewing it over HTTP).
-# NOTE: This setting only makes sense when you have actually set up HTTPS for
-# your Bolt site; if you do, you probably want to combine this flag with the
-# enforce_ssl option to avoid non-SSL requests to the backend altogether.
-cookies_https_only: false
-
 # The length of time a user stays 'logged in'. Change to 0 to end the session when the browser
 # is closed. The default is 1209600: two weeks in seconds.
 cookies_lifetime: 1209600
@@ -294,9 +285,6 @@ extensions:
 # Enforce SSL: if set, all but the front-end pages will enforce an SSL
 # connection (and redirect to HTTPS if you attempt to visit the backend over
 # plain HTTP).
-# NOTE: if you set this, you probably also want to set the cookies_https_only
-# option; without it, users can still be tricked into sending session cookies
-# over plain HTTP, which could allow a MITM attacker to hijack their sessions.
 # enforce_ssl: true
 
 # If configured, Bolt will trust X-Forwarded-XXX headers from the listed IP

--- a/src/Application.php
+++ b/src/Application.php
@@ -76,7 +76,7 @@ class Application extends Silex\Application
             array(
                 'session.storage.options' => array(
                     'name'            => 'bolt_session',
-                    'cookie_secure'   => $this['config']->get('general/cookies_https_only'),
+                    'cookie_secure'   => $this['config']->get('general/enforce_ssl'),
                     'cookie_httponly' => true
                 )
             )

--- a/src/Config.php
+++ b/src/Config.php
@@ -809,7 +809,6 @@ class Config
             'cookies_use_remoteaddr'      => true,
             'cookies_use_browseragent'    => false,
             'cookies_use_httphost'        => true,
-            'cookies_https_only'          => false,
             'cookies_lifetime'            => 14 * 24 * 3600,
             'thumbnails'                  => array(
                 'default_thumbnail' => array(160, 120),

--- a/src/Controllers/Login.php
+++ b/src/Controllers/Login.php
@@ -92,6 +92,10 @@ class Login implements Silex\ControllerProviderInterface
             'randomquote' => true,
         );
 
+        if ($app['config']->get('general/enforce_ssl') && !$app['request']->isSecure()) {
+            return $app->redirect(preg_replace("/^http:/i", "https:", $app['request']->getUri()));
+        }
+
         return $app['render']->render('login/login.twig', array('context' => $context));
     }
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -278,7 +278,7 @@ class Users
             time() + $this->app['config']->get('general/cookies_lifetime'),
             '/',
             $this->app['config']->get('general/cookies_domain'),
-            $this->app['config']->get('general/cookies_https_only'),
+            $this->app['config']->get('general/enforce_ssl'),
             true
         );
 
@@ -559,7 +559,7 @@ class Users
                 time() - 1,
                 '/',
                 $this->app['config']->get('general/cookies_domain'),
-                $this->app['config']->get('general/cookies_https_only'),
+                $this->app['config']->get('general/enforce_ssl'),
                 true
             );
 
@@ -715,7 +715,7 @@ class Users
             time() - 1,
             '/',
             $this->app['config']->get('general/cookies_domain'),
-            $this->app['config']->get('general/cookies_https_only'),
+            $this->app['config']->get('general/enforce_ssl'),
             true
         );
     }


### PR DESCRIPTION
Removing confusion from the SSL config. I removed the setting for cookies_https_only and instead use enforce_ssl throughout the app. Additionally, if enforce_ssl is set, the login page will automatically redirect to https.