### PR TITLE
Properly support both git and Composer install paths for Codeception

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -14,6 +14,6 @@ modules:
             dsn: 'sqlite:app/database/bolt.db'
             user: ''
             password: ''
- #           dump: 'tests/codeception/_data/bolt.db.dump'
+#           dump: 'tests/codeception/_data/bolt.db.dump'
 extensions:
-    enabled: [ CleanupExtension ]
+    enabled: [ CodeceptionEventsExtension ]

--- a/tests/codeception/_bootstrap.php
+++ b/tests/codeception/_bootstrap.php
@@ -8,4 +8,4 @@
 include_once __DIR__ . '/_constants.php';
 
 // Suite clean up extension
-include_once __DIR__ . '/extensions/CleanupExtension.php';
+include_once __DIR__ . '/extensions/CodeceptionEventsExtension.php';

--- a/tests/codeception/_bootstrap.php
+++ b/tests/codeception/_bootstrap.php
@@ -1,44 +1,11 @@
 <?php
 
 /*
- * This is global bootstrap for autoloading
+ * Global bootstrap for autoloading
  */
+
+// Load our constants
+include_once __DIR__ . '/_constants.php';
 
 // Suite clean up extension
 include_once __DIR__ . '/extensions/CleanupExtension.php';
-
-// Define our install type
-if (file_exists(__DIR__ . '/../../../../../vendor/bolt/bolt/')) {
-    $installType = 'composer';
-} else {
-    $installType = 'git';
-}
-
-// Create a constant that defines the Codeception location
-if (!defined('CODECEPTION_ROOT')) {
-    define('CODECEPTION_ROOT', realpath(__DIR__));
-}
-
-// Create a constant that defines the root location
-if (!defined('PROJECT_ROOT')) {
-    if ($installType === 'composer') {
-        define('PROJECT_ROOT', realpath(CODECEPTION_ROOT . '/../../../../..'));
-    } elseif ($installType === 'git') {
-        define('PROJECT_ROOT', realpath(CODECEPTION_ROOT . '/../..'));
-    }
-}
-
-// Path to Nut
-if (!defined('NUT_PATH')) {
-    if ($installType === 'composer') {
-        define('NUT_PATH', realpath(PROJECT_ROOT . '/vendor/bolt/bolt/app/nut'));
-    } elseif ($installType === 'git') {
-        define('NUT_PATH', realpath(PROJECT_ROOT . '/app/nut'));
-    }
-}
-
-echo "Bootstrapped with:\n";
-echo "    Install type: $installType", "\n";
-echo '    Project root: ' . PROJECT_ROOT, "\n";
-echo '    Codeception root: ' . CODECEPTION_ROOT, "\n";
-echo '    Nut path: ' . NUT_PATH, "\n";

--- a/tests/codeception/_bootstrap.php
+++ b/tests/codeception/_bootstrap.php
@@ -1,23 +1,44 @@
 <?php
-// This is global bootstrap for autoloading
 
+/*
+ * This is global bootstrap for autoloading
+ */
+
+// Suite clean up extension
 include_once __DIR__ . '/extensions/CleanupExtension.php';
 
-// // Create a constant that defines the Codeception location
+// Define our install type
+if (file_exists(__DIR__ . '/../../../../../vendor/bolt/bolt/')) {
+    $installType = 'composer';
+} else {
+    $installType = 'git';
+}
+
+// Create a constant that defines the Codeception location
 if (!defined('CODECEPTION_ROOT')) {
     define('CODECEPTION_ROOT', realpath(__DIR__));
 }
 
 // Create a constant that defines the root location
