### PR TITLE
Local extension autoloader enhancements

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -50,15 +50,18 @@ return call_user_func(
             );
         }
 
-        // Register a PHP shutdown function to catch fatal error
-        register_shutdown_function(['\Bolt\Exception\LowlevelException', 'catchFatalErrors']);
+        // Register a PHP shutdown function to catch early fatal errors
+        register_shutdown_function(['\Bolt\Exception\LowlevelException', 'catchFatalErrorsEarly']);
 
-        /** @var Configuration\ResourceManager $config */
+        /** @var \Bolt\Configuration\ResourceManager $config */
         $config->verify();
         $config->compat();
 
         // Create the 'Bolt application'
         $app = new Application(['resources' => $config]);
+
+        // Register a PHP shutdown function to catch fatal errors with the application object
+        register_shutdown_function(['\Bolt\Exception\LowlevelException', 'catchFatalErrors'], $app);
 
         // Initialize the 'Bolt application': Set up all routes, providers, database, templating, etc..
         $app->initialize();

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,4 +1,8 @@
 <?php
+namespace Bolt;
+
+use Bolt\Exception\LowlevelException;
+
 /**
  * Second stage loader. Here we bootstrap the app:
  *
@@ -8,10 +12,6 @@
  * - Load and verify configuration
  * - Initialize the application
  */
