### PR TITLE
Fix the "mysql was selected but is not supported" error notice.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -29,7 +29,7 @@ class Application extends Silex\Application
     public function __construct(array $values = array())
     {
         $values['bolt_version'] = '2.1.0';
-        $values['bolt_name'] = 'alpha1';
+        $values['bolt_name'] = 'alpha2';
         $values['bolt_released'] = false; // True for stable releases
 
         parent::__construct($values);


### PR DESCRIPTION
Simply bumping the version will invalidate the cached config, ensuring the config files are reloaded which allows Bolt to pick up the correct values.