### PR TITLE
Make sure 'async' has access to the template files in `app/view/twig`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -845,11 +845,16 @@ class Config
         $themepath = $this->app['resources']->getPath('templatespath');
         $end = $this->getWhichEnd($this->get('general/branding/path'));
 
-        if ($end == 'frontend' && file_exists($themepath)) {
-            $twigpath = array($themepath);
-        }
+        $twigpath = array();
+
+        // Backend and Async need access to `app/view/twig`
         if ($end == 'backend' || $end == 'async') {
-            $twigpath = array(realpath($this->app['resources']->getPath('app') . '/view/twig'));
+            $twigpath[] = realpath($this->app['resources']->getPath('app') . '/view/twig');
+        }
+
+        // The frontend as well as 'ajaxy' requests from the frontend need access to the theme's path.
+        if (($end == 'frontend' || $end == 'async') && file_exists($themepath)) {
+            $twigpath[] = $themepath;
         }
 
         // If the template path doesn't exist, flash error on the dashboard.

--- a/src/Config.php
+++ b/src/Config.php
@@ -845,9 +845,10 @@ class Config
         $themepath = $this->app['resources']->getPath('templatespath');
         $end = $this->getWhichEnd($this->get('general/branding/path'));
 
-        if (($end == 'frontend' || $end == 'async') && file_exists($themepath)) {
+        if ($end == 'frontend' && file_exists($themepath)) {
             $twigpath = array($themepath);
-        } else {
+        }
+        if ($end == 'backend' || $end == 'async') {
             $twigpath = array(realpath($this->app['resources']->getPath('app') . '/view/twig'));
         }
 


### PR DESCRIPTION
Fixes #2975. Fixes #2977. Does not break #2874 again. 

And, it also fixes a logic-error: Before this change, a request to 'frontend' would have access to templates in `app/view/twig`, if `file_exists($themepath)` was false. 