### PR TITLE
Bugfix/bolt Adding support for multiple slugs when creating uri through ajax

### DIFF
--- a/app/view/lib/bolt/make-uri-slug.js
+++ b/app/view/lib/bolt/make-uri-slug.js
@@ -1,5 +1,5 @@
 /**
- * Functions for working with the automagic URI/Slug generation.
+ * Functions for working with the automagic URI/Slug generation with multipleslug support.
  */
 
 var makeuritimeout;

--- a/app/view/lib/bolt/make-uri-slug.js
+++ b/app/view/lib/bolt/make-uri-slug.js
@@ -12,6 +12,7 @@ function makeUriAjax(text, contenttypeslug, id, slugfield, fulluri) {
             title: text,
             contenttypeslug: contenttypeslug,
             id: id,
+            slugfield: slugfield,
             fulluri: fulluri
         },
         success: function (uri) {

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -255,7 +255,7 @@ class Async implements ControllerProviderInterface
             $request->query->get('contenttypeslug'),
             $request->query->getBoolean('fulluri'),
             true,
-            $request->query->get('slugfield')
+            $request->query->get('slugfield') //for multipleslug support
         );
 
         return $uri;

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -253,7 +253,9 @@ class Async implements ControllerProviderInterface
             $request->query->get('title'),
             $request->query->get('id'),
             $request->query->get('contenttypeslug'),
-            $request->query->getBoolean('fulluri')
+            $request->query->getBoolean('fulluri'),
+            true,
+            $request->query->get('slugfield')
         );
 
         return $uri;

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -2481,7 +2481,7 @@ class Storage
         }
     }
 
-    public function getUri($title, $id = 0, $contenttypeslug = "", $fulluri = true, $allowempty = true)
+    public function getUri($title, $id = 0, $contenttypeslug = "", $fulluri = true, $allowempty = true, $slugfield = 'slug')
     {
         $contenttype = $this->getContentType($contenttypeslug);
         $tablename = $this->getTablename($contenttype['slug']);
@@ -2500,10 +2500,18 @@ class Storage
             $prefix = "";
         }
 
+        $fields = $this->getContentTypeFields($contenttypeslug);
+        //check if fieldname exists, otherwise use 'slug' as fallback
+        if (!in_array($slugfield, $fields)) {
+            $slugfield = 'slug';
+        }
+
         $query = sprintf(
-            "SELECT id from %s WHERE slug=? and id!=?",
-            $tablename
+            "SELECT id from %s WHERE %s=? and id!=?",
+            $tablename,
+            $slugfield
         );
+
         $res = $this->app['db']->executeQuery(
             $query,
             array($slug, $id),

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -2501,7 +2501,7 @@ class Storage
         }
 
         $fields = $this->getContentTypeFields($contenttypeslug);
-        //check if fieldname exists, otherwise use 'slug' as fallback
+        //check if the fieldname exists, otherwise use 'slug' as fallback
         if (!in_array($slugfield, $fields)) {
             $slugfield = 'slug';
         }


### PR DESCRIPTION
When using multiple slugs the backend previously depended on the 'slug' field. When using multiple slugs (or even a different named slug) you could create content with duplicate uri's.
With this fix we send the slugfield through AJAX/Async.php to the getUri (in Storage.php) function. Instead of using a hardcoded 'slug' in the query we can use slugfield. 'slug' is still being used as fallback and when an invalid slugfield is provided.

Please use grunt to recreate the minified bolt.min.js