### PR TITLE
Implement a PHPUnit listener

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="./tests/phpunit/unit/bootstrap.php"
+         bootstrap="tests/phpunit/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
@@ -23,13 +23,13 @@
         </listener>
     </listeners>
     <testsuites>
-        <testsuite name="Bolt Test Suite">
-            <directory suffix="Test.php">./tests/phpunit</directory>
+        <testsuite name="unit">
+            <directory>tests/phpunit/unit/</directory>
         </testsuite>
     </testsuites>
     <filter>
         <whitelist>
-            <directory>./src</directory>
+            <directory>src</directory>
         </whitelist>
     </filter>
     <logging>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,14 @@
         <server name="HTTP_HOST" value="bolt.dev" />
         <server name="REQUEST_URI" value="/bolt" />
     </php>
+    <listeners>
+        <listener file="tests/phpunit/BoltListener.php" class="Bolt\Tests\BoltListener">
+           <arguments>
+              <boolean>true</boolean>
+              <boolean>true</boolean>
+           </arguments>
+        </listener>
+    </listeners>
     <testsuites>
         <testsuite name="Bolt Test Suite">
             <directory suffix="Test.php">./tests/phpunit</directory>

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -9,6 +9,9 @@ namespace Bolt\Tests;
  */
 class BoltListener implements \PHPUnit_Framework_TestListener
 {
+    /** @var array */
+    protected $tracker;
+
     /** @var boolean */
     protected $timer;
 
@@ -127,6 +130,8 @@ class BoltListener implements \PHPUnit_Framework_TestListener
      */
     public function endTest(\PHPUnit_Framework_Test $test, $time)
     {
+        $name = $test->getName();
+        $this->tracker[$name] = $time;
     }
 
     /**
@@ -170,12 +175,15 @@ class BoltListener implements \PHPUnit_Framework_TestListener
      */
     private function cleanTestEnv()
     {
-        if (!$this->reset) {
-            return;
+        // Write out a report about each test's execution time
+        if ($this->timer) {
+            file_put_contents(TEST_ROOT . '/app/cache/unit-test-timer.txt', print_r($this->tracker, true));
         }
 
-        if (is_readable(TEST_ROOT . '/bolt.db')) {
-            unlink(TEST_ROOT . '/bolt.db');
+        if ($this->reset) {
+            if (is_readable(TEST_ROOT . '/bolt.db')) {
+                unlink(TEST_ROOT . '/bolt.db');
+            }
         }
     }
 }

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -27,6 +27,8 @@ class BoltListener implements \PHPUnit_Framework_TestListener
     {
         $this->timer = $timer;
         $this->reset = $reset;
+
+        $this->buildTestEnv();
     }
 
     /**
@@ -36,6 +38,7 @@ class BoltListener implements \PHPUnit_Framework_TestListener
      */
     public function __destruct()
     {
+        $this->cleanTestEnv();
     }
 
     /**
@@ -146,5 +149,33 @@ class BoltListener implements \PHPUnit_Framework_TestListener
      */
     public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
     {
+    }
+
+    /**
+     * Build the pre-requisites for our test environment
+     */
+    private function buildTestEnv()
+    {
+        // Make sure we wipe the db file to start with a clean one
+        if (is_readable(TEST_ROOT . '/bolt.db')) {
+            unlink(TEST_ROOT . '/bolt.db');
+        }
+        copy(PHPUNIT_ROOT . '/resources/db/bolt.db', TEST_ROOT . '/bolt.db');
+
+        @mkdir(TEST_ROOT . '/app/cache/', 0777, true);
+    }
+
+    /**
+     * Clean up after test runs
+     */
+    private function cleanTestEnv()
+    {
+        if (!$this->reset) {
+            return;
+        }
+
+        if (is_readable(TEST_ROOT . '/bolt.db')) {
+            unlink(TEST_ROOT . '/bolt.db');
+        }
     }
 }

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Bolt\Tests;
+
+/**
+ * PHPUnit listener class
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class BoltListener implements \PHPUnit_Framework_TestListener
+{
+    /** @var boolean */
+    protected $timer;
+
+    /** @var boolean */
+    protected $reset;
+
+    /**
+     * Called on init of PHPUnit exectution.
+     *
+     * @see PHPUnit_Util_Configuration
+     *
+     * @param boolean $timer Create test execution timer output
+     * @param boolean $reset Reset test environment after run
+     */
+    public function __construct($timer, $reset)
+    {
+        $this->timer = $timer;
+        $this->reset = $reset;
+    }
+
+    /**
+     * Destructor that will be called at the completion of the PHPUnit execution.
+     *
+     * Add code here to clean up our test environment.
+     */
+    public function __destruct()
+    {
+    }
+
+    /**
+     * An error occurred.
+     *
+     * @see PHPUnit_Framework_TestListener::addError()
+     *
+     * @param \PHPUnit_Framework_Test $test
+     * @param \Exception              $e
+     * @param float                   $time
+     */
+    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    /**
+     * A failure occurred.
+     *
+     * @see PHPUnit_Framework_TestListener::addFailure()
+     *
+     * @param \PHPUnit_Framework_Test                 $test
+     * @param \PHPUnit_Framework_AssertionFailedError $e
+     * @param float                                   $time
+     */
+    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
+    {
+    }
+
+    /**
+     * A test was incomplete.
+     *
+     * @see PHPUnit_Framework_TestListener::addIncompleteTest()
+     *
+     * @param \PHPUnit_Framework_Test $test
+     * @param \Exception              $e
+     * @param float                   $time
+     */
+    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    /**
+     * A test  is deemed risky.
+     *
+     * @see PHPUnit_Framework_TestListener::addRiskyTest()
+     *
+     * @param \PHPUnit_Framework_Test $test
+     * @param \Exception              $e
+     * @param float                   $time
+     */
+    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    /**
+     * Test has been skipped.
+     *
+     * @see PHPUnit_Framework_TestListener::addSkippedTest()
+     *
+     * @param \PHPUnit_Framework_Test $test
+     * @param \Exception              $e
+     * @param float                   $time
+     */
+    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+    }
+
+    /**
+     * A test started.
+     *
+     * @see PHPUnit_Framework_TestListener::startTest()
+     *
+     * @param \PHPUnit_Framework_Test $test
+     */
+    public function startTest(\PHPUnit_Framework_Test $test)
+    {
+    }
+
+    /**
+     * A test ended.
+     *
+     * @see PHPUnit_Framework_TestListener::endTest()
+     *
+     * @param \PHPUnit_Framework_Test $test
+     * @param float                   $time
+     */
+    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    {
+    }
+
+    /**
+     * A test suite started.
+     *
+     * @see PHPUnit_Framework_TestListener::startTestSuite()
+     *
+     * @param \PHPUnit_Framework_TestSuite $suite
+     */
+    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    {
+    }
+
+    /**
+     * A test suite ended.
+     *
+     * @see PHPUnit_Framework_TestListener::endTestSuite()
+     *
+     * @param \PHPUnit_Framework_TestSuite $suite
+     */
+    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    {
+    }
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -4,11 +4,10 @@
  * Test bootstrapper. This leaves out all stuff registering services and
  * related to request dispatching.
  */
