### PR TITLE
Update composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php" : ">=5.4.16",
         "rossriley/flysystem53" : "~1.1",
         "siriusphp/upload" : "~1.2",
-        "silex/silex" : "~1.2",
+        "silex/silex" : "^1.3",
         "silex/web-profiler" : "^1.0",
         "stecman/symfony-console-completion" : "~0.4",
         "swiftmailer/swiftmailer" : "~5.3",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "rossriley/flysystem53" : "~1.1",
         "siriusphp/upload" : "~1.2",
         "silex/silex" : "~1.2",
-        "silex/web-profiler" : "^1.0.7",
+        "silex/web-profiler" : "^1.0",
         "stecman/symfony-console-completion" : "~0.4",
         "swiftmailer/swiftmailer" : "~5.3",
         "symfony/config" : "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "brandonwamboldt/utilphp" : "~1.0",
         "cocur/slugify" : "~1.0",
         "composer/composer" : "dev-master",
-        "doctrine/dbal" : "2.5.1",
+        "doctrine/dbal" : "^2.5",
         "erusev/parsedown-extra" : "~0.2",
         "ext-mbstring" : "*",
         "ext-pdo" : "*",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/web-profiler-bundle" : "^2.7",
         "symfony/yaml" : "^2.7",
         "tdammers/htmlmaid" : "~0.7",
-        "twig/twig" : "~1.16",
+        "twig/twig" : "^1.18",
         "ua-parser/uap-php" : "~3.4"
     },
     "require-dev" : {


### PR DESCRIPTION
Commit messages explain pretty much everything. 

DBAL was locked to 2.5.1 in #2517 to maintain PHP 5.3.3 support… which is kind of invalid now :grin: 