### PR TITLE
[RFC] Delete multiple items more efficiently

### DIFF
--- a/app/src/js/init.js
+++ b/app/src/js/init.js
@@ -200,18 +200,21 @@ var init = {
                 bootbox.confirm(notice, function (confirmed) {
                     $('.alert').alert();
                     if (confirmed === true) {
-                        $.each(aItems, function (index, id) {
-                            // Delete request
-                            $.ajax({
-                                url: Bolt.conf('paths.bolt') + 'content/deletecontent/' +
-                                    $('#item_' + id).closest('table').data('contenttype') + '/' + id +
-                                    '?bolt_csrf_token=' + $('#item_' + id).closest('table').data('bolt_csrf_token'),
-                                type: 'get',
-                                success: function (feedback) {
-                                    $('#item_' + id).hide();
-                                    $('a.deletechosen').hide();
-                                }
-                            });
+                        // Delete request
+                        $.ajax({
+                            url: Bolt.conf('paths.bolt') + 'content/deletecontent/' +
+                                $('#item_' + aItems[0]).closest('table').data('contenttype') + '/' + aItems.join(',') +
+                                '?bolt_csrf_token=' + $('#item_' + aItems[0]).closest('table').data('bolt_csrf_token'),
+                            type: 'get',
+                            success: function (feedback) {
+                                var items = [];
+                                $.each(aItems, function (index, id) {
+                                    items.push(document.getElementById('item_' + id));
+                                });
+
+                                $(items).hide();
+                                $('a.deletechosen').hide();
+                            }
                         });
                     }
                 });

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1069,25 +1069,28 @@ class Backend implements ControllerProviderInterface
     /**
      * Deletes a content item.
      *
-     * @param Application $app             The application/container
-     * @param string      $contenttypeslug The content type slug
-     * @param integer     $id              The content ID
+     * @param Application    $app             The application/container
+     * @param string         $contenttypeslug The content type slug
+     * @param integer|string $id              The content ID or comma-delimited list of IDs
      *
      * @return string
      */
     public function deleteContent(Application $app, $contenttypeslug, $id)
     {
+        $ids = explode(',', $id);
         $contenttype = $app['storage']->getContentType($contenttypeslug);
 
-        $content = $app['storage']->getContent($contenttype['slug'] . "/" . $id);
-        $title = $content->getTitle();
+        foreach($ids as $id) {
+            $content = $app['storage']->getContent($contenttype['slug'] . "/" . $id);
+            $title = $content->getTitle();
 
-        if (!$app['users']->isAllowed("contenttype:{$contenttype['slug']}:delete:$id")) {
-            $app['session']->getFlashBag()->add('error', Trans::__('Permission denied', array()));
-        } elseif ($app['users']->checkAntiCSRFToken() && $app['storage']->deleteContent($contenttype['slug'], $id)) {
-            $app['session']->getFlashBag()->add('info', Trans::__("Content '%title%' has been deleted.", array('%title%' => $title)));
-        } else {
-            $app['session']->getFlashBag()->add('info', Trans::__("Content '%title%' could not be deleted.", array('%title%' => $title)));
+            if (!$app['users']->isAllowed("contenttype:{$contenttype['slug']}:delete:$id")) {
+                $app['session']->getFlashBag()->add('error', Trans::__('Permission denied', array()));
+            } elseif ($app['users']->checkAntiCSRFToken() && $app['storage']->deleteContent($contenttype['slug'], $id)) {
+                $app['session']->getFlashBag()->add('info', Trans::__("Content '%title%' has been deleted.", array('%title%' => $title)));
+            } else {
+                $app['session']->getFlashBag()->add('info', Trans::__("Content '%title%' could not be deleted.", array('%title%' => $title)));
+            }
         }
 
         return Lib::redirect('overview', array('contenttypeslug' => $contenttype['slug']));


### PR DESCRIPTION
This PR adds the ability to batch multiple items together for deletion in a single request.

This is achieved by accepting a comma-delimited list of IDs as a URL and function parameter:
`/bolt/content/deletecontent/pages/1,2,3`
`$controller->deleteContent($app, 'pages', '1,2,3')`

Currently, on an overview page if you select `n` items and "Delete selected" it will trigger `2n` HTTP requests, one to delete and one to "refresh" per item. 

This is quite inefficient and could possibly cause browser/server pain depending on the amount of items you're trying to delete.

Batching these deletes together, this process will only ever trigger 2 requests regardless of the number of items being deleted.

Current functionality will not change - making a request with a single ID will simply be treated as a single length array of IDs.