### PR TITLE
Fixes "Uncaught ReferenceError: CKEDITOR is not defined"

### DIFF
--- a/app/view/js/lib.min.js
+++ b/app/view/js/lib.min.js
@@ -33,7 +33,7 @@ $(function(){$.fn.bootstrapFileInput=function(){this.each(function(a,b){var c=$(
  * @see: https://gist.github.com/DrPheltRight/4131266
  * Written by Luke Morton, licensed under MIT. Adapted for Bolt by Bob.
  */
-(function(a){a.fn.watchChanges=function(){for(var b in CKEDITOR.instances)CKEDITOR.instances[b].updateElement();return this.each(function(){a.data(this,"formHash",a(this).serialize())})},a.fn.hasChanged=function(){var b=!1;for(var c in CKEDITOR.instances)CKEDITOR.instances[c].updateElement();return this.each(function(){var c=a.data(this,"formHash");return null!=c&&c!==a(this).serialize()?(b=!0,!1):void 0}),b}}).call(this,jQuery);
+(function(a){a.fn.watchChanges=function(){if("undefined"!=typeof CKEDITOR)for(var b in CKEDITOR.instances)CKEDITOR.instances[b].updateElement();return this.each(function(){a.data(this,"formHash",a(this).serialize())})},a.fn.hasChanged=function(){var b=!1;if("undefined"!=typeof CKEDITOR)for(var c in CKEDITOR.instances)CKEDITOR.instances[c].updateElement();return this.each(function(){var c=a.data(this,"formHash");return null!=c&&c!==a(this).serialize()?(b=!0,!1):void 0}),b}}).call(this,jQuery);
 
 /*!
  * jQuery Iframe Transport Plugin 1.6.1

--- a/app/view/lib/jquery-watchchanges/jquery-watchchanges.js
+++ b/app/view/lib/jquery-watchchanges/jquery-watchchanges.js
@@ -8,8 +8,10 @@
     $.fn.watchChanges = function () {
 
         // First, make sure the underlying textareas are updated with the content in the CKEditor fields.
-        for (var instanceName in CKEDITOR.instances) {
-            CKEDITOR.instances[instanceName].updateElement();
+        if (typeof CKEDITOR !== 'undefined') {
+            for (var instanceName in CKEDITOR.instances) {
+                CKEDITOR.instances[instanceName].updateElement();
+            }
         }
 
         return this.each(function () {
@@ -21,8 +23,10 @@
         var hasChanged = false;
 
         // First, make sure the underlying textareas are updated with the content in the CKEditor fields.
-        for(var instanceName in CKEDITOR.instances) {
-            CKEDITOR.instances[instanceName].updateElement();
+        if (typeof CKEDITOR !== 'undefined') {
+            for (var instanceName in CKEDITOR.instances) {
+                CKEDITOR.instances[instanceName].updateElement();
+            }
         }
 
         this.each(function () {


### PR DESCRIPTION
Yet another one.

Sidenote: we should move ``jquery-watches`` to our own sourcetree and add it to init.js as it is 30% patched anyway and no updates are to expected