### PR TITLE
added extra snippet locations

### DIFF
--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -583,6 +583,9 @@ class Extensions
             // then insert it into the HTML, somewhere.
             switch ($item['location']) {
                 case SnippetLocation::END_OF_HEAD:
+                case SnippetLocation::AFTER_HEAD_JS: // same as end of head because we cheat a little
+                case SnippetLocation::AFTER_HEAD_CSS: // same as end of head because we cheat a little
+                case SnippetLocation::AFTER_HEAD_META: // same as end of head because meta tags are unordered
                     $html = $this->insertEndOfHead($snippet, $html);
                     break;
                 case SnippetLocation::AFTER_META:
@@ -601,17 +604,25 @@ class Extensions
                     $html = $this->insertAfterJs($snippet, $html);
                     break;
                 case SnippetLocation::START_OF_HEAD:
+                case SnippetLocation::BEFORE_HEAD_JS: // same as start of head because we cheat a little
+                case SnippetLocation::BEFORE_HEAD_CSS: // same as start of head because we cheat a little
+                case SnippetLocation::BEFORE_HEAD_META: // same as start of head because meta tags are unordered
                     $html = $this->insertStartOfHead($snippet, $html);
                     break;
                 case SnippetLocation::START_OF_BODY:
+                case SnippetLocation::BEFORE_BODY_JS: // same as start of body because we cheat a little
+                case SnippetLocation::BEFORE_BODY_CSS: // same as start of body because we cheat a little
                     $html = $this->insertStartOfBody($snippet, $html);
                     break;
                 case SnippetLocation::END_OF_BODY:
+                case SnippetLocation::AFTER_BODY_JS: // same as end of body because we cheat a little
+                case SnippetLocation::AFTER_BODY_CSS: // same as end of body because we cheat a little
                     $html = $this->insertEndOfBody($snippet, $html);
                     break;
                 case SnippetLocation::END_OF_HTML:
                     $html = $this->insertEndOfHtml($snippet, $html);
                     break;
+
                 default:
                     $html .= $snippet . "\n";
                     break;

--- a/src/Extensions/Snippets/Location.php
+++ b/src/Extensions/Snippets/Location.php
@@ -17,20 +17,36 @@ namespace Bolt\Extensions\Snippets;
  */
 class Location
 {
+    // unpredictable
+    const BEFORE_CSS = "beforecss";
     const AFTER_CSS = "aftercss";
+    const BEFORE_JS = "beforejs";
     const AFTER_JS = "afterjs";
     const AFTER_META = "aftermeta";
+
+    // main structure
+    const START_OF_HEAD = "startofhead";
+    const END_OF_HEAD = "endofhead";
+    const START_OF_BODY = "startofbody";
+    const END_OF_BODY = "endofbody";
+    const END_OF_HTML = "endofhtml";
     const AFTER_HTML = "afterhtml";
 
-    const BEFORE_CSS = "beforecss";
-    const BEFORE_JS = "beforejs";
+    // substructure
+    const BEFORE_HEAD_META = "beforeheadmeta";
+    const AFTER_HEAD_META = "afterheadmeta";
 
-    const END_OF_BODY = "endofbody";
-    const END_OF_HEAD = "endofhead";
-    const END_OF_HTML = "endofhtml";
+    const BEFORE_HEAD_CSS = "beforeheadcss";
+    const AFTER_HEAD_CSS = "afterheadcss";
 
-    const START_OF_HEAD = "startofhead";
-    const START_OF_BODY = "startofbody";
+    const BEFORE_HEAD_JS = "beforeheadjs";
+    const AFTER_HEAD_JS = "afterheadjs";
+
+    const BEFORE_BODY_CSS = "beforebodycss";
+    const AFTER_BODY_CSS = "afterbodycss";
+
+    const BEFORE_BODY_JS = "beforebodyjs";
+    const AFTER_BODY_JS = "afterbodyjs";
 
     /**
      * Returns all possible locations (which are constants)


### PR DESCRIPTION
To make the situation in https://github.com/bolt/bolt/issues/1129 clearer I've added the following lcoations for snippets:

* beforeheadmeta
* afterheadmeta
* beforeheadcss
* afterheadcss
* beforeheadjs
* afterheadjs
* beforebodycss
* afterbodycss
* beforebodyjs
* afterbodyjs

The locations are essentially aliases for startofhead, endofhead, startofbody and endofbody because in daily usage those will be all you need.

In the theoretical case where the specific ordering must be even more controlled we'll have to switch to simpledom parsing or something similar.

(Docs will be updated after merge)