### PR TITLE
[2.1] Fix redirect for backend trailing slash redirect (/bolt -> /bolt/). 

### DIFF
--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -161,7 +161,7 @@ class Frontend
             // There's one special edge-case we check for: if the request is for the backend, without trailing
             // slash and it is intercepted by custom routing, we forward the client to that location.
             if ($slug == trim($app['config']->get('general/branding/path'), '/')) {
-                Lib::simpleredirect($app['config']->get('general/branding/path') . '/');
+                return Lib::redirect('dashboard');
             }
             $app->abort(404, "Page $contenttypeslug/$slug not found.");
         }

--- a/src/Library.php
+++ b/src/Library.php
@@ -146,7 +146,7 @@ class Library
         $app = ResourceManager::getApp();
 
         // If the user doesn't have access to the backend, redirect them to the frontend
-        if ($path === 'dashboard' && !$app['users']->isAllowed('dashboard')) {
+        if ($path === 'dashboard' && $app['users']->isValidSession() && !$app['users']->isAllowed('dashboard')) {
             $app['session']->getFlashBag()->clear();
             $path = 'homepage';
         }


### PR DESCRIPTION
Should fix #3082.

I would rather figure out a better way to handle this, but this will work for now. 
If we are at /bolt we should just match Backend::dashboard.