### PR TITLE
Make X-Frame-Options configurable.

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -270,7 +270,7 @@ session_use_storage_handler: true
 # '12' is better.
 hash_strength: 10
 
-# Bolt sets the `X-Frame-Options` and `-Frame-Options` to `SAMEORIGIN` by default, to prevent 
+# Bolt sets the `X-Frame-Options` and `Frame-Options` to `SAMEORIGIN` by default, to prevent
 # clickjacking. When you uncomment the following line and setting it to 'false', you will prevent
 # the setting of these headers.
 # x_frame_options_headers: true

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -271,9 +271,10 @@ session_use_storage_handler: true
 hash_strength: 10
 
 # Bolt sets the `X-Frame-Options` and `Frame-Options` to `SAMEORIGIN` by default, to prevent
-# clickjacking. When you uncomment the following line and setting it to 'false', you will prevent
+# clickjacking. When you uncomment the following line and set it to 'false', you will prevent
 # the setting of these headers.
-# x_frame_options_headers: true
+#headers:
+#  x_frame_options: true
 
 # Bolt uses extensions.bolt.cm to fetch it's extensions by default. You can change that URL here.
 # Do not change this, unless you know what you're doing, and understand the associated risks. If

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -270,6 +270,11 @@ session_use_storage_handler: true
 # '12' is better.
 hash_strength: 10
 
+# Bolt sets the `X-Frame-Options` and `-Frame-Options` to `SAMEORIGIN` by default, to prevent 
+# clickjacking. When you uncomment the following line and setting it to 'false', you will prevent
+# the setting of these headers.
+# x_frame_options_headers: true
+
 # Bolt uses extensions.bolt.cm to fetch it's extensions by default. You can change that URL here.
 # Do not change this, unless you know what you're doing, and understand the associated risks. If
 # you use 'http://extensions.bolt.cm', Bolt will not use SSL, increasing the risk for a MITM

--- a/src/Application.php
+++ b/src/Application.php
@@ -445,8 +445,11 @@ class Application extends Silex\Application
         // Start the 'stopwatch' for the profiler.
         $this['stopwatch']->start('bolt.app.after');
 
-        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
-        $response->headers->set('Frame-Options', 'SAMEORIGIN');
+        // Set the 'X-Frame-Options' headers to prevent click-jacking, unless specifically disabled. Backend only!
+        if ($this['config']->getWhichEnd() == 'backend' && $this['config']->get('general/x_frame_options_headers')) {
+            $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+            $response->headers->set('Frame-Options', 'SAMEORIGIN');
+        }
 
         // true if we need to consider adding html snippets
         if (isset($this['htmlsnippets']) && ($this['htmlsnippets'] === true)) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -446,7 +446,7 @@ class Application extends Silex\Application
         $this['stopwatch']->start('bolt.app.after');
 
         // Set the 'X-Frame-Options' headers to prevent click-jacking, unless specifically disabled. Backend only!
-        if ($this['config']->getWhichEnd() == 'backend' && $this['config']->get('general/x_frame_options_headers')) {
+        if ($this['config']->getWhichEnd() == 'backend' && $this['config']->get('general/headers/x_frame_options')) {
             $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
             $response->headers->set('Frame-Options', 'SAMEORIGIN');
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -826,7 +826,8 @@ class Config
                 'path'        => '/bolt',
                 'provided_by' => array()
             ),
-            'maintenance_mode'            => false
+            'maintenance_mode'            => false,
+            'x_frame_options_headers'     => true
         );
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -827,7 +827,9 @@ class Config
                 'provided_by' => array()
             ),
             'maintenance_mode'            => false,
-            'x_frame_options_headers'     => true
+            'headers'                     => array(
+                'x_frame_options'     => true
+            )
         );
     }
 


### PR DESCRIPTION
Fixes #2814. Changelog line: 

- Change: The 'X-Frame-Options' header is now only sent for backend pages, and can be disabled in `config.yml` (See #2825)