### PR TITLE
Performance improvement for registering nut commands

### DIFF
--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -682,9 +682,6 @@ abstract class BaseExtension implements ExtensionInterface
      */
     public function addConsoleCommand(Command $command)
     {
-        $this->app['nut.commands'] = array_merge(
-            $this->app['nut.commands'],
-            [$command]
-        );
+        $this->app['nut.commands.add']($command);
     }
 }

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -53,6 +53,21 @@ class NutServiceProvider implements ServiceProviderInterface
             }
         );
 
+        $app['nut.commands.add'] = $app->protect(
+            function (Command $command) use ($app) {
+                $app['nut.commands'] = $app->share(
+                    $app->extend(
+                        'nut.commands',
+                        function ($commands) use ($command) {
+                            $commands[] = $command;
+
+                            return $commands;
+                        }
+                    )
+                );
+            }
+        );
+
         // Maintain backwards compatibility
         $app['console'] = $app->share(
             function ($app) {
@@ -63,19 +78,5 @@ class NutServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
-    }
-
-    public static function addCommand(Application $app, Command $command)
-    {
-        $app['nut.commands'] = $app->share(
-            $app->extend(
-                'nut.commands',
-                function ($commands) use ($command) {
-                    $commands[] = $command;
-
-                    return $commands;
-                }
-            )
-        );
     }
 }

--- a/tests/phpunit/unit/Provider/NutServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/NutServiceProviderTest.php
@@ -29,7 +29,7 @@ class NutServiceProviderTest extends BoltUnitTest
         $app->register($provider);
         $app->boot();
         $command = $this->getMock('Symfony\Component\Console\Command\Command', null, ['mockCommand']);
-        NutServiceProvider::addCommand($app, $command);
+        $app['nut.commands.add']($command);
         $this->assertTrue(in_array($command, $app['nut.commands']));
     }
 }


### PR DESCRIPTION
The whole point of `NutServiceProvider::addCommand` was to make it easier to register nut commands **without** invoking/creating every command.

Currently if I have even a _single_ extension that adds a _single_ command, **ALL 21** (20 core + 1 extension) commands will be created for _every_ web request even though they aren't used.

Pimple's extend and share syntax is very verbose (fixed in v3.0) and this shortcut was to help with that.

Even though the method was static it still used the app object passed in; not a static variable (like `Library` or `ResourceManager`). It had no negative effect to unit tests.

----

Perhaps the purposed change could be a compromise?