### PR TITLE
Handle "add" parameter for url generator a new way

### DIFF
--- a/src/Helpers/MenuBuilder.php
+++ b/src/Helpers/MenuBuilder.php
@@ -2,8 +2,8 @@
 
 namespace Bolt\Helpers;
 
-use Bolt\Application;
 use Bolt\Translation\Translator as Trans;
+use Silex\Application;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 class MenuBuilder
@@ -89,15 +89,27 @@ class MenuBuilder
         }
 
         if (isset($item['route'])) {
-            $param = !empty($item['param']) ? $item['param'] : [];
-            $add = !empty($item['add']) ? $item['add'] : '';
-
-            $item['link'] = $this->app->generatePath($item['route'], $param, $add);
+            $item['link'] = $this->resolveRouteToLink($item);
         } elseif (isset($item['path'])) {
             $item = $this->resolvePathToContent($item);
         }
 
         return $item;
+    }
+
+    /**
+     * Resolve the route to a generated url
+     *
+     * @param array $item
+     *
+     * @return string
+     */
+    private function resolveRouteToLink(array $item)
+    {
+        $param = !empty($item['param']) ? $item['param'] : [];
+        $add = !empty($item['add']) ? $item['add'] : '';
+
+        return $this->app['url_generator']->generate($item['route'], $param, $add);
     }
 
     /**

--- a/src/Helpers/MenuBuilder.php
+++ b/src/Helpers/MenuBuilder.php
@@ -112,7 +112,7 @@ class MenuBuilder
         if (isset($item['add'])) {
             $this->app['logger.system']->warning(
                 Trans::__('Menu item property "add" is deprecated. Use "fragment" under "param" instead.'),
-                ['event' => 'config']
+                ['event' => 'deprecated']
             );
             $add = $item['add'];
             if (!empty($add) && $add[0] !== '?') {

--- a/src/Provider/RoutingServiceProvider.php
+++ b/src/Provider/RoutingServiceProvider.php
@@ -5,6 +5,7 @@ namespace Bolt\Provider;
 use Bolt\Routing\CallbackResolver;
 use Bolt\Routing\ControllerCollection;
 use Bolt\Routing\ControllerResolver;
+use Bolt\Routing\UrlGeneratorFragmentWrapper;
 use Bolt\Routing\LazyUrlGenerator;
 use Bolt\Routing\UrlMatcher;
 use Silex\Application;
@@ -44,6 +45,10 @@ class RoutingServiceProvider implements ServiceProviderInterface
             }
             return $route;
         });
+
+        $app['url_generator'] = $app->share($app->extend('url_generator', function ($urlGenerator) {
+            return new UrlGeneratorFragmentWrapper($urlGenerator);
+        }));
 
         $app['url_generator.lazy'] = $app->share(function ($app) {
             return new LazyUrlGenerator(function () use ($app) {

--- a/src/Routing/UrlGeneratorFragmentWrapper.php
+++ b/src/Routing/UrlGeneratorFragmentWrapper.php
@@ -34,9 +34,9 @@ class UrlGeneratorFragmentWrapper implements UrlGeneratorInterface, Configurable
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
         $fragment = null;
-        if (isset($parameters['fragment'])) {
-            $fragment = $parameters['fragment'];
-            unset($parameters['fragment']);
+        if (isset($parameters['#'])) {
+            $fragment = $parameters['#'];
+            unset($parameters['#']);
         }
 
         $url = $this->wrapped->generate($name, $parameters, $referenceType);

--- a/src/Routing/UrlGeneratorFragmentWrapper.php
+++ b/src/Routing/UrlGeneratorFragmentWrapper.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Bolt\Routing;
+
+use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * Wraps a UrlGenerator to allow urls to be generated with a fragment.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class UrlGeneratorFragmentWrapper implements UrlGeneratorInterface, ConfigurableRequirementsInterface
+{
+    /** @var UrlGeneratorInterface */
+    protected $wrapped;
+
+    /**
+     * UrlGeneratorFragmentWrapper constructor.
+     *
+     * @param UrlGeneratorInterface $wrapped
+     */
+    public function __construct(UrlGeneratorInterface $wrapped)
+    {
+        $this->wrapped = $wrapped;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * A key, "fragment", can be passed into $parameters whose value will appended to generated url after a "#"
+     */
+    public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    {
+        $fragment = null;
+        if (isset($parameters['fragment'])) {
+            $fragment = $parameters['fragment'];
+            unset($parameters['fragment']);
+        }
+
+        $url = $this->wrapped->generate($name, $parameters, $referenceType);
+
+        if (!empty($fragment)) {
+            $url .= '#' . $fragment;
+        }
+
+        return $url;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContext(RequestContext $context)
+    {
+        $this->wrapped->setContext($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContext()
+    {
+        return $this->wrapped->getContext();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStrictRequirements($enabled)
+    {
+        if ($this->wrapped instanceof ConfigurableRequirementsInterface) {
+            $this->wrapped->setStrictRequirements($enabled);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStrictRequirements()
+    {
+        if ($this->wrapped instanceof ConfigurableRequirementsInterface) {
+            return $this->wrapped->isStrictRequirements();
+        }
+
+        return null; // requirements check is deactivated completely
+    }
+}

--- a/src/Storage/RecordModifier.php
+++ b/src/Storage/RecordModifier.php
@@ -119,9 +119,16 @@ class RecordModifier
          */
         if ($returnTo) {
             if ($returnTo === 'new') {
-                return new RedirectResponse($this->generateUrl('editcontent', ['contenttypeslug' => $contenttype['slug'], 'id' => $id]));
+                return new RedirectResponse($this->generateUrl('editcontent', [
+                    'contenttypeslug' => $contenttype['slug'],
+                    'fragment'        => $returnTo,
+                    'id'              => $id,
+                ]));
             } elseif ($returnTo === 'saveandnew') {
-                return new RedirectResponse($this->generateUrl('editcontent', ['contenttypeslug' => $contenttype['slug']]));
+                return new RedirectResponse($this->generateUrl('editcontent', [
+                    'contenttypeslug' => $contenttype['slug'],
+                    'fragment'        => $returnTo,
+                ]));
             } elseif ($returnTo === 'ajax') {
                 return $this->createJsonUpdate($contenttype, $id, true);
             } elseif ($returnTo === 'test') {

--- a/tests/phpunit/unit/Routing/UrlGeneratorFragmentWrapperTest.php
+++ b/tests/phpunit/unit/Routing/UrlGeneratorFragmentWrapperTest.php
@@ -36,9 +36,9 @@ class UrlGeneratorFragmentWrapperTest extends BoltUnitTest
      */
     public function testUrlGenerationWithFragment($generator)
     {
-        $path = $generator->generate('foo', ['fragment' => 'bolt']);
+        $path = $generator->generate('foo', ['#' => 'bolt']);
         $this->assertSame('/foo/bar#bolt', $path);
-        $path = $generator->generate('foo', ['hello' => 'world', 'fragment' => 'bolt']);
+        $path = $generator->generate('foo', ['hello' => 'world', '#' => 'bolt']);
         $this->assertSame('/foo/bar?hello=world#bolt', $path);
     }
 

--- a/tests/phpunit/unit/Routing/UrlGeneratorFragmentWrapperTest.php
+++ b/tests/phpunit/unit/Routing/UrlGeneratorFragmentWrapperTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Bolt\Tests\Routing;
+
+use Bolt\Routing\LazyUrlGenerator;
+use Bolt\Routing\UrlGeneratorFragmentWrapper;
+use Bolt\Tests\BoltUnitTest;
+use Silex\Route;
+use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class UrlGeneratorFragmentWrapperTest extends BoltUnitTest
+{
+    public function testUrlGeneratorInterface()
+    {
+        $collection = new RouteCollection();
+        $collection->add('foo', new Route('/foo/bar'));
+        $parent = new UrlGenerator($collection, new RequestContext());
+        $generator = new UrlGeneratorFragmentWrapper($parent);
+
+        $this->assertInstanceOf('\Symfony\Component\Routing\Generator\UrlGeneratorInterface', $generator);
+
+        return $generator;
+    }
+
+    /**
+     * @depends testUrlGeneratorInterface
+     *
+     * @param UrlGeneratorInterface $generator
+     */
+    public function testUrlGenerationWithFragment($generator)
+    {
+        $path = $generator->generate('foo', ['fragment' => 'bolt']);
+        $this->assertSame('/foo/bar#bolt', $path);
+        $path = $generator->generate('foo', ['hello' => 'world', 'fragment' => 'bolt']);
+        $this->assertSame('/foo/bar?hello=world#bolt', $path);
+    }
+
+    /**
+     * @depends testUrlGeneratorInterface
+     *
+     * @param UrlGeneratorInterface $generator
+     */
+    public function testRequestContext($generator)
+    {
+        $generator->setContext(new RequestContext('/bolt'));
+        $this->assertSame('/bolt', $generator->getContext()->getBaseUrl());
+    }
+
+    /**
+     * @depends testUrlGeneratorInterface
+     *
+     * @param ConfigurableRequirementsInterface $generator
+     */
+    public function testConfigurableRequirements($generator)
+    {
+        $generator->setStrictRequirements(true);
+        $this->assertTrue($generator->isStrictRequirements());
+        $generator->setStrictRequirements(false);
+        $this->assertFalse($generator->isStrictRequirements());
+        $generator->setStrictRequirements(null);
+        $this->assertNull($generator->isStrictRequirements());
+    }
+
+    public function testNonConfigurableRequirements()
+    {
+        $generator = new UrlGeneratorFragmentWrapper(new LazyUrlGenerator(function() {}));
+        $generator->setStrictRequirements(true);
+        $this->assertNull($generator->isStrictRequirements());
+    }
+}


### PR DESCRIPTION
`Lib::path` and `Lib::redirect` both have an _add_ parameter which takes a string and appends it onto the end of the generated url. An example:
```php
$add = 'foo=bar#derp'; // I'm just an unstructured blob :(
$path = Lib::path('dashboard', [], $add);
echo $path; // /bolt?foo=bar#derp
```
As this class is deprecated (or trying to be :gun:), we need a new way to handle this functionality. 

Symfony's UrlGenerator will already take extra parameters (not needed in path) and add them to the query string of the generated url. This only leaves the _fragment_ part of the url functionality missing. 

I created a wrapper for the UrlGenerator that will take a `#` key from the parameters and append it. This also keeps the same interface/object, so no need for a "helper" method. 
New way:
```php
$params = ['foo' => 'bar', '#' => 'derp']; // I'm a nice readable array!
$path = $app['url_generator']->generate('dashboard', $params);
echo $path; // /bolt?foo=bar#derp
```

Functionality applied to:
-  `editcontent` route which uses a fragment/anchor for _return to_
- MenuBuilder - updated to maintain BC for _add_ key. New functionality works out of the :package:
- There might be other usages the :koala: hid?... beuller?

Who hates naming? :raising_hand: Let me know if you don't like how something is named, and I can talk you out of it...err..we can talk about it.