### PR TITLE
Restore BoltResponse __toString with nicer error handling

### DIFF
--- a/src/Response/BoltResponse.php
+++ b/src/Response/BoltResponse.php
@@ -141,6 +141,15 @@ class BoltResponse extends Response
         return $this->template->getTemplateName();
     }
     
+    /**
+     * Returns the Response as a string.
+     *
+     * @return string The Response as HTML
+     */
+    public function __toString()
+    {
+        return $this->getContent();
+    }
     
     /**
      * Gets HTML content for the response.

--- a/src/Response/BoltResponse.php
+++ b/src/Response/BoltResponse.php
@@ -149,8 +149,7 @@ class BoltResponse extends Response
     public function __toString()
     {
         try {
-            $output = $this->getContent();
-            return $string;
+            return $this->getContent();
         } catch (\Exception $exception) {
             // the __toString method isn't allowed to throw exceptions
             // so we turn them into an error instead

--- a/src/Response/BoltResponse.php
+++ b/src/Response/BoltResponse.php
@@ -148,7 +148,15 @@ class BoltResponse extends Response
      */
     public function __toString()
     {
-        return $this->getContent();
+        try {
+            $output = $this->getContent();
+            return $string;
+        } catch (\Exception $exception) {
+            // the __toString method isn't allowed to throw exceptions
+            // so we turn them into an error instead
+            trigger_error($e->getMessage() . "\n" . $e->getTraceAsString(), E_USER_ERROR);
+            return '';
+        }
     }
     
     /**

--- a/src/Response/BoltResponse.php
+++ b/src/Response/BoltResponse.php
@@ -150,7 +150,7 @@ class BoltResponse extends Response
     {
         try {
             return $this->getContent();
-        } catch (\Exception $exception) {
+        } catch (\Exception $e) {
             // the __toString method isn't allowed to throw exceptions
             // so we turn them into an error instead
             trigger_error($e->getMessage() . "\n" . $e->getTraceAsString(), E_USER_ERROR);


### PR DESCRIPTION
This should be a decent compromise between the two problems.

The __toString method is restored so extensions that depend on it will continue to function identically.

Whilst PHP disallows exceptions being thrown in the __toString method it seems to be fine with triggering normal errors so, we can catch the original exception and trigger an error with the original exception message.