### PR TITLE
Add experimental Nut commands for database import/export

### DIFF
--- a/src/Nut/DatabaseExport.php
+++ b/src/Nut/DatabaseExport.php
@@ -7,6 +7,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
  * Nut database exporter command
@@ -36,10 +38,43 @@ class DatabaseExport extends BaseCommand
             }
         }
 
+        // Check if export file can be created
         $file = $input->getOption('file');
+        if (!$this->isFileWriteable($file, $output)) {
+            return;
+        }
+
+
         $contenttype = $input->getOption('contenttype');
 
         $contenttype = join(' ', $contenttype);
         $output->writeln("<info>Database exported to $file: $contenttype</info>");
+    }
+
+    /**
+     * Check/create target export file
+     *
+     * @param string          $file
+     * @param OutputInterface $output
+     *
+     * @return boolean
+     */
+    private function isFileWriteable($file, OutputInterface $output)
+    {
+        $fs = new Filesystem();
+
+        if ($fs->exists($file)) {
+            $output->writeln("<error>Specified export file '$file' already exists! Aborting export.</error>");
+            return false;
+        }
+
+        try {
+            $fs->touch($file);
+        } catch (IOException $e) {
+            $output->writeln("<error>Specified export file '$file' can not be created! Aborting export.</error>");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Nut/DatabaseExport.php
+++ b/src/Nut/DatabaseExport.php
@@ -3,12 +3,11 @@
 namespace Bolt\Nut;
 
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Yaml\Dumper;
 
@@ -61,7 +60,7 @@ class DatabaseExport extends BaseCommand
         }
 
         // Export each Contenttype's records to the export file
-        foreach ($this->contenttypes as $contenttype){
+        foreach ($this->contenttypes as $contenttype) {
             $this->exportContenttype($contenttype, $file, $output);
         }
 

--- a/src/Nut/DatabaseExport.php
+++ b/src/Nut/DatabaseExport.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut database exporter command
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class DatabaseExport extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('database:export')
+            ->setDescription('Export the database records to YAML file')
+            ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
+            ->addOption('contenttype',    'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'One or more contenttypes to export records for.')
+            ->addOption('file',           'f', InputOption::VALUE_REQUIRED, 'A YAML file to use for export data. Must end with .yml or .yaml');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getOption('no-interaction')) {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion('Continue with this action? ', false);
+
+            if (!$helper->ask($input, $output, $question)) {
+                return;
+            }
+        }
+
+        $file = $input->getOption('file');
+        $contenttype = $input->getOption('contenttype');
+
+        $contenttype = join(' ', $contenttype);
+        $output->writeln("<info>Database exported to $file: $contenttype</info>");
+    }
+}

--- a/src/Nut/DatabaseExport.php
+++ b/src/Nut/DatabaseExport.php
@@ -25,7 +25,7 @@ class DatabaseExport extends BaseCommand
     {
         $this
             ->setName('database:export')
-            ->setDescription('Export the database records to YAML file')
+            ->setDescription('[EXPERIMENTAL] Export the database records to YAML file')
             ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
             ->addOption('contenttypes',   'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'One or more contenttypes to export records for.')
             ->addOption('file',           'f', InputOption::VALUE_REQUIRED, 'A YAML file to use for export data. Must end with .yml or .yaml');
@@ -33,6 +33,9 @@ class DatabaseExport extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // Warn that this is experimental
+        $output->writeln("<error>\n\nWARNING THIS IS AN EXPERIMENTAL FEATURE\n</error>");
+
         if (!$input->getOption('no-interaction')) {
             $helper = $this->getHelper('question');
             $question = new ConfirmationQuestion('Continue with this action? ', false);

--- a/src/Nut/DatabaseExport.php
+++ b/src/Nut/DatabaseExport.php
@@ -53,6 +53,11 @@ class DatabaseExport extends BaseCommand
             return;
         }
 
+        // If no Contenttypes were passed in, grab 'em all
+        if (empty($contenttypes)) {
+            $this->contenttypes = $this->app['storage']->getContentTypes();
+        }
+
         $contenttypes = join(' ', $contenttypes);
         $output->writeln("<info>Database exported to $file: $contenttypes</info>");
     }

--- a/src/Nut/DatabaseExport.php
+++ b/src/Nut/DatabaseExport.php
@@ -44,6 +44,9 @@ class DatabaseExport extends BaseCommand
 
         // Check if export file can be created
         $file = $input->getOption('file');
+            if (empty($file)) {
+            throw new \RuntimeException('The --file option is required.');
+        }
         if (!$this->isFileWriteable($file, $output)) {
             return;
         }

--- a/src/Nut/DatabaseImport.php
+++ b/src/Nut/DatabaseImport.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut database importer command
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class DatabaseImport extends BaseCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('database:import')
+            ->setDescription('Import database records from a YAML file')
+            ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
+            ->addOption('file',           'f', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A YAML file to use for import data. Must end with .yml or .yaml');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getOption('no-interaction')) {
+            $helper = $this->getHelper('question');
+            $output->writeln('<error>WARNING: This will import records from the given YAML file into the database!</error>');
+            $question = new ConfirmationQuestion('Continue with this action? ', false);
+
+            if (!$helper->ask($input, $output, $question)) {
+                return;
+            }
+        }
+
+        $file = $input->getOption('file');
+
+        $output->writeln("<info>Database imported from $file</info>");
+    }
+}

