### PR TITLE
Allow editing of empty files.

### DIFF
--- a/app/view/twig/editfile/editfile.twig
+++ b/app/view/twig/editfile/editfile.twig
@@ -19,7 +19,7 @@
         class:     'CodeMirror-scroll',
         id:        'form_contents',
         name:      'form[contents]',
-        required:  true,
+        required:  false,
         style:     'width: 98%; min-height: 350px;',
     } %}
 


### PR DESCRIPTION
Do not set required html tag on editfile textareas to allow editing of
empty files.