### PR TITLE
fix fullpath file hashing

### DIFF
--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -36,7 +36,7 @@ class AssetServiceProvider implements ServiceProviderInterface
             $fullPath = $app['resources']->getPath('root') . '/' . $fileName;
 
             if (is_readable($fullPath)) {
-                return substr(md5($app['asset.salt'] . (string) filemtime($fullPath, 0, 10)));
+                return substr(md5($app['asset.salt'] . (string) filemtime($fullPath)), 0, 10);
             } elseif (is_readable($fileName)) {
                 return substr(md5($app['asset.salt'] . (string) filemtime($fileName)), 0, 10);
             }


### PR DESCRIPTION
This fixes an asset hashing bug that made itself known as nice big flashy warnings in the live editor while running under the php server.  Turns out the `substr` wasn't doing too much there.

Looks like the koala slipped on some wet :leaves:!

Cheers!