### PR TITLE
Don't call Grunt subtask that doesn't exist

### DIFF
--- a/app/view/Gruntfile.js
+++ b/app/view/Gruntfile.js
@@ -40,8 +40,7 @@ module.exports = function(grunt) {
                     'sass/**/*.scss'
                 ],
                 tasks: [
-                    'sass:boltCss',
-                    'eol:boltCss'
+                    'sass:boltCss'
                 ]
             },
             boltJs: {


### PR DESCRIPTION
Fixes #2878