### PR TITLE
Only log content not found errors if slug isn't numeric, since next it next checks by id.

### DIFF
--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -120,7 +120,7 @@ class Frontend
         $slug = $app['slugify']->slugify($slug);
 
         // First, try to get it by slug.
-        $content = $app['storage']->getContent($contenttype['slug'], array('slug' => $slug, 'returnsingle' => true));
+        $content = $app['storage']->getContent($contenttype['slug'], array('slug' => $slug, 'returnsingle' => true, 'log_not_found' => !is_numeric($slug)));
 
         if (!$content && is_numeric($slug)) {
             // And otherwise try getting it by ID

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1748,6 +1748,12 @@ class Storage
             $parameters = array_merge((array) $parameters, (array) $whereparameters);
         }
 
+        $logNotFound = true;
+        if (isset($parameters['log_not_found'])) {
+            $logNotFound = $parameters['log_not_found'];
+            unset($parameters['log_not_found']);
+        }
+
         // Decode this textquery
         $decoded = $this->decodeContentQuery($textquery, $parameters);
         if ($decoded === false) {
@@ -1799,11 +1805,13 @@ class Storage
                 return util::array_first($results);
             }
 
-            $msg = sprintf(
-                "Requested specific query '%s', not found.",
-                $textquery
-            );
-            $this->app['logger.system']->error($msg, array('event' => 'storage'));
+            if ($logNotFound) {
+                $msg = sprintf(
+                    "Requested specific query '%s', not found.",
+                    $textquery
+                );
+                $this->app['logger.system']->error($msg, array('event' => 'storage'));
+            }
             $this->app['stopwatch']->stop('bolt.getcontent');
 
             return false;


### PR DESCRIPTION
Only log content not found errors if slug isn't numeric, since next it next checks by id.

Fixes first part of #3176