### PR TITLE
Fix paste issue with fileuploader

### DIFF
--- a/app/src/js/bind-fileupload.js
+++ b/app/src/js/bind-fileupload.js
@@ -11,6 +11,7 @@ function bindFileUpload(key) {
         .fileupload({
             dataType: 'json',
             dropZone: $('#dropzone-' + key),
+            pasteZone: null,
             done: function (e, data) {
                 $.each(data.result, function (index, file) {
                     var filename, message;


### PR DESCRIPTION
Client reported this one, they were trying to copy from Excel into input fields (title etc.) but on paste fileuploader was kicking in thinking they were trying to upload something and popping dialogs up.

There is a similar fix in place already over here: https://github.com/bolt/bolt/blob/release/2.2/app/src/js/upload-files.js#L188