### PR TITLE
Alternative solution to fix #2863

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -240,15 +240,17 @@ wysiwyg:
 
 #mailoptions:
 #  transport: smtp
+#  spool: true
 #  host: localhost
-#  port: 25
 #  username: username
 #  password: password
+#  port: 25
 #  encryption: null
 #  auth_mode: null
 
 #mailoptions:
 #  transport: mail
+#  spool: false
 
 # Bolt allows some modifications to how 'strict' login sessions are. For every option
 # that is set to true, it becomes harder for a bad-willing person to spoof your login

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -229,16 +229,28 @@ wysiwyg:
     disableNativeSpellChecker: true # If set to 'true' it will stop browsers from underlining spelling mistakes
     # viewSourceRoles: [ 'admin', 'developer' ] # the roles which are allowed to use the [Source]-button.
 
-# by default, mail is sent using PHP's built-in mail function. In general, it's advised to use SMTP for sending mail
-# instead. Uncomment the following lines to use an SMTP server with authentication.
-# Please check http://silex.sensiolabs.org/doc/providers/swiftmailer.html for a full range of options
+# Use the 'mailoptions' setting to configure how Bolt sends email. Uncomment one
+# of the two blocks below, to tell Bolt to use 'smtp' or PHP's built-in `mail()`
+# function. Note that the latter might _seem_ easier, but it's been disabled by
+# a lot of webhosts, in order to prevent spam from wrongly configured scripts.
+# If you use it, your mail might disappear into a black hole, and it'll be gone,
+# without it ever producing an error. Generally speaking, using 'smtp' is the
+# better option, so use that, if at all possible.
+# Protip: If your webhost does not support SMTP, sign up for a (free) Mandrill
+# account at https://mandrill.com/ for sending emails reliably, without getting
+# them classified as spam.
+
 #mailoptions:
+#  transport: smtp
 #  host: localhost
 #  port: 25
 #  username: username
 #  password: password
 #  encryption: null
 #  auth_mode: null
+
+#mailoptions:
+#  transport: mail
 
 # Bolt allows some modifications to how 'strict' login sessions are. For every option
 # that is set to true, it becomes harder for a bad-willing person to spoof your login

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -229,16 +229,14 @@ wysiwyg:
     disableNativeSpellChecker: true # If set to 'true' it will stop browsers from underlining spelling mistakes
     # viewSourceRoles: [ 'admin', 'developer' ] # the roles which are allowed to use the [Source]-button.
 
-# Use the 'mailoptions' setting to configure how Bolt sends email. Uncomment one
-# of the two blocks below, to tell Bolt to use 'smtp' or PHP's built-in `mail()`
-# function. Note that the latter might _seem_ easier, but it's been disabled by
-# a lot of webhosts, in order to prevent spam from wrongly configured scripts.
-# If you use it, your mail might disappear into a black hole, and it'll be gone,
-# without it ever producing an error. Generally speaking, using 'smtp' is the
-# better option, so use that, if at all possible.
-# Protip: If your webhost does not support SMTP, sign up for a (free) Mandrill
-# account at https://mandrill.com/ for sending emails reliably, without getting
-# them classified as spam.
+# Use the 'mailoptions' setting to configure how Bolt sends email: using 'smtp'
+# or PHP's built-in `mail()`-function. Note that the latter might _seem_ easier,
+# but it's been disabled by a lot of webhosts, in order to prevent spam from
+# wrongly configured scripts. If you use it, your mail might disappear into a
+# black hole, without producing any errors. Generally speaking, using 'smtp' is
+# the better option, so use that if possible. Protip: If your webhost does not
+# support SMTP, sign up for a (free) Mandrill account at https://mandrill.com/
+# for sending emails reliably.
 
 #mailoptions:
 #  transport: smtp

--- a/src/Application.php
+++ b/src/Application.php
@@ -334,8 +334,8 @@ class Application extends Silex\Application
             // Use the preferred SMTP options.
             $this['swiftmailer.options'] = $this['config']->get('general/mailoptions');
         } else {
-            // No Mail transport has been set. We should gently nudge the user to set the mail 
-            // configuration. See the issue at https://github.com/bolt/bolt/issues/2908
+            // No Mail transport has been set. We should gently nudge the user to set the mail configuration. 
+            // @see: the issue at https://github.com/bolt/bolt/issues/2908
         }
 
         // Set up our secure random generator.

