### PR TITLE
[WIP] Make editable fields 'magic'.

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -520,6 +520,24 @@ class Content implements \ArrayAccess
         $this->setValues($values);
     }
 
+
+    public function wrapValues()
+    {
+        $fields = $this->contenttype['fields'];
+        $allowedEditable = array('text', 'textarea', 'html');
+
+        foreach ($this->values as $key => $value) {
+            $fieldtype = $fields[$key]['type'];
+            if (in_array($fieldtype, $allowedEditable)) {
+                $this->values[$key] = sprintf(
+                        '<span class="editable" data-bolt-field="%s">%s</span>',
+                        $key,
+                        $value
+                    );
+            }
+        }
+    }
+
     protected function getTemplateFieldsContentType() {
         if (is_array($this->contenttype)) {
             if ($templateFieldsConfig = $this->app['config']->get('theme/templatefields')) {

--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -183,6 +183,7 @@ class Frontend
             $app['extensions']->insertSnippet(SnippetLocation::BEFORE_HEAD_JS, '<script>window.boltIsEditing = true;</script>');
             $app['extensions']->addJavascript($jsFile, array('late' => false, 'priority' => 1));
             $app['extensions']->addCss($cssFile, false, 5);
+            $content->wrapValues();
         }
 
         // Then, select which template to use, based on our 'cascading templates rules'

--- a/theme/base-2014/record.twig
+++ b/theme/base-2014/record.twig
@@ -7,10 +7,11 @@
 
         <article>
 
-            <h2 data-bolt-field="title">{{ record.title }}</h2>
+            <h2>{{ record.title }}</h2>
+
 
             {% if record.subtitle %}
-                <h3 data-bolt-field="subtitle">{{ record.subtitle }}</h3>
+                <h3>{{ record.subtitle }}</h3>
             {% endif %}
 
             {% for key,value in record.values if key not in ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'title', 'subtitle', 'ownerid', 'templatefields'] %}
@@ -54,7 +55,7 @@
 
                 {% elseif record.fieldtype(key) in ['html', 'markdown', 'textarea'] %}
 
-                    <div data-bolt-field="{{ key }}">{{ attribute(record, key) }}</div>
+                    {{ attribute(record, key) }}
 
                 {% elseif record.fieldtype(key) == "select" %}
 


### PR DESCRIPTION
I'd like to get rid of having to add `data-bolt-field="{{ key }}"` to the fields you want to have editable. 

So far, this works, except for one thing: The floating toolbars don't show up anymore. 

@pinpickle: Do you have any idea if this is caused by the wrapping element being different? Can't say the CKeditor documentation was a joy to dig through, so I couldn't find much..