### PR TITLE
Codeception speed tweaks

### DIFF
--- a/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
+++ b/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
@@ -13,6 +13,9 @@ class BackendAdminCest
     /** @var array */
     protected $user;
 
+    /** @var array */
+    private $cookies = array('bolt_authtoken' => '', 'bolt_session' => '');
+
     /**
      * @param \AcceptanceTester $I
      */
@@ -38,6 +41,9 @@ class BackendAdminCest
         $I->wantTo('log into the backend as Admin');
 
         $I->loginAs($this->user['admin']);
+        $this->cookies['bolt_authtoken'] = $I->grabCookie('bolt_authtoken');
+        $this->cookies['bolt_session'] = $I->grabCookie('bolt_session');
+
         $I->see('Dashboard');
         $I->see('Configuration', Locator::href('/bolt/users'));
         $I->see("You've been logged on successfully.");
@@ -52,8 +58,11 @@ class BackendAdminCest
     {
         $I->wantTo("Create a 'editor' user");
 
-        $I->loginAs($this->user['admin']);
-        $I->click('Users');
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/users');
+
         $I->click('Add a new user', Locator::href('/bolt/users/edit/'));
         $I->see('Create a new user account');
 
@@ -83,8 +92,11 @@ class BackendAdminCest
     {
         $I->wantTo("Create a 'manager' user");
 
-        $I->loginAs($this->user['admin']);
-        $I->click('Users');
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/users');
+
         $I->click('Add a new user', Locator::href('/bolt/users/edit/'));
         $I->see('Create a new user account');
 
@@ -114,8 +126,11 @@ class BackendAdminCest
     {
         $I->wantTo("Create a 'developer' user");
 
-        $I->loginAs($this->user['admin']);
-        $I->click('Users');
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/users');
+
         $I->click('Add a new user', Locator::href('/bolt/users/edit/'));
         $I->see('Create a new user account');
 
@@ -144,7 +159,10 @@ class BackendAdminCest
     public function editConfigTest(\AcceptanceTester $I)
     {
         $I->wantTo("edit config.yml and set 'canonical', 'notfound' and 'changelog'");
-        $I->loginAs($this->user['admin']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/file/edit/config/config.yml');
 
         $yaml = $I->getUpdatedConfig();
@@ -167,7 +185,11 @@ class BackendAdminCest
         $I->wantTo("edit contenttypes.yml and add a 'Resources' Contenttype");
         $I->loginAs($this->user['admin']);
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/file/edit/config/contenttypes.yml');
+
         $yaml = $I->getUpdatedContenttypes();
         $I->fillField('#form_contents', $yaml);
         $I->click('Save');
@@ -185,8 +207,10 @@ class BackendAdminCest
     public function updateDatabaseTest(\AcceptanceTester $I)
     {
         $I->wantTo("update the database and add the new 'Resources' Contenttype");
-        $I->loginAs($this->user['admin']);
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/dbcheck');
 
         $I->see('The database needs to be updated/repaired');
@@ -207,12 +231,15 @@ class BackendAdminCest
     public function addNotFoundRecordTest(\AcceptanceTester $I)
     {
         $I->wantTo("create a 404 'not-found' record");
-        $I->loginAs($this->user['admin']);
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/editcontent/resources');
+
         $I->see('New Resource', 'h1');
 
-        $body = \file_get_contents(CODECEPTION_DATA . '/not-found.body.html');
+        $body = file_get_contents(CODECEPTION_DATA . '/not-found.body.html');
 
         $I->fillField('#title', '404');
         $I->fillField('#slug',  'not-found');
@@ -233,8 +260,11 @@ class BackendAdminCest
     public function viewAllContenttypesTest(\AcceptanceTester $I)
     {
         $I->wantTo('make sure the admin user can view all content types');
-        $I->loginAs($this->user['admin']);
-        $I->click('Dashboard');
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt');
 
         // Pages
         $I->see('Pages',      Locator::href('/bolt/overview/pages'));
@@ -265,7 +295,10 @@ class BackendAdminCest
     public function editPermissionsTest(\AcceptanceTester $I)
     {
         $I->wantTo('edit permissions.yml and restrict access to certain Contenttypes');
-        $I->loginAs($this->user['admin']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/file/edit/config/permissions.yml');
 
         $yaml = $I->getUpdatedPermissions();
@@ -284,7 +317,10 @@ class BackendAdminCest
     public function editTaxonomyTest(\AcceptanceTester $I)
     {
         $I->wantTo('edit taxonomy.yml and reorder category options');
-        $I->loginAs($this->user['admin']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/file/edit/config/taxonomy.yml');
 
         $yaml = $I->getUpdatedTaxonomy();
@@ -303,7 +339,10 @@ class BackendAdminCest
     public function editMenuTest(\AcceptanceTester $I)
     {
         $I->wantTo('edit menu.yml and reorder category options');
-        $I->loginAs($this->user['admin']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/file/edit/config/menu.yml');
 
         $yaml = $I->getUpdatedMenu();
@@ -323,7 +362,10 @@ class BackendAdminCest
     public function editRoutingTest(\AcceptanceTester $I)
     {
         $I->wantTo('edit routing.yml and add a pagebinding route');
-        $I->loginAs($this->user['admin']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/file/edit/config/routing.yml');
 
         $yaml = $I->getUpdatedRouting();
@@ -344,7 +386,10 @@ class BackendAdminCest
     public function checkSystemLogTest(\AcceptanceTester $I)
     {
         $I->wantTo('use the system log interface.');
-        $I->loginAs($this->user['admin']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/systemlog');
 
         // Layout
@@ -369,7 +414,10 @@ class BackendAdminCest
     public function checkChangeLogTest(\AcceptanceTester $I)
     {
         $I->wantTo('use the change log interface.');
-        $I->loginAs($this->user['admin']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/changelog');
 
         // Layout
@@ -393,7 +441,10 @@ class BackendAdminCest
     public function clearCacheTest(\AcceptanceTester $I)
     {
         $I->wantTo('flush the cache.');
-        $I->loginAs($this->user['admin']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/clearcache');
 
         $I->see('Deleted');
@@ -410,8 +461,10 @@ class BackendAdminCest
     {
         $I->wantTo('log out of the backend as Admin');
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt');
-        $I->loginAs($this->user['admin']);
 
         $I->see('Dashboard');
         $I->click('Logout');

--- a/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
+++ b/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
@@ -13,6 +13,9 @@ class BackendEditorCest
     /** @var array */
     protected $user;
 
+    /** @var array */
+    private $cookies = array('bolt_authtoken' => '', 'bolt_session' => '');
+
     /**
      * @param \AcceptanceTester $I
      */
@@ -36,7 +39,11 @@ class BackendEditorCest
     public function loginEditorTest(\AcceptanceTester $I)
     {
         $I->wantTo("Login as 'editor' user");
+
         $I->loginAs($this->user['editor']);
+        $this->cookies['bolt_authtoken'] = $I->grabCookie('bolt_authtoken');
+        $this->cookies['bolt_session'] = $I->grabCookie('bolt_session');
+
         $I->see('Dashboard');
     }
 
@@ -48,7 +55,11 @@ class BackendEditorCest
     public function viewMenusTest(\AcceptanceTester $I)
     {
         $I->wantTo('make sure the page editor user can only see certain menus');
-        $I->loginAs($this->user['editor']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt');
 
         $I->see('View Pages');
         $I->see('New Page');
@@ -78,7 +89,12 @@ class BackendEditorCest
     public function createRecordsTest(\AcceptanceTester $I)
     {
         $I->wantTo("Create and edit Pages as the 'editor' user");
-        $I->loginAs($this->user['editor']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt');
+
         $I->see('New Page');
 
         $I->click('New Page');
@@ -105,9 +121,11 @@ class BackendEditorCest
     public function checkCreateRecordsEventTest(\AcceptanceTester $I)
     {
         $I->wantTo("Check the PRE_SAVE & POST_SAVE StorageEvent triggered correctly on create");
-        $I->loginAs($this->user['editor']);
 
-        $I->amOnPage('/bolt/editcontent/pages/1');
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/editcontent/pages/1');
 
         $I->seeInField('#title',  'A PAGE I MADE');
         $I->see('Snuck in to teaser during PRE_SAVE on create');
@@ -122,9 +140,11 @@ class BackendEditorCest
     public function deniedPublishPagesTest(\AcceptanceTester $I)
     {
         $I->wantTo("be denied permission to publish Pages as the 'editor' user");
-        $I->loginAs($this->user['editor']);
 
-        $I->amOnPage('/bolt/editcontent/pages/1');
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/editcontent/pages/1');
 
         $I->see('Actions for this Page');
 
@@ -151,9 +171,11 @@ class BackendEditorCest
     public function checkSaveRecordsEventTest(\AcceptanceTester $I)
     {
         $I->wantTo("Check the PRE_SAVE & POST_SAVE StorageEvent triggered correctly on save");
-        $I->loginAs($this->user['editor']);
 
-        $I->amOnPage('/bolt/editcontent/pages/1');
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/editcontent/pages/1');
 
         $I->seeInField('#title',  'A Page I Made');
         $I->see('Added to teaser during PRE_SAVE on save');
@@ -168,8 +190,12 @@ class BackendEditorCest
     public function deniedEditEntriesTest(\AcceptanceTester $I)
     {
         $I->wantTo("be denied permission to edit Entries as the 'editor' user");
-        $I->loginAs($this->user['editor']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/editcontent/entries/');
+
         $I->see('You do not have the right privileges');
     }
 
@@ -181,9 +207,13 @@ class BackendEditorCest
     public function createAboutPageTest(\AcceptanceTester $I)
     {
         $I->wantTo("Create an 'About' page as the 'editor' user");
-        $I->loginAs($this->user['editor']);
-        $I->see('New Page');
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt');
+
+        $I->see('New Page');
         $I->click('New Page');
 
         $teaser = file_get_contents(CODECEPTION_DATA . '/about.teaser.html');

--- a/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
+++ b/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
@@ -13,6 +13,9 @@ class BackendDeveloperCest
     /** @var array */
     protected $user;
 
+    /** @var array */
+    private $cookies = array('bolt_authtoken' => '', 'bolt_session' => '');
+
     /**
      * @param \AcceptanceTester $I
      */
@@ -36,7 +39,11 @@ class BackendDeveloperCest
     public function loginDeveloperTest(\AcceptanceTester $I)
     {
         $I->wantTo("Login as 'developer' user");
+
         $I->loginAs($this->user['developer']);
+        $this->cookies['bolt_authtoken'] = $I->grabCookie('bolt_authtoken');
+        $this->cookies['bolt_session'] = $I->grabCookie('bolt_session');
+
         $I->see('Dashboard');
     }
 
@@ -48,8 +55,10 @@ class BackendDeveloperCest
     public function fileManagementUploadedFilesTest(\AcceptanceTester $I)
     {
         $I->wantTo("Use the 'File management -> Uploaded Files' interface as the 'developer' user");
-        $I->loginAs($this->user['developer']);
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/files');
 
         $file = 'blur-flowers-home-1093.jpg';
@@ -72,8 +81,10 @@ class BackendDeveloperCest
     public function fileManagementViewEditTemplatesTest(\AcceptanceTester $I)
     {
         $I->wantTo("Use the 'File management -> View / edit templates' interface as the 'developer' user");
-        $I->loginAs($this->user['developer']);
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/files/theme');
 
         // Inspect the landing page
@@ -105,10 +116,13 @@ class BackendDeveloperCest
     public function editTemplateTest(\AcceptanceTester $I)
     {
         $I->wantTo("See that the 'developer' user can edit and save the _footer.twig template file.");
-        $I->loginAs($this->user['developer']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/file/edit/theme/base-2014/_footer.twig');
 
         // Put _footer.twig into edit mode
-        $I->amOnPage('bolt/file/edit/theme/base-2014/_footer.twig');
         $I->see('<footer class="large-12 columns">', 'textarea');
 
         // Edit the field
@@ -127,10 +141,13 @@ class BackendDeveloperCest
     public function editTranslationsMessages(\AcceptanceTester $I)
     {
         $I->wantTo("See that the 'developer' user can edit and save a translation.");
-        $I->loginAs($this->user['developer']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/tr');
 
         // Go into edit mode
-        $I->amOnPage('bolt/tr');
         $I->see('contenttypes.general.choose-an-entry', 'textarea');
 
         // Edit the field
@@ -149,10 +166,13 @@ class BackendDeveloperCest
     public function editTranslationsLongMessages(\AcceptanceTester $I)
     {
         $I->wantTo("See that the 'developer' user can edit translation long messages.");
-        $I->loginAs($this->user['developer']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/tr/infos');
 
         // Go into edit mode
-        $I->amOnPage('bolt/tr/infos');
         $I->see('Use this field to upload a photo or image', 'textarea');
 
         // Save it
@@ -168,10 +188,13 @@ class BackendDeveloperCest
     public function editTranslationsContenttypeMessages(\AcceptanceTester $I)
     {
         $I->wantTo("See that the 'developer' user can edit translation Contenttype messages.");
-        $I->loginAs($this->user['developer']);
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/tr/contenttypes');
 
         // Go into edit mode
-        $I->amOnPage('bolt/tr/contenttypes');
         $I->see('contenttypes.entries.text.recent-changes-one', 'textarea');
 
         // Save it
@@ -187,9 +210,12 @@ class BackendDeveloperCest
     public function viewInstalledExtensions(\AcceptanceTester $I)
     {
         $I->wantTo("See that the 'developer' user can view installed extensions.");
-        $I->loginAs($this->user['developer']);
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/extend');
+
         $I->see('Currently Installed Extensions', 'h2');
         $I->see('Install a new Extension',        'h2');
         $I->see('Run update check',               'a');
@@ -205,8 +231,10 @@ class BackendDeveloperCest
     public function configureInstalledExtensions(\AcceptanceTester $I)
     {
         $I->wantTo("See that the 'developer' user can configure installed extensions.");
-        $I->loginAs($this->user['developer']);
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/files/config/extensions');
 
         $I->see('tester-events.bolt.yml', Locator::href("/bolt/file/edit/config/extensions/tester-events.bolt.yml"));

--- a/tests/codeception/acceptance/103-BackendManager/BackendManagerCest.php
+++ b/tests/codeception/acceptance/103-BackendManager/BackendManagerCest.php
@@ -12,6 +12,9 @@ class BackendManagerCest
     /** @var array */
     protected $user;
 
+    /** @var array */
+    private $cookies = array('bolt_authtoken' => '', 'bolt_session' => '');
+
     /**
      * @param \AcceptanceTester $I
      */
@@ -35,7 +38,11 @@ class BackendManagerCest
     public function loginManagerTest(\AcceptanceTester $I)
     {
         $I->wantTo("Login as 'manager' user");
+
         $I->loginAs($this->user['manager']);
+        $this->cookies['bolt_authtoken'] = $I->grabCookie('bolt_authtoken');
+        $this->cookies['bolt_session'] = $I->grabCookie('bolt_session');
+
         $I->see('Dashboard');
     }
 
@@ -47,8 +54,10 @@ class BackendManagerCest
     public function publishAboutPageTest(\AcceptanceTester $I)
     {
         $I->wantTo("Publish the 'About' page as 'manager' user");
-        $I->loginAs($this->user['manager']);
 
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
         $I->amOnPage('bolt/editcontent/pages/2');
 
         $I->see("Easy for editors, and a developer's dream cms");

--- a/tests/codeception/extensions/CodeceptionEventsExtension.php
+++ b/tests/codeception/extensions/CodeceptionEventsExtension.php
@@ -143,6 +143,9 @@ class CodeceptionEventsExtension extends \Codeception\Platform\Extension
 
         // Empty the cache
         system('php ' . NUT_PATH . ' cache:clear');
+
+        // Turn up Twig's anger ratio
+        system('php ' . NUT_PATH . ' config:set strict_variables true');
     }
 
     /**


### PR DESCRIPTION
* Only login Codeception users once per user class run
  * Local acceptance tests dropped from an average of 103 seconds to ~55 seconds per run
* Turn up Twig's anger ratio on acceptance tests (strict_variables: true)