### PR TITLE
initialise tracker as empty array

### DIFF
--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -12,7 +12,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class BoltListener implements \PHPUnit_Framework_TestListener
 {
     /** @var array */
-    protected $tracker;
+    protected $tracker = array();
 
     /** @var boolean */
     protected $timer;


### PR DESCRIPTION
Prevents errors being thrown by sorting a non-array should the tracker be empty.
