### PR TITLE
Add IIS web.config

### DIFF
--- a/web.config
+++ b/web.config
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+		<defaultDocument>
+            <files>
+				<clear />
+                <add value="index.php" />
+                <add value="index.html" />
+                <add value="index.htm" />
+            </files>
+        </defaultDocument>
+        <rewrite>
+            <rules>
+                <clear />
+                <rule name="Deny cache access" enabled="false" patternSyntax="Wildcard" stopProcessing="true">
+                    <match url="*" />
+                    <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
+                        <add input="{URL}" pattern="cache/*" />
+                    </conditions>
+                    <action type="CustomResponse" statusCode="403" statusReason="Forbidden: Access is denied." statusDescription="You do not have permission to view this directory or page using the credentials that you supplied." />
+                </rule>
+                <rule name="Deny yml|db|twig|md file access" enabled="false" stopProcessing="true">
+                    <match url=".*" />
+                    <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
+                        <add input="{URL}" pattern="\.(yml|db|twig|md)$" />
+                    </conditions>
+                    <action type="AbortRequest" />
+                </rule>
+                <rule name="Symfony defend against some worm attacks" stopProcessing="true">
+                    <match url=".*" />
+                    <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
+                        <add input="{URL}" pattern=".*(?:global.asa|default\.ida|root\.exe|\.\.).*" />
+                    </conditions>
+                    <action type="CustomResponse" statusCode="403" statusReason="Forbidden: Access is denied." statusDescription="You do not have permission to view this directory or page using the credentials that you supplied." />
+                </rule>
+                <rule name="Symfony skip all files with .something except .html" enabled="true" stopProcessing="true">
+                    <match url="(.*)" />
+                    <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
+                        <add input="{QUERY_STRING}" pattern=".*\..+$" />
+                        <add input="{QUERY_STRING}" pattern="(?!.*\.html$).*" />
+                    </conditions>
+                    <action type="Rewrite" url="{R:1}" />
+                </rule>
+                <rule name="Symfony we keep the .php files unchanged" enabled="true" stopProcessing="true">
+                    <match url="(.*\.php)(.*)" />
+                    <conditions logicalGrouping="MatchAll" trackAllCaptures="false" />
+                    <action type="Rewrite" url="{R:1}{R:2}" />
+                </rule>
+                <rule name="Default Handler" enabled="true" stopProcessing="true">
+                    <match url="^(.*)$" />
+                    <conditions logicalGrouping="MatchAll" trackAllCaptures="false">
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+                        <add input="{REQUEST_FILENAME}" matchType="IsDirectory" negate="true" />
+                        <add input="{QUERY_STRING}" pattern="/favicon.ico" negate="true" />
+                    </conditions>
+                    <action type="Rewrite" url="index.php" appendQueryString="true" />
+                </rule>
+            </rules>
+        </rewrite>
+        <directoryBrowse enabled="false" />
+        <staticContent>
+            <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+        </staticContent>
+    </system.webServer>
+</configuration>

--- a/web.config
+++ b/web.config
@@ -3,7 +3,7 @@
     <system.webServer>
 		<defaultDocument>
             <files>
-				<clear />
+                <clear />
                 <add value="index.php" />
                 <add value="index.html" />
                 <add value="index.htm" />

--- a/web.config
+++ b/web.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <system.webServer>
-		<defaultDocument>
+        <defaultDocument>
             <files>
                 <clear />
                 <add value="index.php" />


### PR DESCRIPTION
For Issue #3422

Add in IIS URL Rewrite module drop in replacement for Apache .htaccess
file. URL rewriting is handled, as is the woff2 file definition, but I
had to disable the cache access and yml,db,twig,md deny rules as they
interfered with the CMS backend.

WARNING: In order to have this work on IIS you must have the IIS URL
Rewrite module. You will also need to alter the permissions on the files
folder and the PHP extension php_fileinfo will need to be enabled.
Instructions to follow in the documentation repository.