### PR TITLE
Who likes trailing slashes anyways?

### DIFF
--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -158,11 +158,6 @@ class Frontend
 
         // No content, no page!
         if (!$content) {
-            // There's one special edge-case we check for: if the request is for the backend, without trailing
-            // slash and it is intercepted by custom routing, we forward the client to that location.
-            if ($slug == trim($app['config']->get('general/branding/path'), '/')) {
-                Lib::simpleredirect($app['config']->get('general/branding/path') . '/');
-            }
             $app->abort(Response::HTTP_NOT_FOUND, "Page $contenttypeslug/$slug not found.");
         }
 

--- a/src/Library.php
+++ b/src/Library.php
@@ -146,7 +146,7 @@ class Library
         $app = ResourceManager::getApp();
 
         // If the user doesn't have access to the backend, redirect them to the frontend
-        if ($path === 'dashboard' && !$app['users']->isAllowed('dashboard')) {
+        if ($path === 'dashboard' && $app['users']->isValidSession() && !$app['users']->isAllowed('dashboard')) {
             $app['session']->getFlashBag()->clear();
             $path = 'homepage';
         }

--- a/src/Provider/RoutingServiceProvider.php
+++ b/src/Provider/RoutingServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Provider;
 
+use Bolt\Routing\ControllerCollection;
 use Bolt\Routing\ControllerResolver;
 use Bolt\Routing\UrlMatcher;
 use Silex\Application;
@@ -11,6 +12,10 @@ class RoutingServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
+        $app['controllers_factory'] = function ($app) {
+            return new ControllerCollection($app['route_factory']);
+        };
+
         $app['url_matcher'] = $app->share(
             function ($app) {
                 return new UrlMatcher($app['routes'], $app['request_context']);

--- a/src/Routing/ControllerCollection.php
+++ b/src/Routing/ControllerCollection.php
@@ -1,0 +1,23 @@
+<?php
+namespace Bolt\Routing;
+
+/**
+ * When mounting a controller class with a prefix most times you have a route
+ * with a blank path (ex: Backend::dashboard). That is the only route that
+ * flushes to include an (unwanted) trailing slash.
+ *
+ * This fixes that trailing slash.
+ */
+class ControllerCollection extends \Silex\ControllerCollection
+{
+    public function flush($prefix = '')
+    {
+        $routes = parent::flush($prefix);
+        foreach ($routes->all() as $name => $route) {
+            if (substr($route->getPath(), -1) === '/') {
+                $route->setPath(rtrim($route->getPath(), '/'));
+            }
+        }
+        return $routes;
+    }
+}

--- a/tests/phpunit/Controller/ExtendControllerTest.php
+++ b/tests/phpunit/Controller/ExtendControllerTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Bolt\Tests\Controller;
 
-use Bolt\Composer\PackageManager;
 use Bolt\Controllers\Extend;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;
@@ -72,7 +71,7 @@ class ExtendControllerTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $this->allowLogin($app);
-        $request = Request::create('/bolt/extend/');
+        $request = Request::create('/bolt/extend');
         $this->checkTwigForTemplate($app, 'extend/extend.twig');
         $response = $app->handle($request);
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/phpunit/Controller/LoginTest.php
+++ b/tests/phpunit/Controller/LoginTest.php
@@ -28,7 +28,7 @@ class LoginTest extends BoltUnitTest
 
         $response = $app->handle($request);
 
-        $this->assertTrue($response->isRedirect('/bolt/'));
+        $this->assertTrue($response->isRedirect('/bolt'));
     }
 
     public function testPostLoginFailures()
@@ -69,7 +69,7 @@ class LoginTest extends BoltUnitTest
         $users->currentuser = array('username' => 'test', 'roles' => array());
         $app['users'] = $users;
         $request = Request::create('/bolt/login', 'POST', array('action' => 'login'));
-        $this->expectOutputRegex("/Redirecting to \/bolt\//");
+        $this->expectOutputRegex("/Redirecting to \/bolt/");
         $app->run($request);
     }
 
@@ -147,7 +147,7 @@ class LoginTest extends BoltUnitTest
 
         $app['config']->set('permissions/global/dashboard', array());
 
-        $request = Request::create('/bolt/');
+        $request = Request::create('/bolt');
         $response = $app->handle($request);
         $this->assertTrue($response->isRedirect('/'), 'Failed to redirect to homepage');
     }


### PR DESCRIPTION
This removes trailing slashes from `/bolt` and `/bolt/extend`

This is the 2.2 fix for #3082.