### PR TITLE
Replace deprecated symfony/locale with intl. Remove loading intl stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/filesystem" : "^2.7",
         "symfony/finder" : "^2.7",
         "symfony/form" : "^2.7",
-        "symfony/locale" : "^2.7",
+        "symfony/intl" : "^2.7",
         "symfony/security-csrf" : "^2.7",
         "symfony/translation" : "^2.7",
         "symfony/twig-bridge" : "^2.7",

--- a/src/Application.php
+++ b/src/Application.php
@@ -313,12 +313,6 @@ class Application extends Silex\Application
             ['locale_fallbacks' => [Application::DEFAULT_LOCALE]]
         );
 
-        // Loading stub functions for when intl / IntlDateFormatter isn't available.
-        if (!function_exists('intl_get_error_code')) {
-            require_once $this['resources']->getPath('root/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/functions.php');
-            require_once $this['resources']->getPath('root/vendor/symfony/locale/Symfony/Component/Locale/Resources/stubs/IntlDateFormatter.php');
-        }
-
         $this->register(new Provider\TranslationServiceProvider());
     }
 


### PR DESCRIPTION
`symfony/locale` component is deprecated and just calls to `symfony/intl`, requiring that component instead.

Stub files are autoloaded [here](https://github.com/symfony/Intl/blob/master/composer.json#L38-L39).
