### PR TITLE
add optional filter to select field with contenttype values

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -20,7 +20,8 @@
     {% endif %}
     {% set sortingorder = field.sort|default(lookupfield|first) %}
     {% set querylimit = field.limit|default(500) %}
-    {% setcontent lookups = lookuptype order sortingorder nohydrate limit querylimit %}
+    {% set wherefilter = field.filter|default({}) %}
+    {% setcontent lookups = lookuptype where wherefilter order sortingorder nohydrate limit querylimit %}
     {% set values = lookups|selectfield(lookupfield, option.multiple, field.keys|default('id')) %}
 {% endif %}
 


### PR DESCRIPTION
Tiny little feature that allows you to specify an optional filter when the values for a select field are pulled from a contenttype.. eg:

    relatednews:
        type: select
        multiple: true
        values: pages/title
        filter: {categories:news}
        autocomplete: true

