### PR TITLE
Log UI permissions

### DIFF
--- a/app/config/permissions.yml.dist
+++ b/app/config/permissions.yml.dist
@@ -46,7 +46,6 @@ roles:
 # inside the code, so they don't appear here.
 global:
     about: [ everyone ] # view the 'About Bolt' page
-    activitylog: [ admin, developer, chief-editor ]
     clearcache: [ admin, developer ]
     contentaction: [ editor, admin, developer ]
     dashboard: [ everyone ]
@@ -70,6 +69,9 @@ global:
     roles: [ admin, developer ] # view the roles overview    
     maintenance-mode: [ everyone ] # view the frontend when in maintenance mode
     omnisearch: [ everyone ]
+    # Access to the various logs
+    changelog: [ admin, developer, chief-editor ]
+    systemlog: [ admin, developer ]
     # The following permissions are particularly important: login and postLogin
     # determine who may see and use the login form. If you set them to anything
     # but 'anonymous', only users will be able to log in that are logged in

--- a/app/view/twig/components/panel-change.twig
+++ b/app/view/twig/components/panel-change.twig
@@ -2,7 +2,7 @@
  # Sidebar-Panel: Displays the latest activity
  # (Usage Example: Dashboards sidebar)
  #}
-{% extends (isallowed('activitylog')) ? '_base/_panel.twig' : '_base/_nothing.twig' %}
+{% extends (isallowed('changelog')) ? '_base/_panel.twig' : '_base/_nothing.twig' %}
 
 {% block panel_class 'panel-activity' %}
 

--- a/app/view/twig/components/panel-system.twig
+++ b/app/view/twig/components/panel-system.twig
@@ -2,7 +2,7 @@
  # Sidebar-Panel: Displays the latest activity
  # (Usage Example: Dashboards sidebar)
  #}
-{% extends (isallowed('activitylog')) ? '_base/_panel.twig' : '_base/_nothing.twig' %}
+{% extends (isallowed('systemlog')) ? '_base/_panel.twig' : '_base/_nothing.twig' %}
 
 {% block panel_class 'panel-activity' %}
 

--- a/app/view/twig/dashboard/_aside.twig
+++ b/app/view/twig/dashboard/_aside.twig
@@ -34,7 +34,7 @@
 
 {# Latest Activity #}
 <div id="latestactivity">
-    {{ render(path("latestactivity")) }}
+    {{ render(path('latestactivity')) }}
 </div>
 
 {# ? #}

--- a/test/_data/permissions.yml
+++ b/test/_data/permissions.yml
@@ -46,7 +46,6 @@ roles:
 # inside the code, so they don't appear here.
 global:
     about: [ editor, admin, developer ] # view the 'About Bolt' page
-    activitylog: [ admin, developer, chief-editor ]
     clearcache: [ admin, developer ]
     contentaction: [ editor, admin, developer ]
     dashboard: [ everyone ]
@@ -69,6 +68,9 @@ global:
     users: [ admin, developer ] # view user overview
     maintenance-mode: [ everyone ] # view the frontend when in maintenance mode
     omnisearch: [ everyone ]
+    # Access to the various logs
+    changelog: [ admin, developer, chief-editor ]
+    systemlog: [ admin, developer ]
     # The following permissions are particularly important: login and postLogin
     # determine who may see and use the login form. If you set them to anything
     # but 'anonymous', only users will be able to log in that are logged in


### PR DESCRIPTION
* Add changelog and systemlog default roles to permissions
* Use changelog & systemlog permissions for panels

Fixes: #2795
Fixes: #2797

### Changelog
* Change: System activity and change log permissions have changed and users now require `systemlog` and/or `changelog` permissions in `permissions.yml`