### PR TITLE
Fixes broken extension installer

### DIFF
--- a/src/Composer/ExtensionInstaller.php
+++ b/src/Composer/ExtensionInstaller.php
@@ -20,6 +20,8 @@ class ExtensionInstaller
                 $installedPackage = $operation->getPackage();
             } elseif (method_exists($operation, 'getTargetPackage')) {
                 $installedPackage = $operation->getTargetPackage();
+            } else {
+                return;
             }
         } catch (\Exception $e) {
             return;

--- a/src/Composer/ExtensionInstaller.php
+++ b/src/Composer/ExtensionInstaller.php
@@ -15,7 +15,12 @@ class ExtensionInstaller
     public static function handle($event)
     {
         try {
-            $installedPackage = $installedPackage = $event->getOperation()->getPackage();
+            $operation = $event->getOperation();
+            if (method_exists($operation, 'getPackage')) {
+                $installedPackage = $operation->getPackage();
+            } elseif (method_exists($operation, 'getTargetPackage')) {
+                $installedPackage = $operation->getTargetPackage();
+            }
         } catch (\Exception $e) {
             return;
         }

--- a/src/Composer/ExtensionInstaller.php
+++ b/src/Composer/ExtensionInstaller.php
@@ -12,13 +12,14 @@ class ExtensionInstaller
      *
      * @param \Composer\EventDispatcher\Event $event
      */
-    public static function handle(Event $event)
+    public static function handle($event)
     {
-        if (!($event instanceof ScriptEvent || $event instanceof PackageEvent)) {
+        try {
+            $installedPackage = $installedPackage = $event->getOperation()->getPackage();
+        } catch (\Exception $e) {
             return;
         }
 
-        $installedPackage = $event->getComposer()->getPackage();
         $rootExtra = $event->getComposer()->getPackage()->getExtra();
         $extra = $installedPackage->getExtra();
         if (isset($extra['bolt-assets'])) {


### PR DESCRIPTION
I'm proposing to revert this back to how it was pre Jan 20th. I've not been able to get any extension scripts to install with either the type-hinting passed and additionally the current package info:

    $event->getComposer()->getPackage();

seems to always return the root package, not the package of the just installed package. Has anyone who changed and tested this got any more details as to how the current code can run correctly?