### PR TITLE
Consolidate user lookup functions

### DIFF
--- a/app/view/twig/activity/changelog.twig
+++ b/app/view/twig/activity/changelog.twig
@@ -57,7 +57,7 @@
                             {{ entry.comment|default('') }}
                         </td>
                         <td>
-                            {% set user = getuserbyid(entry.ownerid) %}
+                            {% set user = getuser(entry.ownerid) %}
                             {% if user is not empty %}
                                 {% set userlink = macro.userlink(user) %}
                             {% else %}

--- a/app/view/twig/activity/systemlog.twig
+++ b/app/view/twig/activity/systemlog.twig
@@ -107,7 +107,7 @@
                             {% endspaceless %}
                         </td>
                         <td>
-                            {% set user = getuserbyid(entry.ownerid) %}
+                            {% set user = getuser(entry.ownerid) %}
                             {% if user is not empty %}
                                 {% set userlink = macro.userlink(user) %}
                             {% else %}

--- a/app/view/twig/components/panel-change.twig
+++ b/app/view/twig/components/panel-change.twig
@@ -16,7 +16,7 @@
 
     <ul class="activity">
         {% for log in activity %}
-            {% set user = getuserbyid(log.ownerid) %}
+            {% set user = getuser(log.ownerid) %}
             {% if user is not empty %}
                 {% set userlink = macro.userlink(user) %}
             {% else %}

--- a/app/view/twig/components/panel-system.twig
+++ b/app/view/twig/components/panel-system.twig
@@ -16,7 +16,7 @@
 
     <ul class="activity">
         {% for log in activity %}
-            {% set user = getuserbyid( log.ownerid|default('') ) %}
+            {% set user = getuser( log.ownerid|default('') ) %}
             {% if user is not empty %}
                 {% set userlink = macro.userlink(user) %}
             {% else %}

--- a/src/Content.php
+++ b/src/Content.php
@@ -356,7 +356,7 @@ class Content implements \ArrayAccess
 
         // Set the user in the object.
         if ($key === 'ownerid' && !empty($value)) {
-            $this->user = $this->app['users']->getUserById($value);
+            $this->user = $this->app['users']->getUser($value);
         }
 
         // Only set values if they have are actually a field.

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -942,7 +942,7 @@ class Backend implements ControllerProviderInterface
             $contentowner = $app['users']->getCurrentUser();
         } else {
             // For existing items, we'll just keep the current owner.
-            $contentowner = $app['users']->getUserById($content['ownerid']);
+            $contentowner = $app['users']->getUser($content['ownerid']);
         }
 
         // Test write access for uploadable fields
