### PR TITLE
Issue 3818 – Update JS Markdown Options to match Parsedown

### DIFF
--- a/app/resources/translations/de_DE/messages.de_DE.yml
+++ b/app/resources/translations/de_DE/messages.de_DE.yml
@@ -514,6 +514,10 @@ field:
         placeholder:
             address: "Straße, Postleitzahl, Stadt oder Ortsangabe"
         title-pin: "Pin"
+    markdown:
+        label:
+            markedview: "Markdown"
+            preview: "Vorschau"
     slug:
         message:
             set: "Slug setzen:"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -465,6 +465,9 @@ field:
         marker: "Pin"
         placeholder:
             address: "Street, ZIP code, city or other location"
+    markdown:
+        label:
+            preview: "Preview"
     slug:
         message:
             set: "Set the slug to:"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -467,6 +467,7 @@ field:
             address: "Street, ZIP code, city or other location"
     markdown:
         label:
+            markedview: "Markdown"
             preview: "Preview"
     slug:
         message:

--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -13,6 +13,7 @@
 
 {% set ukkit_conf = {
     height:    option.height,
+    lblPreview:  __('field.markdown.label.preview'),
     markdown:  true,
     markedOptions: {
         breaks: false,

--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -14,6 +14,9 @@
 {% set ukkit_conf = {
     height:   option.height,
     markdown: true,
+    markedOptions: {
+        breaks: false,
+    },
     toolbar:  ['bold', 'italic', 'link', 'image', 'blockquote', 'listUl', 'listOl'],
 } %}
 

--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -12,23 +12,23 @@
 {#=== INIT ===========================================================================================================#}
 
 {% set ukkit_conf = {
-    height:   option.height,
-    markdown: true,
+    height:    option.height,
+    markdown:  true,
     markedOptions: {
         breaks: false,
     },
-    toolbar:  ['bold', 'italic', 'link', 'image', 'blockquote', 'listUl', 'listOl'],
+    toolbar:   ['bold', 'italic', 'link', 'image', 'blockquote', 'listUl', 'listOl'],
 } %}
 
 {% set attributes = {
     text: {
-        class:           option.class,
-        data_errortext:  option.errortext,
-        data_uk_htmleditor: ukkit_conf|json_encode,
-        id:              key,
-        name:            name,
-        required:        option.required,
-        style:           (option.height) ? 'height: ' ~ option.height ~ ' !important;' : '',
+        class:               option.class,
+        data_errortext:      option.errortext,
+        data_uk_htmleditor:  ukkit_conf|json_encode,
+        id:                  key,
+        name:                name,
+        required:            option.required,
+        style:               (option.height) ? 'height: ' ~ option.height ~ ' !important;' : '',
     }
 } %}
 

--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -11,10 +11,16 @@
 
 {#=== INIT ===========================================================================================================#}
 
+{% set ukkit_conf = {
+    height:   option.height,
+    markdown: true,
+} %}
+
 {% set attributes = {
     text: {
         class:           option.class,
         data_errortext:  option.errortext,
+        data_uk_htmleditor: ukkit_conf|json_encode,
         id:              key,
         name:            name,
         required:        option.required,
@@ -35,6 +41,6 @@
 
 {% block fieldset_controls %}
     <div class="col-xs-12">
-        <textarea{{ macro.attr(attributes.text) }} data-uk-htmleditor="{ markdown: true, height: '{{option.height}}'}">{{ context.content.get(contentkey)|default('') }}</textarea>
+        <textarea{{ macro.attr(attributes.text) }}>{{ context.content.get(contentkey)|default('') }}</textarea>
     </div>
 {% endblock fieldset_controls %}

--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -14,6 +14,7 @@
 {% set ukkit_conf = {
     height:   option.height,
     markdown: true,
+    toolbar:  ['bold', 'italic', 'link', 'image', 'blockquote', 'listUl', 'listOl'],
 } %}
 
 {% set attributes = {

--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -12,14 +12,14 @@
 {#=== INIT ===========================================================================================================#}
 
 {% set ukkit_conf = {
-    height:    option.height,
+    height:         option.height,
     lblMarkedview:  __('field.markdown.label.markedview'),
-    lblPreview:  __('field.markdown.label.preview'),
-    markdown:  true,
-    markedOptions: {
-        breaks: false,
-    },
-    toolbar:   ['bold', 'italic', 'link', 'image', 'blockquote', 'listUl', 'listOl'],
+    lblPreview:     __('field.markdown.label.preview'),
+    markdown:       true,
+    markedOptions:  {
+                        breaks: false,
+                    },
+    toolbar:        ['bold', 'italic', 'link', 'image', 'blockquote', 'listUl', 'listOl'],
 } %}
 
 {% set attributes = {

--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -13,6 +13,7 @@
 
 {% set ukkit_conf = {
     height:    option.height,
+    lblMarkedview:  __('field.markdown.label.markedview'),
     lblPreview:  __('field.markdown.label.preview'),
     markdown:  true,
     markedOptions: {


### PR DESCRIPTION
>You can use all UIkit components by just adding data-uk-* attributes to your HTML elements without writing a single line of JavaScript. This is UIkit's best practice of using its components and should always be considered first.

Let's do it the easy (and prefered) way for now. Later we can move it to field initialisation. We could set it global, but as we have to set the height option anyway …

While at it i also made translation of Markdown/Preview buttons possible.

- Fixes #3818
- Markdown/Preview buttons translatiable

