### PR TITLE
Permissions streamline

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -1,6 +1,8 @@
 {% import '_macro/_macro.twig' as macro %}
 {% import '_macro/_buic.twig' as buic %}
 
+{% set modifiable = permissions.create or permissions.delete or permissions.publish or permissions.depublish %}
+
 {# If we have 'grouping', print the row with the groupname. #}
 {% if not compact and content.group.name is defined and (loop.first or content.group.name != lastgroup) and request('order') == '' %}
     {% if not loop.first %}</tbody>{% endif %}

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -30,7 +30,7 @@
     {% set link = "?" ~ filter ~ "order=" %}
     <tr>
         {% block listing_header %}
-        {% if not compact and editable %}
+        {% if not compact and modifiable %}
             <th class="check hidden-xs"><input type="checkbox" name="checkRow" title="{{ __('Select all') }}" /></th>
         {% else %}
             <th style="margin: 0; padding: 0;"></th>
@@ -55,7 +55,7 @@
     </tr>
 {% endif %}
 
-<tr {% if content.status!='published' %}class="dim"{% endif %}{% if not compact and editable %} id="item_{{ content.id }}"{% endif %}>
+<tr {% if content.status!='published' %}class="dim"{% endif %}{% if not compact and modifiable %} id="item_{{ content.id }}"{% endif %}>
     {% block listing_id %}
 
         {% if not compact and permissions.delete %}
@@ -73,7 +73,7 @@
             <span>
                 <strong class="visible-xs">№ {{ content.id }}. </strong>
                 <strong>
-                    {% if editable %}
+                    {% if modifiable %}
                         <a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id}) }}" title="Slug: {{ content.slug }}">
                             {{ title }}
                         </a>

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -4,7 +4,7 @@
 {# If we have 'grouping', print the row with the groupname. #}
 {% if not compact and content.group.name is defined and (loop.first or content.group.name != lastgroup) and request('order') == '' %}
     {% if not loop.first %}</tbody>{% endif %}
-    <tbody {% if permissions.publish or permissions.depublish or permissions.create or permissions.delete %}class="sortable"{% endif %}>
+    <tbody {% if modifiable %}class="sortable"{% endif %}>
     <tr class="grouping">
         <th colspan="{% block listing_columns %}6{% endblock %}">
             <h3 {% if loop.first %}class="first"{% endif %}>
@@ -68,7 +68,6 @@
     {% endblock %}
 
     {% block listing_content %}
-
         <td class="excerpt {% if not compact %}large{% endif %}">
             {% set title = content.getTitle|default("<em>(" ~ __("no title …") ~ ")</em>")|raw %}
             <span>
@@ -126,7 +125,7 @@
     {% block listing_actions %}
         <td class="actions">
             <div class="btn-group">
-                {% if permissions.publish or permissions.depublish or permissions.create or permissions.delete %}
+                {% if modifiable %}
                 <a class="btn btn-default btn-xs" href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id}) }}">
                     <i class="fa fa-edit"></i> {{ __('Edit') }}
                 </a>
@@ -153,30 +152,30 @@
                 {% endif %}
 
                 {% from _self import actionform %}
-                {% if content.status != 'published' %}
-                    {% if permissions.publish %}
-                    <li>{{ macro.actionform(content, 'publish', 'fa-circle status-published', __('contenttypes.generic.publish',{'%contenttype%':content.contenttype.slug})) }}</li>
-                    {% endif %}
-                {% else %}
-                    {% if permissions.depublish %}
-                    <li>{{ macro.actionform(content, 'held', 'fa-circle status-held', __("Change status to 'held'")) }}</li>
-                    <li>{{ macro.actionform(content, 'draft', 'fa-circle status-draft', __("Change status to 'draft'")) }}</li>
+                {% if modifiable %}
+                    {% if content.status != 'published' %}
+                        {% if permissions.publish %}
+                        <li>{{ macro.actionform(content, 'publish', 'fa-circle status-published', __('contenttypes.generic.publish',{'%contenttype%':content.contenttype.slug})) }}</li>
+                        {% endif %}
+                    {% else %}
+                        {% if permissions.depublish %}
+                        <li>{{ macro.actionform(content, 'held', 'fa-circle status-held', __("Change status to 'held'")) }}</li>
+                        <li>{{ macro.actionform(content, 'draft', 'fa-circle status-draft', __("Change status to 'draft'")) }}</li>
 
