### PR TITLE
prevent search query from growing too fast (fixes #2850)

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -669,13 +669,14 @@ class Storage
 
         // Build SQL query
         $select = sprintf(
-            'SELECT %s.id FROM %s LEFT JOIN %s ON %s.id = %s.content_id WHERE %s',
+            'SELECT %s.id FROM %s LEFT JOIN %s ON %s.id = %s.content_id WHERE %s GROUP BY %s.id',
             $table,
             $table,
             $taxonomytable,
             $table,
             $taxonomytable,
-            implode(' AND ', $where)
+            implode(' AND ', $where),
+            $table
         );
 
         // Run Query


### PR DESCRIPTION
Quick fix to prevent the search query from growing too large when there are lots of records.

This isn't a permanent solution, but should hold things over until the 2.2 refactor/rewrite of this bit of code.

Cheers!