### PR TITLE
Handling login retreats in after handler so that functionality isn't dependent on Library::redirect

### DIFF
--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -28,7 +28,8 @@ class ResourceManager
     public $urlPrefix = "";
 
     /**
-     * Don't use! Will probably refactored out soon
+     * @var Application
+     * @deprecated Don't use! Will probably refactored out soon
      */
     public static $theApp;
 

--- a/src/Controllers/Login.php
+++ b/src/Controllers/Login.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Controllers;
 
+use Bolt\Application;
 use Silex;
 use Symfony\Component\HttpFoundation\Request;
 use Bolt\Library as Lib;
@@ -36,11 +37,11 @@ class Login implements Silex\ControllerProviderInterface
     /**
      * Handle a login attempt.
      *
-     * @param  Silex\Application $app     The application/container
-     * @param  Request           $request The Symfony Request
+     * @param  Application $app     The application/container
+     * @param  Request     $request The Symfony Request
      * @return string
      */
-    public function postLogin(Silex\Application $app, Request $request)
+    public function postLogin(Application $app, Request $request)
     {
         switch ($request->get('action')) {
             case 'login':
@@ -49,10 +50,9 @@ class Login implements Silex\ControllerProviderInterface
 
                 if ($result) {
                     $app['logger.system']->addInfo('Logged in: ' . $request->get('username'), array('event' => 'authentication'));
-                    $retreat = $app['session']->get('retreat');
-                    $redirect = !empty($retreat) && is_array($retreat) ? $retreat : array('route' => 'dashboard', 'params' => array());
+                    $redirect = $app['session']->get('retreat', array('route' => 'dashboard', 'params' => array()));
 
-                    return Lib::redirect($redirect['route'], $redirect['params']);
+                    return $app->redirect($app->generatePath($redirect['route'], $redirect['params']));
                 }
 
                 return $this->getLogin($app, $request);

--- a/src/Library.php
+++ b/src/Library.php
@@ -135,23 +135,7 @@ class Library
      */
     public static function redirect($path, $param = array(), $add = '')
     {
-        $app = ResourceManager::getApp();
-
-        // Only set the 'retreat' when redirecting to 'login' but not FROM logout.
-        if (($path == 'login') && ($app['request']->get('_route') !== 'logout')) {
-
-            $app['session']->set(
-                'retreat',
-                array(
-                    'route' => $app['request']->get('_route'),
-                    'params' => $app['request']->get('_route_params')
-                )
-            );
-        } else {
-            $app['session']->set('retreat', '');
-        }
-
-        return $app->redirect(self::path($path, $param, $add));
+        return ResourceManager::getApp()->redirect(self::path($path, $param, $add));
     }
 
     /**


### PR DESCRIPTION
Prepping to deprecate Library::redirect and Library::path.

Note:
My thought for 2.2 is to have a base controller that will have shortcut methods like "redirectToRoute"
See [Symfony's Controller](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php)