### PR TITLE
Have PHPUnit listner clear the cache on test start/finish

### DIFF
--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -176,6 +176,9 @@ class BoltListener implements \PHPUnit_Framework_TestListener
         // Create needed directories
         @$fs->mkdir(TEST_ROOT . '/app/cache/', 0777);
         @$fs->mkdir(PHPUNIT_ROOT . '/resources/files/', 0777);
+
+        // Empty the cache
+        system('php ' . NUT_PATH . ' cache:clear');
     }
 
     /**
@@ -204,5 +207,8 @@ class BoltListener implements \PHPUnit_Framework_TestListener
             $fs->remove(TEST_ROOT . '/bolt.db');
             $fs->remove(PHPUNIT_ROOT . '/resources/files/');
         }
+
+        // Empty the cache
+        system('php ' . NUT_PATH . ' cache:clear');
     }
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -32,8 +32,7 @@ if (!defined('BOLT_AUTOLOAD')) {
     }
 
     // Load the autoloader
-    global $CLASSLOADER;
-    $CLASSLOADER = require_once BOLT_AUTOLOAD;
+    require_once BOLT_AUTOLOAD;
 }
 
 // Path to Nut

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -5,6 +5,13 @@
  * related to request dispatching.
  */
 
+// Define our install type
+if (file_exists(__DIR__ . '/../../../../../vendor/bolt/bolt/')) {
+    $installType = 'composer';
+} else {
+    $installType = 'git';
+}
+
 // Install base location
 if (!defined('TEST_ROOT')) {
     define('TEST_ROOT', realpath(__DIR__ . '/../../'));
@@ -27,6 +34,15 @@ if (!defined('BOLT_AUTOLOAD')) {
     // Load the autoloader
     global $CLASSLOADER;
     $CLASSLOADER = require_once BOLT_AUTOLOAD;
+}
+
+// Path to Nut
+if (!defined('NUT_PATH')) {
+    if ($installType === 'composer') {
+        define('NUT_PATH', realpath(TEST_ROOT . '/vendor/bolt/bolt/app/nut'));
+    } elseif ($installType === 'git') {
+        define('NUT_PATH', realpath(TEST_ROOT . '/app/nut'));
+    }
 }
 
 // Load the upload bootstrap


### PR DESCRIPTION
@rossriley a note on the `global $CLASSLOADER;`. 

It was introduced in 1c5973da0f6554695a25c0badded0af19c8dd69c and your 2.1 test work removed the need for it.