### PR TITLE
Fix/yaml config read and write

### DIFF
--- a/src/Configuration/YamlUpdater.php
+++ b/src/Configuration/YamlUpdater.php
@@ -25,6 +25,8 @@ class YamlUpdater
     private $yaml = [];
     /** @var File */
     private $file;
+    /** @var array the parsed yml file */
+    private $parsed;
 
     /**
      * Creates an updater for the given file.
@@ -42,7 +44,7 @@ class YamlUpdater
         $this->yaml = $this->file->read();
 
         // Check that the read-in YAML is valid
-        $this->parser->parse($this->yaml, true, true);
+        $this->parsed = $this->parser->parse($this->yaml, true, true);
 
         // Create a searchable array
         $this->yaml = explode("\n", $this->yaml);
@@ -60,13 +62,17 @@ class YamlUpdater
      */
     public function get($key)
     {
-        $yaml = Yaml::parse($this->file->read());
+        $yaml = $this->parsed;
 
         $keyparts = explode("/", $key);
         while ($key = array_shift($keyparts)) {
             $yaml = &$yaml[$key];
         }
-
+        
+        if (is_array($yaml)) {
+            return Yaml::dump($yaml, 0, 4);
+        }
+        
         return $yaml;
     }
     

--- a/src/Nut/ConfigGet.php
+++ b/src/Nut/ConfigGet.php
@@ -43,7 +43,7 @@ class ConfigGet extends BaseCommand
 
         try {
             $yaml = new YamlUpdater($this->app, $file);
-            $match = $yaml->getValue($key);
+            $match = $yaml->get($key);
 
             if (!empty($match)) {
                 $result = sprintf("%s: %s", $key, $match);

--- a/src/Nut/ConfigGet.php
+++ b/src/Nut/ConfigGet.php
@@ -43,10 +43,10 @@ class ConfigGet extends BaseCommand
 
         try {
             $yaml = new YamlUpdater($this->app, $file);
-            $match = $yaml->get($key);
+            $match = $yaml->getValue($key);
 
             if (!empty($match)) {
-                $result = sprintf("%s: %s", $key, $match['value']);
+                $result = sprintf("%s: %s", $key, $match);
             } else {
                 $result = sprintf("<error>The key '%s' was not found in %s.</error>", $key, $file);
             }

--- a/src/Nut/ConfigSet.php
+++ b/src/Nut/ConfigSet.php
@@ -53,7 +53,7 @@ class ConfigSet extends BaseCommand
         try {
             $yaml = new YamlUpdater($this->app, $file);
 
-            if ($yaml->change($key, $value, $backup)) {
+            if ($yaml->setValue($key, $value, $backup)) {
                 $result = sprintf("New value for <info>%s: %s</info> was successful. File updated.", $key, $value);
             } else {
                 $result = sprintf("<error>The key '%s' was not found in %s.</error>", $key, $file);

--- a/src/Nut/ConfigSet.php
+++ b/src/Nut/ConfigSet.php
@@ -53,7 +53,7 @@ class ConfigSet extends BaseCommand
         try {
             $yaml = new YamlUpdater($this->app, $file);
 
-            if ($yaml->setValue($key, $value, $backup)) {
+            if ($yaml->change($key, $value, $backup)) {
                 $result = sprintf("New value for <info>%s: %s</info> was successful. File updated.", $key, $value);
             } else {
                 $result = sprintf("<error>The key '%s' was not found in %s.</error>", $key, $file);


### PR DESCRIPTION
This should hopefully fix the regression in #3667

The config:get command now just uses the parsed yaml to return a value.

The config:set command uses a smarter multiline regex to find the original and then replaces the value whilst preserving whitespace so tab indentations of any number should work.