### PR TITLE
Manual coverage testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,20 @@ thumbs/
 vendor/
 phpunit.xml
 
-# unless you want to store vendor's "state" in your Git repo.
+# Unless you want to store vendor's "state" in your Git repo.
 composer.phar
 composer.lock
 
-# Files related to testing, file-system cruft and temporary files.
+# Files related to testing
+tests/codeception/_log
+tests/codeception/*/*Tester.php
+tests/phpunit/report
+tests/phpunit/resources/*
+!tests/phpunit/resources/db/
+app/config/permissions.yml.codeception-backup
+/bolt.db
+
+# File-system cruft and temporary files
 scrutinizer.phar
 php-cs-fixer.phar
 .DS_Store
@@ -30,8 +39,6 @@ Vagrantfile
 .swp
 *.lock
 .gitignore
-test/_log
-test/*/*Tester.php
 .buildpath
 .project
 npm-debug.log
@@ -39,10 +46,6 @@ npm-debug.log
 node_modules
 bower_components
 /bolt.log
-tests/report
-tests/resources/*
-/bolt.db
-!tests/resources/db/
 coverage.xml
-
 *.map
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,5 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true" showOnlySummary="true" />
-        <log type="coverage-clover" target="coverage.xml" showUncoveredFiles="true"/>
     </logging>
 </phpunit>

--- a/tests/scripts/coverage.php
+++ b/tests/scripts/coverage.php
@@ -1,0 +1,512 @@
+<?php
+
+namespace Bolt\Tests;
+
+use Guzzle\Http\Client as GuzzleClient;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+include realpath(__DIR__ . '/../../vendor/autoload.php');
+
+class CoverageComparator
+{
+    /**
+     * @var string Bolt's PHPUnit XML configuration file
+     */
+    private $xmlfile;
+
+    /**
+     *
+     */
+    public function __construct()
+    {
+        $this->xmlfile = realpath(__DIR__ . '/../../phpunit.xml.dist');
+    }
+
+    /**
+     * Perform a PHPUnit run and output coverage results
+     *
+     * @param string $output Target PHP file to output serialized resultst to
+     * @param string $test   Test directory or file to run
+     */
+    public function runPhpUnitCoverage($output, $test = null)
+    {
+        // Composer bundled PHPUnit binary
+        $bin = realpath(__DIR__ . '/../../vendor/phpunit/phpunit/composer/bin/phpunit');
+
+        $builder = new ProcessBuilder();
+        $builder->setPrefix($bin);
+
+        // Build the process
+        $process = $builder
+            ->setArguments(
+                array(
+                    '--configuration',
+                    $this->xmlfile,
+                    '--coverage-php',
+                    $output,
+                    $test))
+            ->getProcess()
+            ->enableOutput();
+
+        try {
+            // Run it
+            $retval = $process->run(
+                function ($type, $buffer) {
+                    echo $buffer;
+                }
+            );
+        } catch (ProcessFailedException $e) {
+            echo $e->getMessage();
+        }
+
+        if (!$process->isSuccessful()) {
+            die($process->getErrorOutput());
+        }
+
+        return $retval;
+    }
+
+    /**
+     * Extract the data from the PHPUnit code coverage
+     *
+     * @param PHP_CodeCoverage $codeCoverage
+     *
+     * @return array
+     */
+    private function getCoverageStats(\PHP_CodeCoverage $codeCoverage)
+    {
+        $report = $codeCoverage->getReport();
+        $classCoverage = array();
+
+        foreach ($report as $item) {
+            if (!$item instanceof \PHP_CodeCoverage_Report_Node_File) {
+                continue;
+            }
+
+            $classes = $item->getClassesAndTraits();
+
+            foreach ($classes as $className => $class) {
+                $classStatements        = 0;
+                $coveredClassStatements = 0;
+                $coveredMethods         = 0;
+                $classMethods           = 0;
+
+                foreach ($class['methods'] as $method) {
+                    if ($method['executableLines'] == 0) {
+                        continue;
+                    }
+
+                    $classMethods++;
+                    $classStatements        += $method['executableLines'];
+                    $coveredClassStatements += $method['executedLines'];
+                    if ($method['coverage'] == 100) {
+                        $coveredMethods++;
+                    }
+                }
+
+                if (!empty($class['package']['namespace'])) {
+                    $namespace = '\\' . $class['package']['namespace'] . '::';
+                } elseif (!empty($class['package']['fullPackage'])) {
+                    $namespace = '@' . $class['package']['fullPackage'] . '::';
+                } else {
+                    $namespace = '';
+                }
+
+                if ($coveredClassStatements != 0) {
+                    $classCoverage[$namespace . $className] = array(
+                        'namespace'         => $namespace,
+                        'className '        => $className,
+                        'methodsCovered'    => $coveredMethods,
+                        'methodCount'       => $classMethods,
+                        'statementsCovered' => $coveredClassStatements,
+                        'statementCount'    => $classStatements,
+                    );
+                }
+            }
+        }
+
+        return array(
+            'classes'  => array(
+                'total'  => $report->getNumClassesAndTraits(),
+                'tested' => $report->getNumTestedClassesAndTraits()
+            ),
+            'methods'  => array(
+                'total'  => $report->getNumMethods(),
+                'tested' => $report->getNumTestedMethods()
+            ),
+            'lines'    => array(
+                'total'  => $report->getNumExecutableLines(),
+                'tested' => $report->getNumExecutedLines()
+            ),
+            'coverage' => $classCoverage
+        );
+    }
+
+    /**
+     * Compare two sets of results and return the increased stats
+     *
+     * @param string $beforeFile
+     * @param string $afterFile
+     *
+     * @return array
+     */
+    public function compareCoverageStats($beforeFile, $afterFile)
+    {
+        // Before
+        $codeCoverage = unserialize(file_get_contents($beforeFile));
+        $before = $this->getCoverageStats($codeCoverage);
+
+        // After
+        $codeCoverage = unserialize(file_get_contents($afterFile));
+        $after = $this->getCoverageStats($codeCoverage);
+
+        $increase = array(
+            'classes'  => 0,
+            'methods'  => 0,
+            'lines'    => 0,
+            'coverage' => array()
+        );
+
+        $deltaBefore = $before['classes']['total'] - $before['classes']['tested'];
+        $deltaAfter = $after['classes']['total'] - $after['classes']['tested'];
+        if ($deltaAfter > $deltaBefore) {
+            $increase['classes'] = $deltaAfter - $deltaBefore;
+        }
+
+        $deltaBefore = $before['methods']['total'] - $before['methods']['tested'];
+        $deltaAfter = $after['methods']['total'] - $after['methods']['tested'];
+        if ($deltaAfter > $deltaBefore) {
+            $increase['methods'] = $deltaAfter - $deltaBefore;
+        }
+
+        $deltaBefore = $before['lines']['total'] - $before['lines']['tested'];
+        $deltaAfter = $after['lines']['total'] - $after['lines']['tested'];
+        if ($deltaAfter > $deltaBefore) {
+            $increase['lines'] = $deltaAfter - $deltaBefore;
+        }
+
+        foreach ($after['coverage'] as $class => $data) {
+            // Methods
+            $deltaBefore = $data['methodsCovered'] - $before['coverage'][$class]['methodsCovered'];
+            $deltaAfter = $data['methodCount'] - $before['coverage'][$class]['methodCount'];
+            if ($deltaAfter > $deltaBefore) {
+                $increase['coverage'][$class]['methods'] = $deltaAfter - $deltaBefore;
+            }
+
+            // Statments
+            $deltaBefore = $data['statementsCovered'] - $before['coverage'][$class]['statementsCovered'];
+            $deltaAfter = $data['statementCount'] - $before['coverage'][$class]['statementCount'];
+            if ($deltaAfter > $deltaBefore) {
+                $increase['coverage'][$class]['statements'] = $deltaAfter - $deltaBefore;
+            }
+        }
+
+        return $increase;
+    }
+
+    /**
+     * Format the stats
+     *
+     * @param array $stats
+     *
+     * @return string
+     */
+    public function formatCoverageStats(array $stats)
+    {
+        $coverage = <<<EOF
+### Changes in code coverage
+
+#### Totals
+| Classes | Methods | Lines |
+|---------|---------|-------|
+| {$stats['classes']} | {$stats['methods']} | {$stats['lines']} |
+
+
+EOF;
+
+        $coverage .= <<<EOF
+#### Individual Classes
+| Class | Methods | Statements |
+|-------|---------|------------|
+
+EOF;
+
+        foreach ($stats['coverage'] as $class => $data) {
+            $coverage .= <<<EOF
+| {$class} | {$data['methods']} | {$data['statements']} |
+
+EOF;
+        }
+
+        return $coverage;
+    }
+}
+
+class Git
+{
+    /** @var \Guzzle\Http\Client */
+    private $client;
+
+    /** @var \Symfony\Component\Process\ProcessBuilder */
+    private $builder;
+
+    /**
+     *
+     */
+    public function __construct()
+    {
+        // Guzzle client
+        $this->client = new GuzzleClient('https://api.github.com/repos/bolt/bolt/pulls/');
+
+        // Symfony process
+        $this->builder = new ProcessBuilder();
+
+        // Assume that `git` is in the path
+        $this->builder->setPrefix('git');
+    }
+
+    /**
+     * Get a GitHub PR's JSON
+     *
+     * @param integer $pr
+     */
+    public function getPr($pr)
+    {
+        $response = $this->client->get($pr)->send()->getBody();
+
+        return json_decode($response);
+    }
+
+    /**
+     * Add a git remote to the current git repo
+     *
+     * @param string $name
+     * @param string $url
+     */
+    public function addRemote($name, $url)
+    {
+        // Build the process
+        $process = $this->builder->setArguments(array('remote', 'add', $name, $url))
+            ->getProcess()
+            ->enableOutput();
+
+        // Run it
+        $retval = $process->run();
+
+        if (!$process->isSuccessful()) {
+            die($process->getErrorOutput());
+        }
+
+        echo $process->getOutput(), "\n";
+
+        return $retval;
+    }
+
+    /**
+     * Delete a git remote from the current git repo
+     *
+     * @param string $name
+     */
+    public function delRemote($name)
+    {
+        // Build the process
+        $process = $this->builder->setArguments(array('remote', 'remove', $name))
+            ->getProcess()
+            ->enableOutput();
+
+        // Run it
+        $retval = $process->run();
+
+        if (!$process->isSuccessful()) {
+            die($process->getErrorOutput());
+        }
+
+        echo $process->getOutput(), "\n";
+
+        return $retval;
+    }
+
+    /**
+     * Checkout a remote's branch
+     *
+     * @param string $branch Branch
+     * @param string $name   Remote name
+     */
+    public function checkoutBranch($branch, $name = null)
+    {
+        if ($name) {
+            $this->builder->setArguments(array('checkout', '-b', $branch, "$name/$branch"));
+        } else {
+            $this->builder->setArguments(array('checkout', $branch));
+        }
+
+        // Build the process
+         $process = $this->builder
+            ->getProcess()
+            ->enableOutput();
+
+        // Run it
+        $retval = $process->run();
+
+        if (!$process->isSuccessful()) {
+            die($process->getErrorOutput());
+        }
+
+        echo $process->getOutput(), "\n";
+
+        return $retval;
+    }
+
+    /**
+     * Pull a remote branch
+     *
+     * @param string $repo   Repository name
+     * @param string $branch Branch name
+     */
+    public function pullBranch($remote = null, $branch = null)
+    {
+        if ($remote && $branch) {
+            $this->builder->setArguments(array('pull', $remote, $branch));
+        } elseif ($branch) {
+            $this->builder->setArguments(array('pull', $remote));
+        } else {
+            $this->builder->setArguments(array('pull', $remote));
+        }
+
+        // Build the process
+         $process = $this->builder
+            ->getProcess()
+            ->enableOutput();
+
+        // Run it
+        $retval = $process->run();
+
+        if (!$process->isSuccessful()) {
+            die($process->getErrorOutput());
+        }
+
+        echo $process->getOutput(), "\n";
+
+        return $retval;
+    }
+
+    /**
+     * Checkout a remote's branch
+     *
+     * @param string $branch Branch
+     */
+    public function removeBranch($branch)
+    {
+        $this->builder->setArguments(array('branch', '-D', $branch));
+
+        // Build the process
+         $process = $this->builder
+            ->getProcess()
+            ->enableOutput();
+
+        // Run it
+        $retval = $process->run();
+
+        if (!$process->isSuccessful()) {
+            die($process->getErrorOutput());
+        }
+
+        echo $process->getOutput(), "\n";
+
+        return $retval;
+    }
+
+    /**
+     * Fetch all remote branches
+     */
+    public function fetchAll()
+    {
+        $process = $this->builder->setArguments(array('fetch', '--all'))
+            ->getProcess()
+            ->enableOutput();
+
+        // Run it
+        $retval = $process->run();
+
+        if (!$process->isSuccessful()) {
+            die($process->getErrorOutput());
+        }
+
+        echo $process->getOutput(), "\n";
+
+        return $retval;
+    }
+}
+
+// Get the PR number to test
+if (!isset($_SERVER['argv'][1]) || !is_numeric($_SERVER['argv'][1])) {
+    die("Minimum of a GitHub PR number is required as first argument\n");
+}
+$pr = $_SERVER['argv'][1];
+
+// Get the test, if any to run
+$test = null;
+if (isset($_SERVER['argv'][2])) {
+    $test = 'tests/phpunit/' . str_replace('tests/phpunit/', '', $_SERVER['argv'][2]);
+}
+
+// PHPUnit coverage files
+$beforeFile = sys_get_temp_dir() . '/coverage-before.php';
+$afterFile = sys_get_temp_dir() . '/coverage-after.php';
+
+// Classes
+$gh = new Git();
+$cc = new CoverageComparator();
+
+/*
+ * Pull request data
+ */
+$prDetails = $gh->getPr($pr);
+$remoteName   = 'bolt-fork-' . $prDetails->head->repo->id;
+$remoteUrl    = $prDetails->head->repo->clone_url;
+$remoteBranch = $prDetails->head->ref;
+
+/*
+ * Master test
+ */
+// Checkout and update master
+$gh->checkoutBranch('master');
+$gh->pullBranch('upstream', 'master');
+
+// Run test
+if ($cc->runPhpUnitCoverage($beforeFile, $test)) {
+    die("Failed to run PHPUnit test against master");
+}
+
+/*
+ * Remote tests
+ */
+
+// Get PRs git remote and fetch all branches
+if ($gh->addRemote($remoteName, $remoteUrl)) {
+    $gh->fetchAll();
+}
+
+// Checkout the PRs branch
+if ($gh->checkoutBranch($remoteBranch, $remoteName)) {
+    if ($cc->runPhpUnitCoverage($afterFile, $test)) {
+        $gh->checkoutBranch('master');
+        $gh->removeBranch($remoteBranch);
+        $gh->delRemote($remoteName);
+
+        die("Failed to run PHPUnit test against PR branch");
+    }
+}
+
+// Clean up
+$gh->checkoutBranch('master');
+$gh->removeBranch($remoteBranch);
+$gh->delRemote($remoteName);
+
+// Get the comparison of runs
+$compare = $cc->compareCoverageStats($beforeFile, $afterFile);
+
+// Output results to STDOUT
+echo $cc->formatCoverageStats($compare), "\n";

