### PR TITLE
[Tests] Move PHPUnit resource creation into the listener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,6 @@ before_script:
   - composer install --prefer-dist
   # Set up permissions
   - chmod -R 777 app/database/ app/cache/ app/config/ extensions/ files/ theme/
-  # Set up tests directories
-  - mkdir -p tests/phpunit/unit/Nut/resources/
-  - chmod 777 tests/phpunit/unit/Nut/resources/
-  - mkdir -p tests/phpunit/unit/resources/files/
-  - chmod 777 tests/phpunit/unit/resources/files/
   # Set up MySQL
   - mysql -e "CREATE DATABASE IF NOT EXISTS bolt_travis;" -u root
   - mysql -e "CREATE USER 'bolt_travis'@'localhost' IDENTIFIED BY 'bolt_travis';" -u root

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -2,6 +2,9 @@
 
 namespace Bolt\Tests;
 
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
 /**
  * PHPUnit listener class
  *
@@ -166,13 +169,14 @@ class BoltListener implements \PHPUnit_Framework_TestListener
      */
     private function buildTestEnv()
     {
-        // Make sure we wipe the db file to start with a clean one
-        if (is_readable(TEST_ROOT . '/bolt.db')) {
-            unlink(TEST_ROOT . '/bolt.db');
-        }
-        copy(PHPUNIT_ROOT . '/resources/db/bolt.db', TEST_ROOT . '/bolt.db');
+        $fs = new Filesystem();
 
-        @mkdir(TEST_ROOT . '/app/cache/', 0777, true);
+        // Make sure we wipe the db file to start with a clean one
+        $fs->copy(PHPUNIT_ROOT . '/resources/db/bolt.db', TEST_ROOT . '/bolt.db', true);
+
+        // Create needed directories
+        @$fs->mkdir(TEST_ROOT . '/app/cache/', 0777);
+        @$fs->mkdir(PHPUNIT_ROOT . '/resources/files/', 0777);
     }
 
     /**
@@ -196,9 +200,10 @@ class BoltListener implements \PHPUnit_Framework_TestListener
 
         // Remove the test database
         if ($this->reset) {
-            if (is_readable(TEST_ROOT . '/bolt.db')) {
-                unlink(TEST_ROOT . '/bolt.db');
-            }
+            $fs = new Filesystem();
+
+            $fs->remove(TEST_ROOT . '/bolt.db');
+            $fs->remove(PHPUNIT_ROOT . '/resources/files/');
         }
     }
 }


### PR DESCRIPTION
Allows PHPUnit tests to be run on a fresh clone… 

…and allows me to recover from the heart attack of thinking master was b0rken :stuck_out_tongue_winking_eye: 