+                        {% endif %}
                     {% endif %}
-                {% endif %}
-                {% if permissions.create %}
-                <li><a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id, 'duplicate': 1}) }}">
-                    <i class="fa fa-copy"></i> {{ __('contenttypes.generic.duplicate', {'%contenttype%': content.contenttype.slug}) }}</a></li>
-                {% endif %}
-                {% if permissions.delete %}
-                <li>{{ macro.actionform(content, 'delete',
-                                      'fa-trash',
-                                      __('contenttypes.generic.delete', {'%contenttype%': content.contenttype.slug}),
-                                      "Are you sure you want to delete '" ~ content.getTitle ~ "'?" ) }}
-                </li>
+                    {% if permissions.create %}
+                    <li><a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id, 'duplicate': 1}) }}">
+                        <i class="fa fa-copy"></i> {{ __('contenttypes.generic.duplicate', {'%contenttype%': content.contenttype.slug}) }}</a></li>
+                    {% endif %}
+                    {% if permissions.delete %}
+                    <li>{{ macro.actionform(content, 'delete',
+                                          'fa-trash',
+                                          __('contenttypes.generic.delete', {'%contenttype%': content.contenttype.slug}),
+                                          "Are you sure you want to delete '" ~ content.getTitle ~ "'?" ) }}
+                    </li>
 
                 {% endif %}
-                {% if permissions.publish or permissions.depublish or permissions.create or permissions.delete %}
                     <li class="divider"></li>
                 {% endif %}
                     <li><a class="nolink">{{ __('Author:') }} <strong><i class="fa fa-user"></i>

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -4,7 +4,7 @@
 {# If we have 'grouping', print the row with the groupname. #}
 {% if not compact and content.group.name is defined and (loop.first or content.group.name != lastgroup) and request('order') == '' %}
     {% if not loop.first %}</tbody>{% endif %}
-    <tbody {% if isallowed('edit', contenttype) %}class="sortable"{% endif %}>
+    <tbody {% if permissions.publish or permissions.depublish or permissions.create or permissions.delete %}class="sortable"{% endif %}>
     <tr class="grouping">
         <th colspan="{% block listing_columns %}6{% endblock %}">
             <h3 {% if loop.first %}class="first"{% endif %}>
@@ -58,7 +58,7 @@
 <tr {% if content.status!='published' %}class="dim"{% endif %}{% if not compact and editable %} id="item_{{ content.id }}"{% endif %}>
     {% block listing_id %}
 
-        {% if not compact and editable and isallowed('delete', contenttype) %}
+        {% if not compact and permissions.delete %}
             <td class="check hidden-xs"><input type="checkbox" name="checkRow"></td>
         {% else %}
             <td style="margin: 0; padding: 0;"></td>
@@ -68,6 +68,7 @@
     {% endblock %}
 
     {% block listing_content %}
+
         <td class="excerpt {% if not compact %}large{% endif %}">
             {% set title = content.getTitle|default("<em>(" ~ __("no title …") ~ ")</em>")|raw %}
             <span>
@@ -125,7 +126,7 @@
     {% block listing_actions %}
         <td class="actions">
             <div class="btn-group">
-                {% if editable %}
+                {% if permissions.publish or permissions.depublish or permissions.create or permissions.delete %}
                 <a class="btn btn-default btn-xs" href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id}) }}">
                     <i class="fa fa-edit"></i> {{ __('Edit') }}
                 </a>
@@ -151,33 +152,31 @@
                     </li>
                 {% endif %}
 
-
                 {% from _self import actionform %}
