### PR TITLE
added support for taxonomy default in contenttypes.yml

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -58,8 +58,8 @@ class Content implements \ArrayAccess
                     $defaultValue = $this->app['config']->get('taxonomy/' . $taxonomytype . '/default');
                     
                     // add support for taxonomy default per contenttype
-                     if (isset($this->contenttype['default'.$taxonomytype])){
-                        $defaultValue = $this->contenttype['default'.$taxonomytype];
+                    if (isset($this->contenttype['default_'.$taxonomytype])) {
+                        $defaultValue = $this->contenttype['default_'.$taxonomytype];
                     }
 
                     $options = $this->app['config']->get('taxonomy/' . $taxonomytype . '/options');


### PR DESCRIPTION
with this line in the content constructor we have the option to add a default to the contenttypes.yml.
usage: 
   taxonomy: [mycategories]
   default_mycategories: "category2"