### PR TITLE
Symfony Forms session handling

### DIFF
--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -112,7 +112,7 @@ class General extends AsyncBase
         ];
 
         $response = $this->render('components/panel-news.twig', ['context' => $context]);
-        $response->setCache(['s_maxage' => '3600', 'public' => true]);
+        $response->setPublic()->setSharedMaxAge(3600);
 
         return $response;
     }
@@ -259,7 +259,10 @@ class General extends AsyncBase
         // Parse the field as Markdown, return HTML
         $html = $this->app['markdown']->text($readme);
 
-        return new Response($html, Response::HTTP_OK, ['Cache-Control' => 's-maxage=180, public']);
+        $response = new Response($html, Response::HTTP_OK);
+        $response->setPublic()->setSharedMaxAge(180);
+
+        return $response;
     }
 
     /**
@@ -299,7 +302,10 @@ class General extends AsyncBase
     {
         $html = $this->extensions()->renderWidget($key);
 
-        return new Response($html, Response::HTTP_OK, ['Cache-Control' => 's-maxage=180, public']);
+        $response = new Response($html, Response::HTTP_OK);
+        $response->setPublic()->setSharedMaxAge(180);
+
+        return $response;
     }
 
     /**

--- a/src/EventListener/FormListener.php
+++ b/src/EventListener/FormListener.php
@@ -54,21 +54,23 @@ class FormListener implements EventSubscriberInterface
      */
     public function onFormPreSetData(FormEvent $event)
     {
-        if (!$this->session->isStarted()) {
-            // Enable route specific sesion cookies, generally speaking for front end
-            $storage = new NativeSessionStorage(
-                [
-                    'name'            => $this->tokenName,
-                    'cookie_path'     => $this->request->getRequestUri(),
-                    'cookie_domain'   => $this->config->get('general/cookies_domain'),
-                    'cookie_secure'   => $this->config->get('general/enforce_ssl'),
-                    'cookie_httponly' => true,
-                ],
-                $this->handler
-            );
-
-            $this->session = new Session($storage);
+        if ($this->session->isStarted()) {
+            return;
         }
+
+        // Enable route specific sesion cookies, generally speaking for front end
+        $storage = new NativeSessionStorage(
+            [
+                'name'            => $this->tokenName,
+                'cookie_path'     => $this->request->getRequestUri(),
+                'cookie_domain'   => $this->config->get('general/cookies_domain'),
+                'cookie_secure'   => $this->config->get('general/enforce_ssl'),
+                'cookie_httponly' => true,
+            ],
+            $this->handler
+        );
+
+        $this->session = new Session($storage);
     }
 
     /**

--- a/src/EventListener/FormListener.php
+++ b/src/EventListener/FormListener.php
@@ -1,0 +1,66 @@
+<?php
+namespace Bolt\EventListener;
+
+use Silex\Application;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+
+/**
+ * Symfony Forms listener.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class FormListener implements EventSubscriberInterface
+{
+    /** @var \Silex\Application $app */
+    protected $app;
+
+    /**
+     * Constructor function.
+     *
+     * @param Application $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Handle the form event at the beginning of the Form::setData() method.
+     *
+     * @param FormEvent $event
+     */
+    public function onFormPreSetData(FormEvent $event)
+    {
+    	if (!$this->app['session']->isStarted()) {
+    		// Enable route specific sesion cookies, generally speaking for front end
+	        $this->app['session'] = $this->app->share(function () {
+		        $storage = new NativeSessionStorage(
+		            array(
+		                    'name'            => $this->app['token.session.name'],
+		                    'cookie_path'     => $this->app['request']->getRequestUri(),
+		                    'cookie_domain'   => $this->app['config']->get('general/cookies_domain'),
+		                    'cookie_secure'   => $this->app['config']->get('general/enforce_ssl'),
+		                    'cookie_httponly' => true,
+		            		),
+		            $this->app['session.storage.handler']
+		        );
+
+		        return new Session($storage);
+	        });
+    	}
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SET_DATA => ['onFormPreSetData', 10000],
+        );
+    }
+}

