### PR TITLE
Fixed action intiialisation for stack modals

### DIFF
--- a/app/src/js/modules/stack.js
+++ b/app/src/js/modules/stack.js
@@ -40,7 +40,7 @@
         });
 
         $(elements).on(
-            'shown.bs.modal',
+            'loaded.bs.modal',
             function (e) {
                 bolt.actions.init();
             }


### PR DESCRIPTION
This fixes an issue where you would need to open the modal, close it, then open it again before anything worked.

Using "shown" was trying to bind events directly to elements that didn't exist yet, we need to do it after the contents have loaded.