### PR TITLE
Unit test parameter handling

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,10 +17,45 @@
     <listeners>
         <listener file="tests/phpunit/BoltListener.php" class="Bolt\Tests\BoltListener">
            <arguments>
+              <!-- Configuration files. Can be either .yml or .yml.dist files -->
+              <!-- Locations can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="config">
+                      <string>app/config/config.yml.dist</string>
+                  </element>
+                  <element key="contenttypes">
+                      <string>app/config/contenttypes.yml.dist</string>
+                  </element>
+                  <element key="menu">
+                      <string>app/config/menu.yml.dist</string>
+                  </element>
+                  <element key="permissions">
+                      <string>app/config/permissions.yml.dist</string>
+                  </element>
+                  <element key="routing">
+                      <string>app/config/routing.yml.dist</string>
+                  </element>
+                  <element key="taxonomy">
+                      <string>app/config/taxonomy.yml.dist</string>
+                  </element>
+              </array>
+              <!-- Theme directory. Can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="theme">
+                      <string>theme/base-2014</string>
+                  </element>
+              </array>
+              <!-- The Bolt SQLite database, leave empty to use the one bundled with Bolt's repository -->
+              <!-- Location can be relative to TEST_ROOT directory, the Bolt directory, or an absolute path -->
+              <array>
+                  <element key="boltdb">
+                      <string></string>
+                  </element>
+              </array>
+              <!-- Reset the cache and test temporary directories -->
               <boolean>true</boolean>
+              <!-- Create timer output in app/cache/phpunit-test-timer.txt -->
               <boolean>true</boolean>
-              <boolean>true</boolean>
-              <string>theme/base-2014</string>
            </arguments>
         </listener>
     </listeners>

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -277,25 +277,22 @@ class BoltListener implements \PHPUnit_Framework_TestListener
         @$fs->mkdir(PHPUNIT_WEBROOT . '/app/database/', 0777);
         @$fs->mkdir(PHPUNIT_WEBROOT . '/extensions/', 0777);
         @$fs->mkdir(PHPUNIT_WEBROOT . '/files/', 0777);
+        @$fs->mkdir(PHPUNIT_WEBROOT . '/theme/', 0777);
 
         // Make sure we wipe the db file to start with a clean one
-        $fs->copy(PHPUNIT_ROOT . '/resources/db/bolt.db', PHPUNIT_WEBROOT . '/app/database/bolt.db', true);
+        $fs->copy($this->boltdb, PHPUNIT_WEBROOT . '/app/database/bolt.db', true);
 
         // Copy in config files
         foreach ($this->configs as $config) {
             $fs->copy($config, PHPUNIT_WEBROOT . '/app/config/' . basename($config), true);
         }
 
-        // If enabled, copy in the requested theme
-        if ($this->theme) {
-            @$fs->mkdir(PHPUNIT_WEBROOT . '/theme/', 0777);
+        // Copy in the theme
+        $name = basename($this->theme);
+        $fs->mirror($this->theme, PHPUNIT_WEBROOT . '/theme/' . $name);
 
-            $name = basename($this->path);
-            $fs->mirror(realpath(TEST_ROOT . '/' . $this->path), PHPUNIT_WEBROOT . '/theme/' . $name);
-
-            // Set the theme name in config.yml
-            system('php ' . NUT_PATH . ' config:set theme ' . $name);
-        }
+        // Set the theme name in config.yml
+        system('php ' . NUT_PATH . ' config:set theme ' . $name);
 
         // Empty the cache
         system('php ' . NUT_PATH . ' cache:clear');

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -281,13 +281,10 @@ class BoltListener implements \PHPUnit_Framework_TestListener
         // Make sure we wipe the db file to start with a clean one
         $fs->copy(PHPUNIT_ROOT . '/resources/db/bolt.db', PHPUNIT_WEBROOT . '/app/database/bolt.db', true);
 
