### PR TITLE
Request cache fix

### DIFF
--- a/src/Render.php
+++ b/src/Render.php
@@ -170,7 +170,7 @@ class Render
 
         // Don't use the cache, if we're currently logged in. (unless explicitly enabled in config.yml
         if (!$this->app['config']->get('general/caching/authenticated') &&
-            $this->app['users']->getCurrentUsername() !== '') {
+            $this->app['users']->getCurrentUsername() !== null) {
             return false;
         }
 


### PR DESCRIPTION
Render.php checks if the user is logged in incorrectly on line 173.
$this->app['users']->getCurrentUsername() returns null for users that are not logged instead of an empty string.