-if (!defined('TEST_ROOT')) {
-    define('TEST_ROOT', realpath(__DIR__ . '/../../'));
+if (!defined('PROJECT_ROOT')) {
+    if ($installType === 'composer') {
+        define('PROJECT_ROOT', realpath(CODECEPTION_ROOT . '/../../../../..'));
+    } elseif ($installType === 'git') {
+        define('PROJECT_ROOT', realpath(CODECEPTION_ROOT . '/../..'));
+    }
 }
 
 // Path to Nut
 if (!defined('NUT_PATH')) {
-    if (file_exists(__DIR__ . '/../../app/nut')) {
-        define('NUT_PATH', realpath(__DIR__ . '/../../app/nut'));
-    } else {
-        define('NUT_PATH', realpath(__DIR__ . '/../../bolt/bolt/app/nut'));
+    if ($installType === 'composer') {
+        define('NUT_PATH', realpath(PROJECT_ROOT . '/vendor/bolt/bolt/app/nut'));
+    } elseif ($installType === 'git') {
+        define('NUT_PATH', realpath(PROJECT_ROOT . '/app/nut'));
     }
 }
+
+echo "Bootstrapped with:\n";
+echo "    Install type: $installType", "\n";
+echo '    Project root: ' . PROJECT_ROOT, "\n";
+echo '    Codeception root: ' . CODECEPTION_ROOT, "\n";
+echo '    Nut path: ' . NUT_PATH, "\n";

--- a/tests/codeception/_constants.php
+++ b/tests/codeception/_constants.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Global constants
+ */
+
+// Define our install type
+if (file_exists(__DIR__ . '/../../../../../vendor/bolt/bolt/')) {
+    $installType = 'composer';
+} else {
+    $installType = 'git';
+}
+
+// Create a constant that defines the Codeception location
+if (!defined('CODECEPTION_ROOT')) {
+    define('CODECEPTION_ROOT', realpath(__DIR__));
+}
+
+// Create a constant that defines the root location
+if (!defined('PROJECT_ROOT')) {
+    if ($installType === 'composer') {
+        define('PROJECT_ROOT', realpath(CODECEPTION_ROOT . '/../../../../..'));
+    } elseif ($installType === 'git') {
+        define('PROJECT_ROOT', realpath(CODECEPTION_ROOT . '/../..'));
+    }
+}
+
+// Path to Nut
+if (!defined('NUT_PATH')) {
+    if ($installType === 'composer') {
+        define('NUT_PATH', realpath(PROJECT_ROOT . '/vendor/bolt/bolt/app/nut'));
+    } elseif ($installType === 'git') {
+        define('NUT_PATH', realpath(PROJECT_ROOT . '/app/nut'));
+    }
+}
+
+echo 'Codeception bootstrapped:' . PHP_EOL;
+echo '    Install type:     ' . $installType . PHP_EOL;
+echo '    Project root:     ' . PROJECT_ROOT . PHP_EOL;
+echo '    Codeception root: ' . CODECEPTION_ROOT . PHP_EOL;
+echo '    Nut path:         ' . NUT_PATH . PHP_EOL;

--- a/tests/codeception/acceptance/_bootstrap.php
+++ b/tests/codeception/acceptance/_bootstrap.php
@@ -37,22 +37,22 @@ Fixtures::add('users', array(
     )
 ));
 
-// Set up a fixture for the permissions-yml
-if (file_exists(TEST_ROOT. '/app/config/permissions.yml') && !file_exists(TEST_ROOT. '/app/config/permissions.yml.codeception-backup')) {
-    rename(TEST_ROOT. '/app/config/permissions.yml', TEST_ROOT. '/app/config/permissions.yml.codeception-backup');
+// Set up a test-specific permissions.yml
+if (file_exists(PROJECT_ROOT . '/app/config/permissions.yml') && !file_exists(PROJECT_ROOT . '/app/config/permissions.yml.codeception-backup')) {
+    rename(PROJECT_ROOT . '/app/config/permissions.yml', PROJECT_ROOT. '/app/config/permissions.yml.codeception-backup');
 }
-copy(TEST_ROOT. '/tests/codeception/_data/permissions.yml', TEST_ROOT. '/app/config/permissions.yml');
+copy(CODECEPTION_ROOT . '/_data/permissions.yml', PROJECT_ROOT . '/app/config/permissions.yml');
 
 // Back up the Sqlite DB if it exists
-if (file_exists(TEST_ROOT. '/app/database/bolt.db') && !file_exists(TEST_ROOT. '/app/database/bolt.db.codeception-backup')) {
-    rename(TEST_ROOT. '/app/database/bolt.db', TEST_ROOT. '/app/database/bolt.db.codeception-backup');
-} elseif (file_exists(TEST_ROOT. '/app/database/bolt.db')) {
-    unlink(TEST_ROOT. '/app/database/bolt.db');
+if (file_exists(PROJECT_ROOT . '/app/database/bolt.db') && !file_exists(PROJECT_ROOT . '/app/database/bolt.db.codeception-backup')) {
+    rename(PROJECT_ROOT . '/app/database/bolt.db', PROJECT_ROOT. '/app/database/bolt.db.codeception-backup');
+} elseif (file_exists(PROJECT_ROOT . '/app/database/bolt.db')) {
+    unlink(PROJECT_ROOT . '/app/database/bolt.db');
 }
 
 // Install the local extension
 $fs = new Filesystem();
-$fs->mirror(CODECEPTION_ROOT . '/_data/extensions/local/', TEST_ROOT . '/extensions/local/', null, array('override' => true, 'delete' => true));
+$fs->mirror(CODECEPTION_ROOT . '/_data/extensions/local/', PROJECT_ROOT . '/extensions/local/', null, array('override' => true, 'delete' => true));
 
 // Empty the cache
 system('php ' . NUT_PATH . ' cache:clear');

--- a/tests/codeception/extensions/CleanupExtension.php
+++ b/tests/codeception/extensions/CleanupExtension.php
@@ -91,24 +91,22 @@ class CleanupExtension extends \Codeception\Platform\Extension
     {
         $fs = new Filesystem();
 
-        $root = __DIR__ . '/../../..';
-
         // Sqlite DB
-        if ($fs->exists($root . '/app/database/bolt.db.codeception-backup')) {
+        if ($fs->exists(PROJECT_ROOT . '/app/database/bolt.db.codeception-backup')) {
             $this->writeln('Restoring app/database/bolt.db');
-            $fs->rename($root . '/app/database/bolt.db.codeception-backup', $root . '/app/database/bolt.db', true);
+            $fs->rename(PROJECT_ROOT . '/app/database/bolt.db.codeception-backup', PROJECT_ROOT . '/app/database/bolt.db', true);
         }
 
         // Permissions file
-        if ($fs->exists($root . '/app/config/permissions.yml.codeception-backup')) {
+        if ($fs->exists(PROJECT_ROOT . '/app/config/permissions.yml.codeception-backup')) {
             $this->writeln('Restoring app/config/permissions.yml');
-            $fs->rename($root . '/app/config/permissions.yml.codeception-backup', $root . '/app/config/permissions.yml', true);
+            $fs->rename(PROJECT_ROOT . '/app/config/permissions.yml.codeception-backup', PROJECT_ROOT . '/app/config/permissions.yml', true);
         }
 
         // Events tester local extension
-        if ($fs->exists($root . '/extensions/local/bolt/tester-events/')) {
+        if ($fs->exists(PROJECT_ROOT . '/extensions/local/bolt/tester-events/')) {
             $this->writeln('Removing extensions/local/bolt/tester-events/');
-            $fs->remove($root . '/extensions/local/bolt/tester-events/');
+            $fs->remove(PROJECT_ROOT . '/extensions/local/bolt/tester-events/');
         }
     }
 

--- a/tests/codeception/extensions/CodeceptionEventsExtension.php
+++ b/tests/codeception/extensions/CodeceptionEventsExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class CleanupExtension extends \Codeception\Platform\Extension
+class CodeceptionEventsExtension extends \Codeception\Platform\Extension
 {
     /** @var array list events to listen to */
     public static $events = array(


### PR DESCRIPTION
This should (hopefully) now allow acceptance tests to run/pass on `bolt/composer-install` installs