### PR TITLE
Allow readonly fields via Perister customisation

### DIFF
--- a/src/Storage/Persister.php
+++ b/src/Storage/Persister.php
@@ -12,6 +12,8 @@ use Bolt\Storage\Mapping\ClassMetadata;
 class Persister
 {
     protected $metadata;
+    
+    protected $disabledFields = [];
 
     public function __construct(ClassMetadata $metadata)
     {
@@ -27,7 +29,7 @@ class Persister
      */
     public function persist(QuerySet $queries, $entity, EntityManager $em)
     {
-        foreach ($this->metadata->getFieldMappings() as $key => $mapping) {
+        foreach ($this->getFields() as $key => $mapping) {
             // First step is to allow each Bolt field to transform the data.
             /** @var FieldTypeInterface $field */
             $field = new $mapping['fieldtype']($mapping);
@@ -35,5 +37,38 @@ class Persister
         }
 
         return $entity;
+    }
+    
+    /**
+     * Marks a field to be excluded from persistence
+     * 
+     * @param string $field
+     *
+     * @return void
+     */
+    public function disableField($field)
+    {
+        if (!in_array($field, $this->disabledFields)) {
+            $this->disabledFields[] = $field; 
+        }
+    }
+    
+    /**
+     * Fetch the fields that will be persisted
+     *
+     * @return void
+     * @author 
+     **/
+    protected function getFields()
+    {
+        $mappings = $this->metadata->getFieldMappings();
+        
+        foreach ($this->disabledFields as $field) {
+            if (in_array($field, $mappings)) {
+                unset($mappings[$field]);
+            }
+        }
+        
+        return $mappings;
     }
 }

--- a/src/Storage/Persister.php
+++ b/src/Storage/Persister.php
@@ -54,6 +54,20 @@ class Persister
     }
     
     /**
+     * Marks a previously excluded field to be included on persistence
+     * 
+     * @param string $field
+     *
+     * @return void
+     */
+    public function enableField($field)
+    {
+        if (in_array($field, $this->disabledFields)) {
+            unset($this->disabledFields[$field]); 
+        }
+    }
+    
+    /**
      * Fetch the fields that will be persisted
      *
      * @return void

--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -364,6 +364,14 @@ class Repository implements ObjectRepository
     {
         $this->persister = $persister;
     }
+    
+    /**
+     * @return Persister $persister
+     */
+    public function getPersister()
+    {
+        return $this->persister;
+    }
 
     /**
      * @param Loader $loader


### PR DESCRIPTION
Adds the ability to toggle persistence of an individual field.

`$repo->getPersister()->disableField('password');`

`$repo->getPersister()->enableField('password');`