### PR TITLE
Fix CKeditor autoGrow scroll bug by parsing value as int

### DIFF
--- a/app/src/js/modules/ckeditor.js
+++ b/app/src/js/modules/ckeditor.js
@@ -200,7 +200,7 @@
 
             // Set height
             if (param.height) {
-                config.height = param.height;
+                config.height = parseInt(param.height);
                 // Adjust autogrow values if heigth is out of range
                 config.autoGrow_minHeight = Math.max(config.autoGrow_minHeight, config.height);
                 config.autoGrow_maxHeight = Math.max(config.autoGrow_maxHeight, config.height);


### PR DESCRIPTION
This bug is mentioned in as an aside in #3256

Example configs and documentation establish a standard of having the px unit, for example
```
        html:
            type: html
            height: 150px
```
We need to parse this value as an int to avoid unexpected NaN values.

NaN value in this case prevents CKeditor from autoGrowing properly and results in a missing scrollbar.

something about m&ms