-                {% if editable %}
-                    {% if content.status != 'published' %}
-                        {% if isallowed('publish', content) %}
-
-                        <li>{{ macro.actionform(content, 'publish', 'fa-circle status-published', __('contenttypes.generic.publish',{'%contenttype%':content.contenttype.slug})) }}</li>
-                        {% endif %}
-                    {% else %}
-                        {% if isallowed('depublish', content) %}
-                        <li>{{ macro.actionform(content, 'held', 'fa-circle status-held', __("Change status to 'held'")) }}</li>
-                        <li>{{ macro.actionform(content, 'draft', 'fa-circle status-draft', __("Change status to 'draft'")) }}</li>
-
-                        {% endif %}
+                {% if content.status != 'published' %}
+                    {% if permissions.publish %}
+                    <li>{{ macro.actionform(content, 'publish', 'fa-circle status-published', __('contenttypes.generic.publish',{'%contenttype%':content.contenttype.slug})) }}</li>
                     {% endif %}
-                    {% if isallowed('create', content) %}
-                    <li><a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id, 'duplicate': 1}) }}">
-                        <i class="fa fa-copy"></i> {{ __('contenttypes.generic.duplicate', {'%contenttype%': content.contenttype.slug}) }}</a></li>
-                    {% endif %}
-                    {% if isallowed('delete', content) %}
-                    <li>{{ macro.actionform(content, 'delete',
-                                          'fa-trash',
-                                          __('contenttypes.generic.delete', {'%contenttype%': content.contenttype.slug}),
-                                          "Are you sure you want to delete '" ~ content.getTitle ~ "'?" ) }}
-                    </li>
+                {% else %}
+                    {% if permissions.depublish %}
+                    <li>{{ macro.actionform(content, 'held', 'fa-circle status-held', __("Change status to 'held'")) }}</li>
+                    <li>{{ macro.actionform(content, 'draft', 'fa-circle status-draft', __("Change status to 'draft'")) }}</li>
 
                     {% endif %}
+                {% endif %}
+                {% if permissions.create %}
+                <li><a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id, 'duplicate': 1}) }}">
+                    <i class="fa fa-copy"></i> {{ __('contenttypes.generic.duplicate', {'%contenttype%': content.contenttype.slug}) }}</a></li>
+                {% endif %}
+                {% if permissions.delete %}
+                <li>{{ macro.actionform(content, 'delete',
+                                      'fa-trash',
+                                      __('contenttypes.generic.delete', {'%contenttype%': content.contenttype.slug}),
+                                      "Are you sure you want to delete '" ~ content.getTitle ~ "'?" ) }}
+                </li>
+
+                {% endif %}
+                {% if permissions.publish or permissions.depublish or permissions.create or permissions.delete %}
                     <li class="divider"></li>
                 {% endif %}
                     <li><a class="nolink">{{ __('Author:') }} <strong><i class="fa fa-user"></i>

--- a/app/view/twig/_sub/_editable_record_list.twig
+++ b/app/view/twig/_sub/_editable_record_list.twig
@@ -1,4 +1,4 @@
-{% macro editable_record_list(contenttype, multiplecontent, extra_classes) %}
+{% macro editable_record_list(contenttype, multiplecontent, permissions, extra_classes) %}
 {% set lastgroup = "----" %}
 {% set any_deletable = false %}
 {% set any_editable = false %}
@@ -14,11 +14,11 @@
 
 <table class="{{ extra_classes }} dashboardlisting" data-contenttype="{{ contenttype.slug }}" data-bolt_csrf_token="{{ token() }}">
     {% for content in multiplecontent %}
-        {% set editable = isallowed('edit', content) %}
+        {% set editable = permissions.edit %}
         {% if editable %}
             {% set any_editable = true %}
         {% endif %}
-        {% set deletable = isallowed('delete', content) %}
+        {% set deletable = permissions.delete %}
         {% if deletable %}
             {% set any_deletable = true %}
         {% endif %}

--- a/app/view/twig/_sub/_editable_record_list.twig
+++ b/app/view/twig/_sub/_editable_record_list.twig
@@ -15,7 +15,6 @@
 <table class="{{ extra_classes }} dashboardlisting" data-contenttype="{{ contenttype.slug }}" data-bolt_csrf_token="{{ token() }}">
     {% for content in multiplecontent %}
         {% set editable = permissions.edit %}
-        {% set modifiable = permissions.create or permissions.delete or permissions.publish or permissions.depublish %}
         {% if editable %}
             {% set any_editable = true %}
         {% endif %}

