### PR TITLE
Fix force logic on checkLocalAutoLoader

### DIFF
--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -210,7 +210,7 @@ class Extensions
      */
     public function checkLocalAutoloader($force = false)
     {
-        if (!$this->app['filesystem']->has('extensions://local/') || !$force || $this->app['filesystem']->has('extensions://local/.built')) {
+        if (!$force && (!$this->app['filesystem']->has('extensions://local/') || $this->app['filesystem']->has('extensions://local/.built'))) {
             return;
         }
 


### PR DESCRIPTION
`$force` defaults to false and currently isn't ever set otherwise, the conditional in there meant it will always his that return and never check the autoloaders.