### PR TITLE
New config setting additional_locales

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -17,14 +17,11 @@ theme: base-2014
 
 # The locale that'll be used by the application. If no locale is set the
 # fallback locale is 'en_GB'. For available options, see: http://docs.bolt.cm/locales
+# In some cases it may be needed to specify (non-standard) variations of the locale
+# to get everything to work as desired. This can be done as [nl_NL, Dutch_Netherlands]
+# When specifying multiple locale, make sure the first is a standard locale
 locale: en_GB
 #timezone: UTC
-
-# In some cases it may be needed to add additional locales to force correct handling
-# in all cases. Additional locales defined here will be appended to the locale array
-# that is used in the SetLocale call
-# additional_locales:
-#   - Dutch_Netherlands
 
 # Set maintenance mode true or false
 # While in maintenance mode, only users of level editor or higher can access the site.

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -20,6 +20,12 @@ theme: base-2014
 locale: en_GB
 #timezone: UTC
 
+# In some cases it may be needed to add additional locales to force correct handling
+# in all cases. Additional locales defined here will be appended to the locale array
+# that is used in the SetLocale call
+# additional_locales:
+#   - Dutch_Netherlands
+
 # Set maintenance mode true or false
 # While in maintenance mode, only users of level editor or higher can access the site.
 # All other visitors are presented with a notice that the site is currently offline.

--- a/src/Application.php
+++ b/src/Application.php
@@ -301,6 +301,11 @@ class Application extends Silex\Application
             Application::DEFAULT_LOCALE,
             substr(Application::DEFAULT_LOCALE, 0, 2)
         );
+        
+        // Prepend additional locales
+        $additional_locales = $this['config']->get('general/additional_locales', array());
+        $locale = array_merge($locale, $additional_locales);
+        
         setlocale(LC_ALL, $locale);
 
         $this->register(

--- a/src/Application.php
+++ b/src/Application.php
@@ -281,7 +281,13 @@ class Application extends Silex\Application
 
     public function initLocale()
     {
-        $this['locale'] = $this['config']->get('general/locale', Application::DEFAULT_LOCALE);
+        $configLocale = $this['config']->get('general/locale', Application::DEFAULT_LOCALE);
+        if (!is_array($configLocale)) {
+            $configLocale = array($configLocale);
+        }
+
+        // $app['locale'] should only be a single value.
+        $this['locale'] = reset($configLocale);
 
         // Set The Timezone Based on the Config, fallback to UTC
         date_default_timezone_set(
@@ -291,22 +297,21 @@ class Application extends Silex\Application
         // for javascript datetime calculations, timezone offset. e.g. "+02:00"
         $this['timezone_offset'] = date('P');
 
-        // Set default locale
-        $locale = array(
-            $this['locale'] . '.UTF-8',
-            $this['locale'] . '.utf8',
-            $this['locale'],
-            Application::DEFAULT_LOCALE . '.UTF-8',
-            Application::DEFAULT_LOCALE . '.utf8',
-            Application::DEFAULT_LOCALE,
-            substr(Application::DEFAULT_LOCALE, 0, 2)
-        );
+        // Set default locale, for Bolt
+        $locale = array();
+        foreach ($configLocale as $key => $value) {
+            $locale = array_merge($locale, array(
+                $value . '.UTF-8',
+                $value . '.utf8',
+                $value,
+                Application::DEFAULT_LOCALE . '.UTF-8',
+                Application::DEFAULT_LOCALE . '.utf8',
+                Application::DEFAULT_LOCALE,
+                substr(Application::DEFAULT_LOCALE, 0, 2)
+            ));
+        }
         
-        // Append additional locales
-        $additional_locales = $this['config']->get('general/additional_locales', array());
-        $locale = array_merge($locale, $additional_locales);
-        
-        setlocale(LC_ALL, $locale);
+        setlocale(LC_ALL, array_unique($locale));
 
         $this->register(
             new Silex\Provider\TranslationServiceProvider(),

--- a/src/Application.php
+++ b/src/Application.php
@@ -302,7 +302,7 @@ class Application extends Silex\Application
             substr(Application::DEFAULT_LOCALE, 0, 2)
         );
         
-        // Prepend additional locales
+        // Append additional locales
         $additional_locales = $this['config']->get('general/additional_locales', array());
         $locale = array_merge($locale, $additional_locales);
         


### PR DESCRIPTION
I found that datelocal was not actually using the locale that I had
configured. This seems to be caused by environment specific issues. A
way to solve it is by specifying additional locales. This change adds an
optional config parameter where additional locales can be configured. If
configured they are appended to the local array. Using this, adding
"Dutch_Netherlands" I could get Dutch dates (which did not work by
simply setting nl_NL as the locale)