### PR TITLE
add error messages to the session flash if an upload fails

### DIFF
--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1605,6 +1605,13 @@ class Backend implements ControllerProviderInterface
                                 // Add the file to our stack.
                                 $app['stack']->add($path . "/" . $filename);
                                 $result->confirm();
+                            } else {
+                                foreach ($result->getMessages() as $message) {
+                                    $app['session']->getFlashBag()->add(
+                                        'error',
+                                        $message->__toString()
+                                    );
+                                }
                             }
                         } else {
                             $extensionList = array();


### PR DESCRIPTION
At the moment any upload validation errors go by without being reported to the user.

This only affects uploads from the /bolt/files upload form, ajax uploads via content editing do report the correct error.