### PR TITLE
trimText shouldn't just trim the text, it should also trim whitespace at...

### DIFF
--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -22,7 +22,7 @@ class Html
             $newLength = $desiredLength;
         }
 
-        $str = strip_tags($str);
+        $str = trim(strip_tags($str));
 
         if (mb_strlen($str) > $desiredLength) {
             $str = mb_substr($str, 0, $newLength) . $ellipseStr;


### PR DESCRIPTION
... the beginning and end.

See screenshot:

![screenshot 2015-02-22 15 31 50](https://cloud.githubusercontent.com/assets/1833361/6318890/2c27c5c0-baa8-11e4-9cac-47f32496b71d.png)
