### PR TITLE
Fix pagination for searching via getContent() or {% setcontent %}.

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1637,15 +1637,13 @@ class Storage
         $offset = 0;
 
         // set correct limit and offset if these are set.
-        if ($limit) {
-            if( isset($decoded['parameters']['limit']) ) {
-                $limit = $decoded['parameters']['limit'];
-            }
+        if( isset($decoded['parameters']['limit']) ) {
+            $limit = $decoded['parameters']['limit'];
+        }
 
-            if ($decoded['parameters']['paging'] === true && isset($decoded['parameters']['page'])) {
-                // Pagenumbers are one-based, not zero-based.
-                $offset = $limit * ($decoded['parameters']['page'] - 1);
-            }
+        if ($decoded['parameters']['paging'] === true && isset($decoded['parameters']['page'])) {
+            // Pagenumbers are one-based, not zero-based.
+            $offset = $limit * ($decoded['parameters']['page'] - 1);
         }
 
         $results = $this->searchContent(

--- a/src/Storage.php
+++ b/src/Storage.php
@@ -1633,11 +1633,27 @@ class Storage
      */
     protected function executeGetContentSearch($decoded, $parameters)
     {
+        $limit = 2000;
+        $offset = 0;
+
+        // set correct limit and offset if these are set.
+        if ($limit) {
+            if( isset($decoded['parameters']['limit']) ) {
+                $limit = $decoded['parameters']['limit'];
+            }
+
+            if ($decoded['parameters']['paging'] === true && isset($decoded['parameters']['page'])) {
+                // Pagenumbers are one-based, not zero-based.
+                $offset = $limit * ($decoded['parameters']['page'] - 1);
+            }
+        }
+
         $results = $this->searchContent(
             $parameters['filter'],
             $decoded['contenttypes'],
             null,
-            isset($decoded['parameters']['limit']) ? $decoded['parameters']['limit'] : 2000
+            $limit,
+            $offset
         );
 
         return array(


### PR DESCRIPTION
This allows pagination for using search in `Storage->getContent` calls (in Extensions) as well as `{% setcontent ... %}` calls in Twig. I have no idea why a fallback limit of 2000 was picked, but I've kept everything as it was just in case.

There also seems to be redundant params, e.g. `$decoded['parameters']` and `$parameters`. Not sure if there might be any duplicate functionalities, if you compare with the global front-end search in https://github.com/bolt/bolt/blob/master/src/Controllers/Frontend.php#L317
