### PR TITLE
Always have a fallback for a timezone when it isn't set in either php.ini or config.yml

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -305,16 +305,14 @@ class Application extends Silex\Application
         $this['locale'] = reset($configLocale);
 
         // Set the default timezone if provided in the Config
-        if ($tz = $this['config']->get('general/timezone')) {
-            date_default_timezone_set($tz);
-        }
+        date_default_timezone_set($this['config']->get('general/timezone') ?: ini_get('date.timezone') ?: 'UTC');
 
         // for javascript datetime calculations, timezone offset. e.g. "+02:00"
         $this['timezone_offset'] = date('P');
 
         // Set default locale, for Bolt
         $locale = array();
-        foreach ($configLocale as $key => $value) {
+        foreach ($configLocale as $value) {
             $locale = array_merge($locale, array(
                 $value . '.UTF-8',
                 $value . '.utf8',


### PR DESCRIPTION
Follow up to #3333 & #3334 

Fixes #3377