### PR TITLE
Show error messages instead of throwing cryptic exceptions or fatals.

### DIFF
--- a/src/Nut/Extensions.php
+++ b/src/Nut/Extensions.php
@@ -25,6 +25,13 @@ class Extensions extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (count($this->app['extend.manager']->messages)) {
+            foreach ($this->app['extend.manager']->messages as $message) {
+                $output->writeln(sprintf('<error>%s</error>', $message));
+            }
+            return;
+        }
+
         $installed = $this->app['extend.manager']->showPackage('installed');
         $rows = array();
 


### PR DESCRIPTION
Hi guys,
I've stepped into this issue when the internet connection is down the Nut command line will throw exceptions or fatal errors if you try and run extension related commands because the package manager has not been set up correctly (`$app['extend.online']` is false or `$app['extend.manager']->factory` is null). I think the expected behaviour is to show the error messages instead.

Example, instead of:

> PHP Fatal error:  Call to a member function getIO() on a non-object in /home/ggioffreda/Development/-/vendor/bolt/bolt/src/Composer/PackageManager.php on line 200
> PHP Stack trace:
> ...
> 
> PHP Fatal Error: Bolt Generic
Error: Call to a member function getIO() on a non-objectFile:  vendor/bolt/bolt/src/Composer/PackageManager.phpLine:  200
> * http://docs.bolt.cm/installation - Bolt documentation - Setup
> * http://stackoverflow.com/questions/tagged/bolt-cms - Bolt questions on Stack Overflow
> Whoops\Exception\ErrorException: Call to a member function getIO() on a non-object in file /home/ggioffreda/Development/nz.fonterra.com/vendor/bolt/bolt/src/Composer/PackageManager.php on line 200
> Stack trace:
>   1. () /home/ggioffreda/Development/-/vendor/bolt/bolt/src/Composer/PackageManager.php:200

it will shows:

> cURL experienced an error: [curl] 6: Could not resolve host: extensions.bolt.cm [url] https://extensions.bolt.cm/ping?bolt_ver=2.1.8&amp;bolt_name=pl1&amp;php=5.5.12-2ubuntu4.4&amp;www=unknown
> https://extensions.bolt.cm/ is unreachable.

Regards,
Giovanni