### PR TITLE
Add composer branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,5 +67,10 @@
             "Bolt\\Tests\\": "tests/phpunit"
         }
     },
-    "bin": ["app/nut"]
+    "bin": ["app/nut"],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
Add composer branch alias. This allows composer installers to require `2.1.*@dev` and always have the latest version of this branch