### PR TITLE
remove __toString from BoltResponse

### DIFF
--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -172,10 +172,10 @@ class Async implements ControllerProviderInterface
         // Combine the body. One 'alert' and one 'info' max. Regular info-items can be disabled, but Alerts can't.
         $body = "";
         if (!empty($news['alert'])) {
-            $body .= $app['render']->render('components/panel-news.twig', array('news' => $news['alert']));
+            $body .= $app['render']->render('components/panel-news.twig', array('news' => $news['alert']))->getContent();
         }
         if (!empty($news['information']) && !$app['config']->get('general/backend/news/disable')) {
-            $body .= $app['render']->render('components/panel-news.twig', array('news' => $news['information']));
+            $body .= $app['render']->render('components/panel-news.twig', array('news' => $news['information']))->getContent();
         }
 
         return new Response($body, Response::HTTP_OK, array('Cache-Control' => 's-maxage=3600, public'));
@@ -200,7 +200,7 @@ class Async implements ControllerProviderInterface
                 array(
                     'activity' => $activity
                 )
-            );
+            )->getContent();
         }
 
         $activity = $app['logger.manager']->getActivity('system', 8, null, 'authentication');
@@ -211,7 +211,7 @@ class Async implements ControllerProviderInterface
                 array(
                     'activity' => $activity
                 )
-            );
+            )->getContent();
         }
 
         return new Response($body, Response::HTTP_OK, array('Cache-Control' => 's-maxage=3600, public'));
@@ -381,7 +381,7 @@ class Async implements ControllerProviderInterface
             'contenttype' => $contenttype
         );
 
-        $body = $app['render']->render('components/panel-lastmodified.twig', array('context' => $context));
+        $body = $app['render']->render('components/panel-lastmodified.twig', array('context' => $context))->getContent();
 
         return new Response($body, Response::HTTP_OK, array('Cache-Control' => 's-maxage=60, public'));
     }
@@ -419,7 +419,7 @@ class Async implements ControllerProviderInterface
             'filtered'    => $isFiltered,
         );
 
-        $body = $app['render']->render('components/panel-lastmodified.twig', array('context' => $context));
+        $body = $app['render']->render('components/panel-lastmodified.twig', array('context' => $context))->getContent();
 
         return new Response($body, Response::HTTP_OK, array('Cache-Control' => 's-maxage=60, public'));
     }
@@ -728,7 +728,7 @@ class Async implements ControllerProviderInterface
                 'user'     => $user['displayname'],
                 'ip'       => $request->getClientIp()
             )
-        );
+        )->getContent();
 
         $message = $app['mailer']
             ->createMessage('message')

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1414,7 +1414,7 @@ class Backend implements ControllerProviderInterface
                     array(
                         'sitename' => $app['config']->get('general/sitename')
                     )
-                );
+                )->getContent();
 
                 try {
                     // Send a welcome email

--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -56,7 +56,7 @@ class Frontend
         if ($app['config']->get('general/maintenance_mode')) {
             if (!$app['users']->isAllowed('maintenance-mode')) {
                 $template = $app['templatechooser']->maintenance();
-                $body = $app['render']->render($template);
+                $body = $app['render']->render($template)->getContent();
 
                 return new Response($body, Response::HTTP_SERVICE_UNAVAILABLE);
             }

--- a/src/Response/BoltResponse.php
+++ b/src/Response/BoltResponse.php
@@ -141,15 +141,6 @@ class BoltResponse extends Response
         return $this->template->getTemplateName();
     }
     
-    /**
-     * Returns the Response as a string.
-     *
-     * @return string The Response as HTML
-     */
-    public function __toString()
-    {
-        return $this->getContent();
-    }
     
     /**
      * Gets HTML content for the response.

--- a/src/TwigExtension.php
+++ b/src/TwigExtension.php
@@ -513,7 +513,7 @@ class TwigExtension extends \Twig_Extension
      */
     public function twig($snippet, $extravars = array())
     {
-        return $this->app['safe_render']->render($snippet, $extravars);
+        return $this->app['safe_render']->render($snippet, $extravars)->getContent();
     }
 
     public function decorateTT($str)


### PR DESCRIPTION
I think this should be all that's necessary to remove the __toString method from BoltResponse.

The affected areas on the Dashboard seem to render ok for me too.