### PR TITLE
Fix coverage print help

### DIFF
--- a/tests/scripts/coverage.php
+++ b/tests/scripts/coverage.php
@@ -287,11 +287,11 @@ class Git
      */
     public function __construct()
     {
-        // Config
-        $this->getConfig();
-
         // Output
         $this->output = new ConsoleOutput();
+
+        // Config
+        $this->getConfig();
 
         // Guzzle client
         $this->client = new GuzzleClient('https://api.github.com/repos/bolt/bolt/pulls/', $this->guzzleDefaults);

--- a/tests/scripts/coverage.php
+++ b/tests/scripts/coverage.php
@@ -556,11 +556,11 @@ class CoverageCommand
      */
     public function __construct()
     {
-        // Options
-        $this->getOpts();
-
         // Output
         $this->output = new ConsoleOutput();
+
+        // Options
+        $this->getOpts();
 
         // Git
         $this->git = new Git();


### PR DESCRIPTION
Fix this:
```
PHP Fatal error:  Call to a member function write() on a non-object in /www/jirimedved/bolt/tests/scripts/coverage.php on line 603
PHP Stack trace:
PHP   1. {main}() /www/jirimedved/bolt/tests/scripts/coverage.php:0
PHP   2. Bolt\Tests\CoverageCommand->__construct() /www/jirimedved/bolt/tests/scripts/coverage.php:706
PHP   3. Bolt\Tests\CoverageCommand->getOpts() /www/jirimedved/bolt/tests/scripts/coverage.php:560
PHP   4. Bolt\Tests\CoverageCommand->help() /www/jirimedved/bolt/tests/scripts/coverage.php:625
```