### PR TITLE
Optimisation for backend by caching requests for users.

### DIFF
--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -638,7 +638,7 @@ class Permissions
                     // Either fetch $content, or use the one we passed along.
                     $isContent = $content instanceof \Bolt\Content;
                     if (!$isContent) {
-                        $content = $thiss->app['storage']->getContent("$contenttype/$contentid", ['hydrate' => false]);
+                        $content = $this->app['storage']->getContent("$contenttype/$contentid", ['hydrate' => false]);
                     }
                     if (intval($content['ownerid']) &&
                         (intval($content['ownerid']) === intval($user['id']))) {

--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -478,7 +478,6 @@ class Permissions
      */
     public function isAllowed($what, $user, $contenttype = null, $contentid = null)
     {
-
         $contentobject = null;
 
         // $contenttype might be an array.

--- a/src/Twig/Handler/UserHandler.php
+++ b/src/Twig/Handler/UserHandler.php
@@ -65,7 +65,6 @@ class UserHandler
      */
     public function isAllowed($what, $content = null)
     {
-
         $contenttype = null;
         $contentid = null;
         if ($content instanceof \Bolt\Content) {

--- a/src/Twig/Handler/UserHandler.php
+++ b/src/Twig/Handler/UserHandler.php
@@ -65,11 +65,12 @@ class UserHandler
      */
     public function isAllowed($what, $content = null)
     {
+
         $contenttype = null;
         $contentid = null;
         if ($content instanceof \Bolt\Content) {
             // It's a content record
-            $contenttype = $content->contenttype;
+            $contenttype = $content;
             $contentid = $content['id'];
         } elseif (is_array($content)) {
             // It's a contenttype

--- a/src/Users.php
+++ b/src/Users.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class Users
 {
-    /** @deprecated Visibility will be changed to 'private' for these two in Bolt 3.0 */
+    /** @internal Visibility will be changed to 'private' for these two in Bolt 3.0 */
     public $users = [];
     public $currentuser;
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -12,8 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class Users
 {
-    public $users = [];
-    public $currentuser;
+    private $users = [];
+    private $currentuser;
 
     /** @deprecated Will be removed in Bolt 3.0 */
     public $usertable;
@@ -244,9 +244,9 @@ class Users
 
             /** @var \Bolt\Storage\Entity\Users $userEntity */
             foreach ($tempusers as $userEntity) {
-                $key = $userEntity->getUsername();
+                $id = $userEntity->getId();
                 $userEntity->setPassword('**dontchange**');
-                $this->users[$key] = $userEntity->toArray();
+                $this->users[$id] = $userEntity->toArray();
             }
         }
 
@@ -274,9 +274,18 @@ class Users
      */
     public function getUser($userId)
     {
+
+        // Make sure users have been 'got' already.
+        $this->getUsers();
+
+        // In most cases by far, we'll request an ID, and we can return it here.
+        if (array_key_exists($userId, $this->users)) {
+            return $this->users[$userId];
+        }
+
+        // Fallback: See if we can get it by username or email address.
         if ($userEntity = $this->repository->getUser($userId)) {
             $userEntity->setPassword('**dontchange**');
-
             return $userEntity->toArray();
         }
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -12,8 +12,9 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class Users
 {
-    private $users = [];
-    private $currentuser;
+    /** @deprecated Visibility will be changed to 'private' for these two in Bolt 3.0 */
+    public $users = [];
+    public $currentuser;
 
     /** @deprecated Will be removed in Bolt 3.0 */
     public $usertable;

--- a/src/Users.php
+++ b/src/Users.php
@@ -275,7 +275,6 @@ class Users
      */
     public function getUser($userId)
     {
-
         // Make sure users have been 'got' already.
         $this->getUsers();
 
@@ -287,6 +286,7 @@ class Users
         // Fallback: See if we can get it by username or email address.
         if ($userEntity = $this->repository->getUser($userId)) {
             $userEntity->setPassword('**dontchange**');
+
             return $userEntity->toArray();
         }
 

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -44,7 +44,7 @@ class StorageTest extends BoltUnitTest
     public function testPreFill()
     {
         $app = $this->getApp();
-        $app['users']->users = [1 => $this->addDefaultUser($app)];
+        $this->addDefaultUser($app);
         $prefillMock = new LoripsumMock();
         $app['prefill'] = $prefillMock;
 

--- a/tests/phpunit/unit/Users/UsersTest.php
+++ b/tests/phpunit/unit/Users/UsersTest.php
@@ -35,7 +35,6 @@ class UsersTest extends BoltUnitTest
     {
         // Setup test
         $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
-        $users->users = [$this->user];
 
         // Run test
         $result = $users->getUser(2);
@@ -53,7 +52,6 @@ class UsersTest extends BoltUnitTest
     {
         // Setup test
         $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
-        $users->users = [$this->user];
 
         // Run test
         $result = $users->getUser(0);
@@ -69,7 +67,6 @@ class UsersTest extends BoltUnitTest
     {
         // Setup test
         $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
-        $users->users = [$this->user];
 
         // Run test
         $result = $users->getUser('editor');
@@ -87,7 +84,6 @@ class UsersTest extends BoltUnitTest
     {
         // Setup test
         $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
-        $users->users = [$this->user];
 
         // Run test
         $result = $users->getUser('anotheruser');


### PR DESCRIPTION
As pointed out by @rossriley: No need to fetch users every single time. This PR fetches them once, and returns from memory if possible. This yields a significant improvement in queries / time taken. 

Before: 

![screenshot 2015-07-20 20 11 16](https://cloud.githubusercontent.com/assets/1833361/8784194/fe7f607c-2f20-11e5-92d9-be7ede41fd46.png)

After: 

![screenshot 2015-07-20 20 25 29](https://cloud.githubusercontent.com/assets/1833361/8784199/02587a3a-2f21-11e5-9940-411a6d7f2816.png)
