### PR TITLE
Allow differentation between "news" and "alerts". Fixes 2828

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -327,6 +327,6 @@ extensions:
 # Options for backend user interface
 #backend:
 #  news:
-#    disable: true   # Disable news panel. Defaults to false
+#    disable: true   # Disable news panel. Defaults to false. "Alerts" will still be shown.
 #  stack:
-#    disable: true   # Disable stack usage. Defaults to false
+#    disable: true   # Disable stack usage. Defaults to false.

--- a/app/view/twig/_base/_panel.twig
+++ b/app/view/twig/_base/_panel.twig
@@ -7,7 +7,7 @@
  #         panel_body:   The Body
  #}
 <div class="panel panel-default {% block panel_class %}{% endblock panel_class %}">
-    <div class="panel-heading">
+    <div {% block panel_alert %}class="panel-heading"{% endblock panel_alert %}>
         <i class="fa fa-fw {% block panel_icon %}fa-circle-o{% endblock panel_icon %}"></i>
         {% block panel_head %}[PANEL_HEAD]{% endblock panel_head %}
     </div>

--- a/app/view/twig/components/panel-news.twig
+++ b/app/view/twig/components/panel-news.twig
@@ -6,6 +6,14 @@
 
 {% block panel_class 'panel-news' %}
 
+{% block panel_alert %}
+    {% if news.type == 'alert' %}
+        class="progress-bar progress-bar-danger progress-bar-striped active" style="width: 100%; text-align: left; color: #333; padding: 10px 14px; margin-bottom: 15px; font-weight: bold; color: #000;"
+    {% else %}
+        class="panel-heading"
+    {% endif %}
+{% endblock panel_alert %}
+
 {% block panel_icon 'fa-bullhorn' %}
 
 {% block panel_head news.title %}

--- a/app/view/twig/dashboard/_aside.twig
+++ b/app/view/twig/dashboard/_aside.twig
@@ -22,9 +22,7 @@
 {% endif %}
 
 {# News #}
-{% if not app.config.get('general/backend/news/disable', false) %}
-    {{ render(path('dashboardnews')) }}
-{% endif %}
+{{ render(path('dashboardnews')) }}
 
 {# Stack #}
 {{ panels.stack(7, true) }}


### PR DESCRIPTION
:fire:

Note: Merge #2829 first.

Changelog: 

 - Change: Bolt now distinguishes between 'regular news' and 'alerts' on the Dashboard screen. This way, we can better notify people in case of an urgent security issue. (See #2830)