### PR TITLE
XSS and missing close tag issue fixed. Issues 3590 and 3591

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -356,6 +356,12 @@ class Storage
         $getId = $create ? null : $fieldvalues['id'];
         $fieldvalues['slug'] = $this->getUri($fieldvalues['slug'], $getId, $contenttype['slug'], false, false);
 
+        /**
+        * Replace special characters for HTML 5 entities
+        * Pages/Entries/Showcases update using this method.
+        */
+        $fieldvalues['title'] = htmlspecialchars($fieldvalues['title'], ENT_HTML5);
+
         // Update the content object
         $content->setValues($fieldvalues);
 


### PR DESCRIPTION
Fixes #3590 
Fixed #3591 

Changelog
--------------

* Fixed: Bug that breaks the dashboard and full site if a tag is open but not closed in the title bar. Also prevents possible XSS injection and use of tags in title bar.