-global $CLASSLOADER;
 
 // Install base location
 if (!defined('TEST_ROOT')) {
-    define('TEST_ROOT', realpath(__DIR__ . '/../../../'));
+    define('TEST_ROOT', realpath(__DIR__ . '/../../'));
 }
 
 // PHPUnit's base location
@@ -26,16 +25,9 @@ if (!defined('BOLT_AUTOLOAD')) {
     }
 
     // Load the autoloader
+    global $CLASSLOADER;
     $CLASSLOADER = require_once BOLT_AUTOLOAD;
 }
 
 // Load the upload bootstrap
-require_once 'bootstraps/upload-bootstrap.php';
-
-// Make sure we wipe the db file to start with a clean one
-if (is_readable(TEST_ROOT . '/bolt.db')) {
-    unlink(TEST_ROOT . '/bolt.db');
-}
-copy(PHPUNIT_ROOT . '/resources/db/bolt.db', TEST_ROOT . '/bolt.db');
-
-@mkdir(TEST_ROOT . '/app/cache/', 0777, true);
+require_once 'unit/bootstraps/upload-bootstrap.php';

--- a/tests/phpunit/unit/Logger/ChangeLogTest.php
+++ b/tests/phpunit/unit/Logger/ChangeLogTest.php
@@ -16,7 +16,7 @@ class ChangeLogTest extends BoltUnitTest
 {
     public function testSetup()
     {
-        $app = $this->getApp();
+        $this->resetDb();
     }
 
     public function testGetChangelog()

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -16,6 +16,11 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class StorageTest extends BoltUnitTest
 {
+    public function testSetup()
+    {
+        $this->resetDb();
+    }
+
     public function testGetContentObject()
     {
         $app = $this->getApp();


### PR DESCRIPTION
* Allows for set/clean up functionality
* Bootstrap is globalised for suites, arrange it as such
* Generate a (currently) basic report in `/app/cache/phpunit-test-timer.txt` on individual test times:

```php
278.43		Bolt\Tests\Composer\Action\ShowPackageTest::testRootEnquiry
4.4571		Bolt\Tests\Composer\Action\CheckPackageTest::testUpdateCheck
2.9635		Bolt\Tests\Composer\FactoryTest::testFindVersion
2.2779		Bolt\Tests\Controller\BackendTest::testPrefill
1.7578		Bolt\Tests\Composer\Action\CheckPackageTest::testConstruct
1.7444		Bolt\Tests\Composer\Action\CheckPackageTest::testNewlyAdded
0.9341		Bolt\Tests\Composer\Action\UpdatePackageTest::testRun
0.9012		Bolt\Tests\Composer\FactoryTest::testSSLDowngrade
0.8987		Bolt\Tests\Composer\FactoryTest::testGetComposer
0.8855		Bolt\Tests\Composer\FactoryTest::testGetOutput
0.8810		Bolt\Tests\Translation\TranslationFileTest::testContentMessages
0.8594		Bolt\Tests\Composer\FactoryTest::testConstruct
0.8542		Bolt\Tests\Composer\FactoryTest::testResetComposer
0.8504		Bolt\Tests\Composer\FactoryTest::testGetIo
0.8426		Bolt\Tests\Composer\Action\InstallPackageTest::testRun
0.8151		Bolt\Tests\Composer\Action\SearchPackageTest::testRun
0.8020		Bolt\Tests\Composer\Action\ShowPackageTest::testAvailable
0.6955		Bolt\Tests\Translation\TranslationFileTest::testContent
0.6617		Bolt\Tests\Controller\ExtendControllerTest::testMethodsReturnTemplates
```