### PR TITLE
Handle Flysystem exception correctly when a file is not found.

### DIFF
--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
+use League\Flysystem\FileNotFoundException;
 
 /**
  * Backend controller grouping.
@@ -1622,9 +1623,15 @@ class Backend implements ControllerProviderInterface
             $uploadview = false;
         }
 
-        if ($filesystem->getVisibility($path) === 'public') {
+        try {
+            $visibility = $filesystem->getVisibility($path);
+        } catch (FileNotFoundException $fnfe) {
+            $visibility = false;
+        }
+
+        if ($visibility === 'public') {
             $validFolder = true;
-        } elseif ($filesystem->getVisibility($path) === 'readonly') {
+        } elseif ($visibility === 'readonly') {
             $validFolder = true;
             $uploadview = false;
         } else {


### PR DESCRIPTION
Hi,
just a pretty minor fix. I think that the expected behaviour of the backend in case the "extensions" directory does not exist should be to catch the FileNotFoundException exception and show the error "The folder '%s' could not be found, or is not readable." instead of returning a 500 Internal Server Error.

Regards,
Giovanni