-
-namespace Bolt;
-
-use Bolt\Exception\LowlevelException;
 
 // Do bootstrapping within a new local scope to avoid polluting the global
 return call_user_func(
@@ -26,10 +26,10 @@ return call_user_func(
         // Look for the autoloader in known positions relative to the Bolt-root,
         // and autodetect an appropriate configuration class based on this
         // information. (autoload.php path maps to a configuration class)
-        $autodetectionMappings = array(
+        $autodetectionMappings = [
             $boltRootPath . '/vendor/autoload.php' => 'Standard',
             $boltRootPath . '/../../autoload.php' => 'Composer'
-        );
+        ];
 
         foreach ($autodetectionMappings as $autoloadPath => $configType) {
             if (file_exists($autoloadPath)) {
@@ -42,6 +42,7 @@ return call_user_func(
 
         // None of the mappings matched, error
         if (!isset($config)) {
+            include $boltRootPath . '/src/Exception/LowlevelException.php';
             throw new LowlevelException(
                 "Configuration autodetection failed because The file " .
                 "<code>vendor/autoload.php</code> doesn't exist. Make sure " .
@@ -50,16 +51,14 @@ return call_user_func(
         }
 
         // Register a PHP shutdown function to catch fatal error
-        register_shutdown_function(array('\Bolt\Exception\LowlevelException', 'catchFatalErrors'));
+        register_shutdown_function(['\Bolt\Exception\LowlevelException', 'catchFatalErrors']);
 
-        /**
-         * @var $config Configuration\ResourceManager
-         */
+        /** @var Configuration\ResourceManager $config */
         $config->verify();
         $config->compat();
 
         // Create the 'Bolt application'
-        $app = new Application(array('resources' => $config));
+        $app = new Application(['resources' => $config]);
 
         // Initialize the 'Bolt application': Set up all routes, providers, database, templating, etc..
         $app->initialize();

--- a/src/EventListener/WhoopsListener.php
+++ b/src/EventListener/WhoopsListener.php
@@ -65,6 +65,9 @@ class WhoopsListener implements EventSubscriberInterface
             return;
         }
 
+        // Register Whoops as an error handler
+        $this->whoops->register();
+
         $exception = $event->getException();
 
         ob_start();

--- a/src/Exception/LowlevelException.php
+++ b/src/Exception/LowlevelException.php
@@ -1,7 +1,8 @@
 <?php
 namespace Bolt\Exception;
 
-use Bolt\Configuration\ResourceManager;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Response;
 
 class LowlevelException extends \Exception
 {
@@ -92,11 +93,26 @@ HTML;
     }
 
     /**
+     * Catch and display errors that occur before the Application object has
+     * been instantiated.
+     *
+     * If the error occurs later in the application life cycle, we flush this
+     * output in catchFatalErrors() which has access to the Application object.
+     */
+    public static function catchFatalErrorsEarly()
+    {
+        $error = error_get_last();
+        if (($error['type'] === E_ERROR || $error['type'] === E_PARSE)) {
+            echo nl2br(str_replace(dirname(dirname(__DIR__)), '', $error['message']));
+        }
+    }
+
+    /**
      * Callback for register_shutdown_function() to handle fatal errors.
      *
      * @param \Silex\Application $app
      */
-    public static function catchFatalErrors($app = null)
+    public static function catchFatalErrors(Application $app)
     {
         // Get last error, if any
         $error = error_get_last();
@@ -106,13 +122,11 @@ HTML;
             return;
         }
 
-        if (($error['type'] == E_ERROR || $error['type'] == E_PARSE)) {
+        if (($error['type'] === E_ERROR || $error['type'] === E_PARSE)) {
             $html = self::$html;
 
-            // Get the application object
-            if ($app === null) {
-                $app = ResourceManager::getApp();
-            }
+            // Flush the early error data buffered output from catchFatalErrorsEarly()
+            Response::closeOutputBuffers(0, false);
 
             // Detect if we're being called from a core, an extension or vendor
             $isBoltCoreError  = strpos($error['file'], $app['resources']->getPath('rootpath/src'));

--- a/src/Exception/LowlevelException.php
+++ b/src/Exception/LowlevelException.php
@@ -1,8 +1,9 @@
 <?php
 namespace Bolt\Exception;
 
-use Silex\Application;
+use Bolt\Application;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 
 class LowlevelException extends \Exception
 {
@@ -111,8 +112,9 @@ HTML;
      * Callback for register_shutdown_function() to handle fatal errors.
      *
      * @param \Silex\Application $app
+     * @param boolean            $flush
      */
-    public static function catchFatalErrors(Application $app)
+    public static function catchFatalErrors(Application $app, $flush = true)
     {
         // Get last error, if any
         $error = error_get_last();
@@ -126,7 +128,9 @@ HTML;
             $html = self::$html;
 
             // Flush the early error data buffered output from catchFatalErrorsEarly()
-            Response::closeOutputBuffers(0, false);
+            if ($flush) {
+                Response::closeOutputBuffers(0, false);
+            }
 
             // Detect if we're being called from a core, an extension or vendor
             $isBoltCoreError  = strpos($error['file'], $app['resources']->getPath('rootpath/src'));
@@ -147,6 +151,8 @@ HTML;
                 $html = str_replace('%info%', '', $html);
                 $message = $errorblock;
             } elseif ($isExtensionError === 0) {
+                self::attemptExtensionRecovery($app, $error);
+
                 $base = str_replace($app['resources']->getPath('extensions'), '', $error['file']);
                 $parts = explode(DIRECTORY_SEPARATOR, ltrim($base, '/'));
                 $package = $parts[1] . '/' . $parts[2];
@@ -206,5 +212,57 @@ HTML;
         $output = preg_replace('/(\n+)(\s+)/smi', "\n", $output);
 
         return $output;
+    }
+
+    /**
+     * Attempt to rebuild extension autoloader when a "Class not found" error
+     * occurs.
+     *
+     * @param \Bolt\Application $app
+     * @param array             $error
+     */
+    private static function attemptExtensionRecovery($app, $error)
+    {
+        $cwd = getcwd();
+        if ($error['type'] === E_ERROR && strpos($error['message'], 'Class') === 0) {
+            $path = $_SERVER['PATH_INFO'];
+            if (isset($_SERVER['QUERY_STRING'])) {
+                if (strpos($_SERVER['QUERY_STRING'], 'rebuild-autoloader') !== false) {
+                    header("location: $path?rebuild-done");
+                } elseif (strpos($_SERVER['QUERY_STRING'], 'rebuild-done') !== false) {
+                    chdir($cwd);
+                    return;
+                }
+            }
+
+            restore_error_handler();
+            $html = self::$html;
+            $html = str_replace('%error_title%', 'PHP Fatal Error: Bolt Extensions Class Loader', $html);
+
+            $message = '<b>Attempting to rebuild extension autoloader</b>';
+            $message .= "<p>Redirecting to <a href='$path?rebuild-autoloader'>$path</a> on completion.</p>";
+            $message .= "<script>window.setTimeout(function () { window.location='$path?rebuild-autoloader'; }, 5000);</script>";
+
+            $message = nl2br($message);
+            $html = str_replace('%error%', $message, $html);
+            $html = str_replace('%info%', '', $html);
+            if (php_sapi_name() == 'cli') {
+                $html = self::cleanHTML($html) . "\n\n";
+            }
+            echo $html;
+
+            $app['extend.enabled'] = false;
+            $app['extensions']->checkLocalAutoloader(true);
+            $html = '<div style="max-width: 640px; margin: auto;"><p class="status-ok">Completed rebuild… Attempting reload!</p>';
+            if (php_sapi_name() == 'cli') {
+                $html = self::cleanHTML($html) . "\n\n";
+            }
+            echo $html;
+
+            // Reboot the application and retry loading
+            chdir($cwd);
+            $app->boot();
+            $app->abort(Response::HTTP_MOVED_PERMANENTLY);
+        }
     }
 }

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -211,6 +211,8 @@ class Extensions
                 }
             }
 
+            // Ensure the namespace is valid for PSR-4
+            $namespace = rtrim($namespace, '\\') . '\\';
             $psr4[$namespace] = $paths;
         }
 

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -133,7 +133,11 @@ class Extensions
      */
     public function checkLocalAutoloader($force = false)
     {
-        if (!$force && (!$this->app['filesystem']->has('extensions://local/') || $this->app['filesystem']->has('app://cache/.local.autoload.built'))) {
+        if (!$this->app['filesystem']->has('extensions://local/')) {
+            return;
+        }
+
+        if (!$force && $this->app['filesystem']->has('app://cache/.local.autoload.built')) {
             return;
         }
 

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -13,51 +13,19 @@ use Symfony\Component\Finder\Finder;
 
 class Extensions
 {
-    /**
-     * @var \Bolt\Application
-     */
+    /** @var \Bolt\Application */
     private $app;
-
-    /**
-     * The extension base folder.
-     *
-     * @var string
-     */
+    /** @var string The extension base folder. */
     private $basefolder;
-
-    /**
-     * List of enabled extensions.
-     *
-     * @var ExtensionInterface[]
-     */
+    /** @var ExtensionInterface[] List of enabled extensions. */
     private $enabled = [];
-
-    /**
-     * Queue with widgets to insert.
-     *
-     * @var array
-     */
+    /** @var array Queue with widgets to insert. */
     private $widgetqueue;
-
-    /**
-     * List of menu items to add in the backend.
-     *
-     * @var array
-     */
+    /** @var array List of menu items to add in the backend. */
     private $menuoptions = [];
-
-    /**
-     * Number of registered extensions that need to be able to send mail.
-     *
-     * @var integer
-     */
+    /** @var integer Number of registered extensions that need to be able to send mail. */
     private $mailsenders = 0;
-
-    /**
-     * Contains all initialized extensions.
-     *
-     * @var array
-     */
+    /** @var array Contains all initialized extensions. */
     private $initialized;
 
     /**
@@ -219,7 +187,7 @@ class Extensions
         $boltJson['autoload']['psr-4'] = $boltPsr4;
         $composerJsonFile->write($boltJson);
         $this->app['extend.manager']->dumpautoload();
-        $this->app['filesystem']->write('app://cache/.local.autoload.built', time());
+        $this->app['filesystem']->put('app://cache/.local.autoload.built', time());
     }
 
     /**

--- a/src/Nut/ExtensionsAutoloader.php
+++ b/src/Nut/ExtensionsAutoloader.php
@@ -1,0 +1,39 @@
+<?php
+namespace Bolt\Nut;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut command to update extension autoloaders.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ExtensionsAutoloader extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('extensions:autoloader')
+            ->setDescription('Update the extensions autoloader.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $result = $this->app['extensions']->checkLocalAutoloader(true);
+
+        if ($result === 0) {
+            $this->auditLog(__CLASS__, 'Autoloaders updated');
+        }
+
+        $output->writeln("\n<info>[Done] Autoloaders updated</info>\n");
+        $output->writeln($result, OutputInterface::OUTPUT_PLAIN);
+    }
+}

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -43,6 +43,7 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\ConfigGet($app),
                     new Nut\ConfigSet($app),
                     new Nut\Extensions($app),
+                    new Nut\ExtensionsAutoloader($app),
                     new Nut\ExtensionsEnable($app),
                     new Nut\ExtensionsDisable($app),
                     new Nut\UserAdd($app),

--- a/src/Provider/WhoopsServiceProvider.php
+++ b/src/Provider/WhoopsServiceProvider.php
@@ -87,8 +87,6 @@ class WhoopsServiceProvider implements ServiceProviderInterface
                 $showWhileLoggedOff
             );
         });
-
-        $app['whoops']->register();
     }
 
     /**

--- a/tests/phpunit/unit/Configuration/LowlevelChecksTest.php
+++ b/tests/phpunit/unit/Configuration/LowlevelChecksTest.php
@@ -70,6 +70,28 @@ class LowlevelChecksTest extends BoltUnitTest
         ];
     }
 
+    protected function getApp()
+    {
+        $this->php
+            ->expects($this->any())
+            ->method('is_dir')
+            ->will($this->returnValue(true));
+        $this->php
+            ->expects($this->any())
+            ->method('file_exists')
+            ->will($this->returnValue(true));
+        $this->php
+            ->expects($this->any())
+            ->method('is_writable')
+            ->will($this->returnValue(true));
+        $this->php
+            ->expects($this->any())
+            ->method('is_readable')
+            ->will($this->returnValue(true));
+
+        return parent::getApp();
+    }
+
     public function tearDown()
     {
         \PHPUnit_Extension_FunctionMocker::tearDown();
@@ -304,16 +326,13 @@ class LowlevelChecksTest extends BoltUnitTest
 
     public function testCoreFatalErrorCatch()
     {
-        $app = ['resources' => new Standard(TEST_ROOT)];
-        ResourceManager::$theApp = $app;
-
         $this->php2
             ->expects($this->once())
             ->method('error_get_last')
             ->will($this->returnValue($this->errorResponses['core']));
 
         $this->expectOutputRegex("/PHP Fatal Error: Bolt Core/");
-        LowlevelException::catchFatalErrors();
+        LowlevelException::catchFatalErrors($this->getApp(), false);
     }
 
     public function testVendorFatalErrorCatch()
@@ -326,8 +345,9 @@ class LowlevelChecksTest extends BoltUnitTest
             ->method('error_get_last')
             ->will($this->returnValue($this->errorResponses['vendor']));
 
+        $app = $this->getApp();
         $this->expectOutputRegex("/PHP Fatal Error: Vendor Library/");
-        LowlevelException::catchFatalErrors();
+        LowlevelException::catchFatalErrors($this->getApp(), false);
     }
 
     public function testExtFatalErrorCatch()
@@ -341,7 +361,7 @@ class LowlevelChecksTest extends BoltUnitTest
             ->will($this->returnValue($this->errorResponses['extension']));
 
         $this->expectOutputRegex("/PHP Fatal Error: Bolt Extensions/");
-        LowlevelException::catchFatalErrors();
+        LowlevelException::catchFatalErrors($this->getApp(), false);
     }
 
     public function testGeneralFatalErrorCatch()
@@ -355,7 +375,7 @@ class LowlevelChecksTest extends BoltUnitTest
             ->will($this->returnValue($this->errorResponses['unknown']));
 
         $this->expectOutputRegex("/PHP Fatal Error: Bolt Generic/");
-        LowlevelException::catchFatalErrors();
+        LowlevelException::catchFatalErrors($this->getApp(), false);
     }
 
     public function testAssertWritableDir()


### PR DESCRIPTION
* **[General]**  If vendor/autoload.php is missing, include LowlevelException.php manually.
* **[General]** Added a very early shutdown function to pre-catch errors that occur before the application object is built. Hopefully less *White Screens of Death*

* Added a nut command to force the rebuild `./app/nut extensions:autoloader`
* When a fatal error occurs in an extension that is a result of a missing class, we will try to rebuild the autoloader and then either redirect to the intended page, or display the full error:
![screenshot from 2015-07-11 15-59-41](https://cloud.githubusercontent.com/assets/1427081/8634194/025b7dd4-27e7-11e5-8075-06416050be27.png)
