### PR TITLE
Scrutinizer config

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 # Since we need to run part of your test suite, most libraries will first
 # need to install vendors, for example via composer.
 before_commands:
-    - composer install --dev
+    - composer install
 tools:
     php_cs_fixer:
         extensions:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,7 +9,7 @@ tools:
         command: php-cs-fixer
         enabled: true
         filter:
-            paths: ["app/src/*"]
+            paths: ["src/*"]
         config:
             level: all
     php_cpd:
@@ -31,7 +31,7 @@ tools:
         command: phpcs
         enabled: true
         filter:
-            paths: ["app/src/*"]
+            paths: ["src/*"]
         config:
             standard: PSR2
 #    external_code_coverage:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -11,16 +11,8 @@ tools:
                 - src/
         config:
             level: all
-    php_cpd:
-        command: phpcpd
-        min_lines:   5   # Minimum number of identical lines (default: 5)
-        min_tokens: 70   # Minimum number of identical tokens (default: 70)
-        names:           # A list of names that should be scanned (default: '*.php')
-            - '*.php'
-        excluded_dirs:   # A list of excluded directories.
-            - vendor
-            - files
-            - app/cache/
+    php_sim:
+        min_mass: 30             # Defaults to 16
         enabled: true
     php_code_sniffer:
         extensions:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,27 +2,26 @@ before_commands:
     - composer install
 tools:
     php_cs_fixer:
+        enabled: true
         extensions:
             - php
         command: php-cs-fixer
-        enabled: true
         filter:
             paths:
                 - src/
         config:
             level: all
     php_sim:
+        enabled: true
         min_mass: 30             # Defaults to 16
-        enabled: true
     php_code_sniffer:
-        extensions:
-            - php
-        command: phpcs
-        enabled: true
+        enabled: false
+        config:
+            standard: PSR2
+            include_standards:
+                - CodeSniffer/Bolt/
         filter:
             paths:
                 - src/
-        config:
-            standard: PSR2
 #    external_code_coverage:
 #        timeout: 1200

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,5 +1,3 @@
-# Since we need to run part of your test suite, most libraries will first
-# need to install vendors, for example via composer.
 before_commands:
     - composer install
 tools:
@@ -9,21 +7,20 @@ tools:
         command: php-cs-fixer
         enabled: true
         filter:
-            paths: ["src/*"]
+            paths:
+                - src/
         config:
             level: all
     php_cpd:
         command: phpcpd
-        # Minimum number of identical lines (default: 5)
-        min_lines: 5
-        # Minimum number of identical tokens (default: 70)
-        min_tokens: 70
-        # A list of names that should be scanned (default: '*.php')
-        names:
-            # Default:
+        min_lines:   5   # Minimum number of identical lines (default: 5)
+        min_tokens: 70   # Minimum number of identical tokens (default: 70)
+        names:           # A list of names that should be scanned (default: '*.php')
             - '*.php'
-        # A list of excluded directories.
-        excluded_dirs: ["vendor", "files"]
+        excluded_dirs:   # A list of excluded directories.
+            - vendor
+            - files
+            - app/cache/
         enabled: true
     php_code_sniffer:
         extensions:
@@ -31,7 +28,8 @@ tools:
         command: phpcs
         enabled: true
         filter:
-            paths: ["src/*"]
+            paths:
+                - src/
         config:
             standard: PSR2
 #    external_code_coverage:

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "phpunit/php-code-coverage" : "~2.0",
         "phpunit/phpunit" : "~4.4",
         "sebastian/phpcpd" : "~2.0",
-        "squizlabs/php_codesniffer" : "1.5.*"
+        "squizlabs/php_codesniffer" : "~2.3"
     },
     "minimum-stability" : "beta",
     "config" : {


### PR DESCRIPTION
Apparently we don't have our PHP source files in `app/src/` any longer… who went and did that?

…this should be fun!