### PR TITLE
Deprecate Config::getWhichEnd

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1114,7 +1114,35 @@ class Config
     }
 
     /**
-     * @deprecated Use get('general/database') instead
+     * Get a timestamp, corrected to the timezone.
+     *
+     * @return string Timestamp
+     */
+    public function getTimestamp($when)
+    {
+        $timezone = $this->get('general/timezone');
+        $now = date_format(new \DateTime($when, new \DateTimeZone($timezone)), 'Y-m-d H:i:s');
+
+        return $now;
+    }
+
+    /**
+     * Get the current timestamp, corrected to the timezone.
+     *
+     * @return string Current timestamp
+     */
+    public function getCurrentTimestamp()
+    {
+        $timezone = $this->get('general/timezone');
+        $now = date_format(new \DateTime($timezone), 'Y-m-d H:i:s');
+
+        return $now;
+    }
+
+    /**
+     * Use get('general/database') instead
+     *
+     * @deprecated Since 2.1, to be removed in 3.0.
      *
      * @return array
      */
@@ -1163,31 +1191,5 @@ class Config
         /** @var \Bolt\EventListener\ZoneGuesser $guesser */
         $guesser = $this->app['listener.zone_guesser'];
         return $guesser->setZone($request);
-    }
-
-    /**
-     * Get a timestamp, corrected to the timezone.
-     *
-     * @return string Timestamp
-     */
-    public function getTimestamp($when)
-    {
-        $timezone = $this->get('general/timezone');
-        $now = date_format(new \DateTime($when, new \DateTimeZone($timezone)), 'Y-m-d H:i:s');
-
-        return $now;
-    }
-
-    /**
-     * Get the current timestamp, corrected to the timezone.
-     *
-     * @return string Current timestamp
-     */
-    public function getCurrentTimestamp()
-    {
-        $timezone = $this->get('general/timezone');
-        $now = date_format(new \DateTime($timezone), 'Y-m-d H:i:s');
-
-        return $now;
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1124,56 +1124,45 @@ class Config
     }
 
     /**
-     * Utility function to determine which 'end' we're using right now.
-     * Can be either "frontend", "backend", "async" or "cli".
+     * Use {@see Zone} instead with a {@see Request}.
      *
-     * NOTE: If the Request object has not been initialized by Silex yet,
-     * we create a local version based on the request globals.
+     * If you do not have a request then YDIW. Code should be agnostic
+     * to the current request OR in an app or route middleware.
      *
-     * @param string $mountpoint
+     * Route middlewares apply only to a certain route or group of routes.
+     * See {@see \Bolt\Controller\Async\AsyncBase::before} for an example.
+     *
+     * App middlewares apply to all routes.
+     * See classes in \Bolt\EventListener for examples of these.
+     * These middlewares could also be filtered by checking for Zone inside of listener.
+     *
+     * @deprecated Since 2.3, to be removed in 3.0.
      *
      * @return string
      */
-    public function getWhichEnd($mountpoint = '')
+    public function getWhichEnd()
     {
-        // Get a request object, if not initialized by Silex yet, we'll create our own
-        try {
-            /** @var Request $request */
-            $request = $this->app['request'];
-            if ($zone = Zone::get($request)) {
-                $this->app['end'] = $zone;
-                return $zone;
-            }
-        } catch (\RuntimeException $e) {
-            // Return CLI if request not already exist and we're on the CLI
-            if (php_sapi_name() == 'cli') {
-                $this->app['end'] = 'cli';
+        $zone = $this->determineZone();
+        $this->app['end'] = $zone; // This is also deprecated
+        return $zone;
+    }
 
-                return 'cli';
-            }
+    private function determineZone()
+    {
+        if (PHP_SAPI === 'cli') {
+            return 'cli';
+        }
+        /** @var \Symfony\Component\HttpFoundation\RequestStack $stack */
+        $stack = $this->app['request_stack'];
+        $request = $stack->getCurrentRequest() ?: Request::createFromGlobals();
 
-            $request = Request::createFromGlobals();
+        if ($zone = Zone::get($request)) {
+            return $zone;
         }
 
-        // Default mountpoint is branding path (defaults to 'bolt' unless changed in config)
-        if (empty($mountpoint)) {
-            $mountpoint = $this->get('general/branding/path');
-        }
-
-        // Ensure left slash on mountpoint
-        $mountpoint = '/' . ltrim($mountpoint, '/');
-
-        if (strpos($request->getPathInfo(), '/async') === 0 || $request->isXmlHttpRequest()) {
-            $end = 'async';
-        } elseif (strpos($request->getPathInfo(), $mountpoint) === 0) {
-            $end = 'backend';
-        } else {
-            $end = 'frontend';
-        }
-
-        $this->app['end'] = $end;
-
-        return $end;
+        /** @var \Bolt\EventListener\ZoneGuesser $guesser */
+        $guesser = $this->app['listener.zone_guesser'];
+        return $guesser->setZone($request);
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -1154,8 +1154,9 @@ class Config
     /**
      * Use {@see Zone} instead with a {@see Request}.
      *
-     * If you do not have a request then YDIW. Code should be agnostic
-     * to the current request OR in an app or route middleware.
+     * Going forward, decisions determined by current request
+     * should be done in an app or route middleware.
+     * Application should be setup agnostic to the current request.
      *
      * Route middlewares apply only to a certain route or group of routes.
      * See {@see \Bolt\Controller\Async\AsyncBase::before} for an example.

--- a/src/Controller/Zone.php
+++ b/src/Controller/Zone.php
@@ -4,7 +4,7 @@ namespace Bolt\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Zone constants class to define whic part of the Bolt site that a request is
+ * Zone constants class to define which part of the Bolt site that a request is
  * relative to.
  *
  * @author Carson Full <carsonfull@gmail.com>

--- a/src/EventListener/ZoneGuesser.php
+++ b/src/EventListener/ZoneGuesser.php
@@ -40,12 +40,43 @@ class ZoneGuesser implements EventSubscriberInterface
             return;
         }
 
+        $this->setZone($request);
+    }
+
+    /**
+     * Sets the request's zone if needed and returns it.
+     *
+     * @param Request $request
+     *
+     * @return string
+     */
+    public function setZone(Request $request)
+    {
+        if ($zone = Zone::get($request)) {
+            return $zone;
+        }
+
+        $zone = $this->determineZone($request);
+        Zone::set($request, $zone);
+
+        return $zone;
+    }
+
+    /**
+     * Determine the zone and return it
+     *
+     * @param Request $request
+     *
+     * @return string
+     */
+    protected function determineZone(Request $request)
+    {
         if ($request->isXmlHttpRequest() || $this->isPathApplicable($request, Zone::ASYNC)) {
-            Zone::set($request, Zone::ASYNC);
+            return Zone::ASYNC;
         } elseif ($this->isPathApplicable($request, Zone::BACKEND)) {
-            Zone::set($request, Zone::BACKEND);
+            return Zone::BACKEND;
         } else {
-            Zone::set($request, Zone::FRONTEND);
+            return Zone::FRONTEND;
         }
     }
 


### PR DESCRIPTION
Updated Config::getWhichEnd to use ZoneGuesser and deprecated it.
Also, deprecated `$app['end']`, but there is no way to note that other than the comment.

I tried to document a clear way foward for those trying to use it.

Note: _cli_ is not a Zone, because this doesn't really make sense. It is a simple check and completely unrelated to Request.

Config::getTwigPath is next :gun:

**Ninja Edit:** :koala: is :gun: 