### PR TITLE
Fix Storage not using sort from contenttype

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1510,8 +1510,7 @@ class Storage
             }
 
             if (count($order) == 0) {
-                // we didn't add table, maybe this is an issue
-                $order[] = 'datepublish DESC';
+                $order[] = $this->decodeQueryOrder($contenttype, false) ?: 'datepublish DESC';
             }
 
             if (count($where) > 0) {

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1628,7 +1628,7 @@ class Storage
      *
      * @return array
      */
-    private function executeGetContentSearch($decoded, $parameters)
+    protected function executeGetContentSearch($decoded, $parameters)
     {
         $results = $this->searchContent(
             $parameters['filter'],
@@ -1654,7 +1654,7 @@ class Storage
      *
      * @return array
      */
-    private function executeGetContentQueries($decoded)
+    protected function executeGetContentQueries($decoded)
     {
         // Perform actual queries and hydrate
         $totalResults = false;

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1306,7 +1306,9 @@ class Storage
             }
         }
 
-        if (!isset($metaParameters['limit'])) {
+        if ($decoded['return_single']) {
+            $metaParameters['limit'] = 1;
+        } elseif (!isset($metaParameters['limit'])) {
             $metaParameters['limit'] = 9999;
         }
     }

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -3,10 +3,10 @@ namespace Bolt\Tests\Storage;
 
 use Bolt\Content;
 use Bolt\Events\StorageEvents;
-use Bolt\Exception\StorageException;
 use Bolt\Storage;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Mocks\LoripsumMock;
+use Doctrine\DBAL\Connection;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -181,6 +181,43 @@ class StorageTest extends BoltUnitTest
     {
     }
 
+    public function testGetContentSortOrderFromContentType()
+    {
+        $app = $this->getApp();
+        $app['request'] = Request::create('/');
+        $db = $this->getDbMockBuilder($app['db'])
+            ->setMethods(array('fetchAll'))
+            ->getMock();
+        $app['db'] = $db;
+        $db->expects($this->any())
+            ->method('fetchAll')
+            ->willReturn(array());
+        $storage = new StorageMock($app);
+
+        // Test sorting is pulled from contenttype when not specified
+        $app['config']->set('contenttypes/entries/sort', '-id');
+        $storage->getContent('entries');
+        $this->assertSame('ORDER BY "id" DESC', $storage->queries[0]['queries'][0]['order']);
+    }
+
+    public function testGetContentReturnSingleLimits1()
+    {
+        $app = $this->getApp();
+        $app['request'] = Request::create('/');
+        $db = $this->getDbMockBuilder($app['db'])
+            ->setMethods(array('fetchAll'))
+            ->getMock();
+        $app['db'] = $db;
+        $db->expects($this->any())
+            ->method('fetchAll')
+            ->willReturn(array());
+        $storage = new StorageMock($app);
+
+        // Test returnsingle will set limit to 1
+        $storage->getContent('entries', array('returnsingle' => true));
+        $this->assertSame(1, $storage->queries[0]['parameters']['limit']);
+    }
+
     public function testGetSortOrder()
     {
     }
@@ -227,5 +264,24 @@ class StorageTest extends BoltUnitTest
 
     public function testGetPager()
     {
+    }
+
+    private function getDbMockBuilder(Connection $db)
+    {
+        return $this->getMockBuilder('\Doctrine\DBAL\Connection')
+            ->setConstructorArgs(array($db->getParams(), $db->getDriver(), $db->getConfiguration(), $db->getEventManager()))
+            ->enableOriginalConstructor()
+        ;
+    }
+}
+
+class StorageMock extends Storage
+{
+    public $queries = array();
+
+    protected function executeGetContentQueries($decoded)
+    {
+        $this->queries[] = $decoded;
+        return parent::executeGetContentQueries($decoded);
     }
 }


### PR DESCRIPTION
- Use sort order from contenttype if none is explicitly specified
- Set limit to 1 if returning single.
