### PR TITLE
Have ./run-functional-tests exit with the return code from the Codeception run

### DIFF
--- a/run-functional-tests
+++ b/run-functional-tests
@@ -7,8 +7,12 @@ if [ "$PHP_NEW_ENOUGH" ]
         SERVER_PID=$!
         ./$CODECEPT build
         ./$CODECEPT run
+        RC=$?
         kill "$SERVER_PID"
     else
         PHP_VERSION=$(php -r 'echo PHP_VERSION;')
         echo "Cannot run codeception integration tests, because the installed PHP version ($PHP_VERSION) does not support the built-in web server."
+        RC=0
 fi
+
+exit $RC


### PR DESCRIPTION
There was a problem introduced with #2957 that was shown in the Codeception results, but the script we run exits with it's own value.  This fix captures and exits the script with that return value so that Travis will fail.

This is — obviously — going to trigger a Travis failure itself until #2961 is fixed, but can we please merge it once we know that the PHPUnit tests pass to prevent anything further from sneaking in.