### PR TITLE
Enable live editing for textarea fields

### DIFF
--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -193,13 +193,14 @@
             var fieldType = field.closest('[data-fieldtype]').data('fieldtype');
             var fieldValue = '';
 
-            if (fieldType === 'text' || fieldType === 'textarea') {
-                fieldValue = liveEditor.cleanText($(this), fieldType);
-            } else {
-                if (_.has(ckeditor.instances, fieldName)) {
-                    ckeditor.instances[fieldName].setData($(this).html());
-                }
+            if (fieldType === 'html') {
                 fieldValue = $(this).html();
+
+                if (_.has(ckeditor.instances, fieldName)) {
+                    ckeditor.instances[fieldName].setData(fieldValue);
+                }
+            }else{
+                fieldValue = liveEditor.cleanText($(this), fieldType);
             }
             field.val(fieldValue);
         });

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -195,7 +195,7 @@
             if (fieldType === 'text') {
                 field.val($(this).text());
             } else if (fieldType === 'textarea') {
-                field.val($(this).html().replace(/&nbsp;/g, ' ').replace(/<br.*?>/g, '\n'));
+                field.val($(this).html().replace(/&nbsp;/g, ' ').replace(/\s?<br.*?>\s?/g, '\n'));
             } else {
                 if (_.has(ckeditor.instances, fieldName)) {
                     ckeditor.instances[fieldName].setData($(this).html());

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -224,6 +224,7 @@
      *
      * @param {Object} element - jQuery element to clean
      * @param {String} fieldType - type of field to clean (text, textarea)
+     * @return {String} Value for editcontent input fields
      */
     liveEditor.cleanText = function(element, fieldType) {
         // Preserve newlines and spacing for textarea fields

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -128,11 +128,22 @@
                                     win.getSelection().getRangeAt(0).insertNode(doc.createTextNode(content));
                                 }
                             }
-                        }).on('keypress', function (e) {
-                            return e.which != 13;
-                        }).on('focus blur', function (e) {
-                            $(this).html($(this).text());
                         });
+
+                        if(fieldType == 'textarea') {
+                            $(this).on('keypress', function (e) {
+                                if(e.which == 13) {
+                                    e.preventDefault();
+                                    doc.execCommand('insertHTML', false, '<br><br>');
+                                }
+                            });
+                        } else {
+                            $(this).on('keypress', function (e) {
+                                return e.which != 13;
+                            }).on('focus blur', function (e) {
+                                $(this).html($(this).text());
+                            });
+                        }
                     }
                 }
             });
@@ -183,6 +194,8 @@
 
             if (fieldType === 'text') {
                 field.val($(this).text());
+            } else if (fieldType === 'textarea') {
+                field.val($(this).html().replace(/&nbsp;/g, ' ').replace(/<br.*?>/g, '\n'));
             } else {
                 if (_.has(ckeditor.instances, fieldName)) {
                     ckeditor.instances[fieldName].setData($(this).html());

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -191,17 +191,19 @@
             var fieldName = $(this).data('bolt-field');
             var field = $('#editcontent [name=' + liveEditor.escapejQuery(fieldName) + ']');
             var fieldType = field.closest('[data-fieldtype]').data('fieldtype');
+            var fieldValue = '';
 
             if (fieldType === 'text') {
-                field.val($(this).text());
+                fieldValue = $(this).text();
             } else if (fieldType === 'textarea') {
-                field.val($(this).html($(this).html().replace(/&nbsp;/g, ' ').replace(/\s?<br.*?>\s?/g, '\n')).text());
+                fieldValue = $(this).html($(this).html().replace(/&nbsp;/g, ' ').replace(/\s?<br.*?>\s?/g, '\n')).text();
             } else {
                 if (_.has(ckeditor.instances, fieldName)) {
                     ckeditor.instances[fieldName].setData($(this).html());
                 }
-                field.val($(this).html());
+                fieldValue = $(this).html();
             }
+            field.val(fieldValue);
         });
 
         $(iframe).attr('src', '');

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -101,7 +101,7 @@
 
                 $(this).addClass('bolt-editable');
 
-                if ((!$(this).data('no-edit')) && ((fieldType === 'text') || (fieldType === 'html'))) {
+                if ((!$(this).data('no-edit')) && ((fieldType === 'text') || (fieldType === 'html') || (fieldType === 'textarea'))) {
 
                     $(this).attr('contenteditable', true);
 

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -195,7 +195,7 @@
             if (fieldType === 'text') {
                 field.val($(this).text());
             } else if (fieldType === 'textarea') {
-                field.val($(this).html().replace(/&nbsp;/g, ' ').replace(/\s?<br.*?>\s?/g, '\n'));
+                field.val($(this).html($(this).html().replace(/&nbsp;/g, ' ').replace(/\s?<br.*?>\s?/g, '\n')).text());
             } else {
                 if (_.has(ckeditor.instances, fieldName)) {
                     ckeditor.instances[fieldName].setData($(this).html());

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -21,6 +21,12 @@
 
     var editcontent = bolt.editcontent;
 
+    var editableTypes = [
+        'text',
+        'html',
+        'textarea'
+    ];
+
     /**
      * Initializes the mixin.
      *
@@ -101,7 +107,7 @@
 
                 $(this).addClass('bolt-editable');
 
-                if ((!$(this).data('no-edit')) && ((fieldType === 'text') || (fieldType === 'html') || (fieldType === 'textarea'))) {
+                if ((!$(this).data('no-edit')) && editableTypes.indexOf(fieldType) != -1) {
 
                     $(this).attr('contenteditable', true);
 

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -193,10 +193,8 @@
             var fieldType = field.closest('[data-fieldtype]').data('fieldtype');
             var fieldValue = '';
 
-            if (fieldType === 'text') {
-                fieldValue = $(this).text();
-            } else if (fieldType === 'textarea') {
-                fieldValue = $(this).html($(this).html().replace(/&nbsp;/g, ' ').replace(/\s?<br.*?>\s?/g, '\n')).text();
+            if (fieldType === 'text' || fieldType === 'textarea') {
+                fieldValue = liveEditor.cleanText($(this), fieldType);
             } else {
                 if (_.has(ckeditor.instances, fieldName)) {
                     ckeditor.instances[fieldName].setData($(this).html());
@@ -213,6 +211,26 @@
         bolt.sidebar.fixlength();
 
         liveEditor.removeEvents();
+    };
+
+    /**
+     * Clean contenteditable values for text fields
+     *
+     * @public
+     *
+     * @function cleanText
+     * @memberof Bolt.liveEditor
+     *
+     * @param {Object} element - jQuery element to clean
+     * @param {String} fieldType - type of field to clean (text, textarea)
+     */
+    liveEditor.cleanText = function(element, fieldType) {
+        // Preserve newlines and spacing for textarea fields
+        if(fieldType == 'textarea') {
+            element.html(element.html().replace(/&nbsp;/g, ' ').replace(/\s?<br.*?>\s?/g, '\n'));
+        }
+
+        return element.text();
     };
 
     /**


### PR DESCRIPTION
I've attempted to ensure the features match the equivalent backend field, the main goals being allowing newlines (for cases like running the value through the nl2br twig filter) and getting rid of random cruft (`&nbsp;`s) added by the browser.

Browser default behaviour on enter is to wrap an HTML element (div, p etc.), I've changed this to insert `<br>`s whilst editing which are then converted into newline characters when the live editor is closed.

Ping for Cap'n Liveedit, @Pinpickle, in case he needs to weigh-in.