### PR TITLE
Replace Storage hardcoded instantiation with container reference

### DIFF
--- a/src/Twig/SetcontentNode.php
+++ b/src/Twig/SetcontentNode.php
@@ -20,7 +20,7 @@ class SetcontentNode extends \Twig_Node
 
         $compiler
             ->addDebugInfo($this)
-            ->write('$template_storage = new Bolt\Storage($context[\'app\']);' . "\n")
+            ->write('$template_storage = $context[\'app\'][\'storage\'];' . "\n")
             ->write('$context[\'' . $this->getAttribute('name') . '\'] = ')
             ->write('$template_storage->getContent(')
             ->subcompile($this->getAttribute('contenttype'))


### PR DESCRIPTION
Hi folks,

I have a project requirement which has me redefine the `storage` service in `Bolt\Application`, for filtering results globally based on some criteria.

The fact that a `Bolt\Storage` standalone object is instantiated here bypasses the service in the container, so in my opinion it had to be fixed.

Is there a particular reason why the `storage` service wasn't used here, especially when Twig can get access to the container via `$context['app']`?