### PR TITLE
Fixed to handle correctly file requests with built-in server

### DIFF
--- a/index.php
+++ b/index.php
@@ -33,7 +33,7 @@ if (version_compare(PHP_VERSION, '5.3.3', '<')) {
  * @see: http://silex.sensiolabs.org/doc/web_servers.html#php-5-4
  */
 if (php_sapi_name() == 'cli-server') {
-    $filename = dirname(__DIR__) . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
+    $filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
 
     if (is_file($filename)) {
         return false;


### PR DESCRIPTION
**Problem**

When you use PHP's built-in server the requests to files are not resolving correctly.

The condition to detect if it's file doesn't generate `$filename` correctly:

    if (php_sapi_name() == 'cli-server') {
        $filename = dirname(__DIR__) . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);

        if (is_file($filename)) {
            return false;
        }
    }

This causes these file requests to be like `http://localhost:8000/app/view/img/bolt-logo.png/bolt/userfirst`.

**Solution**

I changed

     $filename = dirname(__DIR__) . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);

with

     $filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);

As PHP version is checked in `index.php` previously there is no problem with `__DIR__`.