### PR TITLE
Fix for #2947 (Adding image to wysiwyg html editor from stack fails.)

### DIFF
--- a/app/view/twig/files_ck/_files.twig
+++ b/app/view/twig/files_ck/_files.twig
@@ -1,6 +1,4 @@
-{% import '_macro/_macro.twig' as macro %}
-
-<table class="dashboardlisting"{{ macro.attr({_bind: ['ckfileselect']}) }}>
+<table class="dashboardlisting">
     <thead>
         <tr>
             <th>{{ __('page.ckeditor-browse-server.files') }}</th>

--- a/app/view/twig/files_ck/files_ck.twig
+++ b/app/view/twig/files_ck/files_ck.twig
@@ -7,6 +7,8 @@
 {% block page_main %}
 
     {% from '_macro/_files_path.twig' import files_path %}
+    {% import '_macro/_macro.twig' as macro %}
+
 
     {# Only show the stack on the topmost level. #}
     {% if context.path == "" %}
@@ -14,7 +16,7 @@
         {{ render(path("showstack", {'items': 7, 'options': 'minimal'})) }}
     {% endif %}
 
-    <h1>{{ block('page_title') }}</h1>
+    <h1{{ macro.attr({_bind: ['ckfileselect']}) }}>{{ block('page_title') }}</h1>
 
     {% set pathoptions = {
         'path': '',


### PR DESCRIPTION
Fixes #2947 as reported by @cooperaj 

### Changelog
+ Fixes #2947 (Adding image to wysiwyg html editor from stack fails.)