--- a/src/Nut/DatabaseImport.php
+++ b/src/Nut/DatabaseImport.php
@@ -29,13 +29,16 @@ class DatabaseImport extends BaseCommand
     {
         $this
             ->setName('database:import')
-            ->setDescription('Import database records from a YAML file')
+            ->setDescription('[EXPERIMENTAL] Import database records from a YAML file')
             ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
             ->addOption('file',           'f', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A YAML file to use for import data. Must end with .yml or .yaml');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        // Warn that this is experimental
+        $output->writeln("<error>\n\nWARNING THIS IS AN EXPERIMENTAL FEATURE\n</error>");
+
         $files = $input->getOption('file');
         if (empty($files)) {
             throw new \RuntimeException('The --files option is required.');

--- a/src/Nut/DatabaseImport.php
+++ b/src/Nut/DatabaseImport.php
@@ -4,16 +4,13 @@ namespace Bolt\Nut;
 
 use Bolt\Helpers\Arr;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Yaml\Dumper;
-use Symfony\Component\Yaml\Parser;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Yaml\Parser;
 
 /**
  * Nut database importer command

--- a/src/Nut/DatabaseImport.php
+++ b/src/Nut/DatabaseImport.php
@@ -37,6 +37,9 @@ class DatabaseImport extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $files = $input->getOption('file');
+        if (empty($files)) {
+            throw new \RuntimeException('The --files option is required.');
+        }
 
         // Check passed files are all valid
         if (!$this->isFilesValid($files, $output)) {

--- a/src/Nut/DatabaseImport.php
+++ b/src/Nut/DatabaseImport.php
@@ -58,9 +58,43 @@ class DatabaseImport extends BaseCommand
             }
         }
 
+        // Check the contenttypes for the requested import
+        if (!$this->isContenttypesValid($output)) {
+            return;
+        }
+
 
         $filenames = join(', ', $files);
         $output->writeln("<info>Database imported from $filenames</info>");
+    }
+
+    /**
+     * Check Contenttype in the import files exists
+     *
+     * @param string          $contenttype
+     * @param OutputInterface $output
+     *
+     * @return array|null
+     */
+    private function isContenttypesValid($output)
+    {
+        foreach ($this->yaml as $file => $data) {
+            if (!is_array($data)) {
+                $output->writeln("<error>File '$file' has malformed Contenttype import data!</error>");
+                return false;
+            }
+
+            foreach (array_keys($data) as $contenttypeslug) {
+                $contenttype = $this->app['storage']->getContentType($contenttypeslug);
+
+                if (empty($contenttype)) {
+                    $output->writeln("<error>File '$file' has invalid contenttype '$contenttypeslug'!</error>");
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -35,6 +35,8 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\LogTrim($app),
                     new Nut\LogClear($app),
                     new Nut\DatabaseCheck($app),
+                    new Nut\DatabaseExport($app),
+                    new Nut\DatabaseImport($app),
                     new Nut\DatabasePrefill($app),
                     new Nut\DatabaseRepair($app),
                     new Nut\TestRunner($app),


### PR DESCRIPTION
* Fixes #3241
* Make the experimental nature of Nut import/export clear
* Will skip records with duplicate slugs
* Should be moved into Bolt\Database class once final approach is agreed upon

Import/Export files must have the `.yml` or `.yaml` extension and use the format:
```yaml
pages:
  - title: Home
    slug: home
    content: Blah blah blah
  - title: Contact Us
    slug: contact
    content: Blah blah blah

entries:
  - title: A Very Important Blog Post
    slug: most-important
    content: This must be on every site install
```

### Changelog
* Added: [Experimental] Ability to import and export Contenttype records via Nut
