### PR TITLE
Update Integrity Manager

### DIFF
--- a/src/Storage/Database/Schema/Manager.php
+++ b/src/Storage/Database/Schema/Manager.php
@@ -235,7 +235,7 @@ class Manager
 
                 /** @var $platform AbstractPlatform */
                 $platform = $this->app['db']->getDatabasePlatform();
-                $queries = $platform->getCreateTableSQL($table);
+                $queries = $platform->getCreateTableSQL($table, AbstractPlatform::CREATE_INDEXES | AbstractPlatform::CREATE_FOREIGNKEYS);
                 foreach ($queries as $query) {
                     $this->app['db']->query($query);
                 }


### PR DESCRIPTION
The database platform's method getCreateTableSQL creates only indexes default, however foreign keys also can be added by the documentation: http://doctrine-dbal.readthedocs.org/en/latest/reference/schema-representation.html
We just have to add the second parameter to getCreateTableSQL call.

This also affects stable branches. I can make PRs to them/it as well if you accept this.

Source and documentation for AbstractPlatform for quick reference: http://www.doctrine-project.org/api/dbal/2.4/source-class-Doctrine.DBAL.Platforms.AbstractPlatform.html#1010