### PR TITLE
Fixes the overlay of the Symfony Icon in our debug toolbar.

### DIFF
--- a/app/view/toolbar/bolt.html.twig
+++ b/app/view/toolbar/bolt.html.twig
@@ -8,8 +8,7 @@
     background-size: 32px 32px;
     background-repeat: no-repeat;
 }
-.sf-minitoolbar img {
-    border: 1px dashed #0F0;
+.sf-minitoolbar svg {
     opacity: 0;
 }
 </style>


### PR DESCRIPTION
Symfony 2.7 switched from a bitmap to an SVG. Fix the CSS accordingly.

