### PR TITLE
Adds support for methods in routing

### DIFF
--- a/src/Controllers/Routing.php
+++ b/src/Controllers/Routing.php
@@ -137,6 +137,10 @@ class Routing implements ControllerProviderInterface
             $route->setHost($host);
         }
 
+        if ($methods = $config['methods']) {
+            $route->setMethods($methods);
+        }
+
         $route->bind($name);
     }
 


### PR DESCRIPTION
This adds support for the use of methods in the routing.yml
The code is based on the example from symfony: http://symfony.com/doc/current/book/routing.html#adding-http-method-requirements

> your-route:
>   path: /mypage
>   defaults:  { _controller: 'Bolt\Controllers\Frontend::listing' }
>   methods:  [POST]

You can use multiple methods:
>   methods:  [POST|GET] 
