### PR TITLE
Disabled generator meta tag

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -38,6 +38,9 @@ maintenance_template: maintenance_default.twig
 # monthly and yearly jobs.  Default: 3 (3 am)
 cron_hour: 3
 
+# Disable the generator meta tag. By default, Bolt add itself to the generator meta tag.
+# generator: false
+
 # If your site is reachable under different urls (say, both blog.example.org/
 # as well as example.org/), it's a good idea to set one of these as the canonical,
 # so it's clear which is the primary address of the site. If you include `https://`,

--- a/src/Application.php
+++ b/src/Application.php
@@ -514,8 +514,11 @@ class Application extends Silex\Application
         if (isset($this['htmlsnippets']) && ($this['htmlsnippets'] === true)) {
             // only add when content-type is text/html
             if (strpos($response->headers->get('Content-Type'), 'text/html') !== false) {
-                // Add our meta generator tag.
-                $this['extensions']->insertSnippet(Extensions\Snippets\Location::AFTER_META, '<meta name="generator" content="Bolt">');
+                // Perhaps add our meta generator tag.
+
+                if ($this['config']->get('general/generator') !== false) {
+                    $this['extensions']->insertSnippet(Extensions\Snippets\Location::AFTER_META, '<meta name="generator" content="Bolt">');
+                }
 
                 // Perhaps add a canonical link.
 


### PR DESCRIPTION
Allow the generator meta tag to be disabled. Still enable by default.