### PR TITLE
Allow 'name' in contenttype to override translation, for 2.1.x

### DIFF
--- a/app/view/twig/nav/_secondary-content.twig
+++ b/app/view/twig/nav/_secondary-content.twig
@@ -2,14 +2,18 @@
 
 {% for slug, contenttype in app.config.get('contenttypes')  %}
     {% if isallowed('contenttype:' ~ slug) %}
+
+        {% set label_plural = __(['contenttypes', contenttype.name|default('contenttype.slug'), 'name', 'plural'], {DEFAULT: contenttype.name}) %}
+        {% set label_singular = __(['contenttypes', contenttype.name|default('contenttype.slug'), 'name', 'singular'], {DEFAULT: contenttype.singular_name}) %}
+
         {% set sub_view = {
             icon: contenttype.icon_many|default(contenttype.show_in_menu ? 'fa:files-o' : 'fa:th-list'),
-            label: __('contenttypes.generic.view', {'%contenttypes%': contenttype.slug}),
+            label: __('contenttypes.generic.view', {'%contenttypes%': label_plural}),
             link: path('overview', {'contenttypeslug': slug})
         } %}
         {% set sub_new = {
             icon: 'fa:plus',
-            label: __('contenttypes.generic.new', {'%contenttype%': slug}),
+            label: __('contenttypes.generic.new', {'%contenttype%': label_singular}),
             link: path('editcontent', {'contenttypeslug': slug}),
             isallowed: 'contenttype:' ~ slug ~ ':create'
         } %}
@@ -29,10 +33,9 @@
                 ]) %}
             {% endfor %}
 
-            {% set label = __(['contenttypes', contenttype.slug, 'name', 'plural'], {DEFAULT: contenttype.name}) %}
             {% set active = (page_nav == 'Content/*' and context.contenttype.slug|default == slug) %}
 
-            {{ nav.submenu(contenttype.icon_many|default(''), label, sub, active, true) }}
+            {{ nav.submenu(contenttype.icon_many|default(''), label_plural, sub, active, true) }}
 
         {# Contenttypes, where show_in_menu is set false #}
         {% else %}


### PR DESCRIPTION
A 2.1.x version of #3239