### PR TITLE
PGSQL encoding settings in post connect event until doctrine/2.5.2 is out

### DIFF
--- a/src/Database/InitListener.php
+++ b/src/Database/InitListener.php
@@ -37,6 +37,11 @@ class InitListener implements ServiceProviderInterface, EventSubscriber
             // see: http://stackoverflow.com/questions/1566602/is-set-character-set-utf8-necessary
             $db->executeQuery('SET NAMES utf8');
             $db->executeQuery('SET CHARACTER_SET_CONNECTION = utf8');
+        } elseif ($platform === 'postgresql') {
+            /**
+             * @link https://github.com/doctrine/dbal/pull/828
+             */
+            $db->executeQuery("SET NAMES 'utf8'");
         }
     }
 


### PR DESCRIPTION
DBAL pgsql sending `options` parameters in connect but it is won't affect client encoding settings but breaks other middlewares like pgbouncer. 
With DBAL 2.5.2 this should be removed! 
See https://github.com/doctrine/dbal/pull/828 for details.