### PR TITLE
Regression in Geolocation: Change value "_address" back to "formatted_address"

### DIFF
--- a/app/view/twig/editcontent/fields/_geolocation.twig
+++ b/app/view/twig/editcontent/fields/_geolocation.twig
@@ -37,7 +37,7 @@
 
     formatted: {
         class:      'matched',
-        name:        name ~ '[_address]',
+        name:        name ~ '[formatted_address]',
         placeholder: '—',
         readonly:    true,
         type:        'text',


### PR DESCRIPTION
:warning::warning::warning: This is a binary compatibility breaking change.

Bug was introduced with [2.2.4](https://github.com/bolt/bolt/commit/5b402492ee470ac3a85292cc04f8d26de119836f#diff-7deb55152c7f64965d4f60501f1e0c21R36) and you can't even blame the :koala: this time.

If you use the the formatted address in the frontend like this:
```
{{ record.values.geolocation._address }}
```
it has to be changed back to the correct call:
```
{{ record.values.geolocation.formatted_address }}
```

This patch should be backported!

PS: values in the database were saved with the wrong key "_address" and would stay this way even after this patch and would have to be written again to be correct. Is there need provide both values on read for 2.2.x versions?

PPS: reported by @SahAssar 