--- a/app/view/twig/_sub/_editable_record_list.twig
+++ b/app/view/twig/_sub/_editable_record_list.twig
@@ -15,6 +15,7 @@
 <table class="{{ extra_classes }} dashboardlisting" data-contenttype="{{ contenttype.slug }}" data-bolt_csrf_token="{{ token() }}">
     {% for content in multiplecontent %}
         {% set editable = permissions.edit %}
+        {% set modifiable = permissions.create or permissions.delete or permissions.publish or permissions.depublish %}
         {% if editable %}
             {% set any_editable = true %}
         {% endif %}

--- a/app/view/twig/dashboard/_recently_edited.twig
+++ b/app/view/twig/dashboard/_recently_edited.twig
@@ -10,7 +10,6 @@
 <table class="table table-striped dashboardlisting">
     {% for content in multiplecontent %}
         {% set permissions = context.permissions[contenttype] %}
-        {% set modifiable = permissions.create or permissions.delete or permissions.publish or permissions.depublish %}
         {% include ['custom/listing/' ~ content.contenttype.slug ~ '.twig', '_sub/_listing.twig']
             with {'excerptlength': 280, 'thumbsize': 54, 'compact': true, 'permissions': permissions} %}
     {% endfor %}

--- a/app/view/twig/dashboard/_recently_edited.twig
+++ b/app/view/twig/dashboard/_recently_edited.twig
@@ -9,8 +9,8 @@
 
 <table class="table table-striped dashboardlisting">
     {% for content in multiplecontent %}
-        {% set editable = isallowed('edit', content) %}
+        {% set editable = context.permissions[contenttype].edit %}
         {% include ['custom/listing/' ~ content.contenttype.slug ~ '.twig', '_sub/_listing.twig']
-            with {'excerptlength': 280, 'thumbsize': 54, 'compact': true} %}
+            with {'excerptlength': 280, 'thumbsize': 54, 'compact': true, 'permissions': context.permissions[contenttype]} %}
     {% endfor %}
 </table>

--- a/app/view/twig/dashboard/_recently_edited.twig
+++ b/app/view/twig/dashboard/_recently_edited.twig
@@ -9,8 +9,9 @@
 
 <table class="table table-striped dashboardlisting">
     {% for content in multiplecontent %}
-        {% set editable = context.permissions[contenttype].edit %}
+        {% set permissions = context.permissions[contenttype] %}
+        {% set modifiable = permissions.create or permissions.delete or permissions.publish or permissions.depublish %}
         {% include ['custom/listing/' ~ content.contenttype.slug ~ '.twig', '_sub/_listing.twig']
-            with {'excerptlength': 280, 'thumbsize': 54, 'compact': true, 'permissions': context.permissions[contenttype]} %}
+            with {'excerptlength': 280, 'thumbsize': 54, 'compact': true, 'permissions': permissions} %}
     {% endfor %}
 </table>

--- a/app/view/twig/omnisearch/omnisearch.twig
+++ b/app/view/twig/omnisearch/omnisearch.twig
@@ -29,7 +29,8 @@
                             <tr>
                                 {% if item.record|default() %}
                                     {% set content = item.record %}
-                                    {% set editable = isallowed('edit', content) %}
+                                    {% set permissions = item.permissions %}
+                                    {% set modifiable = permissions.create or permissions.delete or permissions.publish or permissions.depublish %}
                                     {% include 'omnisearch/_result.twig' with {'excerptlength': 280, 'thumbsize': 54, 'compact': true} %}
                                 {% else %}
                                     <td colspan="4">

--- a/app/view/twig/overview/overview.twig
+++ b/app/view/twig/overview/overview.twig
@@ -26,7 +26,7 @@
 
             {% include '_sub/_messages.twig' %}
 
-            {{ list(context.contenttype, context.multiplecontent, 'table-striped') }}
+            {{ list(context.contenttype, context.multiplecontent, context.permissions, 'table-striped') }}
 
         </div>
 

