### PR TITLE
Prevent logged in user from disabling themself through useractions.

### DIFF
--- a/app/view/twig/users/_userlist-actions.twig
+++ b/app/view/twig/users/_userlist-actions.twig
@@ -7,39 +7,41 @@
         <i class="fa fa-info-sign"></i>
         <span class="caret"></span>
     </button>
-
+    
     <ul class="dropdown-menu pull-right">
-        {% if user.enabled %}
+        {% if context.currentuser.id != user.id  %}
+            {% if user.enabled %}
+                <li>
+                    <form action="{{ path('useraction', {'action': 'disable', 'id': user.id}) }}" method="post">
+                        {% include('_sub/_csrf_token.twig') %}
+                        <button type="submit" class="btn btn-block btn-link">
+                            <span class="pull-left">{{ __('Disable %username%',{'%username%':user.displayname}) }}</span>
+                        </button>
+                    </form>
+                </li>
+            {% else %}
+                <li>
+                    <form action="{{ path('useraction', {'action': 'enable', 'id': user.id}) }}" method="post">
+                        {% include('_sub/_csrf_token.twig') %}
+                        <button type="submit" class="btn btn-block btn-link">
+                            <span class="pull-left">{{ __('Enable %username%',{'%username%':user.displayname}) }}</span>
+                        </button>
+                    </form>
+                </li>
+            {% endif %}
             <li>
-                <form action="{{ path('useraction', {'action': 'disable', 'id': user.id}) }}" method="post">
+                <form action="{{ path('useraction', {'action': 'delete', 'id': user.id}) }}" method="post">
                     {% include('_sub/_csrf_token.twig') %}
-                    <button type="submit" class="btn btn-block btn-link">
-                        <span class="pull-left">{{ __('Disable %username%',{'%username%':user.displayname}) }}</span>
+                    <button type="submit" class="btn btn-block btn-link confirm"
+                    data-confirm="{{ __('Are you sure you want to delete %username%?',{'%username%':user.displayname}) }}" >
+                        <span class="pull-left">{{ __('Delete %username%',{'%username%':user.displayname}) }}</span>
                     </button>
                 </form>
             </li>
-        {% else %}
-            <li>
-                <form action="{{ path('useraction', {'action': 'enable', 'id': user.id}) }}" method="post">
-                    {% include('_sub/_csrf_token.twig') %}
-                    <button type="submit" class="btn btn-block btn-link">
-                        <span class="pull-left">{{ __('Enable %username%',{'%username%':user.displayname}) }}</span>
-                    </button>
-                </form>
+
+            <li class="divider">
             </li>
         {% endif %}
-        <li>
-            <form action="{{ path('useraction', {'action': 'delete', 'id': user.id}) }}" method="post">
-                {% include('_sub/_csrf_token.twig') %}
-                <button type="submit" class="btn btn-block btn-link confirm"
-                data-confirm="{{ __('Are you sure you want to delete %username%?',{'%username%':user.displayname}) }}" >
-                    <span class="pull-left">{{ __('Delete %username%',{'%username%':user.displayname}) }}</span>
-                </button>
-            </form>
-        </li>
-
-        <li class="divider">
-        </li>
 
         <li>
             <a class="nolink">

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1084,10 +1084,12 @@ class Backend implements ControllerProviderInterface
      */
     public function users(Silex\Application $app)
     {
+        $currentuser = $app['users']->getCurrentUser();
         $users = $app['users']->getUsers();
         $sessions = $app['users']->getActiveSessions();
 
         $context = array(
+            'currentuser' => $currentuser,
             'users' => $users,
             'sessions' => $sessions
         );

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1480,6 +1480,13 @@ class Backend implements ControllerProviderInterface
 
             return Lib::redirect('users');
         }
+        
+        $currentuser = $app['users']->getCurrentUser();
+        
+        if ($currentuser['id'] == $user['id']) {
+            $app['session']->getFlashBag()->set('error', 'You cannot ' . $action . ' yourself.');
+            return Lib::redirect('users');
+        }
 
         switch ($action) {
 


### PR DESCRIPTION
Fixes: #2763
Updates: #2764, #2765

* Prevents the logged in user from seeing user actions for their own user account within the admin/users page.
* Prevents the logged in user from submitting a post request method to /user/{action}/{id} if the id parameter is their own.

### Changelog
* Fixed: Logged in user can no longer enable, disable or delete themselves.