### PR TITLE
Twig thumbnail, remove double encoding paths

### DIFF
--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -923,7 +923,7 @@ class TwigExtension extends \Twig_Extension
         $path = $this->app['url_generator']->generate(
             'thumb',
             array(
-                'thumb' => round($width) . 'x' . round($height) . $scale . '/'. Lib::safeFilename($filename),
+                'thumb' => round($width) . 'x' . round($height) . $scale . '/'. $filename,
             )
         );
 


### PR DESCRIPTION
url_generator already rawurlencodes paths, no need for lib::safe name as well