### PR TITLE
Fix #3256: ensure CKEditor fields save when changed

### DIFF
--- a/app/src/js/modules/editcontent.js
+++ b/app/src/js/modules/editcontent.js
@@ -382,7 +382,11 @@
      */
     function watchChanges() {
         $('form#editcontent').find('input, textarea, select').each(function () {
-            if (this.type !== 'textarea' || !$(this).hasClass('ckeditor')) {
+            if (this.type === 'textarea' && $(this).hasClass('ckeditor')) {
+                if (ckeditor.instances[this.id].checkDirty()) {
+                    ckeditor.instances[this.id].updateElement();
+                }
+            }else{
                 var val = getComparable(this);
                 if (val !== undefined) {
                     $(this).data('watch', val);


### PR DESCRIPTION
This fixes the primary bug reported in #3256

The underlying textarea used by CKEditor wasn't being updated when changes were made.