### PR TITLE
[2.2] Local extension autoloader enhancements

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -50,17 +50,18 @@ return call_user_func(
             );
         }
 
-        // Register a PHP shutdown function to catch fatal error
-        register_shutdown_function(array('\Bolt\Exception\LowlevelException', 'catchFatalErrors'));
+        // Register a PHP shutdown function to catch early fatal errors
+        register_shutdown_function(['\Bolt\Exception\LowlevelException', 'catchFatalErrorsEarly']);
 
-        /**
-         * @var $config Configuration\ResourceManager
-         */
+        /** @var \Bolt\Configuration\ResourceManager $config */
         $config->verify();
         $config->compat();
 
         // Create the 'Bolt application'
         $app = new Application(array('resources' => $config));
+
+        // Register a PHP shutdown function to catch fatal errors with the application object
+        register_shutdown_function(['\Bolt\Exception\LowlevelException', 'catchFatalErrors'], $app);
 
         // Initialize the 'Bolt application': Set up all routes, providers, database, templating, etc..
         $app->initialize();

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -288,6 +288,8 @@ class Extensions
                 }
             }
 
+            // Ensure the namespace is valid for PSR-4
+            $namespace = rtrim($namespace, '\\') . '\\';
             $psr4[$namespace] = $paths;
         }
 

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -210,7 +210,11 @@ class Extensions
      */
     public function checkLocalAutoloader($force = false)
     {
-        if (!$force && (!$this->app['filesystem']->has('extensions://local/') || $this->app['filesystem']->has('app://cache/.local.autoload.built'))) {
+        if (!$this->app['filesystem']->has('extensions://local/')) {
+            return;
+        }
+
+        if (!$force && $this->app['filesystem']->has('app://cache/.local.autoload.built')) {
             return;
         }
 

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -264,7 +264,7 @@ class Extensions
         $boltJson['autoload']['psr-4'] = $boltPsr4;
         $composerJsonFile->write($boltJson);
         $this->app['extend.manager']->dumpautoload();
-        $this->app['filesystem']->write('app://cache/.local.autoload.built', time());
+        $this->app['filesystem']->put('app://cache/.local.autoload.built', time());
     }
 
     /**

--- a/src/Nut/ExtensionsAutoloader.php
+++ b/src/Nut/ExtensionsAutoloader.php
@@ -1,0 +1,39 @@
+<?php
+namespace Bolt\Nut;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut command to update extension autoloaders.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ExtensionsAutoloader extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('extensions:autoloader')
+            ->setDescription('Update the extensions autoloader.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $result = $this->app['extensions']->checkLocalAutoloader(true);
+
+        if ($result === 0) {
+            $this->auditLog(__CLASS__, 'Autoloaders updated');
+        }
+
+        $output->writeln("\n<info>[Done] Autoloaders updated</info>\n");
+        $output->writeln($result, OutputInterface::OUTPUT_PLAIN);
+    }
+}

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -43,6 +43,7 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\ConfigGet($app),
                     new Nut\ConfigSet($app),
                     new Nut\Extensions($app),
+                    new Nut\ExtensionsAutoloader($app),
                     new Nut\ExtensionsEnable($app),
                     new Nut\ExtensionsDisable($app),
                     new Nut\UserAdd($app),

--- a/tests/phpunit/unit/Configuration/LowlevelChecksTest.php
+++ b/tests/phpunit/unit/Configuration/LowlevelChecksTest.php
@@ -70,6 +70,28 @@ class LowlevelChecksTest extends BoltUnitTest
         );
     }
 
+    protected function getApp()
+    {
+        $this->php
+            ->expects($this->any())
+            ->method('is_dir')
+            ->will($this->returnValue(true));
+        $this->php
+            ->expects($this->any())
+            ->method('file_exists')
+            ->will($this->returnValue(true));
+        $this->php
+            ->expects($this->any())
+            ->method('is_writable')
+            ->will($this->returnValue(true));
+        $this->php
+            ->expects($this->any())
+            ->method('is_readable')
+            ->will($this->returnValue(true));
+
+        return parent::getApp();
+    }
+
     public function tearDown()
     {
         \PHPUnit_Extension_FunctionMocker::tearDown();
@@ -304,16 +326,13 @@ class LowlevelChecksTest extends BoltUnitTest
 
     public function testCoreFatalErrorCatch()
     {
-        $app = array('resources' => new Standard(TEST_ROOT));
-        ResourceManager::$theApp = $app;
-
         $this->php2
             ->expects($this->once())
             ->method('error_get_last')
             ->will($this->returnValue($this->errorResponses['core']));
 
         $this->expectOutputRegex("/PHP Fatal Error: Bolt Core/");
-        LowlevelException::catchFatalErrors();
+        LowlevelException::catchFatalErrors($this->getApp(), false);
     }
 
     public function testVendorFatalErrorCatch()
@@ -326,8 +345,9 @@ class LowlevelChecksTest extends BoltUnitTest
             ->method('error_get_last')
             ->will($this->returnValue($this->errorResponses['vendor']));
 
+        $app = $this->getApp();
         $this->expectOutputRegex("/PHP Fatal Error: Vendor Library/");
-        LowlevelException::catchFatalErrors();
+        LowlevelException::catchFatalErrors($this->getApp(), false);
     }
 
     public function testExtFatalErrorCatch()
@@ -341,7 +361,7 @@ class LowlevelChecksTest extends BoltUnitTest
             ->will($this->returnValue($this->errorResponses['extension']));
 
         $this->expectOutputRegex("/PHP Fatal Error: Bolt Extensions/");
-        LowlevelException::catchFatalErrors();
+        LowlevelException::catchFatalErrors($this->getApp(), false);
     }
 
     public function testGeneralFatalErrorCatch()
@@ -355,7 +375,7 @@ class LowlevelChecksTest extends BoltUnitTest
             ->will($this->returnValue($this->errorResponses['unknown']));
 
         $this->expectOutputRegex("/PHP Fatal Error: Bolt Generic/");
-        LowlevelException::catchFatalErrors();
+        LowlevelException::catchFatalErrors($this->getApp(), false);
     }
 
     public function testAssertWritableDir()


### PR DESCRIPTION
* **[General]** Added a very early shutdown function to pre-catch errors that occur before the application object is built. Hopefully less *White Screens of Death*

* Added a nut command to force the rebuild `./app/nut extensions:autoloader`
* When a fatal error occurs in an extension that is a result of a missing class, we will try to rebuild the autoloader and then either redirect to the intended page, or display the full error:
![screenshot from 2015-07-11 15-59-41](https://cloud.githubusercontent.com/assets/1427081/8634194/025b7dd4-27e7-11e5-8075-06416050be27.png)
