### PR TITLE
Revert code to a prior version to make sure we don't break BC with exten...

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ Not yet released.
  - Added: Stop Finder from recursing common build folders and place a limit on the maximum depth it will recurse otherwise. (Thanks @Cooperaj, see #3069)
  - Fixed: Removing default taxonomylink route leads to exception (See #3070)
  - Fixed: Don't reset urls when adding base path. (See #3074)
- - Added: Use the X-Forwarded for IP address when an appropriate one exists and the trustedProxies config contains a valid IP. (See #3031)
+ - Added: Use the X-Forwarded for IP address when an appropriate one exists and the trustedProxies config contains a valid IP. (Thanks @Cooperaj, see #3031, #3093)
  
 Bolt 2.1.0
 ----------

--- a/src/Users.php
+++ b/src/Users.php
@@ -43,8 +43,24 @@ class Users
         $this->users = array();
         $this->session = $app['session'];
 
-        // Get the IP stored earlier in the request cycle. If it's missing we're on CLI so use localhost
-        $this->remoteIP = isset($app['request.client_ip']) ? $app['request.client_ip'] : '127.0.0.1';
+        /**
+         * ip could be hidden by proxy
+         *
+         * The fix as finally implemented in https://github.com/bolt/bolt/pull/3031
+         * causes any extensions which access container values that rely on the Request
+         * to break horribly. This will do for now.
+         *
+         * TODO: Fixme.
+         * $this->remoteIP = isset($app['request.client_ip']) ? $app['request.client_ip'] : '127.0.0.1';
+         */
+        if (isset($_SERVER['HTTP_X_FORWARDED_FOR']) &&
+            isset($_SERVER['REMOTE_ADDR']) &&
+            in_array($_SERVER['REMOTE_ADDR'], $this->app['config']->get('general/trustProxies'))
+        ) {
+            $this->remoteIP = $_SERVER['HTTP_X_FORWARDED_FOR'];
+        } else {
+            $this->remoteIP = isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '127.0.0.1';
+        }
 
         // Set 'validsession', to see if the current session is valid.
         $this->validsession = $this->checkValidSession();


### PR DESCRIPTION
...sions in the 2.x cycle

I've left the user provider code in place since it's not hurting and is the only way to access request properties where the availability of a request object is suspect.