### PR TITLE
Less statics for Database\IntegrityChecker

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -73,7 +73,8 @@ class Application extends Silex\Application
 
     protected function initConfig()
     {
-        $this->register(new Provider\ConfigServiceProvider());
+        $this->register(new Provider\IntegrityCheckerProvider())
+            ->register(new Provider\ConfigServiceProvider());
     }
 
     protected function initSession()
@@ -376,7 +377,6 @@ class Application extends Silex\Application
             ->register(new Provider\StorageServiceProvider())
             ->register(new Provider\UsersServiceProvider())
             ->register(new Provider\CacheServiceProvider())
-            ->register(new Provider\IntegrityCheckerProvider())
             ->register(new Provider\ExtensionServiceProvider())
             ->register(new Provider\StackServiceProvider())
             ->register(new Provider\OmnisearchServiceProvider())

--- a/src/Config.php
+++ b/src/Config.php
@@ -71,7 +71,7 @@ class Config
             $this->saveCache();
 
             // if we have to reload the config, we will also want to make sure the DB integrity is checked.
-            Database\IntegrityChecker::invalidate($this->app);
+            $this->app['integritychecker']->invalidate();
         } else {
 
             // In this case the cache is loaded, but because the path of the theme

--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -44,7 +44,6 @@ class Frontend
         // If there are no users in the users table, or the table doesn't exist. Repair
         // the DB, and let's add a new user.
         if (!$app['users']->getUsers()) {
-            //!$app['storage']->getIntegrityChecker()->checkUserTableIntegrity() ||
             $app['session']->getFlashBag()->add('info', Trans::__('There are no users in the database. Please create the first user.'));
 
             return Lib::redirect('useredit', array('id' => ''));
@@ -54,7 +53,6 @@ class Frontend
         $app['htmlsnippets'] = true;
 
         // If we are in maintenance mode and current user is not logged in, show maintenance notice.
-        // @see /app/app.php, $app->error()
         if ($app['config']->get('general/maintenance_mode')) {
             if (!$app['users']->isAllowed('maintenance-mode')) {
                 $template = $app['templatechooser']->maintenance();

--- a/src/Database/IntegrityChecker.php
+++ b/src/Database/IntegrityChecker.php
@@ -51,35 +51,6 @@ class IntegrityChecker
     }
 
     /**
-     * Default value for TEXT fields, differs per platform.
-     *
-     * @return string|null
-     */
-    private function getTextDefault()
-    {
-        $platform = $this->app['db']->getDatabasePlatform();
-        if ($platform instanceof SqlitePlatform || $platform instanceof PostgreSqlPlatform) {
-            return '';
-        }
-
-        return null;
-    }
-
-    /**
-     * Get the 'validity' timestamp's file name.
-     *
-     * @return string
-     */
-    private function getValidityTimestampFilename()
-    {
-        if (empty($this->integrityCachePath)) {
-            $this->integrityCachePath = $this->app['resources']->getPath('cache');;
-        }
-
-        return $this->integrityCachePath . '/' . self::INTEGRITY_CHECK_TS_FILENAME;
-    }
-
-    /**
      * Invalidate our database check by removing the timestamp file from cache.
      *
      * @return void
@@ -702,5 +673,34 @@ class IntegrityChecker
         }
 
         return $this->prefix;
+    }
+
+    /**
+     * Default value for TEXT fields, differs per platform.
+     *
+     * @return string|null
+     */
+    private function getTextDefault()
+    {
+        $platform = $this->app['db']->getDatabasePlatform();
+        if ($platform instanceof SqlitePlatform || $platform instanceof PostgreSqlPlatform) {
+            return '';
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the 'validity' timestamp's file name.
+     *
+     * @return string
+     */
+    private function getValidityTimestampFilename()
+    {
+        if (empty($this->integrityCachePath)) {
+            $this->integrityCachePath = $this->app['resources']->getPath('cache');;
+        }
+
+        return $this->integrityCachePath . '/' . self::INTEGRITY_CHECK_TS_FILENAME;
     }
 }

--- a/src/Database/IntegrityChecker.php
+++ b/src/Database/IntegrityChecker.php
@@ -46,8 +46,6 @@ class IntegrityChecker
 
         // Check the table integrity only once per hour, per session. (since it's pretty time-consuming.
         $this->checktimer = 3600;
-
-        $this->integrityCachePath = $this->app['resources']->getPath('cache');
     }
 
     /**
@@ -698,7 +696,7 @@ class IntegrityChecker
     private function getValidityTimestampFilename()
     {
         if (empty($this->integrityCachePath)) {
-            $this->integrityCachePath = $this->app['resources']->getPath('cache');;
+            $this->integrityCachePath = $this->app['resources']->getPath('cache');
         }
 
         return $this->integrityCachePath . '/' . self::INTEGRITY_CHECK_TS_FILENAME;

--- a/src/Database/IntegrityChecker.php
+++ b/src/Database/IntegrityChecker.php
@@ -25,9 +25,6 @@ class IntegrityChecker
     /** @var string */
     private $prefix;
 
-    /** @var string|null Default value for TEXT fields, differs per platform. */
-    private $textDefault = null;
-
     /** @var \Doctrine\DBAL\Schema\Table[] Current tables. */
     private $tables;
 
@@ -57,14 +54,22 @@ class IntegrityChecker
         // Check the table integrity only once per hour, per session. (since it's pretty time-consuming.
         $this->checktimer = 3600;
 
+        $this->integrityCachePath = $this->app['resources']->getPath('cache');
+    }
+
+    /**
+     * Default value for TEXT fields, differs per platform.
+     *
+     * @return string|null
+     */
+    private function getTextDefault()
+    {
         $platform = $this->app['db']->getDatabasePlatform();
         if ($platform instanceof SqlitePlatform || $platform instanceof PostgreSqlPlatform) {
-            $this->textDefault = '';
+            return '';
         }
 
-        $this->tables = null;
-
-        $this->integrityCachePath = $this->app['resources']->getPath('cache');
+        return null;
     }
 
     /**
@@ -628,7 +633,7 @@ class IntegrityChecker
                     case 'filelist':
                     case 'imagelist':
                     case 'select':
-                        $myTable->addColumn($field, 'text', array('default' => $this->textDefault));
+                        $myTable->addColumn($field, 'text', array('default' => $this->getTextDefault()));
                         break;
                     case 'datetime':
                         $myTable->addColumn($field, 'datetime', array('notnull' => false));


### PR DESCRIPTION
The statics were introduced in 2a5c9d28700ce0eb2e8925426e7f5c522b511d1e for #692. 

The dependency loop that those commits worked around were, in effect, created by overloading the constructor needlessly.

This one is for you, @rossriley :grinning: 

