### PR TITLE
Solves another pagenr parameter decoding...

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1378,7 +1378,7 @@ class Storage
 
         // $decoded['contettypes'] gotten here
         // get page nr. from url if has
-        $metaParameters['page'] = $this->decodePageParameter($decoded['contenttypes'][0]);
+        $metaParameters['page'] = $this->decodePageParameter(implode('_', $decoded['contenttypes']));
 
         $this->prepareDecodedQueryForUse($decoded, $metaParameters, $ctypeParameters);
 

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1798,7 +1798,7 @@ class Storage
 
         // Set up the $pager array with relevant values, but only if we requested paging.
         if (isset($decoded['parameters']['paging'])) {
-            $pagerName = $decoded['contenttypes'][0];
+            $pagerName = implode('_', $decoded['contenttypes']);
             $pager = array(
                 'for' => $pagerName,
                 'count' => $totalResults,


### PR DESCRIPTION
... in case of textquery is something like '(table1,table2,table3)'. Parameter 'page_table1' may refer another paging content currently and makes collision.