### PR TITLE
Fixed warning and incorrect weighting when searching

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -1324,7 +1324,11 @@ class Content implements \ArrayAccess
 
         // Go over all field, and calculate the overall weight.
         foreach ($contenttypeFields[$ct] as $key => $fieldWeight) {
-            $weight += $this->weighQueryText($this->values[$key], $query['use_q'], $query['words'], $fieldWeight);
+            $value = $this->values[$key];
+            if (is_array($value)) {
+                $value = implode(' ', $value);
+            }
+            $weight += $this->weighQueryText($value, $query['use_q'], $query['words'], $fieldWeight);
         }
 
         // Go over all taxonomies, and calculate the overall weight.


### PR DESCRIPTION
In the content search functionality, the result weighting code would
produce a warning message and incorrect behavior when non-scalar fields
(e.g. images, files, addresses...) were included in the search.

This fix first checks for arrays and implodes them as needed.