### PR TITLE
Composer custom backend listing

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -847,6 +847,9 @@ class Config
         // Backend and Async need access to `app/view/twig`
         if ($end == 'backend' || $end == 'async') {
             $twigpath[] = realpath($this->app['resources']->getPath('app') . '/view/twig');
+            if ($this->app['resources']->hasPath('composerbackendviews')) {
+                $twigpath[] = realpath($this->app['resources']->getPath('comoserbackendviews') . '/view/twig');
+            }
         }
 
         // The frontend as well as 'ajaxy' requests from the frontend need access to the theme's path.

--- a/src/Config.php
+++ b/src/Config.php
@@ -848,7 +848,11 @@ class Config
         if ($end == 'backend' || $end == 'async') {
             $twigpath[] = realpath($this->app['resources']->getPath('app') . '/view/twig');
             if ($this->app['resources']->hasPath('composerbackendviews')) {
-                $twigpath[] = realpath($this->app['resources']->getPath('comoserbackendviews') . '/view/twig');
+                $backendviewpath = $this->app['resources']->getPath('composerbackendviews');
+                if (file_exists($backendviewpath)) {
+
+                    $twigpath[] = realpath($backendviewpath);
+                }
             }
         }
 

--- a/src/Configuration/Composer.php
+++ b/src/Configuration/Composer.php
@@ -16,7 +16,7 @@ class Composer extends Standard
         parent::__construct($path, $request);
         $this->setPath('composer', realpath(dirname(__DIR__) . '/../'));
         $this->setPath('app', realpath(dirname(__DIR__) . '/../app/'));
-        $this->setPath('composerbackendviews', $this->getPath('root') . '/app/view/twig/'));
+        $this->setPath('composerbackendviews', realpath($this->getPath('root') . '/app/view/twig/'));
         $this->setUrl('app', '/bolt-public/');
     }
 

--- a/src/Configuration/Composer.php
+++ b/src/Configuration/Composer.php
@@ -16,7 +16,7 @@ class Composer extends Standard
         parent::__construct($path, $request);
         $this->setPath('composer', realpath(dirname(__DIR__) . '/../'));
         $this->setPath('app', realpath(dirname(__DIR__) . '/../app/'));
-        $this->setPath('composerbackendviews', realpath($this->getPath('root') . '/app/view/twig/'));
+        $this->setPath('composerbackendviews', $this->getPath('root') . '/app/view/twig/');
         $this->setUrl('app', '/bolt-public/');
     }
 

--- a/src/Configuration/Composer.php
+++ b/src/Configuration/Composer.php
@@ -16,6 +16,7 @@ class Composer extends Standard
         parent::__construct($path, $request);
         $this->setPath('composer', realpath(dirname(__DIR__) . '/../'));
         $this->setPath('app', realpath(dirname(__DIR__) . '/../app/'));
+        $this->setPath('composerbackendviews', $this->getPath('root') . '/app/view/twig/'));
         $this->setUrl('app', '/bolt-public/');
     }
 

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -190,6 +190,29 @@ class ResourceManager
         return $path;
     }
 
+    /**
+     * Checks if the given name has a path associated with it
+     *
+     * @param string $name of path
+     *
+     * @return Boolean
+     */
+    public function hasPath($name) {
+        $parts = array();
+        if (strpos($name, '/') !== false) {
+            $parts = explode('/', $name);
+            $name = array_shift($parts);
+        }
+
+        if (array_key_exists($name . "path", $this->paths)) {
+            return true;
+        } elseif (array_key_exists($name, $this->paths)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public function setUrl($name, $value)
     {
         $this->urls[$name] = $value;


### PR DESCRIPTION
When in composer, the root app/view/twig isn't added to the Twig renderer, so you can't use custom listing templates (or, override any template if you want to).

This PR fixes that.

This is a fix for 2.1, I'll now work on a master fix