--- a/src/Application.php
+++ b/src/Application.php
@@ -314,7 +314,7 @@ class Application extends Silex\Application
         // Loading stub functions for when intl / IntlDateFormatter isn't available.
         if (!function_exists('intl_get_error_code')) {
             require_once $this['resources']->getPath('root') . '/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/functions.php';
-            require_once $this['resources']->getPath('root') . '/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/IntlDateFormatter.php';            
+            require_once $this['resources']->getPath('root') . '/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/IntlDateFormatter.php';
         }
 
         $this->register(new Provider\TranslationServiceProvider());
@@ -572,7 +572,7 @@ class Application extends Silex\Application
     }
 
     /**
-     * @param  $name
+     * @param $name
      * @return bool
      */
     public function __isset($name)

--- a/src/Application.php
+++ b/src/Application.php
@@ -259,7 +259,7 @@ class Application extends Silex\Application
         $this['twig.loader.filesystem'] = $this->share(
             $this->extend(
                 'twig.loader.filesystem',
-                function (\Twig_Loader_Filesystem $filesystem, $app) {
+                function (\Twig_Loader_Filesystem $filesystem, Application $app) {
                     $filesystem->addPath(
                         $app['resources']->getPath('root') . '/vendor/symfony/web-profiler-bundle/Symfony/Bundle/WebProfilerBundle/Resources/views',
                         'WebProfiler'
@@ -275,7 +275,7 @@ class Application extends Silex\Application
         $app = $this;
         $this->after(
             function () use ($app) {
-                foreach (Lib::hackislyParseRegexTemplates($app['twig.loader.filesystem']) as $template) {
+                foreach (Lib::parseTwigTemplates($app['twig.loader.filesystem']) as $template) {
                     $app['twig.logger']->collectTemplateData($template);
                 }
             }
@@ -313,8 +313,8 @@ class Application extends Silex\Application
 
         // Loading stub functions for when intl / IntlDateFormatter isn't available.
         if (!function_exists('intl_get_error_code')) {
-            require_once $this['resources']->getPath('root') . '/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/functions.php';
-            require_once $this['resources']->getPath('root') . '/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/IntlDateFormatter.php';
+            require_once $this['resources']->getPath('root/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/functions.php');
+            require_once $this['resources']->getPath('root/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/IntlDateFormatter.php');
         }
 
         $this->register(new Provider\TranslationServiceProvider());
@@ -327,16 +327,23 @@ class Application extends Silex\Application
 
         // Setup Swiftmailer, with the selected Mail Transport options: smtp or `mail()`.
         $this->register(new Silex\Provider\SwiftmailerServiceProvider());
-        if ($this['config']->get('general/mailoptions/transport') == 'mail') {
-            // Use the 'mail' transport.
-            $this['swiftmailer.transport'] = \Swift_MailTransport::newInstance();
-            $this['swiftmailer.use_spool'] = false;
-        } else if ($this['config']->get('general/mailoptions')) {
-            // Use the preferred SMTP options.
+        
+        if ($this['config']->get('general/mailoptions')) {
+            // Use the preferred options. Assume it's SMTP, unless set differently.
             $this['swiftmailer.options'] = $this['config']->get('general/mailoptions');
         } else {
             // No Mail transport has been set. We should gently nudge the user to set the mail configuration. 
             // @see: the issue at https://github.com/bolt/bolt/issues/2908
+        }
+
+        if (is_bool($this['config']->get('general/mailoptions/spool')) {
+            // enable or disable the mail spooler.
+            $this['swiftmailer.use_spool'] = $this['config']->get('general/mailoptions/spool');
+        }
+        
+        if ($this['config']->get('general/mailoptions/transport') == 'mail') {
+            // Use the 'mail' transport. Discouraged, but some people want it. ¯\_(ツ)_/¯
+            $this['swiftmailer.transport'] = \Swift_MailTransport::newInstance();
         }
 
         // Set up our secure random generator.
@@ -408,7 +415,7 @@ class Application extends Silex\Application
         $this->mount('/async', new Controllers\Async());
 
         // Mount the 'thumbnail' provider on /thumbs.
-        $this->mount('/thumbs', new \Bolt\Thumbs\ThumbnailProvider());
+        $this->mount('/thumbs', new Thumbs\ThumbnailProvider());
 
         // Mount the 'upload' controller on /upload.
         $this->mount('/upload', new Controllers\Upload());
@@ -417,7 +424,8 @@ class Application extends Silex\Application
         $this->mount($backendPrefix . '/extend', $this['extend']);
 
         if ($this['config']->get('general/enforce_ssl')) {
-            foreach ($this['routes']->getIterator() as $route) {
+            foreach ($this['routes'] as $route) {
+                /** @var \Silex\Route $route */
                 $route->requireHttps();
             }
         }
@@ -544,7 +552,7 @@ class Application extends Silex\Application
             }
 
             // Then, select which template to use, based on our 'cascading templates rules'
-            if ($content instanceof \Bolt\Content && !empty($content->id)) {
+            if ($content instanceof Content && !empty($content->id)) {
                 $template = $this['templatechooser']->record($content);
 
                 return $this['render']->render($template, $content->getTemplateContext());
@@ -565,12 +573,13 @@ class Application extends Silex\Application
     }
 
     /**
-     * @param $name
+     * TODO Can this be removed?
+     * @param string $name
      * @return bool
      */
     public function __isset($name)
     {
-        return (array_key_exists($name, $this));
+        return isset($this[$name]);
     }
 
     public function getVersion($long = true)

--- a/src/Application.php
+++ b/src/Application.php
@@ -325,10 +325,16 @@ class Application extends Silex\Application
         // Make sure we keep our current locale..
         $currentlocale = $this['locale'];
 
-        // Setup Swiftmailer, with optional SMTP settings. If no settings are provided in config.yml, mail() is used.
+        // Setup Swiftmailer, with the selected Mail Transport options: smtp or `mail()`.
         $this->register(new Silex\Provider\SwiftmailerServiceProvider());
-        if ($this['config']->get('general/mailoptions')) {
+        if ($this['config']->get('general/mailoptions/transport') == 'mail') {
+            // Use the 'mail' transport.
+            $this['swiftmailer.transport'] = \Swift_MailTransport::newInstance();
+        } else if ($this['config']->get('general/mailoptions')) {
+            // Use the preferred SMTP options.
             $this['swiftmailer.options'] = $this['config']->get('general/mailoptions');
+        } else {
+            // TODO (for 2.2): No Mail transport has been set. Gently nudge the user to set the mail configuration.
         }
 
         // Set up our secure random generator.

--- a/src/Application.php
+++ b/src/Application.php
@@ -334,7 +334,8 @@ class Application extends Silex\Application
             // Use the preferred SMTP options.
             $this['swiftmailer.options'] = $this['config']->get('general/mailoptions');
         } else {
-            // TODO (for 2.2): No Mail transport has been set. Gently nudge the user to set the mail configuration.
+            // No Mail transport has been set. We should gently nudge the user to set the mail 
+            // configuration. See the issue at https://github.com/bolt/bolt/issues/2908
         }
 
         // Set up our secure random generator.

--- a/src/Application.php
+++ b/src/Application.php
@@ -330,6 +330,7 @@ class Application extends Silex\Application
         if ($this['config']->get('general/mailoptions/transport') == 'mail') {
             // Use the 'mail' transport.
             $this['swiftmailer.transport'] = \Swift_MailTransport::newInstance();
+            $this['swiftmailer.use_spool'] = false;
         } else if ($this['config']->get('general/mailoptions')) {
             // Use the preferred SMTP options.
             $this['swiftmailer.options'] = $this['config']->get('general/mailoptions');

--- a/src/Application.php
+++ b/src/Application.php
@@ -336,7 +336,7 @@ class Application extends Silex\Application
             // @see: the issue at https://github.com/bolt/bolt/issues/2908
         }
 
-        if (is_bool($this['config']->get('general/mailoptions/spool')) {
+        if (is_bool($this['config']->get('general/mailoptions/spool'))) {
             // enable or disable the mail spooler.
             $this['swiftmailer.use_spool'] = $this['config']->get('general/mailoptions/spool');
         }


### PR DESCRIPTION
Do not merge yet!!!

This is a proposed alternative solution to #2863 / #2864. It makes the selection for either 'smtp' or 'mail()' explicit. It needs some more testing (on actual linux machines) to see if it works as intended. 

Comments/critiques welcome.