### PR TITLE
Add a try-exception when parsing `allowtwig` fields.

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -908,7 +908,11 @@ class Content implements \ArrayAccess
         if ($allowtwig && preg_match('/[{][{%#]/', $snippet)) {
             $snippet = html_entity_decode($snippet, ENT_QUOTES, 'UTF-8');
 
-            return $this->app['safe_render']->render($snippet, $this->getTemplateContext());
+            try {
+                return $this->app['safe_render']->render($snippet, $this->getTemplateContext());
+            } catch(\Exception $e) {
+                return $snippet;
+            }
         }
 
         return $snippet;

--- a/src/Content.php
+++ b/src/Content.php
@@ -911,7 +911,7 @@ class Content implements \ArrayAccess
             try {
                 return $this->app['safe_render']->render($snippet, $this->getTemplateContext());
             } catch(\Exception $e) {
-                return $snippet;
+                return $e->getMessage();
             }
         }
 


### PR DESCRIPTION
If you make a Twig typo, such as `{{ record.title }]`, then your front-end explodes. I believe it may be better to show the unparsed content. Though this behaviour does need to be documented.