### PR TITLE
Upload UX improvements

### DIFF
--- a/app/view/twig/editcontent/fields/_file.twig
+++ b/app/view/twig/editcontent/fields/_file.twig
@@ -5,6 +5,7 @@
     label:       field.label|default(''),
     extensions:  field.extensions|default([]),
     upload:      field.upload|default(''),
+    canUpload:   field.canUpload,
     info:        field.info|default('info.upload.file')
 } %}
 
@@ -54,8 +55,8 @@
 
     <div class="col-sm-12 dropzone clearfix" id="dropzone-{{ key }}">
         <input{{ macro.attr(attr_filepath) }}>
-
-        {{ macro.upload_buttons('file', key, attr_upload, option.upload, context.canUpload) }}
+        {% set canUpload = context.canUpload and option.canUpload %}
+        {{ macro.upload_buttons('file', key, attr_upload, option.upload, canUpload) }}
         {{ block.progress(key) }}
         {{ block.serverselect(key, __('Cancel')) }}
 

--- a/app/view/twig/editcontent/fields/_filelist.twig
+++ b/app/view/twig/editcontent/fields/_filelist.twig
@@ -4,6 +4,7 @@
     extensions:  field.extensions|default([]),
     label:       field.label|default(''),
     upload:      field.upload|default(''),
+    canUpload:   field.canUpload,
     info:        field.info|default('info.upload.filelist')
 } %}
 
@@ -69,7 +70,8 @@
 
         <div class="list" data-list="{{ listdata|json_encode }}"></div>
 
-        {{ macro.upload_buttons('file', key, attr_fileupload, option.upload, context.canUpload) }}
+        {% set canUpload = context.canUpload and option.canUpload %}
+        {{ macro.upload_buttons('file', key, attr_fileupload, option.upload, canUpload) }}
 
         <span type="button" class="btn btn-default remove-selected-button">
             <i class="fa fa-trash"></i>

--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -6,6 +6,7 @@
     extensions:  field.extensions|default([]),
     attrib:      (field.attrib is defined) ? (field.attrib is iterable ?: {0: field.attrib}) : false,
     upload:      field.upload|default(''),
+    canUpload:   field.canUpload,
     info:        field.info|default('info.upload.image')
 } %}
 {# attrib[title] #}
@@ -107,7 +108,8 @@
             </div>
         </div>
         {{ block.attributes(key, option, image) }}
-        {{ macro.upload_buttons('image', key, attr_upload, option.upload, context.canUpload) }}
+        {% set canUpload = context.canUpload and option.canUpload %}
+        {{ macro.upload_buttons('image', key, attr_upload, option.upload, canUpload) }}
         {{ block.progress(key) }}
         {{ block.serverselect(key, __('Cancel')) }}
     </div>

--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -4,6 +4,7 @@
     extensions:  field.extensions|default([]),
     label:       field.label|default(''),
     upload:      field.upload|default(''),
+    canUpload:   field.canUpload,
     info:        field.info|default('info.upload.filelist')
 } %}
 
@@ -70,7 +71,8 @@
 
         <div class="list" data-list="{{ listdata|json_encode }}"></div>
 
-        {{ macro.upload_buttons('image', key, attr_fileupload, option.upload, context.canUpload) }}
+        {% set canUpload = context.canUpload and option.canUpload %}
+        {{ macro.upload_buttons('image', key, attr_fileupload, option.upload, canUpload) }}
 
         <textarea name="{{ key }}" id="{{ key }}" class="hide">{{ list_json }}</textarea>
 

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1431,8 +1431,11 @@ class Backend implements ControllerProviderInterface
             $uploadview = false;
         }
         
-        if($filesystem->getVisibility($path) === 'public' ) {
+        if ($filesystem->getVisibility($path) === 'public' ) {
             $validFolder = true;
+        } elseif ($filesystem->getVisibility($path) === 'readonly' ) {
+            $validFolder = true;
+            $uploadview = false;
         } else {
             $app['session']->getFlashBag()->add('error', Trans::__("The folder '%s' could not be found, or is not readable.", array('%s' => $path)));
             $formview = false;

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1430,10 +1430,10 @@ class Backend implements ControllerProviderInterface
         if (!$app['users']->isAllowed("files:uploads")) {
             $uploadview = false;
         }
-
-        try {
+        
+        if($filesystem->getVisibility($path) === 'public' ) {
             $validFolder = true;
-        } catch (\Exception $e) {
+        } else {
             $app['session']->getFlashBag()->add('error', Trans::__("The folder '%s' could not be found, or is not readable.", array('%s' => $path)));
             $formview = false;
             $validFolder = false;
@@ -1513,9 +1513,11 @@ class Backend implements ControllerProviderInterface
             } else {
                 $formview = $form->createView();
             }
+        
+            list($files, $folders) = $filesystem->browse($path, $app);
         }
 
-        list($files, $folders) = $filesystem->browse($path, $app);
+        
 
         // Get the pathsegments, so we can show the path as breadcrumb navigation..
         $pathsegments = array();

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -888,7 +888,22 @@ class Backend implements ControllerProviderInterface
         } else {
             // For existing items, we'll just keep the current owner.
             $contentowner = $app['users']->getUser($content['ownerid']);
+        } 
+        
+        // Test write access for uploadable fields
+        foreach ($contenttype['fields'] as $key=>&$values) {
+            if (isset($values['upload'])) {
+                $canUpload = $app['filesystem']->getFilesystem()->getVisibility($values['upload']);
+                if ($canUpload === 'public') {
+                    $values['canUpload'] = true;
+                } else {
+                    $values['canUpload'] = false;
+                }
+            } else {
+                $values['canUpload'] = true;
+            }
         }
+        
 
         $context = array(
             'contenttype' => $contenttype,


### PR DESCRIPTION
Fix for #2455 

Checks for private visibility and show error message if path is inaccessible.
Adds a new check for `readonly` and shows normal listing but with upload form disabled.