### PR TITLE
Move generator and related tags to END_OF_HEAD

### DIFF
--- a/src/EventListener/SnippetListener.php
+++ b/src/EventListener/SnippetListener.php
@@ -82,7 +82,7 @@ class SnippetListener implements EventSubscriberInterface
         }
     }
 
-    protected function insert($snippet, $location = Location::AFTER_META)
+    protected function insert($snippet, $location = Location::END_OF_HEAD)
     {
         $this->extensions->insertSnippet($location, $snippet);
     }


### PR DESCRIPTION
Affects generator, canonical and favicon.

Fixes #3622 & #1129 & #2786.