### PR TITLE
Allow either 'defer', or 'async' attribute to be added to JavaScript loading in extensions

### DIFF
--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -477,6 +477,9 @@ abstract class BaseExtension implements ExtensionInterface
                 'late'     => isset($args[1]) ? isset($args[1]) : false,
                 'priority' => isset($args[2]) ? isset($args[2]) : 0,
             );
+
+            $message = 'addJavascript() called with deprecated function parameters by ' . $this->getName();
+            $this->app['logger.system']->error($message, array('event' => 'deprecated'));
         }
 
         // check if the file exists.

--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -463,19 +463,29 @@ abstract class BaseExtension implements ExtensionInterface
      * Add a javascript file to the rendered HTML.
      *
      * @param string  $filename File name to add to src=""
-     * @param boolean $late     True to add to the end of the HTML <body>
-     * @param integer $priority Loading priority
-     * @param string  $attrib   Either 'defer', or 'async'
+     * @param array   $options  'late'     - True to add to the end of the HTML <body>
+     *                          'priority' - Loading priority
+     *                          'attrib'   - Either 'defer', or 'async'
      */
-    public function addJavascript($filename, $late = false, $priority = 0, $attrib = false)
+    public function addJavascript($filename, $options = array())
     {
+        // Handle pre-2.2 function parameters, namely $late and $priority
+        if (!is_array($options)) {
+            $args = func_get_args();
+
+            $options = array(
+                'late'     => isset($args[1]) ? isset($args[1]) : false,
+                'priority' => isset($args[2]) ? isset($args[2]) : 0,
+            );
+        }
+
         // check if the file exists.
         if (file_exists($this->basepath . '/' . $filename)) {
             // file is located relative to the current extension.
-            $this->app['extensions']->addJavascript($this->getBaseUrl() . $filename, $late, $priority, $attrib);
+            $this->app['extensions']->addJavascript($this->getBaseUrl() . $filename, $options);
         } elseif (file_exists($this->app['paths']['themepath'] . '/' . $filename)) {
             // file is located relative to the theme path.
-            $this->app['extensions']->addJavascript($this->app['paths']['theme'] . $filename, $late, $priority, $attrib);
+            $this->app['extensions']->addJavascript($this->app['paths']['theme'] . $filename, $options);
         } else {
             // Nope, can't add the CSS.
             $message = "Couldn't add Javascript '$filename': File does not exist in '" . $this->getBaseUrl() . "'.";

--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -462,19 +462,20 @@ abstract class BaseExtension implements ExtensionInterface
     /**
      * Add a javascript file to the rendered HTML.
      *
-     * @param string $filename
-     * @param bool   $late
-     * @param int    $priority
+     * @param string  $filename File name to add to src=""
+     * @param boolean $late     True to add to the end of the HTML <body>
+     * @param integer $priority Loading priority
+     * @param string  $attrib   Either 'defer', or 'async'
      */
-    public function addJavascript($filename, $late = false, $priority = 0)
+    public function addJavascript($filename, $late = false, $priority = 0, $attrib = false)
     {
         // check if the file exists.
-        if (file_exists($this->basepath . "/" . $filename)) {
+        if (file_exists($this->basepath . '/' . $filename)) {
             // file is located relative to the current extension.
-            $this->app['extensions']->addJavascript($this->getBaseUrl() . $filename, $late, $priority);
-        } elseif (file_exists($this->app['paths']['themepath'] . "/" . $filename)) {
+            $this->app['extensions']->addJavascript($this->getBaseUrl() . $filename, $late, $priority, $attrib);
+        } elseif (file_exists($this->app['paths']['themepath'] . '/' . $filename)) {
             // file is located relative to the theme path.
-            $this->app['extensions']->addJavascript($this->app['paths']['theme'] . $filename, $late, $priority);
+            $this->app['extensions']->addJavascript($this->app['paths']['theme'] . $filename, $late, $priority, $attrib);
         } else {
             // Nope, can't add the CSS.
             $message = "Couldn't add Javascript '$filename': File does not exist in '" . $this->getBaseUrl() . "'.";
@@ -485,17 +486,17 @@ abstract class BaseExtension implements ExtensionInterface
     /**
      * Add a CSS file to the rendered HTML.
      *
-     * @param string $filename
-     * @param bool   $late
-     * @param int    $priority
+     * @param string  $filename File name to add to href=""
+     * @param boolean $late     True to add to the end of the HTML <body>
+     * @param integer $priority Loading priority
      */
     public function addCSS($filename, $late = false, $priority = 0)
     {
         // check if the file exists.
-        if (file_exists($this->basepath . "/" . $filename)) {
+        if (file_exists($this->basepath . '/' . $filename)) {
             // file is located relative to the current extension.
             $this->app['extensions']->addCss($this->getBaseUrl() . $filename, $late, $priority);
-        } elseif (file_exists($this->app['paths']['themepath'] . "/" . $filename)) {
+        } elseif (file_exists($this->app['paths']['themepath'] . '/' . $filename)) {
             // file is located relative to the theme path.
             $this->app['extensions']->addCss($this->app['paths']['theme'] . $filename, $late, $priority);
         } else {

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -425,17 +425,27 @@ class Extensions
      * the other javascript files.
      *
      * @param string  $filename File name to add to src=""
-     * @param boolean $late     True to add to the end of the HTML <body>
-     * @param integer $priority Loading priority
-     * @param string  $attrib   Either 'defer', or 'async'
+     * @param array   $options  'late'     - True to add to the end of the HTML <body>
+     *                          'priority' - Loading priority
+     *                          'attrib'   - Either 'defer', or 'async'
      */
-    public function addJavascript($filename, $late = false, $priority = 0, $attrib = false)
+    public function addJavascript($filename, $options = array())
     {
+        // Handle pre-2.2 function parameters, namely $late and $priority
+        if (!is_array($options)) {
+            $args = func_get_args();
+
+            $options = array(
+                'late'     => isset($args[1]) ? isset($args[1]) : false,
+                'priority' => isset($args[2]) ? isset($args[2]) : 0,
+            );
+        }
+
         $this->assets['js'][md5($filename)] = array(
             'filename' => $filename,
-            'late'     => $late,
-            'priority' => $priority,
-            'attrib'   => $attrib == 'defer' || $attrib == 'async' ? $attrib : false
+            'late'     => isset($options['late'])     ? $options['late']     : false,
+            'priority' => isset($options['priority']) ? $options['priority'] : 0,
+            'attrib'   => isset($options['attrib'])   ? $options['attrib']   : false
         );
     }
 

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -407,9 +407,9 @@ class Extensions
      * Add a particular CSS file to the output. This will be inserted before the
      * other css files.
      *
-     * @param string $filename
-     * @param bool   $late
-     * @param int    $priority
+     * @param string  $filename File name to add to href=""
+     * @param boolean $late     True to add to the end of the HTML <body>
+     * @param integer $priority Loading priority
      */
     public function addCss($filename, $late = false, $priority = 0)
     {
@@ -424,16 +424,18 @@ class Extensions
      * Add a particular javascript file to the output. This will be inserted after
      * the other javascript files.
      *
-     * @param string $filename
-     * @param bool   $late
-     * @param int    $priority
+     * @param string  $filename File name to add to src=""
+     * @param boolean $late     True to add to the end of the HTML <body>
+     * @param integer $priority Loading priority
+     * @param string  $attrib   Either 'defer', or 'async'
      */
-    public function addJavascript($filename, $late = false, $priority = 0)
+    public function addJavascript($filename, $late = false, $priority = 0, $attrib = false)
     {
         $this->assets['js'][md5($filename)] = array(
-            'filename'  => $filename,
-            'late'      => $late,
-            'priority'  => $priority
+            'filename' => $filename,
+            'late'     => $late,
+            'priority' => $priority,
+            'attrib'   => $attrib == 'defer' || $attrib == 'async' ? $attrib : false
         );
     }
 
@@ -687,11 +689,12 @@ class Extensions
             array_walk($files, create_function('&$v, $k', '$v = $v[2];'));
 
             foreach ($files as $file) {
-                $late = $file['late'];
+                $late     = $file['late'];
                 $filename = $file['filename'];
+                $attrib   = $file['attrib'] ? ' ' . $file['attrib'] : '';
 
-                if ($type == 'js') {
-                    $htmlJs = sprintf('<script src="%s"></script>', $filename);
+                if ($type === 'js') {
+                    $htmlJs = sprintf('<script src="%s"%s></script>', $filename, $attrib);
                     if ($late) {
                         $html = $this->insertEndOfBody($htmlJs, $html);
                     } else {


### PR DESCRIPTION
**UPDATED**
The `addJavaScript()` function now:
* Takes an $option array parameter (handles deprecated calls)
* Allows extensions to defer, or asynchronously load their added JavaScript assets, e.g.:

```php
$this->addJavascript('js/jquery.min.js', array('late' => true, 'priority' => 10, 'attrib' => 'async defer'));
```
Produces something similar to:
```html
<script src="/js/jquery.min.js" async defer></script>
```

### Changelog
* Changed: The extension function now takes an option parameter `array('late' => true, 'priority' => 10, 'attrib' => 'async defer')`
* Added: Ability for extensions to defer, or asynchronously load JavaScript