@@ -1213,7 +1213,7 @@ class Backend implements ControllerProviderInterface
 
         // Get the user we want to edit (if any)
         if (!empty($id)) {
-            $user = $app['users']->getUserById($id);
+            $user = $app['users']->getUser($id);
 
             // Verify the current user has access to edit this user
             if (!$app['permissions']->isAllowedToManipulate($user, $currentuser)) {
@@ -1512,7 +1512,7 @@ class Backend implements ControllerProviderInterface
 
             return Lib::redirect('users');
         }
-        $user = $app['users']->getUserById($id);
+        $user = $app['users']->getUser($id);
 
         if (!$user) {
             $app['session']->getFlashBag()->add('error', 'No such user.');

--- a/src/Logger/ChangeLogItem.php
+++ b/src/Logger/ChangeLogItem.php
@@ -203,7 +203,7 @@ class ChangeLogItem implements \ArrayAccess
         }
         if (isset($values['ownerid'])) {
             $this->ownerid = $values['ownerid'];
-            $user = $this->app['users']->getUserById($values['ownerid']);
+            $user = $this->app['users']->getUser($values['ownerid']);
 
             if (isset($user['displayname'])) {
                 $this->username = $user['displayname'];

--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -127,7 +127,7 @@ class Permissions
      * Gets the roles for a given user. If a content type is specified, the
      * "owner" role is added if appropriate.
      *
-     * @param array   $user    An array as returned by Users::getUserById() or Users::getUserByUsername()
+     * @param array   $user    An array as returned by Users::getUser()
      * @param Content $content An optional Content object to check ownership
      *
      * @throws \Exception

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -152,7 +152,7 @@ class Storage
         $content['datedepublish'] = null;
 
         $username = array_rand($this->app['users']->getUsers(), 1);
-        $user = $this->app['users']->getUserByUsername($username);
+        $user = $this->app['users']->getUser($username);
 
         $content['ownerid'] = $user['id'];
 

--- a/src/Twig/Handler/UserHandler.php
+++ b/src/Twig/Handler/UserHandler.php
@@ -24,10 +24,8 @@ class UserHandler
     }
 
     /**
-     * @deprecated Please use getUserById or getUserByUsername
-     *
-     * Get an array of data for a user, based on the given name or id. Returns
-     * an array on success, and false otherwise.
+     * Get an array of data for a user, based on the given name, email address,
+     * or ID. Returns an array on success, and false otherwise.
      *
      * @param mixed $who
      *
@@ -36,32 +34,6 @@ class UserHandler
     public function getUser($who)
     {
         return $this->app['users']->getUser($who);
-    }
-
-   /**
-    * Get an array of data for a user, based on the given id. Returns
-    * an array on success, and false otherwise.
-    *
-    * @param mixed $id
-    *
-    * @return mixed
-    */
-    public function getUserById($id)
-    {
-        return $this->app['users']->getUserById($id);
-    }
-
-    /**
-     * Get an array of data for a user, based on the given username. Returns
-     * an array on success, and false otherwise.
-     *
-     * @param mixed $who
-     *
-     * @return mixed
-     */
-    public function getUserByUsername($who)
-    {
-        return $this->app['users']->getUserByUsername($who);
     }
 
     /**

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -54,8 +54,6 @@ class TwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('firebug',            array($this, 'printFirebug')),
             new \Twig_SimpleFunction('first',              array($this, 'first')),
             new \Twig_SimpleFunction('getuser',            array($this, 'getUser')),
-            new \Twig_SimpleFunction('getuserbyid',        array($this, 'getUserById')),
-            new \Twig_SimpleFunction('getuserbyusername',  array($this, 'getUserByUsername')),
             new \Twig_SimpleFunction('getuserid',          array($this, 'getUserId')),
             new \Twig_SimpleFunction('htmllang',           array($this, 'htmlLang')),
             new \Twig_SimpleFunction('image',              array($this, 'image')),
@@ -231,29 +229,11 @@ public function getTests()
     }
 
     /**
-     * @deprecated Please use getUserById or getUserByUsername
-     *
      * @see \Bolt\Twig\Handler\UserHandler::getUser()
      */
     public function getUser($who)
     {
         return $this->handlers['user']->getUser($who);
-    }
-
-    /**
-     * @see \Bolt\Twig\Handler\UserHandler::getUserById()
-     */
-    public function getUserById($id)
-    {
-        return $this->handlers['user']->getUserById($id);
-    }
-
-    /**
-     * @see \Bolt\Twig\Handler\UserHandler::getUserByUsername()
-     */
-    public function getUserByUsername($who)
-    {
-        return $this->handlers['user']->getUserByUsername($who);
     }
 
     /**

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -89,7 +89,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     protected function addDefaultUser(Application $app)
     {
         //check if default user exists before adding
-        $existingUser = $app['users']->getUserByUsername('admin');
+        $existingUser = $app['users']->getUser('admin');
         if (false !== $existingUser) {
             return $existingUser;
         }

--- a/tests/phpunit/unit/Controller/BackendTest.php
+++ b/tests/phpunit/unit/Controller/BackendTest.php
@@ -711,7 +711,7 @@ class BackendTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $controller = new Backend();
-        $user = $app['users']->getUserById(1);
+        $user = $app['users']->getUser(1);
         $app['users']->currentuser = $user;
         $app['request'] = $request = Request::create('/bolt/useredit/1');
 
@@ -743,7 +743,7 @@ class BackendTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $controller = new Backend();
-        $user = $app['users']->getUserById(1);
+        $user = $app['users']->getUser(1);
         $app['users']->currentuser = $user;
 
         $perms = $this->getMock('Bolt\Permissions', array('isAllowedToManipulate'), array($app));
@@ -782,7 +782,7 @@ class BackendTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $controller = new Backend();
-        $user = $app['users']->getUserById(1);
+        $user = $app['users']->getUser(1);
 
         $app['users']->currentuser = $user;
 
@@ -877,7 +877,7 @@ class BackendTest extends BoltUnitTest
 
          // Symfony forms need a CSRF token so we have to mock this too
         $this->removeCSRF($app);
-        $user = $app['users']->getUserById(1);
+        $user = $app['users']->getUser(1);
         $app['users']->currentuser = $user;
         $app['request'] = $request = Request::create('/bolt/profile');
         $response = $controller->profile($app, $request);
@@ -978,7 +978,7 @@ class BackendTest extends BoltUnitTest
             ->will($this->returnValue(true));
         $app['users'] = $users;
 
-        $currentuser = $app['users']->getUserById(1);
+        $currentuser = $app['users']->getUser(1);
         $app['users']->currentuser = $currentuser;
 
         // This request should fail because the user doesnt exist.
@@ -1067,7 +1067,7 @@ class BackendTest extends BoltUnitTest
         $app['users'] = $users;
 
         // Setup the current user
-        $user = $app['users']->getUserById(1);
+        $user = $app['users']->getUser(1);
         $app['users']->currentuser = $user;
 
         // This mocks a failure and ensures the error is reported

--- a/tests/phpunit/unit/Logger/ChangeLogItemTest.php
+++ b/tests/phpunit/unit/Logger/ChangeLogItemTest.php
@@ -27,9 +27,9 @@ class ChangeLogItemTest extends BoltUnitTest
         $this->setExpectedException('InvalidArgumentException');
         $test = $cl->nonexistent;
 
-        $users = $this->getMock('Bolt\Users', array('getUserById'), array($app));
+        $users = $this->getMock('Bolt\Users', array('getUser'), array($app));
         $users->expects($this->any())
-            ->method('getUserById')
+            ->method('getUser')
             ->will($this->returnValue(array('displayname' => 'Tester', 'username' => 'test')));
 
         $app['users'] = $users;
@@ -57,9 +57,9 @@ class ChangeLogItemTest extends BoltUnitTest
     public function testGetMutationType()
     {
         $app = $this->getApp();
-        $users = $this->getMock('Bolt\Users', array('getUserById'), array($app));
+        $users = $this->getMock('Bolt\Users', array('getUser'), array($app));
         $users->expects($this->any())
-            ->method('getUserById')
+            ->method('getUser')
             ->will($this->returnValue(array('displayname' => 'Tester', 'username' => 'test')));
 
         $app['users'] = $users;
@@ -85,9 +85,9 @@ class ChangeLogItemTest extends BoltUnitTest
     public function testStandardChangeField()
     {
         $app = $this->getApp();
-        $users = $this->getMock('Bolt\Users', array('getUserById'), array($app));
+        $users = $this->getMock('Bolt\Users', array('getUser'), array($app));
         $users->expects($this->any())
-            ->method('getUserById')
+            ->method('getUser')
             ->will($this->returnValue(array('displayname' => 'Tester', 'username' => 'test')));
 
         $app['users'] = $users;

--- a/tests/phpunit/unit/Users/UsersTest.php
+++ b/tests/phpunit/unit/Users/UsersTest.php
@@ -8,7 +8,6 @@ use Bolt\Tests\BoltUnitTest;
  *
  * @author Steven de Vries <info@stevendevries.nl>
  **/
-
 class UsersTest extends BoltUnitTest
 {
     /**
@@ -21,53 +20,50 @@ class UsersTest extends BoltUnitTest
      */
     protected function setUp()
     {
-        $this->user = array('id'=>5, 'username'=>'test', 'email' => 'test@example.com');
+        $this->user = array('id' => 5, 'username' => 'test', 'email' => 'test@example.com');
     }
 
     /**
-     * @covers Bolt\Users::GetUserById
+     * @covers Bolt\Users::getUser
      */
     public function testGetUserById()
     {
         //setup test
         $users = $this->getMock('Bolt\Users', array('getUsers'), array($this->getApp()));
-        $users->expects($this->once())->method('getUsers')->willReturn(array($this->user));
         $users->users = array($this->user);
 
         //run test
-        $result = $users->GetUserById(5);
+        $result = $users->getUser(5);
 
         //check result
         $this->assertEquals($this->user, $result);
     }
 
     /**
-     * @covers Bolt\Users::GetUserById
+     * @covers Bolt\Users::getUser
      */
     public function testGetUserByUnknownId()
     {
         //setup test
         $users = $this->getMock('Bolt\Users', array('getUsers'), array($this->getApp()));
-        $users->expects($this->once())->method('getUsers')->willReturn(array($this->user));
         $users->users = array($this->user);
-        
+
         //run test
-        $result = $users->GetUserById(2);
+        $result = $users->getUser(2);
 
         //check result
         $this->assertEquals(false, $result);
     }
 
     /**
-     * @covers Bolt\Users::GetUser
+     * @covers Bolt\Users::getUser
      */
     public function testGetUserWithId()
     {
         //setup test
         $users = $this->getMock('Bolt\Users', array('getUsers'), array($this->getApp()));
-        $users->expects($this->once())->method('getUsers')->willReturn(array($this->user));
         $users->users = array($this->user);
-        
+
         //run test
         $result = $users->GetUser(5);
 
@@ -76,34 +72,32 @@ class UsersTest extends BoltUnitTest
     }
 
     /**
-     * @covers Bolt\Users::getUserByUsername
+     * @covers Bolt\Users::getUser
      */
     public function testGetUserByUsername()
     {
         //setup test
         $users = $this->getMock('Bolt\Users', array('getUsers'), array($this->getApp()));
-        $users->expects($this->once())->method('getUsers')->willReturn(array($this->user));
         $users->users = array($this->user);
-        
+
         //run test
-        $result = $users->getUserByUsername('test');
+        $result = $users->getUser('test');
 
         //check result
         $this->assertEquals($this->user, $result);
     }
 
     /**
-     * @covers Bolt\Users::getUserByUsername
+     * @covers Bolt\Users::getUser
      */
     public function testGetUserByUnknownUsername()
     {
         //setup test
         $users = $this->getMock('Bolt\Users', array('getUsers'), array($this->getApp()));
-        $users->expects($this->once())->method('getUsers')->willReturn(array($this->user));
         $users->users = array($this->user);
-        
+
         //run test
-        $result = $users->getUserByUsername('anotheruser');
+        $result = $users->getUser('anotheruser');
 
         //check result
         $this->assertEquals(false, $result);
@@ -118,7 +112,7 @@ class UsersTest extends BoltUnitTest
         $users = $this->getMock('Bolt\Users', array('loginUsername', 'loginEmail'), array($this->getApp()));
         $users->expects($this->once())->method('loginUsername')->willReturn(true);
         $users->expects($this->never())->method('loginEmail');
-        
+
         //run test
         $result = $users->login('anotheruser', 'test123');
 


### PR DESCRIPTION
I was looking at an error on password reset where we were calling getUserByEmail() but that wasn't implemented.  Looking further the getUser*() function it seems we can just consolidate them.

@StevendeVries this affects you guys, the core functionality remains unchanged, jut dropping those new functions… can you chime in if you see any issues.