### PR TITLE
Fixed ParsedownExtra usage.

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -14,6 +14,7 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 class Content implements \ArrayAccess
 {
     protected $app;
+    protected $parsedown;
     public $id;
     public $values = array();
     public $taxonomy;
@@ -84,6 +85,8 @@ class Content implements \ArrayAccess
 
             $this->setValues($values);
         }
+
+        $this->parsedown = new \ParsedownExtra();
     }
 
     /**
@@ -676,11 +679,11 @@ class Content implements \ArrayAccess
                     $value = $this->preParse($this->values[$name], $allowtwig);
 
                     // Parse the field as Markdown, return HTML
-                    $value = \ParsedownExtra::instance()->text($value);
+                    $value = $this->parsedown->text($value);
 
                     $config = $this->app['config']->get('general/htmlcleaner');
                     $allowed_tags = !empty($config['allowed_tags']) ? $config['allowed_tags'] :
-                        array('div', 'p', 'br', 'hr', 's', 'u', 'strong', 'em', 'i', 'b', 'li', 'ul', 'ol', 'blockquote', 'pre', 'code', 'tt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'dd', 'dl', 'dh', 'table', 'tbody', 'thead', 'tfoot', 'th', 'td', 'tr', 'a', 'img');
+                        array('div', 'p', 'br', 'hr', 's', 'u', 'strong', 'em', 'i', 'b', 'li', 'ul', 'ol', 'blockquote', 'pre', 'code', 'tt', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'dd', 'dl', 'dt', 'table', 'tbody', 'thead', 'tfoot', 'th', 'td', 'tr', 'a', 'img');
                     $allowed_attributes = !empty($config['allowed_attributes']) ? $config['allowed_attributes'] :
                         array('id', 'class', 'name', 'value', 'href', 'src');
 


### PR DESCRIPTION
 Bolt was calling ParsedownExtra in a way that meant it was getting a Parseodown instance and consequently the functionality that ParsedownExtra provides was not made available. Namely definition lists and footnotes.

I've also made sure that the correct definition list tags were included in the allowed tags. Since 'dh' is incorrect and what is needed is 'dt'

Fixes #3195