### PR TITLE
Reset dirty check after updating ckeditor field. Fixes #3256

### DIFF
--- a/app/src/js/modules/editcontent.js
+++ b/app/src/js/modules/editcontent.js
@@ -385,6 +385,7 @@
             if (this.type === 'textarea' && $(this).hasClass('ckeditor')) {
                 if (ckeditor.instances[this.id].checkDirty()) {
                     ckeditor.instances[this.id].updateElement();
+                    ckeditor.instances[this.id].resetDirty();
                 }
             }else{
                 var val = getComparable(this);


### PR DESCRIPTION
This fixes the remaining issue reported by @EJanuszewski on #3256 where templatefields of `type: html` would cause the page navigation confirmation to display despite having saved.