--- a/app/view/twig/relatedto/relatedto.twig
+++ b/app/view/twig/relatedto/relatedto.twig
@@ -33,7 +33,7 @@
             <div class="col-md-9">
                 {% include 'relatedto/_toolbar.twig' %}
                 {# TODO: add order #}
-                {{ list(context.show_contenttype, context.related_content, '') }}
+                {{ list(context.show_contenttype, context.related_content, context.permissions, '') }}
             </div>
 
             <aside class="col-md-3">

--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -39,9 +39,10 @@ class Permissions
 
     /** @var \Silex\Application */
     private $app;
-
-    // per-request permission cache
+    /** @var array Per-request permission cache */
     private $rqcache;
+    /** @var array The list of ContentType permissions */
+    private $contentTypePermissions = ['view', 'edit', 'create', 'publish', 'depublish', 'change-ownership'];
 
     public function __construct(Silex\Application $app)
     {
@@ -353,6 +354,24 @@ class Permissions
         $roles = $this->getRolesByContentTypePermission($permissionName, $contenttype);
 
         return in_array($roleName, $roles);
+    }
+
+    /**
+     * Return a list of ContentType permissions that a user has for the ContentType.
+     *
+     * @param array  $user
+     * @param string $contentTypeSlug
+     *
+     * @return boolean[]
+     */
+    public function getUserContentTypePermissions(array $user, $contentTypeSlug)
+    {
+        $permissions = [];
+        foreach ($this->contentTypePermissions as $contentTypePermission) {
+            $permissions[$contentTypePermission] = $this->isAllowed($contentTypePermission, $user, $contentTypeSlug);
+        }
+
+        return $permissions;
     }
 
     /**

--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -357,6 +357,16 @@ class Permissions
     }
 
     /**
+     * Get the list of ContentType permissions available.
+     *
+     * @return string[]
+     */
+    public function getContentTypePermissions()
+    {
+        return $this->contentTypePermissions;
+    }
+
+    /**
      * Return a list of ContentType permissions that a user has for the ContentType.
      *
      * @param array  $user

--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -42,7 +42,15 @@ class Permissions
     /** @var array Per-request permission cache */
     private $rqcache;
     /** @var array The list of ContentType permissions */
-    private $contentTypePermissions = ['view', 'edit', 'create', 'publish', 'depublish', 'change-ownership'];
+    private $contentTypePermissions = [
+        'create'           => false,
+        'change-ownership' => false,
+        'delete'           => false,
+        'edit'             => false,
+        'publish'          => false,
+        'depublish'        => false,
+        'view'             => false,
+    ];
 
     public function __construct(Silex\Application $app)
     {
@@ -359,7 +367,7 @@ class Permissions
     /**
      * Get the list of ContentType permissions available.
      *
-     * @return string[]
+     * @return boolean[]
      */
     public function getContentTypePermissions()
     {
@@ -377,7 +385,7 @@ class Permissions
     public function getUserContentTypePermissions(array $user, $contentTypeSlug)
     {
         $permissions = [];
-        foreach ($this->contentTypePermissions as $contentTypePermission) {
+        foreach (array_keys($this->contentTypePermissions) as $contentTypePermission) {
             $permissions[$contentTypePermission] = $this->isAllowed($contentTypePermission, $user, $contentTypeSlug);
         }
 

--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -3,6 +3,7 @@
 namespace Bolt\AccessControl;
 
 use Bolt\Content;
+use Bolt\Storage\Entity;
 use Bolt\Translation\Translator as Trans;
 use Silex;
 
@@ -377,12 +378,12 @@ class Permissions
     /**
      * Return a list of ContentType permissions that a user has for the ContentType.
      *
-     * @param array  $user
-     * @param string $contentTypeSlug
+     * @param string             $contentTypeSlug
+     * @param array|Entity\Users $user
      *
      * @return boolean[]
      */
-    public function getUserContentTypePermissions(array $user, $contentTypeSlug)
+    public function getContentTypeUserPermissions($contentTypeSlug, $user)
     {
         $permissions = [];
         foreach (array_keys($this->contentTypePermissions) as $contentTypePermission) {

--- a/src/Controller/Backend/BackendBase.php
+++ b/src/Controller/Backend/BackendBase.php
@@ -135,6 +135,21 @@ abstract class BackendBase extends Base
     }
 
     /**
+     * Helper to get a user's permissions for a ContentType.
+     *
+     * @param string             $contentTypeSlug
+     * @param array|Entity\Users $user
+     */
+    protected function getContentTypeUserPermissions($contentTypeSlug, $user = null)
+    {
+        if ($user === null) {
+            return $this->app['permissions']->getContentTypePermissions();
+        }
+
+        return $this->app['permissions']->getContentTypeUserPermissions($contentTypeSlug, $user);
+    }
+
+    /**
      * Returns the Login object.
      *
      * @return \Bolt\AccessControl\Login

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -250,7 +250,7 @@ class General extends BackendBase
                     'order'   => 'datechanged DESC',
                     'hydrate' => false
                 ]);
-                $permissions[$key] = $this->app['permissions']->getUserContentTypePermissions($user, $contenttype);
+                $permissions[$key] = $this->getContentTypeUserPermissions($contenttype, $user);
 
                 if (!empty($latest[$key])) {
                     $total += count($latest[$key]);

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -244,7 +244,7 @@ class General extends BackendBase
 
         // Get the 'latest' from each of the content types.
         foreach ($this->getOption('contenttypes') as $key => $contenttype) {
-            if ($this->isAllowed('contenttype:' . $key) && $contenttype['show_on_dashboard'] === true) {
+            if ($this->isAllowed('contenttype:' . $key) && $contenttype['show_on_dashboard'] === true && $user !== null) {
                 $latest[$key] = $this->getContent($key, [
                     'limit'   => $limit,
                     'order'   => 'datechanged DESC',

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -238,6 +238,8 @@ class General extends BackendBase
     {
         $total  = 0;
         $latest = [];
+        $user = $this->users()->getCurrentUser();
+        $permissions = [];
         $limit  = $limit ?: $this->getOption('general/recordsperdashboardwidget');
 
         // Get the 'latest' from each of the content types.
@@ -248,6 +250,7 @@ class General extends BackendBase
                     'order'   => 'datechanged DESC',
                     'hydrate' => false
                 ]);
+                $permissions[$key] = $this->app['permissions']->getUserContentTypePermissions($user, $contenttype);
 
                 if (!empty($latest[$key])) {
                     $total += count($latest[$key]);
@@ -257,6 +260,7 @@ class General extends BackendBase
 
         return [
             'latest'          => $latest,
+            'permissions'     => $permissions,
             'suggestloripsum' => ($total === 0),
         ];
     }

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -230,12 +230,13 @@ class Records extends BackendBase
         }
 
         $multiplecontent = $this->getContent($contenttypeslug, $contentparameters);
+        $user = $this->users()->getCurrentUser();
 
         $context = [
             'contenttype'     => $contenttype,
             'multiplecontent' => $multiplecontent,
             'filter'          => $filter,
-            'permissions'     => $this->app['permissions']->getUserContentTypePermissions($this->users()->getCurrentUser(), $contenttypeslug)
+            'permissions'     => $user ? $this->app['permissions']->getUserContentTypePermissions($user, $contenttypeslug) : null
         ];
 
         return $this->render('overview/overview.twig', $context);

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -151,6 +151,12 @@ class Records extends BackendBase
             'publish' => 'published',
             'draft'   => 'draft',
         ];
+        // Map actions to requred permission
+        $actionPermissions = [
+            'publish' => 'publish',
+            'held'    => 'depublish',
+            'draft'   => 'depublish',
+        ];
 
         if (!isset($actionStatuses[$action])) {
             $this->flashes()->error(Trans::__('No such action for content.'));
@@ -162,9 +168,9 @@ class Records extends BackendBase
         $content = $this->getContent("$contenttypeslug/$id");
         $title = $content->getTitle();
 
-        if (!$this->isAllowed("contenttype:$contenttypeslug:edit:$id") ||
+        if (!$this->isAllowed("contenttype:$contenttypeslug:{$actionPermissions[$action]}:$id") ||
         !$this->users()->isContentStatusTransitionAllowed($content['status'], $newStatus, $contenttypeslug, $id)) {
-            $this->flashes()->error(Trans::__('You do not have the right privileges to edit that record.'));
+            $this->flashes()->error(Trans::__('You do not have the right privileges to %ACTION% that record.', ['%ACTION%' => $actionPermissions[$action]]));
 
             return $this->redirectToRoute('overview', ['contenttypeslug' => $contenttypeslug]);
         }

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -236,7 +236,7 @@ class Records extends BackendBase
             'contenttype'     => $contenttype,
             'multiplecontent' => $multiplecontent,
             'filter'          => $filter,
-            'permissions'     => $user ? $this->app['permissions']->getUserContentTypePermissions($user, $contenttypeslug) : null
+            'permissions'     => $user ? $this->app['permissions']->getUserContentTypePermissions($user, $contenttypeslug) : $this->app['permissions']->getContentTypePermissions()
         ];
 
         return $this->render('overview/overview.twig', $context);

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -234,7 +234,8 @@ class Records extends BackendBase
         $context = [
             'contenttype'     => $contenttype,
             'multiplecontent' => $multiplecontent,
-            'filter'          => $filter
+            'filter'          => $filter,
+            'permissions'     => $this->app['permissions']->getUserContentTypePermissions($this->users()->getCurrentUser(), $contenttypeslug)
         ];
 
         return $this->render('overview/overview.twig', $context);

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -230,13 +230,12 @@ class Records extends BackendBase
         }
 
         $multiplecontent = $this->getContent($contenttypeslug, $contentparameters);
-        $user = $this->users()->getCurrentUser();
 
         $context = [
             'contenttype'     => $contenttype,
             'multiplecontent' => $multiplecontent,
             'filter'          => $filter,
-            'permissions'     => $user ? $this->app['permissions']->getUserContentTypePermissions($user, $contenttypeslug) : $this->app['permissions']->getContentTypePermissions()
+            'permissions'     => $this->getContentTypeUserPermissions($contenttypeslug, $this->users()->getCurrentUser())
         ];
 
         return $this->render('overview/overview.twig', $context);
@@ -300,6 +299,7 @@ class Records extends BackendBase
             'relations'        => $relations,
             'show_contenttype' => $showContenttype,
             'related_content'  => is_null($relations) ? null : $content->related($showContenttype['slug']),
+            'permissions'      => $this->getContentTypeUserPermissions($contenttypeslug, $this->users()->getCurrentUser())
         ];
 
         return $this->render('relatedto/relatedto.twig', $context);

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -324,7 +324,7 @@ class Users extends BackendBase
     public function viewRoles()
     {
         $contenttypes = $this->getOption('contenttypes');
-        $permissions = ['view', 'edit', 'create', 'publish', 'depublish', 'change-ownership'];
+        $permissions = $this->app['permissions']->getContentTypePermissions();
         $effectivePermissions = [];
         foreach ($contenttypes as $contenttype) {
             foreach ($permissions as $permission) {

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -327,7 +327,7 @@ class Users extends BackendBase
         $permissions = $this->app['permissions']->getContentTypePermissions();
         $effectivePermissions = [];
         foreach ($contenttypes as $contenttype) {
-            foreach ($permissions as $permission) {
+            foreach (array_keys($permissions) as $permission) {
                 $effectivePermissions[$contenttype['slug']][$permission] =
                 $this->app['permissions']->getRolesByContentTypePermission($permission, $contenttype['slug']);
             }

--- a/src/Omnisearch.php
+++ b/src/Omnisearch.php
@@ -351,6 +351,7 @@ class Omnisearch
         if (!$this->showRecords) {
             return;
         }
+        $user = $this->app['users']->getCurrentUser();
 
         $searchresults = $this->app['storage']->searchContent($query);
         /** @var Content[] $searchresults */
@@ -374,6 +375,7 @@ class Omnisearch
 
             if ($withRecord) {
                 $item['record'] = $result;
+                $item['permissions'] = $this->app['permissions']->getContentTypeUserPermissions($result->contenttype['slug'], $user);
             }
 
             $this->register($item);


### PR DESCRIPTION
Provide a `Permissions::getContentTypeUserPermissions()` function to get a user's permissions 
* 'create', 'edit', 'delete', 'publish', 'depublish', 'view' and 'change-ownership'

Allows
* Permissions to be passed into the Twig context as a variable.
* Remove repeated use of `isallowed()` in Twig
* Allows for use cases such as when user doesn't have `edit` permission, but can be granted `publish` permission
* Fixes #3802 for master (2.2 backport to come)

**Note:** In master this will require further clean up before v2.3.0 and I am sure @rarila will want to refactor some Twig stuff :+1: 

Ping @bnelson-cainc 