### PR TITLE
Avoid a missing array key from displaying a warning

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -1524,8 +1524,8 @@ class Content implements \ArrayAccess
         }
 
         foreach ($this->contenttype['fields'] as $config) {
-            if ($config['type'] == 'slug') {
-                foreach ($config['uses'] as $ptrField) {
+            if ($config['type'] == 'slug' && isset($config['uses'])) {
+                foreach ((array) $config['uses'] as $ptrField) {
                     if (isset($fields[$ptrField])) {
                         $fields[$ptrField] = 100;
                     }


### PR DESCRIPTION
This fixes #3712.

Now `$config['uses']` is checked for existence _and_ explicitly converted to an array in case it's originally a single string.