### PR TITLE
Nicer 'sub menu' for "Other content". Fixes #3120.

### DIFF
--- a/app/view/twig/nav/_secondary-content.twig
+++ b/app/view/twig/nav/_secondary-content.twig
@@ -1,6 +1,6 @@
 {% set sub_hide = [] %}
 
-{% for slug, contenttype in app.config.get('contenttypes') %}
+{% for slug, contenttype in app.config.get('contenttypes')  %}
     {% if isallowed('contenttype:' ~ slug) %}
         {% set sub_view = {
             icon: contenttype.icon_many|default(contenttype.show_in_menu ? 'fa:files-o' : 'fa:th-list'),
@@ -37,11 +37,17 @@
         {# Contenttypes, where show_in_menu is set false #}
         {% else %}
 
-            {% set sub_hide = sub_hide|merge(sub) %}
+            {% set sub_view = {
+                icon: contenttype.icon_many|default(contenttype.show_in_menu ? 'fa:files-o' : 'fa:th-list'),
+                label: __(['contenttypes', contenttype.slug, 'name', 'plural'], {DEFAULT: contenttype.name}),
+                link: path('overview', {'contenttypeslug': slug})
+            } %}
+
+            {% set sub_hide = sub_hide|merge([sub_view]) %}
 
         {% endif %}
     {% endif %}
 {% endfor %}
 
 {# Display contenttypes, that have show_in_menu set to false in a submenu #}
-{{ nav.submenu('fa:th-list', __('Other contenttypes'), sub_hide) }}
+{{ nav.submenu('fa:th-list', __('Other content'), sub_hide) }}


### PR DESCRIPTION
We _almost_ had this functionality in core already, using the `show_in_menu: false` option in `contenttypes.yml`. This PR cleans it up a bit. 

Before: 

![screen shot 2015-03-23 at 18 34 28](https://cloud.githubusercontent.com/assets/1833361/6786356/0b8228b0-d18c-11e4-88a9-1b919b6ca9ad.png)

After: 

![screen shot 2015-03-23 at 18 34 08](https://cloud.githubusercontent.com/assets/1833361/6786365/106dda54-d18c-11e4-855b-b43c17756254.png)
