### PR TITLE
Add the possibility to choose which field to display as backend title…

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -1001,6 +1001,15 @@ class Content implements \ArrayAccess
         $names = array_merge($names, ['nom', 'sujet']); // FR
         $names = array_merge($names, ['nombre', 'sujeto']); // ES
 
+        // If a field has the attribute "use_as_title" set to true, assume that's the title.
+        if (!empty($this->contenttype['fields'])) {
+            foreach ($this->contenttype['fields'] as $key => $field) {
+                if ($field['use_as_title'] == true) {
+                    return $key;
+                }
+            }
+        }
+
         foreach ($names as $name) {
             if (isset($this->values[$name])) {
                 return $name;
@@ -1014,6 +1023,11 @@ class Content implements \ArrayAccess
                     return $key;
                 }
             }
+        }
+
+        // Otherwhise return the slug if exists
+        if (isset($this->values['slug'])) {
+            return 'slug';
         }
 
         // nope, no title was found.


### PR DESCRIPTION
Hi,

With these modifications, it is possible to choose which field to show as content title in the backend.

Some of my content_type only have a date field and a file field and the title were all
"no content..." or "no title...". Now it is the date.
Use the attribue *use_as_title: true* in the field definitions:
```yml
journal-de-balgau:
    name: Journal de Balgau
    singular_name: Journal de Balgau
    fields:
        date_journal:
            type: date
            use_as_title: true
        slug:
            type: slug
        fichier:
            type: file
            extensions: [ pdf ]
            upload: "journal-de-balgau"
(...)
```

Additionally if no title field has been detected, we try to display the *slug* if it exists.
