### PR TITLE
added config var replacement ability

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -182,7 +182,7 @@ class Config
      * @param mixed $value
      * @return mixed
      */
-    private function doReplacements($value)
+    protected function doReplacements($value)
     {
         if (!is_array($value) && ('%' !== substr($value,0,1) && '%' !== substr($value, -1, 1))) {
             return $value;

--- a/src/Config.php
+++ b/src/Config.php
@@ -170,10 +170,36 @@ class Config
         }
 
         if ($value !== null) {
-            return $value;
+            return $this->doReplacements($value);
         }
 
         return $default;
+    }
+
+    /**
+     * replaces placeholders in config values %foo% will be resolved to $app['foo'] from the container
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    private function doReplacements($value)
+    {
+        if (!is_array($value) && ('%' !== substr($value,0,1) && '%' !== substr($value, -1, 1))) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $k => $v) {
+                $value[$k] = $this->doReplacements($v);
+            }
+            return $value;
+        }
+
+        if (is_string($value)) {
+            return $this->app[substr($value, 1,strlen($value)-2)];
+        }
+
+        return $value;
     }
 
     /**


### PR DESCRIPTION
this PR adds the ability to use service container parameters in your configuration files.

imagine you have this:

```php
$app['debug'] = true
$app['mysql-host'] = "lolcathost"
```

you can then use this vars in your yaml files like this

```yaml
debug: %debug%
database:
    host: %mysql-host%
```

this is useful if you configure your application through environment variables (e.g. with this tool: https://github.com/ivoba/dotenv-service-provider)