### PR TITLE
Set the canonical correctly. Fixes #3201

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -310,7 +310,7 @@ class Application extends Silex\Application
                 substr(Application::DEFAULT_LOCALE, 0, 2)
             ));
         }
-        
+
         setlocale(LC_ALL, array_unique($locale));
 
         $this->register(
@@ -481,7 +481,7 @@ class Application extends Silex\Application
                 if ($this['config']->get('general/canonical')) {
                     $snippet = sprintf(
                         '<link rel="canonical" href="%s">',
-                        htmlspecialchars($this['paths']['canonicalurl'], ENT_QUOTES)
+                        htmlspecialchars($this['resources']->getUrl('canonicalurl'), ENT_QUOTES)
                     );
                     $this['extensions']->insertSnippet(Extensions\Snippets\Location::AFTER_META, $snippet);
                 }
@@ -489,9 +489,9 @@ class Application extends Silex\Application
                 // Perhaps add a favicon.
                 if ($this['config']->get('general/favicon')) {
                     $snippet = sprintf(
-                        '<link rel="shortcut icon" href="//%s%s%s">',
-                        htmlspecialchars($this['paths']['canonical'], ENT_QUOTES),
-                        htmlspecialchars($this['paths']['theme'], ENT_QUOTES),
+                        '<link rel="shortcut icon" href="%s%s%s">',
+                        htmlspecialchars($this['resources']->getUrl('hosturl'), ENT_QUOTES),
+                        htmlspecialchars($this['resources']->getUrl('theme'), ENT_QUOTES),
                         htmlspecialchars($this['config']->get('general/favicon'), ENT_QUOTES)
                     );
                     $this['extensions']->insertSnippet(Extensions\Snippets\Location::AFTER_META, $snippet);

--- a/src/Content.php
+++ b/src/Content.php
@@ -946,6 +946,17 @@ class Content implements \ArrayAccess
         return preg_replace('/^([^?]*).*$/', '\\1', $link);
     }
 
+    /**
+     * Checks if the current record is set as the homepage.
+     */
+    public function isHome()
+    {
+        $homepage = $this->app['config']->get('general/homepage');
+
+        return (($this->contenttype['singular_slug'].'/'.$this->get('id') == $homepage) ||
+           ($this->contenttype['singular_slug'].'/'.$this->get('id') == $homepage));
+    }
+
     protected function getRouteRequirementParams(array $route)
     {
         $params = array();

--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -135,9 +135,17 @@ class Frontend
         // Then, select which template to use, based on our 'cascading templates rules'
         $template = $app['templatechooser']->record($content);
 
-        // Setting the canonical path and the editlink.
         $paths = $app['resources']->getPaths();
-        $app['resources']->setUrl('canonicalurl', sprintf('%s%s', $paths['canonical'], $content->link()));
+
+        // Setting the canonical URL.
+        if ($content->isHome() && ($template == $app['config']->get('general/homepage_template'))) {
+            $app['resources']->setUrl('canonicalurl', $paths['rooturl']);
+        } else {
+            $url = $paths['canonical'] . $content->link();
+            $app['resources']->setUrl('canonicalurl', $url);
+        }
+
+        // Setting the editlink
         $app['editlink'] = Lib::path('editcontent', array('contenttypeslug' => $contenttype['slug'], 'id' => $content->id));
         $app['edittitle'] = $content->getTitle();
 


### PR DESCRIPTION
- Set the canonical correctly for pages like `/entry/12`
- If we're on the homepage record, _and_ it's rendered with the same template, set the canonical to root.