### PR TITLE
Session cookie handling at logon/logoff

### DIFF
--- a/app/view/twig/_sub/_messages.twig
+++ b/app/view/twig/_sub/_messages.twig
@@ -8,7 +8,7 @@
 
 {% macro messages(key, class) %}
     {% set shown = [] %}
-    {% for msg in app.session.flashBag.get(key) %}
+    {% for msg in app['logger.flash'].get(key) %}
         {% if msg not in shown %}
             <div class="alert alert-{{ class|default(key) }}">
                 <button class="close" data-dismiss="alert">×</button>
@@ -20,7 +20,7 @@
 {% endmacro %}
 
 {% import _self as self %}
-{% if wrapper is defined and wrapper and app.session.flashBag.keys() is not empty %}
+{% if wrapper is defined and wrapper and app['logger.flash'].keys() is not empty %}
     <div class="row">
         <div class="col-md-8">
             {{ self.flashbag }}

--- a/src/Controller/Backend/Authentication.php
+++ b/src/Controller/Backend/Authentication.php
@@ -91,6 +91,7 @@ class Authentication extends BackendBase
 
         $response = $this->redirectToRoute('login');
         $response->headers->clearCookie($this->app['token.authentication.name']);
+        $response->headers->clearCookie($this->app['token.session.name']);
 
         return $response;
     }

--- a/src/Logger/FlashLogger.php
+++ b/src/Logger/FlashLogger.php
@@ -121,6 +121,18 @@ class FlashLogger implements FlashLoggerInterface, FlashBagAttachableInterface
     /**
      * {@inheritdoc}
      */
+    public function keys()
+    {
+        if ($this->flashBag) {
+            return $this->flashBag->keys();
+        }
+
+        return array_keys($this->flashes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function attachFlashBag(FlashBagInterface $flashBag)
     {
         if ($this->flashBag) {
@@ -145,6 +157,6 @@ class FlashLogger implements FlashLoggerInterface, FlashBagAttachableInterface
      */
     public function isFlashBagAttached()
     {
-        return (bool)$this->flashBag;
+        return (bool) $this->flashBag;
     }
 }

--- a/src/Logger/FlashLoggerInterface.php
+++ b/src/Logger/FlashLoggerInterface.php
@@ -82,4 +82,12 @@ interface FlashLoggerInterface
      * Clear out messages.
      */
     public function clear();
+
+
+    /**
+     * Returns a list of all defined types.
+     *
+     * @return array
+     */
+    public function keys();
 }


### PR DESCRIPTION
Currently a session is started on loading of the login page, and this sets a session cookie, and that cookie isn't cleared at logoff.

This addresses this limitation meaning that a system user, once logged out, will get full caching from Varish & Co.