### PR TITLE
Adding PHPdocumentor task

### DIFF
--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -8,7 +8,9 @@ module.exports = function(grunt) {
         },
         path: {
             tmp: 'tmp',
-            doc: 'docs',
+            doc: {
+                js: 'docs/js'
+            },
             src: {
                 js: 'js',
                 lib: 'lib',

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -9,7 +9,8 @@ module.exports = function(grunt) {
         path: {
             tmp: 'tmp',
             doc: {
-                js: 'docs/js'
+                js: 'docs/js',
+                php: 'docs/php'
             },
             src: {
                 js: 'js',

--- a/app/src/grunt/aliases.yml
+++ b/app/src/grunt/aliases.yml
@@ -33,3 +33,9 @@ prepareCkeditor:
     - bom:prepareCkeditor                   # Remove unneeded bom
     - eol:prepareCkeditor                   # Convert CRLF to LF
     - endline:prepareCkeditor               # Add newlines to *.js
+
+# API DOCUMENTATION CREATION TASKS
+docJs:
+    - jsdoc:boltJs
+docPhp:
+    - phpdocumentor:bolt

--- a/app/src/grunt/jsdoc.js
+++ b/app/src/grunt/jsdoc.js
@@ -14,7 +14,7 @@ module.exports = {
             '<%= path.src.js %>/modules/*.js',
             '<%= path.src.js %>/modules/fields/*.js'
         ],
-        dest: '<%= path.doc %>',
+        dest: '<%= path.doc.js %>',
         options: {
             private: true,
             configure : 'jsdoc.json'

--- a/app/src/grunt/jsdoc.js
+++ b/app/src/grunt/jsdoc.js
@@ -1,5 +1,5 @@
 /*
- * EOL: Generate comments based documentation.
+ * JSDOC: Generate comments based documentation.
  */
 module.exports = {
     /*

--- a/app/src/grunt/phpdocumentor.js
+++ b/app/src/grunt/phpdocumentor.js
@@ -1,0 +1,14 @@
+/*
+ * PHPDOCUMENTOR: Runs the PHPDocumentor documentation generator tool.
+ */
+module.exports = {
+    /*
+     * TARGET:  Generate Bolt API documentation
+     */
+    bolt: {
+        options: {
+            directory: '../../src',
+            target: '<%= path.doc.php %>'
+        }
+    }
+};

--- a/app/src/package.json
+++ b/app/src/package.json
@@ -22,6 +22,7 @@
     "grunt-eol": "~0.2.0",
     "grunt-jsdoc": "^0.5.8",
     "grunt-modernizr": "~0.6.0",
+    "grunt-phpdocumentor": "^0.4.1",
     "grunt-remove": "~0.1.0",
     "grunt-sass": "~0.17.0",
     "jsdoc": "^3.3.0-beta2",


### PR DESCRIPTION
Adding PHPdocumentor task, run by ``grunt docPhp``.

:warning: For now this is for **internal usage** only and not meant to define and document a public API.