--- a/tests/scripts/coverage.php
+++ b/tests/scripts/coverage.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * Functionality to handle PHPUnit coverage comparision
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+
 namespace Bolt\Tests;
 
 use Guzzle\Http\Client as GuzzleClient;
@@ -29,6 +35,8 @@ class CoverageComparator
      *
      * @param string $output Target PHP file to output serialized resultst to
      * @param string $test   Test directory or file to run
+     *
+     * @return integer
      */
     public function runPhpUnitCoverage($output, $test = null)
     {
@@ -271,6 +279,8 @@ class Git
      * Get a GitHub PR's JSON
      *
      * @param integer $pr
+     *
+     * @return stdClass
      */
     public function getPr($pr)
     {
@@ -284,6 +294,8 @@ class Git
      *
      * @param string $name
      * @param string $url
+     *
+     * @return integer
      */
     public function addRemote($name, $url)
     {
@@ -308,6 +320,8 @@ class Git
      * Delete a git remote from the current git repo
      *
      * @param string $name
+     *
+     * @return integer
      */
     public function delRemote($name)
     {
@@ -333,6 +347,8 @@ class Git
      *
      * @param string $branch Branch
      * @param string $name   Remote name
+     *
+     * @return integer
      */
     public function checkoutBranch($branch, $name = null)
     {
@@ -364,6 +380,8 @@ class Git
      *
      * @param string $repo   Repository name
      * @param string $branch Branch name
+     *
+     * @return integer
      */
     public function pullBranch($remote = null, $branch = null)
     {
@@ -396,6 +414,8 @@ class Git
      * Checkout a remote's branch
      *
      * @param string $branch Branch
+     *
+     * @return integer
      */
     public function removeBranch($branch)
     {
@@ -420,6 +440,8 @@ class Git
 
     /**
      * Fetch all remote branches
+     *
+     * @return integer
      */
     public function fetchAll()
     {

--- a/tests/scripts/coverage.php
+++ b/tests/scripts/coverage.php
@@ -462,6 +462,17 @@ class Git
     }
 }
 
+if (isset($_SERVER['argv'][1]) &&
+    (isset($_SERVER['argv'][1]) === 'help' ||
+     isset($_SERVER['argv'][1]) === '--help' ||
+     isset($_SERVER['argv'][1]) === '-h')
+    ) {
+        echo "php tests/scripts/coverage.php [PR number] [test]\n\n";
+        echo "Where:\n";
+        echo "\t[PR number]\t- GitHub PR number (required)\n";
+        echo "\t[test]\t\t- Directory or file to limit tests to (optional)\n";
+}
+
 // Get the PR number to test
 if (!isset($_SERVER['argv'][1]) || !is_numeric($_SERVER['argv'][1])) {
     die("Minimum of a GitHub PR number is required as first argument\n");
@@ -499,7 +510,7 @@ $git->pullBranch('upstream', 'master');
 
 // Run test
 if ($comparator->runPhpUnitCoverage($beforeFile, $test)) {
-    die("Failed to run PHPUnit test against master");
+    die("Failed to run PHPUnit test against master\n");
 }
 
 /*


### PR DESCRIPTION
This change removes the code coverage from every PHPUnit run, and instead allows execution of a PHP script to test against both `master` and a PR's branch (plucked from a PR number).

```bash
php tests/scripts/coverage.php 3023
```
Optionally you can give the name (or path) of at directory in `tests/phpunit/`:
```bash
php tests/scripts/coverage.php 3023 Configuration
```
or a specific file:

```bash
php tests/scripts/coverage.php 3023 tests/phpunit/Configuration/ResourceManagerTest.php
```

And if changes in coverage are calculated, it will output to the console Mardown that can be pasted into the PR's discussion:

### Changes in code coverage

#### Totals
| Classes | Methods | Lines |
|---------|---------|-------|
| 15 | 24 | 13 |

#### Individual Classes
| Class | Methods | Statements |
|-------|---------|------------|
| \Bolt::Application | 12 | 11 |
| \Bolt::Config | 12 | 15 |
| \Bolt\Configuration::Composer | 22 | 5 |
| \Bolt\Configuration::ComposerChecks | 10 | 23 |
| \Bolt\Configuration::LowlevelChecks | 9 | 14 |
| \Bolt\Configuration::ResourceManager | 16 | 28 |
| \Bolt\Configuration::Standard | 13 | 15 |
| \Bolt\Exception::LowLevelDatabaseException | 23 | 5 |
| \Bolt\Exception::LowlevelException | 8 | 24 |
| \Bolt\Field::Base | 10 | 10 |
| \Bolt\Field::Manager | 16 | 10 |
| \Bolt::Library | 13 | 26 |
| \Bolt\Provider::ConfigServiceProvider | 22 | 22 |
| \Bolt\Provider::PathServiceProvider | 17 | 15 |
