### PR TITLE
Send "New Bolt site" e-mail upon first user creation only

### DIFF
--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1422,28 +1422,30 @@ class Backend implements ControllerProviderInterface
             } else {
                 $app['logger.system']->info(Trans::__('page.edit-users.log.user-added', array('%user%' => $user['displayname'])), array('event' => 'security'));
 
-                // Create a welcome email
-                $mailhtml = $app['render']->render(
-                    'email/firstuser.twig',
-                    array(
-                        'sitename' => $app['config']->get('general/sitename')
-                    )
-                )->getContent();
+                if ($firstuser) {
+                    // Create a welcome email
+                    $mailhtml = $app['render']->render(
+                        'email/firstuser.twig',
+                        array(
+                            'sitename' => $app['config']->get('general/sitename')
+                        )
+                    )->getContent();
 
-                try {
-                    // Send a welcome email
-                    $message = $app['mailer']
-                        ->createMessage('message')
-                        ->setSubject(Trans::__('New Bolt site has been set up'))
-                        ->setFrom(array($app['config']->get('general/mailoptions/senderMail', $user['email']) => $app['config']->get('general/mailoptions/senderName', $app['config']->get('general/sitename'))))
-                        ->setTo(array($user['email']   => $user['displayname']))
-                        ->setBody(strip_tags($mailhtml))
-                        ->addPart($mailhtml, 'text/html');
+                    try {
+                        // Send a welcome email
+                        $message = $app['mailer']
+                            ->createMessage('message')
+                            ->setSubject(Trans::__('New Bolt site has been set up'))
+                            ->setFrom(array($app['config']->get('general/mailoptions/senderMail', $user['email']) => $app['config']->get('general/mailoptions/senderName', $app['config']->get('general/sitename'))))
+                            ->setTo(array($user['email']   => $user['displayname']))
+                            ->setBody(strip_tags($mailhtml))
+                            ->addPart($mailhtml, 'text/html');
 
-                    $app['mailer']->send($message);
-                } catch (\Exception $e) {
-                    // Sending message failed. What else can we do, sending with snailmail?
-                    $app['logger.system']->error("The 'mailoptions' need to be set in app/config/config.yml", array('event' => 'config'));
+                        $app['mailer']->send($message);
+                    } catch (\Exception $e) {
+                        // Sending message failed. What else can we do, sending with snailmail?
+                        $app['logger.system']->error("The 'mailoptions' need to be set in app/config/config.yml", array('event' => 'config'));
+                    }
                 }
             }
 


### PR DESCRIPTION
Currently in `2.2`, the **New Bolt website** e-mail is sent to any new user that gets created in the backend. This message should only be sent to the root account e-mail address upon first user creation, as it's just a confirmation that the `mailer` service is working correctly, which normal users don't care about, and don't really have to know about.

What's more is that the Twig template used for generating the message content doesn't use translation, and I don't really feel like explaining to my French-speaking clients why they're receiving unintelligible e-mails in English when I create their account in the backend :sweat_smile:

I'm pull requesting this against `release/2.2` as I consider this behavior a bug.

As far as I can tell, the problem is solved in `master`.