### PR TITLE
Add .jshintrc

### DIFF
--- a/app/src/.jshintrc
+++ b/app/src/.jshintrc
@@ -1,0 +1,16 @@
+{
+    "curly": true,
+    "immed": true,
+    "indent": 4,
+    "latedef": true,
+    "maxlen": 120,
+    "noarg": true,
+    "nonbsp": true,
+    "singleGroups": false,
+    "undef": true,
+    "globals": {
+        "module": true,
+        "process": true,
+        "require": true
+    }
+}

--- a/app/src/grunt-tasks/sass.js
+++ b/app/src/grunt-tasks/sass.js
@@ -37,7 +37,8 @@ module.exports = function (grunt) {
                     grunt.log.error();
                     grunt.log.error(error.message);
                     if (error.file) {
-                        grunt.log.error(path.relative(process.cwd(), error.file) + '#L' + error.line + ':' + error.column);
+                        var msg = path.relative(process.cwd(), error.file) + '#L' + error.line + ':' + error.column;
+                        grunt.log.error(msg);
                     }
                     done(false);
                 } else {

--- a/app/src/grunt/bom.js
+++ b/app/src/grunt/bom.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * BOM: Byte Order Mark (BOM) removal
  */

--- a/app/src/grunt/bootlint.js
+++ b/app/src/grunt/bootlint.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * BOOTLINT: HTML linter for Bootstrap projects
  */

--- a/app/src/grunt/concat.js
+++ b/app/src/grunt/concat.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * CONCAT: Concatenate files
  */

--- a/app/src/grunt/copy.js
+++ b/app/src/grunt/copy.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * COPY: Copy files and folders
  */

--- a/app/src/grunt/endline.js
+++ b/app/src/grunt/endline.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * ENDLINE: Adds a newline at end of a file
  */

--- a/app/src/grunt/eol.js
+++ b/app/src/grunt/eol.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * EOL: Convert line endings
  */

--- a/app/src/grunt/htmllint.js
+++ b/app/src/grunt/htmllint.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * HTMLLINT: html validation using the vnu.jar markup checker.
  */

--- a/app/src/grunt/jsdoc.js
+++ b/app/src/grunt/jsdoc.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * JSDOC: Generate comments based documentation.
  */

--- a/app/src/grunt/jshint.js
+++ b/app/src/grunt/jshint.js
@@ -1,4 +1,4 @@
-/* global module */
+/* global moduled */
 
 /*
  * JSHINT: Validates files with JSHint
@@ -9,44 +9,7 @@ module.exports = {
      */
     boltJs: {
         options: {
-            browser: true,      // Defines globals exposed by modern browsers
-            curly: true,        // Always put curly braces around blocks
-            devel: true,        // Defines globals that are usually used for logging/debugging
-            immed: true,        // Prohibits the use of immediate function invocations without parentheses
-            indent: 4,          // Tab width
-            latedef: true,      // Prohibits the use of a variable before it was defined
-            maxlen: 120,        // Maximum length of a line
-            noarg: true,        // Prohibits the use of arguments.caller and arguments.callee
-            nonbsp: true,       // Warns about "non-breaking whitespace" characters
-            singleGroups: false, // Prohibits the use of the grouping operator for single-expression statements
-            undef: true,        // Prohibits the use of undeclared variables
-            globals: {
-                // Bolt
-                Bolt: true,                 // bolt.js
-                bolt: true,                 // bolt/console.js
-                FilelistHolder: true,       // bolt/upload-files.js
-                Files: true,                // bolt/obj-files.js
-                Folders: true,              // bolt/obj-folders.js
-                init: true,                 // bolt/init.js
-                Moments: true,              // bolt/obj-moments.js
-                Stack: true,                // bolt/obj-stack.js
-                site: true,                 // bolt/extend.js/extend.twig
-                baseurl: true,              // bolt/extend.js/extend.twig
-                rootpath: true,             // bolt/extend.js/extend.twig
-                // Bolt global functions
-                bindFileUpload: true,       // bolt/bindfileuploads.js
-                // Vendor
-                $: true,                    // jQuery
-                _: true,                    // underscore.js
-                Backbone: true,             // backbone.min.js
-                bootbox: true,              // bootbox.min.js
-                CKEDITOR: true,             // ckeditor.js
-                CodeMirror: true,           // ckeditor.js
-                google: true,               // Google
-                jQuery: true,               // jQuery
-                moment: true,               // moment.min.js
-                Modernizr: true             // modernizr.min.js
-            }
+            jshintrc: true
         },
         src: '<%= files.boltJs %>'
     }

--- a/app/src/grunt/jshint.js
+++ b/app/src/grunt/jshint.js
@@ -1,5 +1,3 @@
-/* global moduled */
-
 /*
  * JSHINT: Validates files with JSHint
  */

--- a/app/src/grunt/jshint.js
+++ b/app/src/grunt/jshint.js
@@ -10,5 +10,19 @@ module.exports = {
             jshintrc: true
         },
         src: '<%= files.boltJs %>'
+    },
+
+    /*
+     * TARGET:  Checks grunt js files
+     */
+    grunt: {
+        options: {
+            jshintrc: true
+        },
+        src: [
+            'Gruntfile.js',
+            'grunt/**.js',
+            'grunt-tasks/**.js'
+        ]
     }
 };

