### PR TITLE
Handle safe_mode being set in PHP 5.3 with a string or a boolean (credit @Umbrielsama)

### DIFF
--- a/src/Configuration/LowlevelChecks.php
+++ b/src/Configuration/LowlevelChecks.php
@@ -95,6 +95,10 @@ class LowlevelChecks
 
     public function checkSafeMode()
     {
+        if (is_string($this->safeMode)) {
+            $this->safeMode = $this->safeMode == '1' || strtolower($this->safeMode) === 'on' ? 1 : 0;
+        }
+
         if ($this->safeMode) {
             throw new LowlevelException(
                 "Bolt requires 'Safe mode' to be <b>off</b>. Please send your hoster to " .


### PR DESCRIPTION
Fixes #2964