--- a/src/Form/FormEventTypeExtension.php
+++ b/src/Form/FormEventTypeExtension.php
@@ -2,6 +2,7 @@
 namespace Bolt\Form;
 
 use Bolt\EventListener\FormListener;
+use Silex\Application;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -12,11 +13,30 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class FormEventTypeExtension extends AbstractTypeExtension
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    /** @var \Silex\Application $app */
+    protected $app;
+
+    /**
+     * Constructor function.
+     *
+     * @param Application $app
+     */
+    public function __construct(Application $app)
     {
-        $builder->addEventSubscriber(new FormListener());
+        $this->app = $app;
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addEventSubscriber(new FormListener($this->app));
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getExtendedType()
     {
         return 'form';

--- a/src/Form/FormEventTypeExtension.php
+++ b/src/Form/FormEventTypeExtension.php
@@ -1,10 +1,12 @@
 <?php
 namespace Bolt\Form;
 
+use Bolt\Config;
 use Bolt\EventListener\FormListener;
-use Silex\Application;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Symfony Form subscriber extension.
@@ -13,17 +15,29 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class FormEventTypeExtension extends AbstractTypeExtension
 {
-    /** @var \Silex\Application $app */
-    protected $app;
+    /** @var SessionInterface $session */
+    protected $session;
+    /** @var \Bolt\Config $config */
+    protected $config;
+    /** @var Request $request */
+    protected $request;
+    /** @var NativeFileSessionHandler $handler */
+    protected $handler;
+    /** @var string $tokenName */
+    protected $tokenName;
 
     /**
      * Constructor function.
      *
      * @param Application $app
      */
-    public function __construct(Application $app)
+    public function __construct(SessionInterface $session, Request $request, Config $config, $handler, $tokenName)
     {
-        $this->app = $app;
+        $this->session   = $session;
+        $this->request   = $request;
+        $this->config    = $config;
+        $this->handler   = $handler;
+        $this->tokenName = $tokenName;
     }
 
     /**
@@ -31,7 +45,13 @@ class FormEventTypeExtension extends AbstractTypeExtension
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addEventSubscriber(new FormListener($this->app));
+        $builder->addEventSubscriber(new FormListener(
+            $this->session,
+            $this->request,
+            $this->config,
+            $this->handler,
+            $this->tokenName
+        ));
     }
 
     /**

--- a/src/Form/FormEventTypeExtension.php
+++ b/src/Form/FormEventTypeExtension.php
@@ -1,0 +1,24 @@
+<?php
+namespace Bolt\Form;
+
+use Bolt\EventListener\FormListener;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Symfony Form subscriber extension.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class FormEventTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addEventSubscriber(new FormListener());
+    }
+
+    public function getExtendedType()
+    {
+        return 'form';
+    }
+}

--- a/src/Form/Type/FormEventTypeExtension.php
+++ b/src/Form/Type/FormEventTypeExtension.php
@@ -1,5 +1,5 @@
 <?php
-namespace Bolt\Form;
+namespace Bolt\Form\Type;
 
 use Bolt\Config;
 use Bolt\EventListener\FormListener;

--- a/src/Form/Type/FormEventTypeExtension.php
+++ b/src/Form/Type/FormEventTypeExtension.php
@@ -5,7 +5,7 @@ use Bolt\Config;
 use Bolt\EventListener\FormListener;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
@@ -19,8 +19,8 @@ class FormEventTypeExtension extends AbstractTypeExtension
     protected $session;
     /** @var \Bolt\Config $config */
     protected $config;
-    /** @var Request $request */
-    protected $request;
+    /** @var RequestStack $requestStack */
+    protected $requestStack;
     /** @var NativeFileSessionHandler $handler */
     protected $handler;
     /** @var string $tokenName */
@@ -31,13 +31,13 @@ class FormEventTypeExtension extends AbstractTypeExtension
      *
      * @param Application $app
      */
-    public function __construct(SessionInterface $session, Request $request, Config $config, $handler, $tokenName)
+    public function __construct(SessionInterface $session, RequestStack $requestStack, Config $config, $handler, $tokenName)
     {
-        $this->session   = $session;
-        $this->request   = $request;
-        $this->config    = $config;
-        $this->handler   = $handler;
-        $this->tokenName = $tokenName;
+        $this->session      = $session;
+        $this->requestStack = $requestStack;
+        $this->config       = $config;
+        $this->handler      = $handler;
+        $this->tokenName    = $tokenName;
     }
 
     /**
@@ -47,7 +47,7 @@ class FormEventTypeExtension extends AbstractTypeExtension
     {
         $builder->addEventSubscriber(new FormListener(
             $this->session,
-            $this->request,
+            $this->requestStack,
             $this->config,
             $this->handler,
             $this->tokenName

--- a/src/Provider/FormServiceProvider.php
+++ b/src/Provider/FormServiceProvider.php
@@ -79,6 +79,18 @@ class FormServiceProvider implements ServiceProviderInterface
             return [];
         });
 
+        /*
+         * Custom CSRF provider set up.
+         *
+         * Silex 1.2 providers (SessionCsrfProvider and DefaultCsrfProvider) are
+         * deprecated.
+         */
+        $app['form.csrf_provider'] = $app->share(function ($app) {
+            $storage = isset($app['session']) ? new SessionTokenStorage($app['session']) : new NativeSessionTokenStorage();
+
+            return new CsrfTokenManager(null, $storage);
+        });
+
         $app['form.extension.csrf'] = $app->share(function ($app) {
             if (isset($app['translator'])) {
                 return new CsrfExtension($app['form.csrf_provider'], $app['translator']);
@@ -121,18 +133,6 @@ class FormServiceProvider implements ServiceProviderInterface
 
         $app['form.resolved_type_factory'] = $app->share(function ($app) {
             return new ResolvedFormTypeFactory();
-        });
-
-        /*
-         * Custom CSRF provider set up.
-         *
-         * Silex 1.2 providers (SessionCsrfProvider and DefaultCsrfProvider) are
-         * deprecated.
-         */
-        $app['form.csrf_provider'] = $app->share(function ($app) {
-            $storage = isset($app['session']) ? new SessionTokenStorage($app['session']) : new NativeSessionTokenStorage();
-
-            return new CsrfTokenManager(null, $storage);
         });
     }
 

--- a/src/Provider/FormServiceProvider.php
+++ b/src/Provider/FormServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bolt\Provider;
 
-use Bolt\Form\FormEventTypeExtension;
+use Bolt\Form\Type\FormEventTypeExtension;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;

--- a/src/Provider/FormServiceProvider.php
+++ b/src/Provider/FormServiceProvider.php
@@ -70,7 +70,13 @@ class FormServiceProvider implements ServiceProviderInterface
         // Add the Bolt event subscriber extension.
         $app['form.type.extensions'] = $app->share(function ($app) {
             return [
-                new FormEventTypeExtension($app)
+                new FormEventTypeExtension(
+                    $app['session'],
+                    $app['request'],
+                    $app['config'],
+                    $app['session.storage.handler'],
+                    $app['token.session.name']
+                ),
             ];
 
         });

--- a/src/Provider/FormServiceProvider.php
+++ b/src/Provider/FormServiceProvider.php
@@ -72,7 +72,7 @@ class FormServiceProvider implements ServiceProviderInterface
             return [
                 new FormEventTypeExtension(
                     $app['session'],
-                    $app['request'],
+                    $app['request_stack'],
                     $app['config'],
                     $app['session.storage.handler'],
                     $app['token.session.name']

--- a/src/Provider/FormServiceProvider.php
+++ b/src/Provider/FormServiceProvider.php
@@ -1,0 +1,142 @@
+<?php
+namespace Bolt\Provider;
+
+use Bolt\Form\FormEventTypeExtension;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
+use Symfony\Component\Form\Extension\Csrf\CsrfProvider\DefaultCsrfProvider;
+use Symfony\Component\Form\Extension\Csrf\CsrfProvider\SessionCsrfProvider;
+use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension as FormValidatorExtension;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\Form\ResolvedFormTypeFactory;
+use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use Symfony\Component\Security\Csrf\TokenStorage\NativeSessionTokenStorage;
+use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
+
+/**
+ * Symfony Form component Provider.
+ *
+ * Based upon Silex\Provider\FormServiceProvider from Silex 1.2 with parts
+ * introduced from 2.0. Ideally this will eventually phased out, but Silex and
+ * Symfony are currently incompatible with our needs for both in-built
+ * subscribers and Session token handling.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class FormServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        if (!class_exists('Locale') && !class_exists('Symfony\Component\Locale\Stub\StubLocale')) {
+            throw new \RuntimeException('You must either install the PHP intl extension or the Symfony Locale Component to use the Form extension.');
+        }
+
+        if (!class_exists('Locale')) {
+            $r = new \ReflectionClass('Symfony\Component\Locale\Stub\StubLocale');
+            $path = dirname(dirname($r->getFilename())).'/Resources/stubs';
+
+            require_once $path.'/functions.php';
+            require_once $path.'/Collator.php';
+            require_once $path.'/IntlDateFormatter.php';
+            require_once $path.'/Locale.php';
+            require_once $path.'/NumberFormatter.php';
+        }
+
+        /*
+         * Custom secret. Default Silex uses an MD5 hash of this file name, most
+         * likely as it is deemed to be an implementation detail. Well, we're
+         * implementing then.
+         */
+        $app['form.secret'] = $app->share(function ($app) {
+            if (!$app['session']->isStarted()) {
+                return;
+            } elseif ($secret = $app['session']->get('form.secret')) {
+                return $secret;
+            } else {
+                $secret = $app['randomgenerator']->generate(32);
+                $app['session']->set('form.secret', $secret);
+
+                return $secret;
+            }
+        });
+
+        $app['form.types'] = $app->share(function ($app) {
+            return [];
+        });
+
+        // Add the Bolt event subscriber extension.
+        $app['form.type.extensions'] = $app->share(function ($app) {
+            return [
+                new FormEventTypeExtension($app)
+            ];
+
+        });
+
+        $app['form.type.guessers'] = $app->share(function ($app) {
+            return [];
+        });
+
+        $app['form.extension.csrf'] = $app->share(function ($app) {
+            if (isset($app['translator'])) {
+                return new CsrfExtension($app['form.csrf_provider'], $app['translator']);
+            }
+
+            return new CsrfExtension($app['form.csrf_provider']);
+        });
+
+        $app['form.extensions'] = $app->share(function ($app) {
+            $extensions = [
+                $app['form.extension.csrf'],
+                new HttpFoundationExtension(),
+            ];
+
+            if (isset($app['validator'])) {
+                $extensions[] = new FormValidatorExtension($app['validator']);
+
+                if (isset($app['translator'])) {
+                    $r = new \ReflectionClass('Symfony\Component\Form\Form');
+                    $file = dirname($r->getFilename()).'/Resources/translations/validators.'.$app['locale'].'.xlf';
+                    if (file_exists($file)) {
+                        $app['translator']->addResource('xliff', $file, $app['locale'], 'validators');
+                    }
+                }
+            }
+
+            return $extensions;
+        });
+
+        $app['form.factory'] = $app->share(function ($app) {
+            return Forms::createFormFactoryBuilder()
+                ->addExtensions($app['form.extensions'])
+                ->addTypes($app['form.types'])
+                ->addTypeExtensions($app['form.type.extensions'])
+                ->addTypeGuessers($app['form.type.guessers'])
+                ->setResolvedTypeFactory($app['form.resolved_type_factory'])
+                ->getFormFactory()
+            ;
+        });
+
+        $app['form.resolved_type_factory'] = $app->share(function ($app) {
+            return new ResolvedFormTypeFactory();
+        });
+
+        /*
+         * Custom CSRF provider set up.
+         *
+         * Silex 1.2 providers (SessionCsrfProvider and DefaultCsrfProvider) are
+         * deprecated.
+         */
+        $app['form.csrf_provider'] = $app->share(function ($app) {
+            $storage = isset($app['session']) ? new SessionTokenStorage($app['session']) : new NativeSessionTokenStorage();
+
+            return new CsrfTokenManager(null, $storage);
+        });
+    }
+
+    public function boot(Application $app)
+    {
+    }
+}


### PR DESCRIPTION
This completes the explicit session handling issues.

Where a session isn't started, and a CSRF is still required, we will adjust the cookie path that `Session` uses to be specific route for the page…

:koala: power!