### PR TITLE
debug_print_backtrace() returns void and can't be passed to a variable

### DIFF
--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -425,7 +425,9 @@ class ResourceManager
     public static function getApp()
     {
         if (! static::$theApp) {
-            $message = sprintf("The Bolt 'Application' object isn't initialized yet so the container can't be accessed here: <code>%s</code>", htmlspecialchars(debug_print_backtrace(), ENT_QUOTES));
+            $trace = debug_backtrace(false);
+            $trace = $trace[0]['file'] . '::' . $trace[0]['line'];
+            $message = sprintf("The Bolt 'Application' object isn't initialized yet so the container can't be accessed here: <code>%s</code>", $trace);
             throw new \RuntimeException($message);
         }
 

--- a/tests/Configuration/ResourceManagerTest.php
+++ b/tests/Configuration/ResourceManagerTest.php
@@ -394,8 +394,6 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
     public function testEarlyStaticFails()
     {
         $this->setExpectedException('RuntimeException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
         $app = ResourceManager::getApp();
-
     }
 }


### PR DESCRIPTION
Fixes #2610. Ugly, but does the job until this is refactored out.