### PR TITLE
Add tests for templatefields

### DIFF
--- a/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
+++ b/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
@@ -231,4 +231,39 @@ class BackendEditorCest
         $I->see('Quick to set up and easily extendible');
         $I->see('The new Page has been saved.');
     }
+
+    /**
+     * Create a contact page with templatefields
+     *
+     * @param \AcceptanceTester $I
+     */
+    public function checkTemplateFieldsTest(\AcceptanceTester $I)
+    {
+        $I->wantTo("Create a contact page with templatefields");
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt');
+
+        $I->see('New Page');
+        $I->click('New Page');
+
+        $I->fillField('#title',         'Contact Page');
+        $I->fillField('#slug',          'contact');
+        $I->selectOption('#template',   'extrafields.twig');
+
+        $I->click('Save Page', '#savecontinuebutton');
+        $I->see('The new Page has been saved.');
+        $I->click('CONTACT PAGE');
+
+        // Page has been saved, fill templatefields
+        $I->see('Template', 'a[data-toggle=tab]');
+
+        $I->fillField('#templatefields-section_1', 'This is the contact text');
+        $I->click('Save Page');
+
+        $I->click('CONTACT PAGE');
+        $I->seeInField('#templatefields-section_1', 'This is the contact text');
+    }
 }

--- a/tests/codeception/acceptance/103-BackendManager/BackendManagerCest.php
+++ b/tests/codeception/acceptance/103-BackendManager/BackendManagerCest.php
@@ -69,4 +69,27 @@ class BackendManagerCest
 
         $I->see('The changes to this Page have been saved.');
     }
+
+    /**
+     * Publish the 'Contact' page.
+     *
+     * @param \AcceptanceTester $I
+     */
+    public function publishContactPageTest(\AcceptanceTester $I)
+    {
+        $I->wantTo("Publish the 'Contact' page with templtaefields as 'manager' user");
+
+        // Set up the browser
+        $I->setCookie('bolt_authtoken', $this->cookies['bolt_authtoken']);
+        $I->setCookie('bolt_session', $this->cookies['bolt_session']);
+        $I->amOnPage('bolt/editcontent/pages/3');
+
+        $I->see("This is the contact text");
+
+        $I->selectOption('#statusselect', 'published');
+
+        $I->click('Save', '#savecontinuebutton');
+
+        $I->see('The changes to this Page have been saved.');
+    }
 }

--- a/tests/codeception/acceptance/200-Frontend/FrontendCest.php
+++ b/tests/codeception/acceptance/200-Frontend/FrontendCest.php
@@ -61,6 +61,20 @@ class FrontendCest
     }
 
     /**
+     * Check the contact page for templatefields
+     *
+     * @param \AcceptanceTester $I
+     */
+    public function checkContactPageTest(\AcceptanceTester $I)
+    {
+        $I->wantTo('see that the contact page and templatefields works');
+
+        $I->amOnPage('contact');
+
+        $I->see("This is the contact text");
+    }
+
+    /**
      * Check a viewless contenttype can't be routed to.
      *
      * @param \AcceptanceTester $I


### PR DESCRIPTION
@GawainLynch for some reason when saving a page with title `Contact Page`, it is getting saved with `CONTACT PAGE`. Does this have something to do with the save hooks?

Regardless, this tests for working templatefields