### PR TITLE
Only setting default timezone if config provides it

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -291,10 +291,10 @@ class Application extends Silex\Application
         // $app['locale'] should only be a single value.
         $this['locale'] = reset($configLocale);
 
-        // Set The Timezone Based on the Config, fallback to UTC
-        date_default_timezone_set(
-            $this['config']->get('general/timezone') ?: 'UTC'
-        );
+        // Set the default timezone if provided in the Config
+        if ($tz = $this['config']->get('general/timezone')) {
+            date_default_timezone_set($tz);
+        }
 
         // for javascript datetime calculations, timezone offset. e.g. "+02:00"
         $this['timezone_offset'] = date('P');


### PR DESCRIPTION
Fixes #3302

[date_default_timezone_get](http://php.net/manual/en/function.date-default-timezone-get.php) checks value from `date_default_timezone_set` first, then `date.timezone` from ini, then system timezone, then falls back to 'UTC'. So we don't need to check ini ourselves, we just need to not override the value.

I think this change aligns more with the purpose of the config option. We only want to override the default timezone if it is provided in the config. If someone else wants to call `date_default_timezone_set` and override it themselves they can just leave the config entry out and we won't clobber them.

Note: A strict warning is now emitted though if `date.timezone` isn't set in ini and `timezone` isn't set in config. 