--- a/app/src/grunt/modernizr.js
+++ b/app/src/grunt/modernizr.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * MODERNIZR: Modernizr builder
  */

--- a/app/src/grunt/phpdocumentor.js
+++ b/app/src/grunt/phpdocumentor.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * PHPDOCUMENTOR: Runs the PHPDocumentor documentation generator tool.
  */

--- a/app/src/grunt/postcss.js
+++ b/app/src/grunt/postcss.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * POSTCSS: Transforming CSS with JS plugins
  */

--- a/app/src/grunt/remove.js
+++ b/app/src/grunt/remove.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * REMOVE: Remove directory and files
  */

--- a/app/src/grunt/sass.js
+++ b/app/src/grunt/sass.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * SASS: Compile Sass to CSS
  */

--- a/app/src/grunt/uglify.js
+++ b/app/src/grunt/uglify.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * UGLIFY: Minify files with UglifyJS
  */

--- a/app/src/grunt/watch.js
+++ b/app/src/grunt/watch.js
@@ -1,5 +1,3 @@
-/* global module */
-
 /*
  * WATCH: Run predefined tasks whenever watched file patterns are added, changed or deleted
  */

--- a/app/src/js/.jshintrc
+++ b/app/src/js/.jshintrc
@@ -1,0 +1,33 @@
+{
+    "browser": true,
+    "curly": true,
+    "devel": true,
+    "immed": true,
+    "indent": 4,
+    "latedef": true,
+    "maxlen": 120,
+    "noarg": true,
+    "nonbsp": true,
+    "singleGroups": false,
+    "undef": true,
+    "globals": {
+        "$": true,
+        "Backbone": true,
+        "Bolt": true,
+        "CKEDITOR": true,
+        "CodeMirror": true,
+        "FilelistHolder": true,
+        "Modernizr": true,
+        "_": true,
+        "baseurl": true,
+        "bindFileUpload": true,
+        "bootbox": true,
+        "confirm": true,
+        "google": true,
+        "init": true,
+        "jQuery": true,
+        "moment": true,
+        "rootpath": true,
+        "site": true
+    }
+}


### PR DESCRIPTION
- Moved the jshint config into ``js/.jshintrc``
- Added ``.jshintrc`` for grunt files
- Removed inline jshint directives for globals
- Added ``jshint:grunt`` grunt target
- Fixed two small issues

Now IDEs and editors can make use of ``jshint`` with Bolts settings.