### PR TITLE
Also watch for changes in grunt-local

### DIFF
--- a/app/src/grunt/watch.js
+++ b/app/src/grunt/watch.js
@@ -37,7 +37,8 @@ module.exports = {
         files: [
             'Gruntfile.js',
             'grunt/*.js',
-            'grunt/*.yml'
+            'grunt/*.yml',
+            'grunt-local/*.js'
         ],
         options: {
             reload: true


### PR DESCRIPTION
Adding ``grunt-local`` there makes grunt reload (local) configuration. Until now cached versions of local configs were used until restart of grunt. Now the cache is dumped on reload.