### PR TITLE
Add composer install acceptance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
 
 services:
   - mysql
+  - postgresql
+
+addons:
+  postgresql: "9.3"
 
 before_install:
   - sudo add-apt-repository -y ppa:nginx/stable
@@ -63,6 +67,7 @@ before_script:
   - psql -c "GRANT ALL PRIVILEGES ON DATABASE bolt_travis TO bolt_travis;" -U postgres
 
 script:
+  ## Default install tests
   # PHPUnit
   - phpunit -c phpunit.xml.dist
   # Codeception set up (PHP >5.3)
@@ -75,6 +80,37 @@ script:
   # Codeception PostgreSQL run (PHP >5.3)
   - ./tests/scripts/travis-db-config postgres
   - if [[ $TRAVIS_PHP_VERSION =~ (^5.[456]|^7|^hhvm) ]]; then ./vendor/codeception/codeception/codecept run ; fi
+  ## Composer install test
+  # To enable Composer tests, set RUN_COMPOSER_TEST=true in the web UI at https://travis-ci.org/bolt/bolt/settings/env_vars
+  # - if [[ $RUN_COMPOSER_TEST != true ]] ; then echo "Composer tests disabled. " ; exit 0 ; fi
+  # Remove git installed stuff
+  - rm ./* -rf ; rm .git* -rf
+  # Get the composer.json from our bolt/composer-install repo
+  - git clone https://github.com/bolt/composer-install.git .tmp
+  - cp .tmp/composer.json .
+  # Add requires
+  - composer require --no-update "bolt/bolt:dev-master" "phpunit/phpunit:~4.5" "codeception/codeception:*" lstrojny/phpunit-function-mocker
+  # Create the project
+  - composer create-project --no-interaction --prefer-dist
+  # Set up MySQL
+  - mysql -e "DROP DATABASE bolt_travis;" -u root
+  - mysql -e "CREATE DATABASE IF NOT EXISTS bolt_travis;" -u root
+  - mysql -e "GRANT ALL PRIVILEGES ON bolt_travis.* TO 'bolt_travis'@'localhost';" -u root
+  - mysql -e "FLUSH PRIVILEGES;" -u root
+  # Set up PostgreSQL
+  - psql -c "DROP DATABASE bolt_travis;" -U postgres
+  - psql -c "CREATE DATABASE bolt_travis;" -U postgres
+  - psql -c "GRANT ALL PRIVILEGES ON DATABASE bolt_travis TO bolt_travis;" -U postgres
+  # Codeception set up (PHP >5.3)
+  - if [[ $TRAVIS_PHP_VERSION =~ (^5.[456]|^7|^hhvm) ]]; then ./vendor/codeception/codeception/codecept build  --config ./vendor/bolt/bolt/codeception.yml ; fi
+  # Codeception Sqlite run (PHP >5.3)
+  - if [[ $TRAVIS_PHP_VERSION =~ (^5.[456]|^7|^hhvm) ]]; then ./vendor/codeception/codeception/codecept run --config ./vendor/bolt/bolt/codeception.yml ; fi
+  # Codeception MySQL run (PHP >5.3)
+  - ./vendor/bolt/bolt/tests/scripts/travis-db-config mysql
+  - if [[ $TRAVIS_PHP_VERSION =~ (^5.[456]|^7|^hhvm) ]]; then ./vendor/codeception/codeception/codecept run --config ./vendor/bolt/bolt/codeception.yml ; fi
+  # Codeception PostgreSQL run (PHP >5.3)
+  - ./vendor/bolt/bolt/tests/scripts/travis-db-config postgres
+  - if [[ $TRAVIS_PHP_VERSION =~ (^5.[456]|^7|^hhvm) ]]; then ./vendor/codeception/codeception/codecept run --config ./vendor/bolt/bolt/codeception.yml ; fi
 
 after_script:
 

--- a/tests/scripts/travis-db-config
+++ b/tests/scripts/travis-db-config
@@ -1,5 +1,9 @@
 #!/bin/bash
-pwd
+
+DB_NAME=bolt_travis
+DB_USER=bolt_travis
+DB_PASS=bolt_travis
+
 if [[ $1 != "mysql" && $1 != "postgres" ]] ; then
     echo "This script requires either 'mysql' or 'postgres' as a parameter"
     exit 1
@@ -21,10 +25,10 @@ cat $BOLT/app/config/config.yml.dist > $CONFIGYML
 
 if [[ $1 = "mysql" ]] ; then
     echo "Configuring MySQL in $CONFIGYML"
-    perl -p -i -e "undef $/; s/driver: sqlite\n  databasename: bolt/driver: mysql\n  databasename: bolt_travis\n  username: bolt_travis\n  password: bolt_travis/g" $CONFIGYML
+    perl -p -i -e "undef $/; s/driver: sqlite\n  databasename: bolt/driver: mysql\n  databasename: $DB_NAME\n  username: $DB_USER\n  password: $DB_PASS/g" $CONFIGYML
 elif [[ "$1" = "postgres" ]] ; then
     echo "Configuring PostgreSQL in $CONFIGYML"
-    perl -p -i -e "undef $/; s/driver: sqlite\n  databasename: bolt/driver: postgres\n  databasename: bolt_travis\n  username: bolt_travis\n  password: bolt_travis/g" $CONFIGYML
+    perl -p -i -e "undef $/; s/driver: sqlite\n  databasename: bolt/driver: postgres\n  databasename: $DB_NAME\n  username: $DB_USER\n  password: $DB_PASS/g" $CONFIGYML
 else
     echo "Invalid parameter"
     exit 1


### PR DESCRIPTION
This takes us to:
* Acceptance tests for git **and** Composer install types
* Acceptance tests for all three database platforms, for both install types

I'm going to get some :beers: now.