### PR TITLE
Guzzle 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "ext-pdo" : "*",
         "filp/whoops" : "~1.1",
         "guzzle/guzzle" : "~3.9",
+        "guzzlehttp/guzzle": "~3.9|~5.2",
         "hautelook/phpass" : "~0.3",
         "ircmaxell/random-lib" : "~1.1",
         "monolog/monolog" : "~1.12",

--- a/src/Application.php
+++ b/src/Application.php
@@ -33,6 +33,9 @@ class Application extends Silex\Application
         $values['bolt_name'] = 'alpha';
         $values['bolt_released'] = false; // `true` for stable releases, `false` for alpha, beta and RC.
 
+        /** @internal Parameter to track a deprecated PHP version */
+        $values['deprecated.php'] = version_compare(PHP_VERSION, '5.4.0', '<');
+
         parent::__construct($values);
 
         $this->register(new PathServiceProvider());

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -546,7 +546,11 @@ class PackageManager
 
         try {
             /** @var $response \Guzzle\Http\Message\Response  */
-            $response = $this->app['guzzle.client']->head($uri, null, array('query' => $query))->send();
+            if ($this->app['deprecated.php']) {
+                $response = $this->app['guzzle.client']->head($uri, null, array('query' => $query))->send();
+            } else {
+                $response = $this->app['guzzle.client']->head($uri, [], ['query' => $query]);
+            }
 
             return $response->getStatusCode();
         } catch (CurlException $e) {

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -133,7 +133,12 @@ class Async implements ControllerProviderInterface
             }
 
             try {
-                $fetchedNewsData = $app['guzzle.client']->get($url, null, $curlOptions)->send()->getBody(true);
+                if ($app['deprecated.php']) {
+                    $fetchedNewsData = $app['guzzle.client']->get($url, null, $curlOptions)->send()->getBody(true);
+                } else {
+                    $fetchedNewsData = $app['guzzle.client']->get($url, [], $curlOptions)->getBody(true);
+                }
+
                 $fetchedNewsItems = json_decode($fetchedNewsData);
                 if ($fetchedNewsItems) {
                     $news = array();

--- a/src/Provider/GuzzleServiceProvider.php
+++ b/src/Provider/GuzzleServiceProvider.php
@@ -3,7 +3,8 @@
 namespace Bolt\Provider;
 
 use Guzzle\Service\Builder\ServiceBuilder;
-use Guzzle\Service\Client;
+use Guzzle\Service\Client as ServiceClient;
+use GuzzleHttp\Client;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -17,6 +18,21 @@ class GuzzleServiceProvider implements ServiceProviderInterface
             $app['guzzle.plugins'] = array();
         }
 
+        /** @deprecated */
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            return $this->compat($app);
+        }
+    }
+
+    /**
+     * PHP 5.3 compatibility services
+     *
+     * @deprecated
+     *
+     * @param Application $app
+     */
+    private function compat(Application $app)
+    {
         // Register a Guzzle ServiceBuilder
         $app['guzzle'] = $app->share(
             function () use ($app) {
@@ -33,7 +49,7 @@ class GuzzleServiceProvider implements ServiceProviderInterface
         // Register a simple Guzzle Client object (requires absolute URLs when guzzle.base_url is unset)
         $app['guzzle.client'] = $app->share(
             function () use ($app) {
-                $client = new Client($app['guzzle.base_url']);
+                $client = new ServiceClient($app['guzzle.base_url']);
                 foreach ($app['guzzle.plugins'] as $plugin) {
                     $client->addSubscriber($plugin);
                 }

--- a/src/Provider/GuzzleServiceProvider.php
+++ b/src/Provider/GuzzleServiceProvider.php
@@ -19,9 +19,22 @@ class GuzzleServiceProvider implements ServiceProviderInterface
         }
 
         /** @deprecated */
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+        if ($app['deprecated.php']) {
             return $this->compat($app);
         }
+
+        // Register a simple Guzzle Client object (requires absolute URLs when guzzle.base_url is unset)
+        $app['guzzle.client'] = $app->share(
+            function () use ($app) {
+                $options = ['base_url' => $app['guzzle.base_url']];
+                $client = new Client($options);
+                foreach ($app['guzzle.plugins'] as $plugin) {
+                    $client->addSubscriber($plugin);
+                }
+
+                return $client;
+            }
+        );
     }
 
     /**

--- a/src/Provider/PrefillServiceProvider.php
+++ b/src/Provider/PrefillServiceProvider.php
@@ -12,7 +12,8 @@ class PrefillServiceProvider implements ServiceProviderInterface
     {
         $app['prefill'] = $app->share(
             function ($app) {
-                $prefill = new Prefill($app['guzzle.client']);
+                /** @deprecated remove $app['deprecated.php'] for PHP 5.3 derp */
+                $prefill = new Prefill($app['guzzle.client'], $app['deprecated.php']);
 
                 return $prefill;
             }

--- a/src/Storage/Prefill.php
+++ b/src/Storage/Prefill.php
@@ -2,7 +2,8 @@
 
 namespace Bolt\Storage;
 
-use Guzzle\Service\Client;
+use GuzzleHttp\Client;
+use Guzzle\Service\Client as ServiceClient;
 
 /**
  * Handles Fetching Prefill Content from an API service.
@@ -14,10 +15,20 @@ class Prefill
     /**
      * Constructor function.
      *
-     * @param \Guzzle\Service\Client $client
+     * @param \GuzzleHttp\Client|\Guzzle\Service\Client $client
      */
-    public function __construct(Client $client)
+    public function __construct($client, $deprecated = false)
     {
+        /** @deprecated */
+        $this->deprecated = $deprecated;
+        if (!($client instanceof \GuzzleHttp\Client || $client instanceof \Guzzle\Service\Client)) {
+            throw new \InvalidArgumentException(sprintf(
+                'First argument passed to %s must be an instance of GuzzleHttp\Client or Guzzle\Service\Client, instance of %s given.',
+                __CLASS__,
+                get_class($client)
+                ));
+        }
+
         $this->client = $client;
     }
 
@@ -33,6 +44,10 @@ class Prefill
     {
         $uri = $base . ltrim($request, '/');
 
-        return $this->client->get($uri, array('timeout' => 10))->send()->getBody(true);
+        if ($this->deprecated['deprecated.php']) {
+            return $this->client->get($uri, array('timeout' => 10))->send()->getBody(true);
+        } else {
+            return $this->client->get($uri, array('timeout' => 10))->getBody(true);
+        }
     }
 }

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -44,6 +44,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
         $config->verify();
 
         $bolt = new Application(array('resources' => $config));
+        $bolt['deprecated.php'] = version_compare(PHP_VERSION, '5.4.0', '<');
         $bolt['config']->set(
             'general/database',
             array(

--- a/tests/phpunit/unit/Storage/PrefillTest.php
+++ b/tests/phpunit/unit/Storage/PrefillTest.php
@@ -3,7 +3,9 @@ namespace Bolt\Tests\Storage;
 
 use Bolt\Tests\BoltUnitTest;
 use Guzzle\Http\Message\RequestFactory;
-use Guzzle\Http\Message\Response;
+use Guzzle\Http\Message\Response as V3Response;
+use GuzzleHttp\Message\MessageFactory;
+use GuzzleHttp\Message\Response;
 
 /**
  * Class to test src/Storage/Prefill.
@@ -15,19 +17,28 @@ class PrefillTest extends BoltUnitTest
     public function testUrl()
     {
         $app = $this->getApp();
-        $factory = new RequestFactory;
-        $request = $factory->create('GET', '/');
-        $response = new Response('200');
-        $guzzle = $this->getMock('Guzzle\Service\Client', array('get', 'send'));
-        $request->setClient($guzzle);
+
+        if ($app['deprecated.php']) {
+            $factory = new RequestFactory;
+            $request = $factory->create('GET', '/');
+            $response = new V3Response('200');
+            $guzzle = $this->getMock('Guzzle\Service\Client', array('get', 'send'));
+            $request->setClient($guzzle);
+
+            $guzzle->expects($this->once())
+                ->method('send')
+                ->will($this->returnValue($response));
+        } else {
+            $factory = new MessageFactory;
+            $request = $factory->createRequest('GET', '/');
+            $response = new Response('200');
+            $guzzle = $this->getMock('GuzzleHttp\Client', array('get'));
+        }
+
         $guzzle->expects($this->once())
             ->method('get')
             ->with('http://loripsum.net/api/1/veryshort')
             ->will($this->returnValue($request));
-
-        $guzzle->expects($this->once())
-            ->method('send')
-            ->will($this->returnValue($response));
 
         $app['guzzle.client'] = $guzzle;
         $app['prefill']->get('/1/veryshort');


### PR DESCRIPTION
Codeception pulls in Guzzle 5, so in preparation for us dropping PHP 5.3 support later in the year, this allows PHP 5.4.0+ to use Guzzle 5 and PHP 5.3 stays on Guzzle 3.