### PR TITLE
Allow local overriding of grunt options (especially generation of sourcemaps)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ npm-debug.log
 *.map
 app/src/tmp/
 app/src/docs/
+app/src/grunt.json
 
 # File-system cruft and temporary files
 scrutinizer.phar

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -80,6 +80,11 @@ module.exports = function(grunt) {
         }
     };
 
+    // Optionally overwrite options with grunt.json
+    if (grunt.file.exists('grunt.json')) {
+        require('deep-extend')(options, grunt.file.readJSON('grunt.json'));
+    }
+
     require('load-grunt-config')(grunt, {data: options});
 
 };

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -2,7 +2,10 @@ module.exports = function(grunt) {
     grunt.util.linefeed = '\n';
 
     var options = {
-        sourceMap: true,
+        sourceMap: {
+            css: false,
+            js: false
+        },
         path: {
             tmp: 'tmp',
             doc: 'docs',

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -2,6 +2,7 @@ module.exports = function(grunt) {
     grunt.util.linefeed = '\n';
 
     var options = {
+        sourceMap: true,
         path: {
             tmp: 'tmp',
             doc: 'docs',

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -1,17 +1,29 @@
-Node/Grunt modules for backend’s frontend workflow.
+# Bolts backend’s frontend workflow using grunt
 
----
+## Local options
 
-#Range Specifiers
+Add a file ``app/src/grunt.json`` in which you put the options you want to overwrite.
+This file is ignored by git.
+
+Example file to enable generation of sourcemaps:
+
+    {
+        "sourceMap": {
+            "css": true,
+            "js": true
+        }
+    }
+
+##Range Specifiers
 
 Just for the forgetful people and as JSON allows no comments …
 
-##Caret:
+###Caret:
 
     ^0.0.3:   = 0.0.3
     ^0.1.2:   ≥ 0.1.2-0  and  < 0.2.0-0
     ^1.2.3:   ≥ 1.2.3-0  and  < 2.0.0-0
 
-##Tilde:
+###Tilde:
 
     ~1.2.3:   ≥ 1.2.3-0  and  < 1.3.0-0

--- a/app/src/grunt/concat.js
+++ b/app/src/grunt/concat.js
@@ -8,7 +8,7 @@ module.exports = {
     installLibJs: {
         options: {
             separator: '\n\n',
-            sourceMap: true,
+            sourceMap: '<%= sourceMap %>',
             sourceMapName: '<%= path.dest.js %>/maps/lib.min.js.map'
         },
         nonull: true,

--- a/app/src/grunt/concat.js
+++ b/app/src/grunt/concat.js
@@ -8,7 +8,7 @@ module.exports = {
     installLibJs: {
         options: {
             separator: '\n\n',
-            sourceMap: '<%= sourceMap %>',
+            sourceMap: '<%= sourceMap.js %>',
             sourceMapName: '<%= path.dest.js %>/maps/lib.min.js.map'
         },
         nonull: true,

--- a/app/src/grunt/remove.js
+++ b/app/src/grunt/remove.js
@@ -30,5 +30,18 @@ module.exports = {
             '<%= path.dest.css %>/bolt.css.map',
             '<%= path.dest.css %>/liveeditor.css.map'
         ]
+    },
+
+    /*
+     * TARGET:  Remove js source maps
+     */
+    soureMapJs: {
+        fileList: [
+            '<%= path.dest.js %>/maps/bolt.min.js.map',
+            '<%= path.dest.js %>/maps/lib.min.js.map'
+        ],
+        dirList: [
+            '<%= path.dest.js %>/maps'
+        ]
     }
 };

--- a/app/src/grunt/remove.js
+++ b/app/src/grunt/remove.js
@@ -19,5 +19,16 @@ module.exports = {
         dirList: [
             '<%= path.tmp %>'
         ]
+    },
+
+    /*
+     * TARGET:  Remove css source maps
+     */
+    soureMapCss: {
+        fileList: [
+            '<%= path.dest.css %>/bolt-old-ie.css.map',
+            '<%= path.dest.css %>/bolt.css.map',
+            '<%= path.dest.css %>/liveeditor.css.map'
+        ]
     }
 };

--- a/app/src/grunt/sass.js
+++ b/app/src/grunt/sass.js
@@ -16,7 +16,7 @@ module.exports = {
             unixNewlines: true,
             banner: '<%= banner.boltCss %>',
             precision: 5,
-            sourceMap: true,
+            sourceMap: '<%= sourceMap %>',
             sourceMapContents: true
         },
         files: [

--- a/app/src/grunt/sass.js
+++ b/app/src/grunt/sass.js
@@ -16,7 +16,7 @@ module.exports = {
             unixNewlines: true,
             banner: '<%= banner.boltCss %>',
             precision: 5,
-            sourceMap: '<%= sourceMap %>',
+            sourceMap: '<%= sourceMap.css %>',
             sourceMapContents: true
         },
         files: [

--- a/app/src/grunt/uglify.js
+++ b/app/src/grunt/uglify.js
@@ -8,7 +8,7 @@ module.exports = {
     prepareLibJs: {
         options: {
             preserveComments: 'some',
-            sourceMap: '<%= sourceMap %>',
+            sourceMap: '<%= sourceMap.js %>',
             sourceMapIncludeSources: true
         },
         files: [{
@@ -107,7 +107,7 @@ module.exports = {
      */
     prepareBootstrapJs: {
         options: {
-            sourceMap: '<%= sourceMap %>',
+            sourceMap: '<%= sourceMap.js %>',
             sourceMapIncludeSources: true
         },
         files: {
@@ -130,7 +130,7 @@ module.exports = {
     boltJs: {
         options: {
             banner: '<%= banner.boltJs %>',
-            sourceMap: '<%= sourceMap %>',
+            sourceMap: '<%= sourceMap.js %>',
             sourceMapName: '<%= path.dest.js %>/maps/bolt.min.js.map'
         },
         files: {

--- a/app/src/grunt/uglify.js
+++ b/app/src/grunt/uglify.js
@@ -8,7 +8,7 @@ module.exports = {
     prepareLibJs: {
         options: {
             preserveComments: 'some',
-            sourceMap: true,
+            sourceMap: '<%= sourceMap %>',
             sourceMapIncludeSources: true
         },
         files: [{
@@ -107,7 +107,7 @@ module.exports = {
      */
     prepareBootstrapJs: {
         options: {
-            sourceMap: true,
+            sourceMap: '<%= sourceMap %>',
             sourceMapIncludeSources: true
         },
         files: {
@@ -130,7 +130,7 @@ module.exports = {
     boltJs: {
         options: {
             banner: '<%= banner.boltJs %>',
-            sourceMap: true,
+            sourceMap: '<%= sourceMap %>',
             sourceMapName: '<%= path.dest.js %>/maps/bolt.min.js.map'
         },
         files: {

--- a/app/src/package.json
+++ b/app/src/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "bootstrap-sass": "3.2.0",
+    "deep-extend": "^0.3.3",
     "font-awesome": "~4.3.0",
     "grunt": "~0.4.5",
     "grunt-bom-removal": "~0.2.0",


### PR DESCRIPTION
:warning:  Generation of sourcemaps is now switched off by default.

Add ``app/src/grunt.json`` and enter

```json
{
    "sourceMap": {
        "css": true,
        "js": true
    }
}
```
there to get them generated. That file is ignored by git.

:warning: Generated css and js files should be committed without sourcemaps from now on!
