### PR TITLE
Don't crash the backend when log.ownerid doesn't exist (yet).

### DIFF
--- a/app/view/twig/components/panel-system.twig
+++ b/app/view/twig/components/panel-system.twig
@@ -16,7 +16,7 @@
 
     <ul class="activity">
         {% for log in activity %}
-            {% set user = getuser(log.ownerid) %}
+            {% set user = getuser( log.ownerid|default('') ) %}
             {% if user is not empty %}
                 {% set userlink = macro.userlink(user) %}
             {% else %}


### PR DESCRIPTION
This happens when updating: Before the user gets a chance to update the DB, Bolt shouldn't crash on non-present values before they get a change to update the DB.