### PR TITLE
Local grunt options changed and enabling linting of HTML/Bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ npm-debug.log
 *.map
 app/src/tmp/
 app/src/docs/
+app/src/grunt-local/
 app/src/grunt.json
 
 # File-system cruft and temporary files

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -88,6 +88,7 @@ module.exports = function(grunt) {
         localOptions = {};
 
     grunt.file.expand('./grunt-local/*.js').map(function (confPath) {
+        grunt.verbose.writeln('Load local options "' + confPath + '"');
         localOptions[path.basename(confPath, '.js')] = require(confPath);
     });
     require('deep-extend')(options, localOptions);

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
     grunt.util.linefeed = '\n';
 
     var options = {
-        sourceMap: {
+        sourcemap: {
             css: false,
             js: false
         },

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -87,6 +87,8 @@ module.exports = function(grunt) {
         require('deep-extend')(options, grunt.file.readJSON('grunt.json'));
     }
 
-    require('load-grunt-config')(grunt, {data: options});
-
+    require('load-grunt-config')(grunt, {
+        data: options,
+        jitGrunt: true
+    });
 };

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -83,11 +83,16 @@ module.exports = function(grunt) {
         }
     };
 
-    // Optionally overwrite options with grunt.json
-    if (grunt.file.exists('grunt.json')) {
-        require('deep-extend')(options, grunt.file.readJSON('grunt.json'));
-    }
+    // Optionally overwrite options with grunt-local/*.js
+    var path = require('path'),
+        localOptions = {};
 
+    grunt.file.expand('./grunt-local/*.js').map(function (confPath) {
+        localOptions[path.basename(confPath, '.js')] = require(confPath);
+    });
+    require('deep-extend')(options, localOptions);
+
+    // Start
     require('load-grunt-config')(grunt, {
         data: options,
         jitGrunt: {

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -89,6 +89,10 @@ module.exports = function(grunt) {
 
     require('load-grunt-config')(grunt, {
         data: options,
-        jitGrunt: true
+        jitGrunt: {
+            staticMappings: {
+                pages: 'grunt-tasks/pages.js'
+            }
+        }
     });
 };

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
         },
         path: {
             tmp: 'tmp',
+            pages: 'tmp/pages',
             doc: {
                 js: 'docs/js',
                 php: 'docs/php'

--- a/app/src/Gruntfile.js
+++ b/app/src/Gruntfile.js
@@ -92,7 +92,8 @@ module.exports = function(grunt) {
         data: options,
         jitGrunt: {
             staticMappings: {
-                pages: 'grunt-tasks/pages.js'
+                pages: 'grunt-tasks/pages.js',
+                htmllint: 'grunt-html'
             }
         }
     });

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -12,16 +12,14 @@ The content of these files look like:
 These files are ignored by git.
 
 
-### Sourcemaps
+### Sourcemaps (grunt-local/sourcemaps.js)
 
-Example file to enable generation of sourcemaps:
+Sample file to enable generation of sourcemaps:
 
-    {
-        "sourcemap": {
-            "css": true,
-            "js": true
-        }
-    }
+    module.exports = {
+        "css": true,
+        "js": true
+    };
 
 ### Pages
 

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -5,6 +5,8 @@
 Add a file ``app/src/grunt.json`` in which you put the options you want to overwrite.
 This file is ignored by git.
 
+### Sourcemaps
+
 Example file to enable generation of sourcemaps:
 
     {
@@ -13,6 +15,129 @@ Example file to enable generation of sourcemaps:
             "js": true
         }
     }
+### Pages
+
+For the linting tasks you have to define a list of pages to download to the ``tmp/pages`` folder.
+
+    {
+        "pages": {
+            "baseurl": "http://bolt.localhost/bolt/",
+            "requests": { … }
+        }
+    }
+
+The key of the ``requests`` part is the filename and the value defines the page to download.
+
+- If the request starts with ``#`` the entry is ignored. A little helper, as there are no comments in JSON.
+- If no extension is given on the request key ``.html`` is automatically appended.
+- If the value is a string it is handled as a GET request with that value a relative url.
+- If the value is an empty string the key is used as value.
+- If the value is an object it is used as request configuration (see https://github.com/request/request).
+- If the key is ``@login`` it is handled as not saved login request.
+  The value has to be ``{"u": "<username>", "p": "<password>"}`` then.
+- If the key is ``@logout`` it is handled as not saved logout request. The value has to be ``{}`` then.
+
+#### Example: Key handling
+
+Three requests save the same page to file ``login.html``.
+
+    "pages": {
+        "baseurl": "http://bolt.localhost/bolt/",
+        "requests": {
+                "login": "",
+                "login": "login",
+                "login.html": "login"
+                "#this entry is ignored": "login"
+            }
+        }
+    }
+
+#### Example: POST request
+
+Issue a manual login (same as ``@login``, only page is saved as ``dashboard.html``):
+
+    "pages": {
+        "baseurl": "http://bolt.localhost/bolt/",
+        "requests": {
+            "dashboard": {
+                "url": "login",
+                "method": "POST",
+                "form": {
+                    "username": "<enter username here>",
+                    "password": "<enter password here>",
+                    "action": "login"
+                }
+            }
+        }
+    }
+
+#### Example: "Full" interface check
+    {
+        "pages": {
+            "baseurl": "http://bolt.localhost/bolt/",
+            "requests": {
+                "login": "",
+                "@login": {"u": "<enter username here>", "p": "<enter password here>"},
+
+                "#___ Dashboard ___": null,
+                "dashboard": "/",
+
+                "#___ Configuration: Users & Permissions ___": null,
+                "config-users": "users",
+                "config-users-new": "users/edit",
+                "config-users-edit": "users/edit/1",
+                "config-roles": "roles",
+                "config-permissions": "file/edit/config/permissions.yml",
+
+                "#___ Configuration: Main configuration ___": null,
+                "config-main": "file/edit/config/config.yml",
+
+                "#___ Configuration: Contenttypes ___": null,
+                "config-contenttypes": "file/edit/config/contenttypes.yml",
+
+                "#___ Configuration: Taxonomy ___": null,
+                "config-taxonomy": "file/edit/config/taxonomy.yml",
+
+                "#___ Configuration: Menu ___": null,
+                "config-menu": "file/edit/config/menu.yml",
+
+                "#___ Configuration: Routing ___": null,
+                "config-routing": "file/edit/config/routing.yml",
+
+                "#___ Configuration: Check database ___": null,
+                "config-dbcheck": "dbcheck",
+                "config-prefill": "prefill",
+
+                "#___ Configuration: Clear the cache ___": null,
+                "config-clearcache": "clearcache",
+
+                "#___ Configuration: Change Log ___": null,
+                "config-changelog": "changelog",
+
+                "#___ Configuration: System Log ___": null,
+                "config-systemlog": "systemlog",
+
+                "#___ File Management ___": null,
+                "files-files": "files",
+                "files-theme": "files/theme",
+
+                "#___ Translations ___": null,
+                "translations-messages": "tr",
+                "translations-long-messages": "tr/infos",
+                "translations-contenttypes": "tr/contenttypes",
+
+                "#___ Extras ___": null,
+                "extras-view-install": "extend",
+                "extras-configure": "files/config/extensions",
+
+                "#___ Main Menu ___": null,
+                "profile": "profile",
+
+                "@logout": {},
+            }
+        }
+    }
+
 
 ##Range Specifiers
 

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -156,11 +156,12 @@ You can override bootlint options, e.g.:
 
 You can override bootlint options, e.g.:
 
-    {
-        "htmllint": {
-            "ignore": "Element “link” is missing required attribute “property”."
-        }
-    }
+    module.exports = {
+        ignore: [
+            "Element “link” is missing required attribute “property”.",
+            /^Duplicate ID/
+        ]
+    };
 
 
 ##Range Specifiers

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -17,20 +17,18 @@ These files are ignored by git.
 Sample file to enable generation of sourcemaps:
 
     module.exports = {
-        "css": true,
-        "js": true
+        css: true,
+        js: true
     };
 
-### Pages
+### Pages (grunt-local/pages.js)
 
 For the linting tasks you have to define a list of pages to download to the ``tmp/pages`` folder.
 
-    {
-        "pages": {
-            "baseurl": "http://bolt.localhost/bolt/",
-            "requests": { … }
-        }
-    }
+    module.exports = {
+        baseurl: "http://bolt.localhost/bolt/",
+        requests: { … }
+    };
 
 The key of the ``requests`` part is the filename and the value defines the page to download.
 
@@ -40,109 +38,108 @@ The key of the ``requests`` part is the filename and the value defines the page 
 - If the value is an empty string the key is used as value.
 - If the value is an object it is used as request configuration (see https://github.com/request/request).
 - If the key is ``@login`` it is handled as not saved login request.
-  The value has to be ``{"u": "<username>", "p": "<password>"}`` then.
+  The value has to be ``{u: "<username>", p: "<password>"}`` then.
 - If the key is ``@logout`` it is handled as not saved logout request. The value has to be ``{}`` then.
 
 #### Example: Key handling
 
 Three requests save the same page to file ``login.html``.
 
-    "pages": {
-        "baseurl": "http://bolt.localhost/bolt/",
-        "requests": {
+    module.exports = {
+        baseurl: "http://bolt.localhost/bolt/",
+        requests: {
                 "login": "",
                 "login": "login",
                 "login.html": "login"
                 "#this entry is ignored": "login"
             }
         }
-    }
+    };
 
 #### Example: POST request
 
 Issue a manual login (same as ``@login``, only page is saved as ``dashboard.html``):
 
-    "pages": {
-        "baseurl": "http://bolt.localhost/bolt/",
-        "requests": {
-            "dashboard": {
-                "url": "login",
-                "method": "POST",
-                "form": {
-                    "username": "<enter username here>",
-                    "password": "<enter password here>",
-                    "action": "login"
+    module.exports = {
+        baseurl: "http://bolt.localhost/bolt/",
+        requests: {
+            dashboard: {
+                url: "login",
+                method: "POST",
+                form: {
+                    username: "<enter username here>",
+                    password: "<enter password here>",
+                    action: "login"
                 }
             }
         }
-    }
+    };
 
 #### Example: "Full" interface check
     {
-        "pages": {
-            "baseurl": "http://bolt.localhost/bolt/",
-            "requests": {
-                "login": "",
-                "@login": {"u": "<enter username here>", "p": "<enter password here>"},
+    module.exports = {
+        baseurl: "http://bolt.localhost/bolt/",
+        requests: {
+            "login": "",
+            "@login": {"u": "<enter username here>", "p": "<enter password here>"},
 
-                "#___ Dashboard ___": null,
-                "dashboard": "/",
+            // Dashboard
+            "dashboard": "/",
 
-                "#___ Configuration: Users & Permissions ___": null,
-                "config-users": "users",
-                "config-users-new": "users/edit",
-                "config-users-edit": "users/edit/1",
-                "config-roles": "roles",
-                "config-permissions": "file/edit/config/permissions.yml",
+            // Configuration: Users & Permissions
+            "config-users": "users",
+            "config-users-new": "users/edit",
+            "config-users-edit": "users/edit/1",
+            "config-roles": "roles",
+            "config-permissions": "file/edit/config/permissions.yml",
 
-                "#___ Configuration: Main configuration ___": null,
-                "config-main": "file/edit/config/config.yml",
+            // Configuration: Main configuration
+            "config-main": "file/edit/config/config.yml",
 
-                "#___ Configuration: Contenttypes ___": null,
-                "config-contenttypes": "file/edit/config/contenttypes.yml",
+            // Configuration: Contenttypes
+            "config-contenttypes": "file/edit/config/contenttypes.yml",
 
-                "#___ Configuration: Taxonomy ___": null,
-                "config-taxonomy": "file/edit/config/taxonomy.yml",
+            // Configuration: Taxonomy
+            "config-taxonomy": "file/edit/config/taxonomy.yml",
 
-                "#___ Configuration: Menu ___": null,
-                "config-menu": "file/edit/config/menu.yml",
+            // Configuration: Menu
+            "config-menu": "file/edit/config/menu.yml",
 
-                "#___ Configuration: Routing ___": null,
-                "config-routing": "file/edit/config/routing.yml",
+            // Configuration: Routing
+            "config-routing": "file/edit/config/routing.yml",
 
-                "#___ Configuration: Check database ___": null,
-                "config-dbcheck": "dbcheck",
-                "config-prefill": "prefill",
+            // Configuration: Check database
+            "config-dbcheck": "dbcheck",
+            "config-prefill": "prefill",
 
-                "#___ Configuration: Clear the cache ___": null,
-                "config-clearcache": "clearcache",
+            // Configuration: Clear the cache
+            "config-clearcache": "clearcache",
 
-                "#___ Configuration: Change Log ___": null,
-                "config-changelog": "changelog",
+            // Configuration: Change Log
+            "config-changelog": "changelog",
 
-                "#___ Configuration: System Log ___": null,
-                "config-systemlog": "systemlog",
+            // Configuration: System Log
+            "config-systemlog": "systemlog",
 
-                "#___ File Management ___": null,
-                "files-files": "files",
-                "files-theme": "files/theme",
+            // File Management
+            "files-files": "files",
+            "files-theme": "files/theme",
 
-                "#___ Translations ___": null,
-                "translations-messages": "tr",
-                "translations-long-messages": "tr/infos",
-                "translations-contenttypes": "tr/contenttypes",
+            // Translations
+            "translations-messages": "tr",
+            "translations-long-messages": "tr/infos",
+            "translations-contenttypes": "tr/contenttypes",
 
-                "#___ Extras ___": null,
-                "extras-view-install": "extend",
-                "extras-configure": "files/config/extensions",
+            // Extras
+            "extras-view-install": "extend",
+            "extras-configure": "files/config/extensions",
 
-                "#___ Main Menu ___": null,
-                "profile": "profile",
+            // Main Menu
+            "profile": "profile",
 
-                "@logout": {},
-            }
+            "@logout": {},
         }
-    }
+    };
 
 ### Bootlint
 

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -2,8 +2,15 @@
 
 ## Local options
 
-Add a file ``app/src/grunt.json`` in which you put the options you want to overwrite.
-This file is ignored by git.
+Add JS options files to ``app/src/grunt-local/`` in which you put the options you want to overwrite.
+The content of these files look like:
+
+    module.exports = {
+        value: "The value"
+    };
+
+These files are ignored by git.
+
 
 ### Sourcemaps
 

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -17,7 +17,7 @@ These files are ignored by git.
 Example file to enable generation of sourcemaps:
 
     {
-        "sourceMap": {
+        "sourcemap": {
             "css": true,
             "js": true
         }

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -15,6 +15,7 @@ Example file to enable generation of sourcemaps:
             "js": true
         }
     }
+
 ### Pages
 
 For the linting tasks you have to define a list of pages to download to the ``tmp/pages`` folder.
@@ -136,6 +137,19 @@ Issue a manual login (same as ``@login``, only page is saved as ``dashboard.html
                 "@logout": {},
             }
         }
+    }
+
+### Bootlint
+
+You can override bootlint options, e.g.:
+
+    {
+        "bootlint": {
+            "relaxerror": ["W012"],
+            "showallerrors": false,
+            "stoponerror": false,
+            "stoponwarning": false
+        };
     }
 
 

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -145,14 +145,12 @@ Issue a manual login (same as ``@login``, only page is saved as ``dashboard.html
 
 You can override bootlint options, e.g.:
 
-    {
-        "bootlint": {
-            "relaxerror": ["W012"],
-            "showallerrors": false,
-            "stoponerror": false,
-            "stoponwarning": false
-        }
-    }
+    module.exports = {
+        relaxerror: ["W012"],
+        showallerrors: false,
+        stoponerror: true,
+        stoponwarning: false
+    };
 
 ### Htmllint
 

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -149,7 +149,17 @@ You can override bootlint options, e.g.:
             "showallerrors": false,
             "stoponerror": false,
             "stoponwarning": false
-        };
+        }
+    }
+
+### Htmllint
+
+You can override bootlint options, e.g.:
+
+    {
+        "htmllint": {
+            "ignore": "Element “link” is missing required attribute “property”."
+        }
     }
 
 

--- a/app/src/README.md
+++ b/app/src/README.md
@@ -32,7 +32,6 @@ For the linting tasks you have to define a list of pages to download to the ``tm
 
 The key of the ``requests`` part is the filename and the value defines the page to download.
 
-- If the request starts with ``#`` the entry is ignored. A little helper, as there are no comments in JSON.
 - If no extension is given on the request key ``.html`` is automatically appended.
 - If the value is a string it is handled as a GET request with that value a relative url.
 - If the value is an empty string the key is used as value.
@@ -51,7 +50,6 @@ Three requests save the same page to file ``login.html``.
                 "login": "",
                 "login": "login",
                 "login.html": "login"
-                "#this entry is ignored": "login"
             }
         }
     };

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -38,6 +38,7 @@ module.exports = function (grunt) {
             if (dest.substr(0, 1) !== '#') {
                 // Set request options.
                 if (typeof pages[dest] === 'object') {
+                    // Command shortcut: Login
                     if (dest === '@login' && pages[dest].u && pages[dest].p) {
                         options = {
                             url: "login",
@@ -48,6 +49,14 @@ module.exports = function (grunt) {
                                 action: "login"
                             }
                         };
+                    // Command shortcut: Logout
+                    } else if (dest === '@logout') {
+                        options = {
+                            url: "logout",
+                            method: "POST",
+                            form: {}
+                        };
+                    // Request options
                     } else {
                         options = pages[dest];
                     }

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -26,6 +26,10 @@ module.exports = function (grunt) {
             grunt.file.delete(outpath);
         }
         grunt.file.mkdir(outpath);
+        if (!grunt.file.isDir(outpath)) {
+            grunt.log.error('Output directory "' + outpath + '" missing!');
+            return done(false);
+        }
 
         // Request all required pages.
         pages = grunt.config('pages.requests');

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -3,15 +3,42 @@
  */
 module.exports = function (grunt) {
     grunt.registerTask('pages', 'Downloads rendered pages from a Bolt server', function () {
-        var outpath;
+        var outpath,
+            outfile,
+            baseurl,
+            pages,
+            options;
 
         // Require config variables.
         grunt.config.requires(
-            'path.tmp'
+            'path.tmp',
+            'pages.baseurl',
+            'pages.requests'
         );
 
         // Create output directory inside tmp folder.
         outpath = grunt.config('path.tmp') + '/pages';
         grunt.file.mkdir(outpath);
+
+        // Request all required pages.
+        pages = grunt.config('pages.requests');
+        for (var dest in pages) {
+            // Set request options.
+            if (typeof pages[dest] === 'object') {
+                options = pages[dest];
+            } else {
+                options = {
+                    url: pages[dest] !== '' ? pages[dest] : dest
+                };
+            }
+            options.baseUrl = options.baseUrl || grunt.config('pages.baseurl');
+
+            // Path, where to put the file. Make it always end with ".html"
+            outfile = outpath + '/' + dest.replace(/^(.+)\.html$/, '$1') + '.html';
+
+            // Some verbose output.
+            grunt.verbose.writeln('Get page "' + outfile + '":');
+            grunt.verbose.writeln(require('util').inspect(options, false, 2, true));
+        }
     });
 };

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -3,5 +3,15 @@
  */
 module.exports = function (grunt) {
     grunt.registerTask('pages', 'Downloads rendered pages from a Bolt server', function () {
+        var outpath;
+
+        // Require config variables.
+        grunt.config.requires(
+            'path.tmp'
+        );
+
+        // Create output directory inside tmp folder.
+        outpath = grunt.config('path.tmp') + '/pages';
+        grunt.file.mkdir(outpath);
     });
 };

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -19,8 +19,12 @@ module.exports = function (grunt) {
             'pages.requests'
         );
 
-        // Create output directory inside tmp folder.
+
+        // Create empty output directory inside tmp folder.
         outpath = grunt.config('path.tmp') + '/pages';
+        if (grunt.file.isDir(outpath)) {
+            grunt.file.delete(outpath);
+        }
         grunt.file.mkdir(outpath);
 
         // Request all required pages.

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -7,7 +7,8 @@ module.exports = function (grunt) {
             outfile,
             baseurl,
             pages,
-            options;
+            options,
+            queue = [];
 
         // Require config variables.
         grunt.config.requires(
@@ -39,6 +40,12 @@ module.exports = function (grunt) {
             // Some verbose output.
             grunt.verbose.writeln('Get page "' + outfile + '":');
             grunt.verbose.writeln(require('util').inspect(options, false, 2, true));
+
+            // Build a request queue.
+            queue.push({
+                opt: options,
+                out: outfile
+            });
         }
     });
 };

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -1,0 +1,7 @@
+/*
+ * PAGES: Downloads rendered pages from a Bolt server
+ */
+module.exports = function (grunt) {
+    grunt.registerTask('pages', 'Downloads rendered pages from a Bolt server', function () {
+    });
+};

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -3,7 +3,8 @@
  */
 module.exports = function (grunt) {
     grunt.registerTask('pages', 'Downloads rendered pages from a Bolt server', function () {
-        var outpath,
+        var done = this.async(),
+            outpath,
             outfile,
             baseurl,
             pages,
@@ -46,6 +47,18 @@ module.exports = function (grunt) {
                 opt: options,
                 out: outfile
             });
+        }
+
+        getNextPage();
+
+        function getNextPage() {
+            var next = queue.shift();
+
+            if (next) {
+                getNextPage();
+            } else {
+                done();
+            }
         }
     });
 };

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -26,26 +26,29 @@ module.exports = function (grunt) {
         // Request all required pages.
         pages = grunt.config('pages.requests');
         for (var dest in pages) {
-            // Set request options.
-            if (typeof pages[dest] === 'object') {
-                options = pages[dest];
-            } else {
-                options = {
-                    url: pages[dest] !== '' ? pages[dest] : dest
-                };
+            // Ignore requests with a destination that starts with "#".
+            if (dest.substr(0, 1) !== '#') {
+                // Set request options.
+                if (typeof pages[dest] === 'object') {
+                    options = pages[dest];
+                } else {
+                    options = {
+                        url: pages[dest] !== '' ? pages[dest] : dest
+                    };
+                }
+                options.baseUrl = options.baseUrl || grunt.config('pages.baseurl');
+                options.followAllRedirects = true; // "followRedirect" doesn't seem to work with 302.
+                options.jar = true;
+
+                // Path, where to put the file. Make it always end with ".html"
+                outfile = outpath + '/' + dest.replace(/^(.+)\.html$/, '$1') + '.html';
+
+                // Build a request queue.
+                queue.push({
+                    opt: options,
+                    out: outfile
+                });
             }
-            options.baseUrl = options.baseUrl || grunt.config('pages.baseurl');
-            options.followAllRedirects = true; // "followRedirect" doesn't seem to work with 302.
-            options.jar = true;
-
-            // Path, where to put the file. Make it always end with ".html"
-            outfile = outpath + '/' + dest.replace(/^(.+)\.html$/, '$1') + '.html';
-
-            // Build a request queue.
-            queue.push({
-                opt: options,
-                out: outfile
-            });
         }
 
         getNextPage();

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -34,54 +34,51 @@ module.exports = function (grunt) {
         // Request all required pages.
         pages = grunt.config('pages.requests');
         for (var dest in pages) {
-            // Ignore requests with a destination that starts with "#".
-            if (dest.substr(0, 1) !== '#') {
-                // Set request options.
-                if (typeof pages[dest] === 'object') {
-                    // Command shortcut: Login
-                    if (dest === '@login' && pages[dest].u && pages[dest].p) {
-                        options = {
-                            url: "login",
-                            method: "POST",
-                            form: {
-                                username: pages[dest].u,
-                                password: pages[dest].p,
-                                action: "login"
-                            }
-                        };
-                    // Command shortcut: Logout
-                    } else if (dest === '@logout') {
-                        options = {
-                            url: "logout",
-                            method: "POST",
-                            form: {}
-                        };
-                    // Request options
-                    } else {
-                        options = pages[dest];
-                    }
-                } else {
+            // Set request options.
+            if (typeof pages[dest] === 'object') {
+                // Command shortcut: Login
+                if (dest === '@login' && pages[dest].u && pages[dest].p) {
                     options = {
-                        url: pages[dest] !== '' ? pages[dest] : dest
+                        url: "login",
+                        method: "POST",
+                        form: {
+                            username: pages[dest].u,
+                            password: pages[dest].p,
+                            action: "login"
+                        }
                     };
-                }
-                options.baseUrl = options.baseUrl || grunt.config('pages.baseurl');
-                options.followAllRedirects = true; // "followRedirect" doesn't seem to work with 302.
-                options.jar = true;
-
-                // Path, where to put the file. Make it always end with ".html"
-                if (dest.substr(0, 1) === '@') {
-                    outfile = dest;
+                // Command shortcut: Logout
+                } else if (dest === '@logout') {
+                    options = {
+                        url: "logout",
+                        method: "POST",
+                        form: {}
+                    };
+                // Request options
                 } else {
-                    outfile = outpath + '/' + dest.replace(/^(.+)\.html$/, '$1') + '.html';
+                    options = pages[dest];
                 }
-
-                // Build a request queue.
-                queue.push({
-                    opt: options,
-                    out: outfile
-                });
+            } else {
+                options = {
+                    url: pages[dest] !== '' ? pages[dest] : dest
+                };
             }
+            options.baseUrl = options.baseUrl || grunt.config('pages.baseurl');
+            options.followAllRedirects = true; // "followRedirect" doesn't seem to work with 302.
+            options.jar = true;
+
+            // Path, where to put the file. Make it always end with ".html"
+            if (dest.substr(0, 1) === '@') {
+                outfile = dest;
+            } else {
+                outfile = outpath + '/' + dest.replace(/^(.+)\.html$/, '$1') + '.html';
+            }
+
+            // Build a request queue.
+            queue.push({
+                opt: options,
+                out: outfile
+            });
         }
 
         getNextPage();

--- a/app/src/grunt-tasks/pages.js
+++ b/app/src/grunt-tasks/pages.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
 
 
         // Create empty output directory inside tmp folder.
-        outpath = grunt.config('path.tmp') + '/pages';
+        outpath = grunt.config('path.pages');
         if (grunt.file.isDir(outpath)) {
             grunt.file.delete(outpath);
         }

--- a/app/src/grunt/aliases.yml
+++ b/app/src/grunt/aliases.yml
@@ -39,3 +39,9 @@ docJs:
     - jsdoc:boltJs
 docPhp:
     - phpdocumentor:bolt
+
+# LINTING TASKS
+lintHtml:
+    - pages
+    - htmllint:pages                        # Validate html of downloaded pages defined in grunt.json
+

--- a/app/src/grunt/aliases.yml
+++ b/app/src/grunt/aliases.yml
@@ -44,4 +44,7 @@ docPhp:
 lintHtml:
     - pages
     - htmllint:pages                        # Validate html of downloaded pages defined in grunt.json
+lintBoot:
+    - pages
+    - bootlint:pages                        # Validate bootstrap of downloaded pages defined in grunt.json
 

--- a/app/src/grunt/bootlint.js
+++ b/app/src/grunt/bootlint.js
@@ -1,13 +1,15 @@
 /*
  * BOOTLINT: HTML linter for Bootstrap projects
  */
-module.exports = function (grunt) {
+module.exports = function (grunt, options) {
     var conf = {
         relaxerror: [],
         showallerrors: false,
         stoponerror: false,
         stoponwarning: false
     };
+    // Override settings
+    require('deep-extend')(conf, options.bootlint);
 
     return {
         /*

--- a/app/src/grunt/bootlint.js
+++ b/app/src/grunt/bootlint.js
@@ -1,0 +1,21 @@
+/*
+ * BOOTLINT: HTML linter for Bootstrap projects
+ */
+module.exports = function (grunt) {
+    var conf = {
+        relaxerror: [],
+        showallerrors: false,
+        stoponerror: false,
+        stoponwarning: false
+    };
+
+    return {
+        /*
+         * TARGET:  Check html files in "path.pages"
+         */
+        pages: {
+            options: conf,
+            src: '<%= path.pages %>/*.html'
+        }
+    };
+};

--- a/app/src/grunt/concat.js
+++ b/app/src/grunt/concat.js
@@ -8,7 +8,7 @@ module.exports = {
     installLibJs: {
         options: {
             separator: '\n\n',
-            sourceMap: '<%= sourceMap.js %>',
+            sourceMap: '<%= sourcemap.js %>',
             sourceMapName: '<%= path.dest.js %>/maps/lib.min.js.map'
         },
         nonull: true,

--- a/app/src/grunt/htmllint.js
+++ b/app/src/grunt/htmllint.js
@@ -1,0 +1,13 @@
+/*
+ * HTMLLINT: html validation using the vnu.jar markup checker.
+ */
+module.exports = {
+    /*
+     * TARGET:  Check html files in "path.pages"
+     */
+    pages: {
+        options: {
+        },
+        src: '<%= path.pages %>/*.html'
+    }
+};

--- a/app/src/grunt/htmllint.js
+++ b/app/src/grunt/htmllint.js
@@ -1,13 +1,18 @@
 /*
  * HTMLLINT: html validation using the vnu.jar markup checker.
  */
-module.exports = {
-    /*
-     * TARGET:  Check html files in "path.pages"
-     */
-    pages: {
-        options: {
-        },
-        src: '<%= path.pages %>/*.html'
-    }
+module.exports = function (grunt, options) {
+    var conf = {};
+    // Override settings
+    require('deep-extend')(conf, options.htmllint);
+
+    return {
+        /*
+         * TARGET:  Check html files in "path.pages"
+         */
+        pages: {
+            options: conf,
+            src: '<%= path.pages %>/*.html'
+        }
+    };
 };

--- a/app/src/grunt/sass.js
+++ b/app/src/grunt/sass.js
@@ -16,7 +16,7 @@ module.exports = {
             unixNewlines: true,
             banner: '<%= banner.boltCss %>',
             precision: 5,
-            sourceMap: '<%= sourceMap.css %>',
+            sourceMap: '<%= sourcemap.css %>',
             sourceMapContents: true
         },
         files: [

--- a/app/src/grunt/uglify.js
+++ b/app/src/grunt/uglify.js
@@ -8,7 +8,7 @@ module.exports = {
     prepareLibJs: {
         options: {
             preserveComments: 'some',
-            sourceMap: '<%= sourceMap.js %>',
+            sourceMap: '<%= sourcemap.js %>',
             sourceMapIncludeSources: true
         },
         files: [{
@@ -107,7 +107,7 @@ module.exports = {
      */
     prepareBootstrapJs: {
         options: {
-            sourceMap: '<%= sourceMap.js %>',
+            sourceMap: '<%= sourcemap.js %>',
             sourceMapIncludeSources: true
         },
         files: {
@@ -130,7 +130,7 @@ module.exports = {
     boltJs: {
         options: {
             banner: '<%= banner.boltJs %>',
-            sourceMap: '<%= sourceMap.js %>',
+            sourceMap: '<%= sourcemap.js %>',
             sourceMapName: '<%= path.dest.js %>/maps/bolt.min.js.map'
         },
         files: {

--- a/app/src/package.json
+++ b/app/src/package.json
@@ -20,6 +20,7 @@
         "grunt-contrib-watch": "~0.6.1",
         "grunt-endline": "~0.2.4",
         "grunt-eol": "~0.2.0",
+        "grunt-html": "^4.0.3",
         "grunt-jsdoc": "^0.5.8",
         "grunt-modernizr": "~0.6.0",
         "grunt-phpdocumentor": "^0.4.1",

--- a/app/src/package.json
+++ b/app/src/package.json
@@ -12,6 +12,7 @@
         "font-awesome": "~4.3.0",
         "grunt": "~0.4.5",
         "grunt-bom-removal": "~0.2.0",
+        "grunt-bootlint": "^0.9.0",
         "grunt-contrib-concat": "~0.5.0",
         "grunt-contrib-copy": "~0.5.0",
         "grunt-contrib-cssmin": "~0.11.0",

--- a/app/src/package.json
+++ b/app/src/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "Bolt-2-backend",
-  "version": "2.0.2",
-  "description": "Required Node/Grunt modules for backend's frontend workflow.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bolt/bolt.git"
-  },
-  "devDependencies": {
-    "bootstrap-sass": "3.2.0",
-    "deep-extend": "^0.3.3",
-    "font-awesome": "~4.3.0",
-    "grunt": "~0.4.5",
-    "grunt-bom-removal": "~0.2.0",
-    "grunt-contrib-concat": "~0.5.0",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-cssmin": "~0.11.0",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-uglify": "~0.5.1",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-endline": "~0.2.4",
-    "grunt-eol": "~0.2.0",
-    "grunt-jsdoc": "^0.5.8",
-    "grunt-modernizr": "~0.6.0",
-    "grunt-phpdocumentor": "^0.4.1",
-    "grunt-remove": "~0.1.0",
-    "grunt-sass": "~0.17.0",
-    "jsdoc": "^3.3.0-beta2",
-    "load-grunt-config": "~0.16.0",
-    "load-grunt-tasks": "~0.6.0",
-    "node-sass": "~1.2.3"
-  }
+    "name": "Bolt-2-backend",
+    "version": "2.0.2",
+    "description": "Required Node/Grunt modules for backend's frontend workflow.",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bolt/bolt.git"
+    },
+    "devDependencies": {
+        "bootstrap-sass": "3.2.0",
+        "deep-extend": "^0.3.3",
+        "font-awesome": "~4.3.0",
+        "grunt": "~0.4.5",
+        "grunt-bom-removal": "~0.2.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-copy": "~0.5.0",
+        "grunt-contrib-cssmin": "~0.11.0",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-endline": "~0.2.4",
+        "grunt-eol": "~0.2.0",
+        "grunt-jsdoc": "^0.5.8",
+        "grunt-modernizr": "~0.6.0",
+        "grunt-phpdocumentor": "^0.4.1",
+        "grunt-remove": "~0.1.0",
+        "grunt-sass": "~0.17.0",
+        "jsdoc": "^3.3.0-beta2",
+        "load-grunt-config": "~0.16.0",
+        "load-grunt-tasks": "~0.6.0",
+        "node-sass": "~1.2.3"
+    }
 }

--- a/app/src/package.json
+++ b/app/src/package.json
@@ -28,6 +28,7 @@
         "jsdoc": "^3.3.0-beta2",
         "load-grunt-config": "~0.16.0",
         "load-grunt-tasks": "~0.6.0",
-        "node-sass": "~1.2.3"
+        "node-sass": "~1.2.3",
+        "request": "^2.55.0"
     }
 }


### PR DESCRIPTION
- Local grunt options are now stored in single Javascript files inside ``grunt-local/``. This enables us to use real comments and regular expressions.

- Bolts backend pages can now be linted for HTML errors with the command``grunt lintHtml``.

- Bolts backend pages can now be linted for Bootstrap errors with the command``grunt lintBoot``.

For the linting you can define in ``grunt-local/pages.js`` which files you get from your local server. These are stored in ``tmp/pages`` and then are used for linting. For more information on this see ``Readme.md``.

:warning: Don't forget to ``npm install``
:warning: Convert your local settings in ``grunt.json`` to the new system and remove the file as this file will be removed from the grunt ignore list in the future.
