### PR TITLE
Add extra check for view permission for quicklinks

### DIFF
--- a/app/view/twig/dashboard/_quicklinks-buttons.twig
+++ b/app/view/twig/dashboard/_quicklinks-buttons.twig
@@ -1,6 +1,6 @@
 <div class="btn-group">
     {% for contenttypeslug, contenttype in app.config.get('contenttypes') %}
-        {% if isallowed('contenttype:' ~ contenttypeslug ~ ':create') %}
+        {% if isallowed('contenttype:' ~ contenttypeslug ~ ':create') and isallowed('contenttype:' ~ contenttypeslug ~ ':view') %}
             <a class="btn btn-default" href="{{ path('editcontent', {'contenttypeslug': contenttypeslug}) }}">
                 <i class="fa fa-plus"></i> {{ __('contenttypes.generic.new', {'%contenttype%': contenttypeslug}) }}
             </a>

--- a/app/view/twig/dashboard/_quicklinks-dropdown.twig
+++ b/app/view/twig/dashboard/_quicklinks-dropdown.twig
@@ -5,7 +5,7 @@
     </a>
     <ul class="dropdown-menu">
     {% for contenttypeslug, contenttype in app.config.get('contenttypes') %}
-        {% if isallowed('contenttype:' ~ contenttypeslug ~ ':create') %}
+        {% if isallowed('contenttype:' ~ contenttypeslug ~ ':create') and isallowed('contenttype:' ~ contenttypeslug ~ ':view') %}
             <li>
                 <a href="{{ path('editcontent', {'contenttypeslug': contenttypeslug}) }}">
                     <i class="fa fa-plus"></i>


### PR DESCRIPTION
When allowing a user to create a contenttype but without view permission (perhaps create it with a custom extension). An exemple is a resource contenttype. I've added a check to make sure the user is able view the contenttype.

Another check that might be handy for the future is a check on show_on_dashboard: false