### PR TITLE
[master] Break here if $contentId is `` or `0` instead of only on strictly `null`

### DIFF
--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -623,7 +623,7 @@ class Permissions
                 }
 
                 // Handle special case for owner.
-                if ($contentId === null) {
+                if (empty($contentId)) {
                     break;
                 }
 


### PR DESCRIPTION
Fixes #3883 for 'master'.

If we try to get permissions for pages/ (for a new record, without existing id), don't get stuck in a loop where we retrieve all records for that contenttype.