### PR TITLE
[2.2] Reenable BackendTest::testPrefill

### DIFF
--- a/tests/phpunit/unit/Controller/BackendTest.php
+++ b/tests/phpunit/unit/Controller/BackendTest.php
@@ -299,6 +299,7 @@ class BackendTest extends BoltUnitTest
     public function testPrefill()
     {
         $app = $this->getApp();
+        $this->addDefaultUser($app);
         $controller = new Backend();
 
         $app['request'] =  $request = Request::create('/bolt/prefill');
@@ -314,10 +315,6 @@ class BackendTest extends BoltUnitTest
 
         // Test for the Exception if connection fails to the prefill service
         $store = $this->getMock('Bolt\Storage', array('preFill'), array($app));
-
-        $this->markTestIncomplete(
-            'Needs work.'
-        );
 
         if ($app['deprecated.php']) {
             $store->expects($this->any())


### PR DESCRIPTION
This brings the 2.2 branch PHPUnit tests back to 100% pass