### PR TITLE
Bugfix extension theme installer

### DIFF
--- a/app/src/js/extend.js
+++ b/app/src/js/extend.js
@@ -298,7 +298,7 @@ var BoltExtender = Object.extend(Object, {
 				'%AVAILABLE%':   available,
 				'%README%':      ext.readme ? conf.readme_button.subst({'%README%': ext.readme}) : '',
 				'%CONFIG%':      ext.config ? conf.config_button.subst({'%CONFIG%': ext.config}) : '',
-				'%THEME%':       ext.type == 'bolt-theme' ? conf.theme_button : '',
+				'%THEME%':       ext.type == 'bolt-theme' ? conf.theme_button.subst({'%NAME%': ext.name}) : '',
 				'%BASEURL%':     baseurl,
 				'%UNINSTALL%':   uninstall,
 				'%DESCRIPTION%': ext.descrip ? ext.descrip : '&lt;No description provided&gt;',

--- a/app/src/js/extend.js
+++ b/app/src/js/extend.js
@@ -410,10 +410,10 @@ var BoltExtender = Object.extend(Object, {
         )
         .done(function(data) {
             if (data[0].type === 'bolt-extension') {
-                controller.extensionPostInstall(data);
+                controller.extensionPostInstall(data[0]);
             }
             if (data[0].type === 'bolt-theme') {
-                controller.themePostInstall(data);
+                controller.themePostInstall(data[0]);
             }
         })
         .fail(function(data) {

--- a/src/Controllers/Extend.php
+++ b/src/Controllers/Extend.php
@@ -171,6 +171,10 @@ class Extend implements ControllerProviderInterface, ServiceProviderInterface
     {
         $theme = $request->get('theme');
         $newName = $request->get('name');
+        
+        if (empty($theme)) {
+            return new Response(Trans::__('No theme name found. Theme is not generated.'));
+        }
 
         if (! $newName) {
             $newName = basename($theme);


### PR DESCRIPTION
This changes fix theme generation / copy bug in extension installer.

Fixes #3107 

Changelog

* Fix: theme name placeholder (fix: Copy to theme folder button)
* Fix: Assign only an extension object from data array (fix: name not visible)
* Added: Prevent empty theme name for generateTheme() in Extend-Controller (other suggestions?)

My first pull request. Any feedback welcome :)