### PR TITLE
Fix role permissions

### DIFF
--- a/app/config/permissions.yml.dist
+++ b/app/config/permissions.yml.dist
@@ -33,6 +33,21 @@ roles:
         description: This user can log on, but is not allowed to edit any content.
         label: Guest Editor
 
+# Role hierarchy settings
+roles-hierarchy:
+    # This will restrict users from being able to add, edit, enable, disable
+    # and delete users with the same or higher role than their own.
+    # For example:
+    # Users with a role of developer can only be added, edited, enabled, disabled
+    # and deleted by [ root, admin ] roles.
+    manipulate:
+        admin: [ ]
+        developer: [ admin ]
+        chief-editor: [ admin, developer ]
+        editor: [ admin, developer, chief-editor ]
+        guest: [ admin, developer, chief-editor ]
+
+
 # Now we'll define some permissions. Each permission comes with a list of roles
 # that grant access.
 
@@ -81,19 +96,6 @@ global:
     # Likewise, 'logout' needs to be granted to 'everyone', otherwise people
     # cannot log out anymore.
     logout: [ everyone ]
-
-    # User roled-based hierarchy settings. This will restrict users from being
-    # able to add, edit, enable, disable and delete users with a higher role
-    # than their own.
-    # For example:
-    # Users with a role of admin can only be added, edited, enabled, disabled and
-    # deleted by [ root, admin ] roles.
-    users:roles-hierarchy:root: [ root ]
-    users:roles-hierarchy:admin: [ root, admin ]
-    users:roles-hierarchy:developer: [ root, admin, developer ]
-    users:roles-hierarchy:chief-editor: [ root, admin, developer, chief-editor ]
-    users:roles-hierarchy:editor: [ root, admin, developer, chief-editor ]
-    users:roles-hierarchy:guest: [ root, admin, developer, chief-editor ]
 
 # For content type related actions, permissions can be set individually for
 # each content type. For this, we define three groups of permission sets.

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1226,6 +1226,9 @@ class Backend implements ControllerProviderInterface
                 $user['roles'] = array(Permissions::ROLE_ROOT);
             }
 
+            $id = isset($user['id']) ? $user['id'] : null;
+            $user['roles'] = $app['users']->filterManipulatableRoles($id, $user['roles']);
+
             $res = $app['users']->saveUser($user);
 
             if ($user['id']) {
@@ -1817,7 +1820,6 @@ class Backend implements ControllerProviderInterface
         $app['users']->checkForRoot();
 
         // Most of the 'check if user is allowed' happens here: match the current route to the 'allowed' settings.
-        $id = $request->attributes->get('id');
         if (!$app['users']->isValidSession() && !$app['users']->isAllowed($route)) {
             $app['session']->getFlashBag()->add('info', Trans::__('Please log on.'));
 

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1060,7 +1060,9 @@ class Backend implements ControllerProviderInterface
             0 => Trans::__('page.edit-users.activated.no')
         );
 
-        $roles = $app['permissions']->getManipulatableRoles($currentuser);
+        $roles = array_map(function ($role) {
+            return $role['label'];
+        }, $app['permissions']->getDefinedRoles());
 
         $form = $this->getUserForm($app, $user, true);
 
@@ -1127,9 +1129,19 @@ class Backend implements ControllerProviderInterface
             }
         }
 
+        /** @var \Symfony\Component\Form\FormView|\Symfony\Component\Form\FormView[] $formView */
+        $formView = $form->createView();
+
+        $manipulatableRoles = $app['permissions']->getManipulatableRoles($currentuser);
+        foreach ($formView['roles'] as $role) {
+            if (!in_array($role->vars['value'], $manipulatableRoles)) {
+                $role->vars['attr']['disabled'] = 'disabled';
+            }
+        }
+
         $context = array(
             'kind' => empty($id) ? 'create' : 'edit',
-            'form' => $form->createView(),
+            'form' => $formView,
             'note' => '',
             'displayname' => $user['displayname'],
         );

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -988,6 +988,12 @@ class Backend implements ControllerProviderInterface
         $users = $app['users']->getUsers();
         $sessions = $app['users']->getActiveSessions();
 
+        foreach ($users as $name => $user) {
+            if (($key = array_search(Permissions::ROLE_EVERYONE, $user['roles'], true)) !== false) {
+                unset($users[$name]['roles'][$key]);
+            }
+        }
+
         $context = array(
             'currentuser' => $currentuser,
             'users' => $users,

--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -49,6 +49,8 @@ class Permissions
 
     /**
      * Write an entry to the permission audit log
+     *
+     * @param string $msg
      */
     private function audit($msg)
     {
@@ -268,6 +270,10 @@ class Permissions
 
     /**
      * Lists the roles that would grant the specified global permission.
+     *
+     * @param string $permissionName
+     *
+     * @return string[]
      */
     public function getRolesByGlobalPermission($permissionName)
     {
@@ -275,7 +281,9 @@ class Permissions
     }
 
     /**
-     * Gets the configured global roles.
+     * Gets the configured global permissions.
+     *
+     * @return array
      */
     public function getGlobalRoles()
     {

--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -158,7 +158,7 @@ class Permissions
      *
      * @param array $currentUser
      *
-     * @return string[]
+     * @return string[] list of role names
      */
     public function getManipulatableRoles(array $currentUser)
     {
@@ -166,7 +166,7 @@ class Permissions
 
         foreach ($this->getDefinedRoles() as $roleName => $role) {
             if ($this->checkPermission($currentUser['roles'], 'users:roles-hierarchy:' . $roleName)) {
-                $roles[$roleName] = $role['label'];
+                $roles[] = $roleName;
             }
         }
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -2,10 +2,10 @@
 
 namespace Bolt;
 
+use Bolt\Translation\Translator as Trans;
 use Doctrine\DBAL\DBALException;
 use Hautelook\Phpass\PasswordHash;
 use Silex;
-use Bolt\Translation\Translator as Trans;
 use UAParser;
 
 /**
@@ -972,7 +972,7 @@ class Users
         $manipulatableRoles = $this->app['permissions']->getManipulatableRoles($this->currentuser);
 
         $roles = array();
-        // Remove roles if the current use can manipulate that role
+        // Remove roles if the current user can manipulate that role
         foreach ($oldRoles as $role) {
             if ($role === Permissions::ROLE_EVERYONE) {
                 continue;


### PR DESCRIPTION
Ok this should fix #2927 #2893 #2892.
Additionally:
- It removes the role "everyone" from user's roles list in Backend.
- All roles are shown in useredit form, but unmanipulatable ones are disabled. (this is accounts for #2927)

I did change the permissions config. I think the spot it is now is better suited for the future. Possibly if we want to break out _manipulate_ into _add_, _edit_, _enable/disable_, _delete_, etc.