### PR TITLE
Fixes unittest by doing a replace db with testdb foreach phpunit run using bootstrap

### DIFF
--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -46,3 +46,8 @@ if (!defined('NUT_PATH')) {
 
 // Load the upload bootstrap
 require_once 'unit/bootstraps/upload-bootstrap.php';
+
+if (is_readable(TEST_ROOT . '/bolt.db')) {
+    unlink(TEST_ROOT . '/bolt.db');
+}
+copy(TEST_ROOT . '/tests/phpunit/unit/resources/db/bolt.db', TEST_ROOT . '/bolt.db');


### PR DESCRIPTION
With v2.2.x the delete/copy test.db was removed. When running a testsuite it will only work correctly the first time, the second/third/etc the previous data still exists.

Using resetDb() in the Setup gives the following error:
unlink(/vagrant/vendor/bolt/bolt/bolt.db): Text file busy

Restoring the unlink/copy fixes this issue.
