### PR TITLE
When Extensions::addJavascript() is passed a pre-2.2 parameter we need to account for all 2.2 options

### DIFF
--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -438,6 +438,7 @@ class Extensions
             $options = array(
                 'late'     => isset($args[1]) ? isset($args[1]) : false,
                 'priority' => isset($args[2]) ? isset($args[2]) : 0,
+                'attrib'   => false
             );
         }
 


### PR DESCRIPTION
Fixes #3158 

I blame the :koala: 