### PR TITLE
Issue 3951 theme config override

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -252,8 +252,10 @@ class Frontend extends ConfigurableBase
         if(!($amount = $this->getOption("theme/listing_records", false))) {
             $amount = (!empty($contenttype['listing_records']) ? $contenttype['listing_records'] : $this->getOption('general/listing_records'));    
         }
+        if(!($order = $this->getOption("theme/listing_sort", false))) {
+            $order = (!empty($contenttype['sort']) ? $contenttype['sort'] : $this->getOption('general/listing_sort'));    
+        }
         
-        $order = (!empty($contenttype['sort']) ? $contenttype['sort'] : $this->getOption('general/listing_sort'));
         $content = $this->getContent($contenttype['slug'], ['limit' => $amount, 'order' => $order, 'page' => $page, 'paging' => true]);
 
         $template = $this->templateChooser()->listing($contenttype);
@@ -295,7 +297,7 @@ class Frontend extends ConfigurableBase
         $page = $query->get($pagerid, $query->get('page', 1));
         // Theme value takes precedence over default config (https://github.com/bolt/bolt/issues/3951)
         $amount = $this->getOption("theme/listing_records", false) ?: $this->getOption('general/listing_records');
-        $order = $this->getOption('general/listing_sort');
+        $order = $this->getOption("theme/listing_sort", false) ?: $this->getOption('general/listing_sort');
         $content = $this->app['storage']->getContentByTaxonomy($taxonomytype, $slug, ['limit' => $amount, 'order' => $order, 'page' => $page]);
 
         // See https://github.com/bolt/bolt/pull/2310

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -249,10 +249,10 @@ class Frontend extends ConfigurableBase
         $page = $request->query->get($pagerid, $request->query->get('page', 1));
         
         // Theme value takes precedence over CT & default config (https://github.com/bolt/bolt/issues/3951)
-        if(!($amount = $this->getOption("theme/listing_records", false))) {
+        if (!($amount = $this->getOption("theme/listing_records", false))) {
             $amount = (!empty($contenttype['listing_records']) ? $contenttype['listing_records'] : $this->getOption('general/listing_records'));    
         }
-        if(!($order = $this->getOption("theme/listing_sort", false))) {
+        if (!($order = $this->getOption("theme/listing_sort", false))) {
             $order = (!empty($contenttype['sort']) ? $contenttype['sort'] : $this->getOption('general/listing_sort'));    
         }
         
@@ -362,8 +362,8 @@ class Frontend extends ConfigurableBase
         $page = $request->query->get($param, $request->query->get('page', 1));
 
         // Theme value takes precedence over default config (https://github.com/bolt/bolt/issues/3951)
-        if(!($pageSize = $this->getOption("theme/search_results_records", false))) {
-            if(!($pageSize = $this->getOption("general/search_results_records", false))) {
+        if (!($pageSize = $this->getOption("theme/search_results_records", false))) {
+            if (!($pageSize = $this->getOption("general/search_results_records", false))) {
                 $pageSize = $this->getOption("theme/listing_records", false) ?: $this->getOption('general/listing_records', 10);
             }
         }

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -364,7 +364,7 @@ class Frontend extends ConfigurableBase
         // Theme value takes precedence over default config (https://github.com/bolt/bolt/issues/3951)
         if(!($pageSize = $this->getOption("theme/search_results_records", false))) {
             if(!($pageSize = $this->getOption("general/search_results_records", false))) {
-                $pageSize = ($this->getOption('general/listing_records') ?: 10);
+                $pageSize = $this->getOption("theme/listing_records", false) ?: $this->getOption('general/listing_records', 10);
             }
         }
         

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -361,8 +361,13 @@ class Frontend extends ConfigurableBase
         $param = Pager::makeParameterId($context);
         $page = $request->query->get($param, $request->query->get('page', 1));
 
-        $pageSize = $this->getOption('general/search_results_records') ?: ($this->getOption('general/listing_records') ?: 10);
-
+        // Theme value takes precedence over default config (https://github.com/bolt/bolt/issues/3951)
+        if(!($pageSize = $this->getOption("theme/search_results_records", false))) {
+            if(!($pageSize = $this->getOption("general/search_results_records", false))) {
+                $pageSize = ($this->getOption('general/listing_records') ?: 10);
+            }
+        }
+        
         $offset = ($page - 1) * $pageSize;
         $limit = $pageSize;
 

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -247,7 +247,12 @@ class Frontend extends ConfigurableBase
         $pagerid = Pager::makeParameterId($contenttypeslug);
         // First, get some content
         $page = $request->query->get($pagerid, $request->query->get('page', 1));
-        $amount = (!empty($contenttype['listing_records']) ? $contenttype['listing_records'] : $this->getOption('general/listing_records'));
+        
+        // Theme value takes precedence over CT & default config (https://github.com/bolt/bolt/issues/3951)
+        if(!($amount = $this->getOption("theme/listing_records", false))) {
+            $amount = (!empty($contenttype['listing_records']) ? $contenttype['listing_records'] : $this->getOption('general/listing_records'));    
+        }
+        
         $order = (!empty($contenttype['sort']) ? $contenttype['sort'] : $this->getOption('general/listing_sort'));
         $content = $this->getContent($contenttype['slug'], ['limit' => $amount, 'order' => $order, 'page' => $page, 'paging' => true]);
 
@@ -288,7 +293,8 @@ class Frontend extends ConfigurableBase
          /* @var $query \Symfony\Component\HttpFoundation\ParameterBag */
         $query = $request->query;
         $page = $query->get($pagerid, $query->get('page', 1));
-        $amount = $this->getOption('general/listing_records');
+        // Theme value takes precedence over default config (https://github.com/bolt/bolt/issues/3951)
+        $amount = $this->getOption("theme/listing_records", false) ?: $this->getOption('general/listing_records');
         $order = $this->getOption('general/listing_sort');
         $content = $this->app['storage']->getContentByTaxonomy($taxonomytype, $slug, ['limit' => $amount, 'order' => $order, 'page' => $page]);
 

--- a/theme/base-2014/config.yml
+++ b/theme/base-2014/config.yml
@@ -23,6 +23,13 @@ headerimage:
 # listing_template: listing.twig
 # search_results_template: listing.twig
 
+# Amount of records and sorting in listing. If you 're creating a theme for distribution, you can 
+# specify the amount of records displayed on listing pages, including search results. The values 
+# you will set in this config will override the ones defined in the global app/config/config.yml.
+# listing_records : 10
+# listing_sort : datepublish DESC
+# search_results_records: 10
+
 templatefields:
     extrafields.twig:
         section_1:


### PR DESCRIPTION
Hi, 

this PR aims to provide a theme override for `listing_records`, `listing_sort` and `search_results_records`.

Fixes #3951 
