### PR TITLE
[Tests] Add optional parameters to PHPUnit listener to copy/remove a theme directory

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,8 @@
            <arguments>
               <boolean>true</boolean>
               <boolean>true</boolean>
+              <boolean>false</boolean>
+              <string>theme/base-2014</string>
            </arguments>
         </listener>
     </listeners>


### PR DESCRIPTION
This is off by default. However it's greatest potential use, presently, is for extension unit testing. They can specify our listener and a relative path to a theme and that will get installed and configured.

e.g. An extension's phpunit.xml.dist would just add this:
```xml
    <listeners>
        <listener file="vendor/bolt/bolt/tests/phpunit/BoltListener.php" class="Bolt\Tests\BoltListener">
           <arguments>
              <boolean>true</boolean>
              <boolean>true</boolean>
              <boolean>true</boolean>
              <string>vendor/bolt/bolt/theme/base-2014</string>
           </arguments>
        </listener>
    </listeners>
```