### PR TITLE
Break here if $contentId is `` or `0` instead of only on strictly `null`

### DIFF
--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -621,7 +621,7 @@ class Permissions
                 }
 
                 // Handle special case for owner.
-                if ($contentId === null) {
+                if (empty($contentId)) {
                     break;
                 }
 


### PR DESCRIPTION
Fixes #3883 

If we try to get permissions for `pages/` (for a new record, without existing id), don't get stuck in a loop where we retrieve all records for that contenttype. 

