### PR TITLE
Cast booleans to integer to force correct PDO handling

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -533,6 +533,9 @@ class Storage
                 if (is_string($fieldvalues[$key])) {
                     // Trim strings
                     $fieldvalues[$key] = trim($fieldvalues[$key]);
+                } elseif (is_bool($fieldvalues[$key])) {
+                    // Convert literal booleans to 0/1 to ensure cross-db consistency
+                    $fieldvalues[$key] = (int)$fieldvalues[$key];
                 }
             } else {
                 // unset columns we don't need to store.


### PR DESCRIPTION
This solves a rather unusual bug whereby on Postgresql saving of a contenttype containing a boolean set to false would fail with a fatal error.

Looking deeper it seems that Doctrine handles native booleans by casting the values to strings, meaning that `false` gets converted to `''`

To convert properly the Doctrine platform adapter requires one of these options:

```php
private $booleanLiterals = array(
        'true' => array(
            't',
            'true',
            'y',
            'yes',
            'on',
            '1'
        ),
        'false' => array(
            'f',
            'false',
            'n',
            'no',
            'off',
            '0'
        )
    );
```

So the easiest way to handle this, rather than explicitly casting each contenttype to a type is to handle casting to one of the above before sending to save.