-        // Copy in fresh config distribution files
-        $fs->copy(TEST_ROOT . '/app/config/config.yml.dist',       PHPUNIT_WEBROOT . '/app/config/config.yml.dist', true);
-        $fs->copy(TEST_ROOT . '/app/config/contenttypes.yml.dist', PHPUNIT_WEBROOT . '/app/config/contenttypes.yml.dist', true);
-        $fs->copy(TEST_ROOT . '/app/config/menu.yml.dist',         PHPUNIT_WEBROOT . '/app/config/menu.yml.dist', true);
-        $fs->copy(TEST_ROOT . '/app/config/permissions.yml.dist',  PHPUNIT_WEBROOT . '/app/config/permissions.yml.dist', true);
-        $fs->copy(TEST_ROOT . '/app/config/routing.yml.dist',      PHPUNIT_WEBROOT . '/app/config/routing.yml.dist', true);
-        $fs->copy(TEST_ROOT . '/app/config/taxonomy.yml.dist',     PHPUNIT_WEBROOT . '/app/config/taxonomy.yml.dist', true);
+        // Copy in config files
+        foreach ($this->configs as $config) {
+            $fs->copy($config, PHPUNIT_WEBROOT . '/app/config/' . basename($config), true);
+        }
 
         // If enabled, copy in the requested theme
         if ($this->theme) {

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -12,41 +12,128 @@ use Symfony\Component\Filesystem\Filesystem;
 class BoltListener implements \PHPUnit_Framework_TestListener
 {
     /** @var array */
-    protected $tracker = [];
-
+    protected $configs = [
+        'config'       => 'app/config/config.yml.dist',
+        'contenttypes' => 'app/config/contenttypes.yml.dist',
+        'menu'         => 'app/config/menu.yml.dist',
+        'permissions'  => 'app/config/permissions.yml.dist',
+        'routing'      => 'app/config/routing.yml.dist',
+        'taxonomy'     => 'app/config/taxonomy.yml.dist'
+    ];
+    /** @var string */
+    protected $theme;
+    /** @var string */
+    protected $boltdb;
     /** @var boolean */
     protected $timer;
-
-    /** @var boolean */
-    protected $reset;
-
-    /** @var boolean */
-    protected $theme;
-
-    /** @var string */
-    protected $path;
-
+    /** @var array */
+    protected $tracker = [];
     /** @var string */
     protected $currentSuite;
+    /** @var boolean */
+    protected $reset;
 
     /**
      * Called on init of PHPUnit exectution.
      *
      * @see PHPUnit_Util_Configuration
      *
-     * @param boolean $timer Create test execution timer output
-     * @param boolean $reset Reset test environment after run
-     * @param boolean $theme Copy in theme directory
-     * @param string  $path  Relative path to a theme to import
+     * @param array   $configs Location of configuration files
+     * @param string  $theme   Location of the theme
+     * @param string  $boltdb  Location of Sqlite database
+     * @param boolean $reset   Reset test environment after run
+     * @param boolean $timer   Create test execution timer output
      */
-    public function __construct($timer, $reset, $theme, $path)
+    public function __construct($configs = [], $theme = false, $boltdb = false, $reset = true, $timer = true)
     {
-        $this->timer = $timer;
+        $this->configs = $this->getConfigs($configs);
+        $this->theme = $this->getTheme($theme);
+        $this->boltdb = $this->getBoltDb($boltdb);
         $this->reset = $reset;
-        $this->theme = $theme;
-        $this->path  = $path;
+        $this->timer = $timer;
 
         $this->buildTestEnv();
+    }
+
+    /**
+     * Get a valid array of configuration files.
+     *
+     * @param array $configs
+     *
+     * @return array
+     */
+    protected function getConfigs(array $configs)
+    {
+        foreach ($configs as $name => $file) {
+            if (empty($file)) {
+                $configs[$name] = $this->getPath($name, $this->config[$name]);
+            } else {
+                $configs[$name] = $this->getPath($name, $file);
+            }
+        }
+
+        return $configs;
+    }
+
+    /**
+     * Get the path to the theme to be used in the unit test.
+     *
+     * @param string $theme
+     *
+     * @return string
+     */
+    protected function getTheme($theme)
+    {
+        if ($theme === false || (isset($theme['theme']) && $theme['theme'] === '')) {
+            return $this->getPath('theme', 'theme/base-2014');
+        } else {
+            return $this->getPath('theme', $theme['theme']);
+        }
+    }
+
+    /**
+     * Get the Bolt unit test Sqlite database.
+     *
+     * @param string $boltdb
+     *
+     * @return string
+     */
+    protected function getBoltDb($boltdb)
+    {
+        if ($boltdb === false || (isset($boltdb['boltdb']) && $boltdb['boltdb'] === '')) {
+            return $this->getPath('bolt.db', 'tests/phpunit/unit/resources/db/bolt.db');
+        } else {
+            return $this->getPath('bolt.db', $boltdb['boltdb']);
+        }
+    }
+
+    /**
+     * Resolve a file path.
+     *
+     * @param string $name
+     * @param string $file
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return string
+     */
+    protected function getPath($name, $file)
+    {
+        if (INSTALL_TYPE === 'composer') {
+            if (file_exists(TEST_ROOT . '/vendor/bolt/bolt/' . $file)) {
+                return TEST_ROOT . '/' . $file;
+            }
+        } else {
+            if (file_exists(TEST_ROOT . '/' . $file)) {
+                return TEST_ROOT . '/' . $file;
+            }
+        }
+
+        if (file_exists($file)) {
+            return $file;
+        }
+
+        throw new \InvalidArgumentException("The file parameter '$name:' '$file' in the PHPUnit XML file is invalid.");
     }
 
     /**

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -6,10 +6,12 @@
  */
 
 // Define our install type
-if (file_exists(__DIR__ . '/../../../../../vendor/bolt/bolt/')) {
-    $installType = 'composer';
-} else {
-    $installType = 'git';
+if (!defined('INSTALL_TYPE')) {
+    if (file_exists(__DIR__ . '/../../../../../vendor/bolt/bolt/')) {
+        define('INSTALL_TYPE', 'composer');
+    } else {
+        define('INSTALL_TYPE', 'git');
+    }
 }
 
 // Install base location
@@ -28,11 +30,9 @@ if (!defined('PHPUNIT_WEBROOT')) {
 }
 
 if (!defined('BOLT_AUTOLOAD')) {
-    if (is_dir(TEST_ROOT . '/../../../vendor/')) {
-        // Composer install
+    if (INSTALL_TYPE === 'composer') {
         define('BOLT_AUTOLOAD', TEST_ROOT . '/../../autoload.php');
     } else {
-        // Git/tarball install
         define('BOLT_AUTOLOAD', TEST_ROOT . '/vendor/autoload.php');
     }
 
@@ -42,9 +42,9 @@ if (!defined('BOLT_AUTOLOAD')) {
 
 // Path to Nut
 if (!defined('NUT_PATH')) {
-    if ($installType === 'composer') {
+    if (INSTALL_TYPE === 'composer') {
         define('NUT_PATH', realpath(TEST_ROOT . '/vendor/bolt/bolt/app/nut'));
-    } elseif ($installType === 'git') {
+    } elseif (INSTALL_TYPE === 'git') {
         define('NUT_PATH', realpath(TEST_ROOT . '/app/nut'));
     }
 }


### PR DESCRIPTION
This (should) make the unit test environment fully configurable for configuration files, theme and Sqlite database.

The biggest win here is for extension authors that want to unit test extensions with customised configuration (routes/contenttypes/etc) and Sqlite databases. Of course if you don't want to use Sqlite, that will be overridden in the passed in `config.yml` file.

There is an update to the docs [pending in a branch here](https://github.com/bolt/docs/compare/bolt:master...GawainLynch:update-phpunit-docs?expand=1) for once this is merged and back-ported into `release/2.2`, including the work in and #3850.

Special thanks go out to the :koala: who was busy eating :leaves:  and left me alone long enough to finish this today!

Ping @slahav… this should be exactly what you all need. :grin: 