### PR TITLE
Fix typo/copy paste oopsie in homepage test

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -954,7 +954,7 @@ class Content implements \ArrayAccess
         $homepage = $this->app['config']->get('general/homepage');
 
         return (($this->contenttype['singular_slug'].'/'.$this->get('id') == $homepage) ||
-           ($this->contenttype['singular_slug'].'/'.$this->get('id') == $homepage));
+           ($this->contenttype['singular_slug'].'/'.$this->get('slug') == $homepage));
     }
 
     protected function getRouteRequirementParams(array $route)


### PR DESCRIPTION
This is a fix for the fix (#3214) for #3201 

https://github.com/bolt/bolt/commit/9ed06a0f7aba358dbd7646db93f8a4dbfb87ffa9#diff-41eef01f213bbe09b595d7594b6f199dR956

Was checking `[singular_slug] / [id]` twice instead of `||`ing with `[slug]`