### PR TITLE
Rewrite of getContent (search functionality) to use new storage layer

### DIFF
--- a/src/Provider/QueryServiceProvider.php
+++ b/src/Provider/QueryServiceProvider.php
@@ -7,6 +7,7 @@ use Bolt\Storage\Query\Query;
 use Bolt\Storage\Query\QueryParameterParser;
 use Bolt\Storage\Query\SearchConfig;
 use Bolt\Storage\Query\SearchQuery;
+use Bolt\Storage\Query\SearchWeighter;
 use Bolt\Storage\Query\SelectQuery;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -25,6 +26,8 @@ class QueryServiceProvider implements ServiceProviderInterface
             function ($app) {
                 $parser = new ContentQueryParser($app['storage']);
                 $parser->addService('select', $app['query.select']);
+                $parser->addService('search', $app['query.search']);
+                $parser->addService('search_weighter', $app['query.search_weighter']);
 
                 return $parser;
             }
@@ -51,6 +54,12 @@ class QueryServiceProvider implements ServiceProviderInterface
         $app['query.search_config'] = $app->share(
             function ($app) {
                 return new SearchConfig($app['config']);
+            }
+        );
+        
+        $app['query.search_weighter'] = $app->share(
+            function ($app) {
+                return new SearchWeighter($app['query.search_config']);
             }
         );
     }

--- a/src/Provider/QueryServiceProvider.php
+++ b/src/Provider/QueryServiceProvider.php
@@ -5,6 +5,8 @@ namespace Bolt\Provider;
 use Bolt\Storage\Query\ContentQueryParser;
 use Bolt\Storage\Query\Query;
 use Bolt\Storage\Query\QueryParameterParser;
+use Bolt\Storage\Query\SearchConfig;
+use Bolt\Storage\Query\SearchQuery;
 use Bolt\Storage\Query\SelectQuery;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -37,6 +39,18 @@ class QueryServiceProvider implements ServiceProviderInterface
         $app['query.select'] = $app->share(
             function ($app) {
                 return new SelectQuery($app['storage']->createQueryBuilder(), $app['query.parser.handler']);
+            }
+        );
+        
+        $app['query.search'] = $app->share(
+            function ($app) {
+                return new SearchQuery($app['storage']->createQueryBuilder(), $app['query.parser.handler'], $app['query.search_config']);
+            }
+        );
+        
+        $app['query.search_config'] = $app->share(
+            function ($app) {
+                return new SearchConfig($app['config']);
             }
         );
     }

--- a/src/Provider/QueryServiceProvider.php
+++ b/src/Provider/QueryServiceProvider.php
@@ -28,6 +28,7 @@ class QueryServiceProvider implements ServiceProviderInterface
                 $parser->addService('select', $app['query.select']);
                 $parser->addService('search', $app['query.search']);
                 $parser->addService('search_weighter', $app['query.search_weighter']);
+                $parser->addService('search_config', $app['query.search_config']);
 
                 return $parser;
             }

--- a/src/Storage/Query/Adapter/PostgresSearch.php
+++ b/src/Storage/Query/Adapter/PostgresSearch.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bolt\Storage\Query\Adapter;
+
+use Bolt\Storage\Query\SearchConfig;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ *  Handler to build a fulltext search query for Postgres
+ */
+class PostgresSearch
+{
+    
+    protected $qb;
+    protected $config;
+    protected $searchWords;
+    
+    public function __construct(QueryBuilder $qb, SearchConfig $config, array $searchWords)
+    {
+        $this->qb = $qb;
+        $this->config = $config;
+        $this->searchWords = $searchWords;
+    }
+   
+    public function getQuery()
+    {
+        $words = implode("&", $this->searchWords);
+        $this->qb->addSelect("ts_rank(bsearch.document, to_tsquery('".$words."'))", "score");
+    }
+}

--- a/src/Storage/Query/Adapter/PostgresSearch.php
+++ b/src/Storage/Query/Adapter/PostgresSearch.php
@@ -14,6 +14,7 @@ class PostgresSearch
     protected $qb;
     protected $config;
     protected $searchWords;
+    protected $contenttype;
     
     public function __construct(QueryBuilder $qb, SearchConfig $config, array $searchWords)
     {
@@ -21,11 +22,59 @@ class PostgresSearch
         $this->config = $config;
         $this->searchWords = $searchWords;
     }
+    
+    public function setContentType($type) {
+        $this->contenttype = $type;
+    }
    
     public function getQuery()
     {
         $words = implode("&", $this->searchWords);
-        $this->qb->addSelect("ts_rank(bsearch.document, to_tsquery('".$words."'))", "score");
+        $sub = clone $this->qb;
+        $this->qb->addSelect("ts_rank(bsearch.document, to_tsquery('".$words."')) as score");
+        $sub->select("*");
+        $select = [];
 
+        $fieldsToSearch = $this->config->getConfig($this->contenttype);
+        $joins = $this->config->getJoins($this->contenttype);
+        $fieldsToSearch = array_diff_key($fieldsToSearch, array_flip($joins));
+        
+        $from = $this->qb->getQueryPart('from');
+        if (isset($from[0]['alias'])) {
+            $alias = $from[0]['alias'];
+        } else {
+            $alias = $from[0]['table'];
+        }
+        foreach ($fieldsToSearch as $fieldName=>$config) {
+            $weight = $this->getWeight($config['weight']);
+            $select[] = "setweight(to_tsvector($alias.$fieldName), '$weight')";
+        }
+        $sub->select("*, ".implode(' || ', $select). ' AS document');
+        $sub->groupBy("$alias.id");
+
+
+        $this->qb->from("(".$sub->getSQL().")", 'bsearch');
+        
+        $this->qb->where("bsearch.document @@ to_tsquery('".$words."')");
+        $this->qb->orderBy('score', 'DESC');
+        return $this->qb;
+    }
+    
+    public function getWeight($score) {
+        switch (true) {
+            case ($score >= 75):
+                return 'A';
+                break;
+            case ($score >= 50):
+                return 'B';
+                break;
+            case ($score >= 25):
+                return 'C';
+                break;
+            case ($score < 25):
+                return 'D';
+                break;           
+        }
+        return 'A';
     }
 }

--- a/src/Storage/Query/Adapter/PostgresSearch.php
+++ b/src/Storage/Query/Adapter/PostgresSearch.php
@@ -26,5 +26,6 @@ class PostgresSearch
     {
         $words = implode("&", $this->searchWords);
         $this->qb->addSelect("ts_rank(bsearch.document, to_tsquery('".$words."'))", "score");
+
     }
 }

--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -11,6 +11,7 @@ use Bolt\Storage\Query\Handler\OrderHandler;
 use Bolt\Storage\Query\Handler\PrintQueryHandler;
 use Bolt\Storage\Query\Handler\RandomQueryHandler;
 use Bolt\Storage\Query\Handler\ReturnSingleHandler;
+use Bolt\Storage\Query\Handler\SearchQueryHandler;
 use Bolt\Storage\Query\Handler\SelectQueryHandler;
 
 /**
@@ -60,6 +61,7 @@ class ContentQueryParser
     protected function setupDefaults()
     {
         $this->addHandler('select', new SelectQueryHandler());
+        $this->addHandler('search', new SearchQueryHandler());
         $this->addHandler('random', new RandomQueryHandler());
         $this->addHandler('first', new FirstQueryHandler());
         $this->addHandler('latest', new LatestQueryHandler());

--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -34,7 +34,7 @@ class ContentQueryParser
 
     protected $identifier;
 
-    protected $operations = ['search', 'latest', 'first', 'random'];
+    protected $operations = ['search', 'latest', 'first', 'random', 'nativesearch'];
 
     protected $directives = [];
 
@@ -65,6 +65,7 @@ class ContentQueryParser
         $this->addHandler('random', new RandomQueryHandler());
         $this->addHandler('first', new FirstQueryHandler());
         $this->addHandler('latest', new LatestQueryHandler());
+        $this->addHandler('nativesearch', new NativeSearchHandler());
 
         $this->addDirectiveHandler('returnsingle', new ReturnSingleHandler());
         $this->addDirectiveHandler('order', new OrderHandler());

--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -7,6 +7,7 @@ use Bolt\Storage\Query\Handler\FirstQueryHandler;
 use Bolt\Storage\Query\Handler\GetQueryHandler;
 use Bolt\Storage\Query\Handler\LatestQueryHandler;
 use Bolt\Storage\Query\Handler\LimitHandler;
+use Bolt\Storage\Query\Handler\NativeSearchHandler;
 use Bolt\Storage\Query\Handler\OrderHandler;
 use Bolt\Storage\Query\Handler\PrintQueryHandler;
 use Bolt\Storage\Query\Handler\RandomQueryHandler;

--- a/src/Storage/Query/Handler/NativeSearchHandler.php
+++ b/src/Storage/Query/Handler/NativeSearchHandler.php
@@ -42,6 +42,9 @@ class NativeSearchHandler
             $adapter = new PostgresSearch($query, $config, explode(' ', $search));
             $adapter->setContentType($contenttype);
             $result = $repo->findWith($adapter->getQuery());
+            $set->add($result, $contenttype);
         }
+        
+        return $set;
     }
 }

--- a/src/Storage/Query/Handler/NativeSearchHandler.php
+++ b/src/Storage/Query/Handler/NativeSearchHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Bolt\Storage\Query\Handler;
+
+use Bolt\Storage\Query\ContentQueryParser;
+use Bolt\Storage\Query\QueryResultset;
+use Bolt\Storage\Query\SearchQueryResultset;
+use Bolt\Storage\Query\Adapter\PostgresSearch;
+
+/**
+ *  Handler class to perform a native search where the db adapter supports full=text
+ * language searching, thus avoiding the need to weight the results in PHP code.
+ */
+class NativeSearchHandler
+{
+    /**
+     * @param ContentQueryParser $contentQuery
+     *
+     * @return SearchQueryResultset
+     */
+    public function __invoke(ContentQueryParser $contentQuery)
+    {
+        
+        $params = $contentQuery->getEntityManager()->createQueryBuilder()->getConnection()->getParams();
+        if (strpos($params['driver'], 'postgres') !== false) {
+            return $this->postgresSearch($contentQuery);
+        } else {
+            return call_user_func_array($contentQuery->getHandler('search'), [$contentQuery]);
+        }
+        
+    }
+    
+    public function postgresSearch(ContentQueryParser $contentQuery)
+    {
+        $set = new SearchQueryResultset();
+
+        foreach ($contentQuery->getContentTypes() as $contenttype) {
+            $repo = $contentQuery->getEntityManager()->getRepository($contenttype);
+            $query = $repo->createQueryBuilder($contenttype);
+            $config = $contentQuery->getService('search_config');
+            $search = $contentQuery->getParameter('filter');
+            $adapter = new PostgresSearch($query, $config, explode(' ', $search));
+            
+        }
+    }
+}

--- a/src/Storage/Query/Handler/NativeSearchHandler.php
+++ b/src/Storage/Query/Handler/NativeSearchHandler.php
@@ -40,7 +40,8 @@ class NativeSearchHandler
             $config = $contentQuery->getService('search_config');
             $search = $contentQuery->getParameter('filter');
             $adapter = new PostgresSearch($query, $config, explode(' ', $search));
-            
+            $adapter->setContentType($contenttype);
+            $result = $repo->findWith($adapter->getQuery());
         }
     }
 }

--- a/src/Storage/Query/Handler/SearchQueryHandler.php
+++ b/src/Storage/Query/Handler/SearchQueryHandler.php
@@ -4,6 +4,7 @@ namespace Bolt\Storage\Query\Handler;
 
 use Bolt\Storage\Query\ContentQueryParser;
 use Bolt\Storage\Query\QueryResultset;
+use Bolt\Storage\Query\SearchQueryResultset;
 
 /**
  *  Handler class to perform search query and then weight the fetched resultset.
@@ -28,14 +29,15 @@ class SearchQueryHandler
             $searchParam = $contentQuery->getParameter('filter');
             $query->setParameters($contentQuery->getParameters());
             $query->setSearch($searchParam);
-            
+                        
             $contentQuery->runDirectives($query);
-
+            
             $result = $repo->queryWith($query);
             if ($result) {
                 
                 if (count($result)>0) {
                     $weighter = $contentQuery->getService('search_weighter');
+                    $weighter->setContentType($contenttype);
                     $weighter->setResults($result);
                     $weighter->setSearchWords($query->getSearchWords());
                     

--- a/src/Storage/Query/Handler/SearchQueryHandler.php
+++ b/src/Storage/Query/Handler/SearchQueryHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Bolt\Storage\Query\Handler;
+
+use Bolt\Storage\Query\ContentQueryParser;
+use Bolt\Storage\Query\QueryResultset;
+
+/**
+ *  Handler class to perform search query and then weight the fetched resultset.
+ */
+class SearchQueryHandler
+{
+    /**
+     * @param ContentQueryParser $contentQuery
+     *
+     * @return SearchQueryResultset
+     */
+    public function __invoke(ContentQueryParser $contentQuery)
+    {
+        $set = new SearchQueryResultset();
+
+        foreach ($contentQuery->getContentTypes() as $contenttype) {
+            $query = $contentQuery->getService('search');
+            $repo = $contentQuery->getEntityManager()->getRepository($contenttype);
+            $query->setQueryBuilder($repo->createQueryBuilder($contenttype));
+            $query->setContentType($contenttype);
+
+            $searchParam = $contentQuery->getParameter('filter');
+            $query->setParameters($contentQuery->getParameters());
+            $query->setSearch($searchParam);
+            
+            $contentQuery->runDirectives($query);
+
+            $result = $repo->queryWith($query);
+            if ($result) {
+                
+                if (count($result)>0) {
+                    $weighter = $contentQuery->getService('search_weighter');
+                    $weighter->setResults($result);
+                    $weighter->setSearchWords($query->getSearchWords());
+                    
+                    $scores = $weighter->weight();                    
+                    $set->add($result, $contenttype, $scores);
+                } else {
+                    $set->add($result, $contenttype);
+                }
+                
+            }
+        }
+
+        if ($query->getSingleFetchMode()) {
+            return $set->current();
+        } else {
+            return $set;
+        }
+    }
+}

--- a/src/Storage/Query/QueryResultset.php
+++ b/src/Storage/Query/QueryResultset.php
@@ -3,8 +3,10 @@
 namespace Bolt\Storage\Query;
 
 /**
- * This class works keeps a set of queries that will eventually
- * be executed sequentially.
+ * This class is a wrapper that handles single or multiple
+ * sets or results fetched via a query. They can be iterated
+ * normally, or split by label, eg just results from one
+ * contenttype.
  */
 class QueryResultset extends \AppendIterator implements \Countable
 {

--- a/src/Storage/Query/SearchConfig.php
+++ b/src/Storage/Query/SearchConfig.php
@@ -94,7 +94,7 @@ class SearchConfig
             } else {
                 $weight = 50;
             }
-            $this->searchableTypes[$contenttype]['taxonomy'][$taxonomy] = ['weight'=>$weight];
+            $this->searchableTypes[$contenttype][$taxonomy] = ['weight'=>$weight];
            
         }
         

--- a/src/Storage/Query/SearchConfig.php
+++ b/src/Storage/Query/SearchConfig.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Bolt\Storage\Query;
+
+use Bolt\Config;
+
+/**
+* This class takes an overall config array as input and parses into values
+* applicable for performing searches.
+*
+* This takes into account contenttypes that aren't searchable along with
+* taxonomy and field weightings.
+*/
+class SearchConfig
+{
+    
+    protected $config = [];
+    protected $searchableTypes = [];
+    
+    
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+        $this->parseContenttypes();
+    }
+    
+    /**
+     * Get the config of all fields for a given content type.
+     * @param  string $contenttype
+     * @return array|false
+     */
+    public function getConfig($contenttype)
+    {
+        if (array_key_exists($contenttype, $this->searchableTypes)) {
+            return $this->searchableTypes[$contenttypes];
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Get the config of one given field for a given content type.
+     * @param  string $contenttype
+     * @param  string $field
+     * @return array|false
+     */
+    public function getFieldConfig($contenttype, $field)
+    {
+        if (isset($this->searchableTypes[$contenttype][$field])) {
+            return $this->searchableTypes[$contenttype][$field];
+        }
+        
+        return false;
+    }
+    
+    
+    /**
+     * Iterates over the main config and delegates weighting to both
+     * searchable columns and searchable taxonomies.
+     *
+     * @return void
+     */
+    protected function parseContenttypes()
+    {
+        $contenttypes = $this->config->get('contenttypes');
+        
+        foreach ($contenttypes as $type => $values) {
+            if (! $this->isInvisible($type)) {
+                $this->getSearchableColumns($type);
+                if (isset($values['taxonomy'])) {
+                    $this->parseTaxonomies($type, $values['taxonomy']);
+                }
+            }
+        }
+    }
+    
+    /**
+     * Iterates the taxonomies for a given contenttype, then assigns a
+     * weighting based on type.
+     *
+     * @param  string $contenttype
+     * @param  array $taxonomies
+     * @return void
+     */
+    protected function parseTaxonomies($contenttype, $taxonomies)
+    {
+        foreach ((array)$taxonomies as $taxonomy) {
+            $taxonomyConfig = $this->config->get('taxonomies/'.$taxonomy);
+            
+            if (isset($taxonomyConfig['searchweight'])) {
+                $weight = $taxonomyConfig['searchweight'];
+            } elseif (isset($taxonomyConfig['behaves_like']) && $taxonomyConfig['behaves_like'] == 'tags') {
+                $weight = 75;
+            } else {
+                $weight = 50;
+            }
+            $this->searchableTypes[$contenttype]['taxonomy'][$taxonomy] = ['weight'=>$weight];
+           
+        }
+        
+    }
+    
+    /**
+     * Determine what columns are searchable for a given contenttype.
+     *
+     * @param  string $type
+     * @return void
+     */
+    protected function getSearchableColumns($type)
+    {
+        $fields = $this->config->get('contenttypes/'.$type.'/fields');
+        
+        foreach ($fields as $field => $options) {
+            if (in_array($options['type'], ['text','textarea','html','markdown']) || $options['searchable'] == true) {
+                if (isset($options['searchweight'])) {
+                    $weight = (int)$options['searchweight'];
+                } elseif (
+                        isset($fields['slug']['uses'] &&
+                        in_array($field, (array)$fields['slug']['uses'])) {
+                        $weight = 100;
+                } else {
+                    $weight = 50;
+                }
+                
+                        $this->searchableTypes[$type][$field] = ['weight'=>$weight];
+            }
+        }
+    }
+    
+    /**
+     * Does some checks to see whether a contenttype should appear in search results.
+     * This is based on contenttype options.
+     *
+     * @param  string  $contenttype
+     * @return boolean
+     */
+    protected function isInvisible($contenttype)
+    {
+        $info = $this->config->get('contenttypes/'.$contenttype);
+        if ($info) {
+            if (array_key_exists('viewless', $info) && $info['viewless'] == true) {
+                return true;
+            }
+            if (array_key_exists('searchable', $info) && $info['searchable'] == false) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+}

--- a/src/Storage/Query/SearchConfig.php
+++ b/src/Storage/Query/SearchConfig.php
@@ -16,6 +16,7 @@ class SearchConfig
     
     protected $config = [];
     protected $searchableTypes = [];
+    protected $joins = [];
     
     
     public function __construct(Config $config)
@@ -94,9 +95,21 @@ class SearchConfig
                 $weight = 50;
             }
             $this->searchableTypes[$contenttype][$taxonomy] = ['weight'=>$weight];
-           
+            $this->joins[$contenttype][] = $taxonomy;
         }
         
+    }
+    
+    /**
+     * Helper method to return the join search columns for a contenttype
+     * weighting based on type.
+     *
+     * @param  string $contenttype
+     * @return array
+     */
+    public function getJoins($contenttype)
+    {
+        return $this->joins[$contenttype];
     }
     
     /**

--- a/src/Storage/Query/SearchConfig.php
+++ b/src/Storage/Query/SearchConfig.php
@@ -32,7 +32,7 @@ class SearchConfig
     public function getConfig($contenttype)
     {
         if (array_key_exists($contenttype, $this->searchableTypes)) {
-            return $this->searchableTypes[$contenttypes];
+            return $this->searchableTypes[$contenttype];
         }
         
         return false;
@@ -114,9 +114,7 @@ class SearchConfig
             if (in_array($options['type'], ['text','textarea','html','markdown']) || $options['searchable'] == true) {
                 if (isset($options['searchweight'])) {
                     $weight = (int)$options['searchweight'];
-                } elseif (
-                        isset($fields['slug']['uses'] &&
-                        in_array($field, (array)$fields['slug']['uses'])) {
+                } elseif (isset($fields['slug']['uses']) && in_array($field, (array)$fields['slug']['uses'])) {
                         $weight = 100;
                 } else {
                     $weight = 50;

--- a/src/Storage/Query/SearchConfig.php
+++ b/src/Storage/Query/SearchConfig.php
@@ -85,11 +85,10 @@ class SearchConfig
     protected function parseTaxonomies($contenttype, $taxonomies)
     {
         foreach ((array)$taxonomies as $taxonomy) {
-            $taxonomyConfig = $this->config->get('taxonomies/'.$taxonomy);
-            
+            $taxonomyConfig = $this->config->get('taxonomy/'.$taxonomy);
             if (isset($taxonomyConfig['searchweight'])) {
                 $weight = $taxonomyConfig['searchweight'];
-            } elseif (isset($taxonomyConfig['behaves_like']) && $taxonomyConfig['behaves_like'] == 'tags') {
+            } elseif (isset($taxonomyConfig['behaves_like']) && $taxonomyConfig['behaves_like'] === 'tags') {
                 $weight = 75;
             } else {
                 $weight = 50;

--- a/src/Storage/Query/SearchQuery.php
+++ b/src/Storage/Query/SearchQuery.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bolt\Storage\Query;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * This query class coordinates a search query building mainly on the same 
+ * filtering system used in the SelectQuery class. The main difference is
+ * the addition of weighting, which is driven by documented here:.
+ *
+ *  @link https://docs.bolt.cm/content-search
+ *
+ *  The resulting QueryBuilder object is then passed through to the individual
+ *  field handlers where they can perform value transformations.
+ *
+ *  @author Ross Riley <riley.ross@gmail.com>
+ */
+class SearchQuery extends SelectQuery implements QueryInterface
+{
+    
+    protected $search;
+    
+    /**
+     * @param QueryBuilder $qb
+     */
+    public function __construct(QueryBuilder $qb, QueryParameterParser $parser, array $config)
+    {
+        parent::__construct($qb, $parser);
+        $this->config = $config;
+    }
+    
+    public function setSearch($search)
+    {
+        $this->search = $search;
+    }
+}

--- a/src/Storage/Query/SearchQuery.php
+++ b/src/Storage/Query/SearchQuery.php
@@ -92,20 +92,14 @@ class SearchQuery extends SelectQuery implements QueryInterface
         }
 
         if (!$config = $this->config->getConfig($this->contenttype)) {
-            throw new QueryParseException('You have attempted to run a search query on an unknown contenttype', 1);
+            throw new QueryParseException('You have attempted to run a search query on an unknown contenttype or one that is not searchable', 1);
         }
 
         $params = $this->params;
         unset($params['filter']);
 
         foreach ($config as $field => $options) {
-            if ($field === 'taxonomy') {
-                foreach ($options as $taxonomy => $values) {
-                    $params[$taxonomy] = $this->getSearchParameter();
-                }
-            } else {
-                $params[$field] = $this->getSearchParameter();
-            }
+            $params[$field] = $this->getSearchParameter();
         }
 
         $this->params = $params;

--- a/src/Storage/Query/SearchQueryResultset.php
+++ b/src/Storage/Query/SearchQueryResultset.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bolt\Storage\Query;
+
+/**
+ * This class builds on the default QueryResultset to add
+ * the ability to merge sets based on weighted scores.
+ */
+class SearchQueryResultset extends QueryResultset
+{
+    protected $results = [];
+
+    protected $scores = [];
+
+    /**
+     * @param array  $results A set of results
+     * @param string $type    An optional label to partition results
+     * @param array  $scores  An array of scores for the corresponding results
+     */
+    public function add($results, $type = null, $scores = [])
+    {
+        if ($type) {
+            $this->results[$type] = $results;
+            $this->scores[$type] = $scores;
+            $this->sortSingle($type);
+        } else {
+            $this->results = array_merge($this->results, $results);
+        }
+
+        $this->append(new \ArrayIterator($results));
+    }
+    
+    public function sortSingle($label)
+    {
+        $results = $this->get($label);
+        $scores = $this->scores[$label];
+        arsort($scores);
+        $sorted = [];
+        
+        foreach ($scores as $k=>$v) {
+            $sorted[] = $results[$k];
+        }
+        
+        $this->results[$type] = $sorted;
+    }
+    
+    public function sortAll()
+    {
+        
+    }
+    
+    
+}

--- a/src/Storage/Query/SearchQueryResultset.php
+++ b/src/Storage/Query/SearchQueryResultset.php
@@ -44,10 +44,4 @@ class SearchQueryResultset extends QueryResultset
         $this->results[$label] = $sorted;
     }
     
-    public function sortAll()
-    {
-        
-    }
-    
-    
 }

--- a/src/Storage/Query/SearchQueryResultset.php
+++ b/src/Storage/Query/SearchQueryResultset.php
@@ -19,7 +19,7 @@ class SearchQueryResultset extends QueryResultset
      */
     public function add($results, $type = null, $scores = [])
     {
-        if ($type) {
+        if ($type !== null) {
             $this->results[$type] = $results;
             $this->scores[$type] = $scores;
             $this->sortSingle($type);
@@ -41,7 +41,7 @@ class SearchQueryResultset extends QueryResultset
             $sorted[] = $results[$k];
         }
         
-        $this->results[$type] = $sorted;
+        $this->results[$label] = $sorted;
     }
     
     public function sortAll()

--- a/src/Storage/Query/SearchWeighter.php
+++ b/src/Storage/Query/SearchWeighter.php
@@ -113,11 +113,19 @@ class SearchWeighter
         
         foreach ($this->getContentFields() as $field => $weightings) {
             $textualContent = $result->{$field};
+            
+            // This is to handle taxonomies that need to be converted from an array
+            // into a string of words.
+            if (is_array($textualContent)) {
+                $textualContent = implode(" ", $textualContent);
+            }
+            
             $textualContent = strip_tags($textualContent);
             $textualContent = preg_replace('/[^\w\s]/', '', $textualContent);
             $textualContent = mb_strtolower($textualContent);
             $corpus[$field] = $textualContent;
         }
+        
         $dictionary = [];
         $count = array();
 

--- a/src/Storage/Query/SearchWeighter.php
+++ b/src/Storage/Query/SearchWeighter.php
@@ -34,7 +34,7 @@ class SearchWeighter
      *
      * @param QueryResultset $results
      */
-    public function setResults(QueryResultset $results)
+    public function setResults(array $results)
     {
         $this->results = $results;
     }

--- a/src/Storage/Query/SearchWeighter.php
+++ b/src/Storage/Query/SearchWeighter.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Bolt\Storage\Query;
+
+/**
+ * This class takes a fetched resultset and sorts them based on the weighting
+ * settings in the SearchConfig class.
+ */
+class SearchWeighter
+{
+    protected $config;
+
+    protected $results;
+
+    protected $searchWords;
+
+    protected $contenttype;
+
+    /**
+     * Constructor takes a compiled SearchConfig which is essentially an array
+     * of fields that we will search for text content, along with their corresponding
+     * weighting score.
+     *
+     * @param SearchConfig $config
+     */
+    public function __construct(SearchConfig $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Sets an iterable group of results, this normally comes directly
+     * from the database query.
+     *
+     * @param QueryResultset $results
+     */
+    public function setResults(QueryResultset $results)
+    {
+        $this->results = $results;
+    }
+
+    /**
+     * Sets the contenttype that we are weighting, that is, what type the results
+     * array is. That allows us to map against the configuration to see which fields
+     * to scan for relevant text.
+     *
+     * @param string $type
+     */
+    public function setContentType($type)
+    {
+        $this->contenttype = $type;
+    }
+
+    /**
+     * Sets the words that we want to query against. Normally this comes from the
+     * filter in a search, exploded into an array so the words are separated.
+     *
+     * @param array $words
+     */
+    public function setSearchWords(array $words)
+    {
+        $this->searchWords = $words;
+    }
+
+    /**
+     * This is the public method that gets a score for a the set of results.
+     *
+     * @return array An array of scores for each of the corresponding results
+     */
+    public function weight()
+    {
+        $scores = [];
+        foreach ($this->results as $result) {
+            $scores[] = $this->getResultScore($result);
+        }
+
+        return $scores;
+    }
+
+    /**
+     * Helper method to fetch the fields for an individual contenttype.
+     *
+     * @return [type] [description]
+     */
+    protected function getContentFields()
+    {
+        return $this->config->getConfig($this->contenttype);
+    }
+
+    /**
+     * This is a simple version of the Vector Space Model.
+     *
+     *   @link https://en.wikipedia.org/wiki/Vector_space_model
+     *
+     * The goal is to determine a relavance score for a corpus of values
+     * based on both the existence of a word or words but also based on
+     * how important the words are.
+     *
+     * For example, when querying results against a search of 'lorem ipsum';
+     * a result with the title 'Lorem Ipsum' should score higher
+     * than a result with the title 'An article about robots and lorem ipsum'
+     *
+     * The ratio of the appearance of the query words to the overall size of
+     * the document is used to produce a better score.
+     *
+     * @param Object $result A single result to score
+     *
+     * @return array An array consisting of a count / dictionary of words
+     */
+    protected function buildResultIndex($result)
+    {
+        $corpus = [];
+        
+        foreach ($this->getContentFields() as $field => $weightings) {
+            $textualContent = $result->{$field};
+            $textualContent = strip_tags($textualContent);
+            $textualContent = preg_replace('/[^\w\s]/', '', $textualContent);
+            $textualContent = mb_strtolower($textualContent);
+            $corpus[$field] = $textualContent;
+        }
+        $dictionary = [];
+        $count = array();
+
+        foreach ($corpus as $id => $doc) {
+            $terms = explode(' ', $doc);
+            $count[$id] = count($terms);
+
+            foreach ($terms as $term) {
+                if (!isset($dictionary[$term])) {
+                    $dictionary[$term] = ['frequency' => 0, 'postings' => []];
+                }
+                if (!isset($dictionary[$term]['postings'][$id])) {
+                    $dictionary[$term]['frequency']++;
+                    $dictionary[$term]['postings'][$id] = ['frequency' => 0];
+                }
+
+                $dictionary[$term]['postings'][$id]['frequency']++;
+            }
+        }
+
+        return ['count' => $count, 'dictionary' => $dictionary];
+    }
+
+    /**
+     * This method uses the index built in the method above to do some quick
+     * score calculations for each word of the query, versus each word of the 
+     * index dictionary.
+     * 
+     * @param  Object $result 
+     * @return float         
+     */
+    protected function getResultScore($result)
+    {
+        $output = [];
+
+        $corpus = $this->buildResultIndex($result);
+        $count = count($corpus['count']);
+
+        // This block iterates the search query words and checks both their
+        // existence and frequency in the index.
+        // 
+        // The score is passed through log(x, 2) to reduce the smooth the difference.
+        // 
+        foreach ($this->searchWords as $word) {
+            $word = mb_strtolower($word);
+            if (isset($corpus['dictionary'][$word])) {
+                $entry = $corpus['dictionary'][$word];
+                foreach ($entry['postings'] as $field => $posting) {
+
+                    //get term frequency–inverse document frequency
+                    $score = $posting['frequency'] * log($count + 1 / $entry['frequency'] + 1, 2);
+
+                    if (isset($output[$field])) {
+                        $output[$field] += $score;
+                    } else {
+                        $output[$field] = $score;
+                    }
+                }
+            }
+        }
+
+        // length normalise, we do this to stop smaller amounts of text having
+        // a disproportionate effect on the score.
+        foreach ($output as $field => $score) {
+            $output[$field] = $score / $corpus['count'][$field];
+        }
+
+        // Finally this weights by using the field specific weighting value that
+        // is set inside `contenttypes.yml` This uses a weighting factor from 0 to
+        // 100 that alters the score accordingly.
+        $weights = $this->getContentFields();
+        foreach ($output as $field => &$score) {
+            if (isset($weights[$field]['weight'])) {
+                $multiplier = $weights[$field]['weight'] / 100;
+
+                if ($multiplier > 0) {
+                    $score = $score * $multiplier;
+                }
+            }
+        }
+
+        return array_sum($output);
+    }
+}

--- a/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
@@ -225,5 +225,19 @@ class ContentQueryParserTest extends BoltUnitTest
 
     }
     
+    public function testNativeSearchHandlerFallback()
+    {
+        $app = $this->getApp();
+
+        $qb = new ContentQueryParser($app['storage'], $app['query.select']);
+        $qb->addService('search', $app['query.search']);
+        $qb->addService('search_weighter', $app['query.search_weighter']);
+        $qb->setQuery('pages/nativesearch/4');
+        $qb->setParameters(['filter' => 'lorem ipsum']);
+        $res = $qb->fetch();
+        $this->assertEquals(4, $res->count());
+
+    }
+        
 
 }

--- a/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
@@ -210,4 +210,20 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb->removeOperation('featured');
         $this->assertFalse(in_array('featured', $qb->getOperations()));
     }
+    
+    public function testSearchHandler()
+    {
+        $app = $this->getApp();
+
+        $qb = new ContentQueryParser($app['storage'], $app['query.select']);
+        $qb->addService('search', $app['query.search']);
+        $qb->addService('search_weighter', $app['query.search_weighter']);
+        $qb->setQuery('pages/search/4');
+        $qb->setParameters(['filter' => 'lorem ipsum']);
+        $res = $qb->fetch();
+        $this->assertEquals(4, $res->count());
+
+    }
+    
+
 }

--- a/tests/phpunit/unit/Storage/Query/NativeSearchTest.php
+++ b/tests/phpunit/unit/Storage/Query/NativeSearchTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bolt\Tests\Storage\Query;
+
+use Bolt\Tests\BoltUnitTest;
+
+/**
+ * Class to test src/Storage/Query/QueryTest.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class NativeSearchTest extends BoltUnitTest
+{
+    public function testQueryBuild()
+    {
+        $app = $this->getApp();
+        $this->addSomeContent();
+
+        $results = $app['query']->getContent('pages/nativesearch', ['filter' => 'lorem ipsum']);
+        
+        
+    }
+
+    
+}

--- a/tests/phpunit/unit/Storage/Query/SearchConfigTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchConfigTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Bolt\Tests\Storage\Query;
+
+use Bolt\Storage\Query\SearchConfig;
+use Bolt\Tests\BoltUnitTest;
+
+/**
+ * Class to test src/Storage/Query/QueryTest.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class SearchConfigTest extends BoltUnitTest
+{
+    public function testSetup()
+    {
+        $app = $this->getApp();
+        $search = new SearchConfig($app['config']);
+        $this->assertTrue(is_array($search->getConfig('pages')));
+    }
+    
+    public function testNonExistent()
+    {
+        $app = $this->getApp();
+        $search = new SearchConfig($app['config']);
+        $this->assertFalse($search->getConfig('nonexistent'));
+    }
+    
+    public function testIndividualField()
+    {
+        $app = $this->getApp();
+        $search = new SearchConfig($app['config']);
+        $this->assertTrue(is_array($search->getFieldConfig('pages', 'title')));
+        $this->assertFalse($search->getFieldConfig('pages', 'nonexistent'));
+    }
+    
+    public function testViewless()
+    {
+        $app = $this->getApp();
+        $app['config']->set('contenttypes/pages/viewless', true);
+        $search = new SearchConfig($app['config']);
+        $this->assertFalse($search->getConfig('pages'));
+    }
+    
+    public function testWeighting()
+    {
+        $app = $this->getApp();
+        $app['config']->set('contenttypes/pages/fields/body/searchweight', 100);
+        $search = new SearchConfig($app['config']);
+        $fieldConfig = $search->getFieldConfig('pages', 'body');
+        $this->assertEquals(100, $fieldConfig['weight']);
+    }
+    
+    public function testTaxonomyWeighting()
+    {
+        $app = $this->getApp();
+        $app['config']->set('taxonomy/chapters/searchweight', 100);
+        $search = new SearchConfig($app['config']);
+        $fieldConfig = $search->getFieldConfig('pages', 'chapters');
+        $this->assertEquals(100, $fieldConfig['weight']);
+    }
+    
+    public function testTagsTaxonomyWeighting()
+    {
+        $app = $this->getApp();
+        $search = new SearchConfig($app['config']);
+        $fieldConfig = $search->getFieldConfig('entries', 'tags');
+        $this->assertEquals(75, $fieldConfig['weight']);
+    }
+
+
+}

--- a/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bolt\Tests\Storage\Query;
+
+use Bolt\Storage\Query\SelectQuery;
+use Bolt\Tests\BoltUnitTest;
+
+/**
+ * Class to test src/Storage/Query/SelectQuery.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class SearchQueryTest extends BoltUnitTest
+{
+    public function testQuery()
+    {
+        $app = $this->getApp();
+        $this->addSomeContent();
+
+        $filter = 'lorem ipsum';
+
+        $query = $app['query.search'];
+        $query->setContentType('pages');
+        $query->setSearch($filter);
+        $expr = $query->getWhereExpression();
+        echo $expr;
+    }
+}

--- a/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
@@ -63,6 +63,25 @@ class SearchQueryTest extends BoltUnitTest
         $this->assertEquals('%ipsum%', $params['body_2']);
         $this->assertEquals('%lorem%', $params['chapters_1']);
         $this->assertEquals('%ipsum%', $params['chapters_2']);
-        
+    }
+    
+    public function testContenttypeFailure()
+    {
+        $app = $this->getApp();
+        $filter = 'main other';
+        $query = $app['query.search'];
+        $query->setContentType('showcases');
+        $this->setExpectedException('Bolt\Exception\QueryParseException');
+        $query->setSearch($filter);
+    }
+    
+    public function testMissingContenttypeFailure()
+    {
+        $app = $this->getApp();
+        $filter = 'main other';
+        $query = $app['query.search'];
+        $query->setContentType('nonexistent');
+        $this->setExpectedException('Bolt\Exception\QueryParseException');
+        $query->setSearch($filter);
     }
 }

--- a/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
@@ -23,6 +23,17 @@ class SearchQueryTest extends BoltUnitTest
         $query->setContentType('pages');
         $query->setSearch($filter);
         $expr = $query->getWhereExpression();
-        echo $expr;
+        $this->assertEquals('((pages.title LIKE :title_1) OR (pages.title LIKE :title_2)) AND ((pages.teaser LIKE :teaser_1) OR (pages.teaser LIKE :teaser_2)) AND ((pages.body LIKE :body_1) OR (pages.body LIKE :body_2)) AND ((pages.chapters LIKE :chapters_1) OR (pages.chapters LIKE :chapters_2))', $expr);
+        $params = $query->getWhereParameters();
+        $this->assertArrayHasKey('title_1', $params);
+        $this->assertArrayHasKey('title_2', $params);
+        $this->assertArrayHasKey('teaser_1', $params);
+        $this->assertArrayHasKey('teaser_2', $params);
+        $this->assertArrayHasKey('body_1', $params);
+        $this->assertArrayHasKey('body_2', $params);
+        $this->assertArrayHasKey('chapters_1', $params);
+        $this->assertArrayHasKey('chapters_2', $params);
+        $this->assertEquals('%lorem%', $params['title_1']);
+        $this->assertEquals('%ipsum%', $params['title_2']);
     }
 }

--- a/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
@@ -6,7 +6,7 @@ use Bolt\Storage\Query\SelectQuery;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Storage/Query/SelectQuery.
+ * Class to test src/Storage/Query/SearchQuery.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -23,7 +23,29 @@ class SearchQueryTest extends BoltUnitTest
         $query->setContentType('pages');
         $query->setSearch($filter);
         $expr = $query->getWhereExpression();
-        $this->assertEquals('((pages.title LIKE :title_1) OR (pages.title LIKE :title_2)) AND ((pages.teaser LIKE :teaser_1) OR (pages.teaser LIKE :teaser_2)) AND ((pages.body LIKE :body_1) OR (pages.body LIKE :body_2)) AND ((pages.chapters LIKE :chapters_1) OR (pages.chapters LIKE :chapters_2))', $expr);
+        $this->assertEquals('((pages.title LIKE :title_1) OR (pages.title LIKE :title_2)) OR ((pages.teaser LIKE :teaser_1) OR (pages.teaser LIKE :teaser_2)) OR ((pages.body LIKE :body_1) OR (pages.body LIKE :body_2)) OR ((pages.chapters LIKE :chapters_1) OR (pages.chapters LIKE :chapters_2))', $expr);
+        $params = $query->getWhereParameters();
+        $this->assertArrayHasKey('title_1', $params);
+        $this->assertArrayHasKey('title_2', $params);
+        $this->assertArrayHasKey('teaser_1', $params);
+        $this->assertArrayHasKey('teaser_2', $params);
+        $this->assertArrayHasKey('body_1', $params);
+        $this->assertArrayHasKey('body_2', $params);
+        $this->assertArrayHasKey('chapters_1', $params);
+        $this->assertArrayHasKey('chapters_2', $params);
+        $this->assertEquals('%lorem%', $params['title_1']);
+        $this->assertEquals('%ipsum%', $params['title_2']);        
+    }
+    
+    public function testAndParameterQuery()
+    {
+        $app = $this->getApp();
+        $filter = 'lorem + ipsum';
+        $query = $app['query.search'];
+        $query->setContentType('pages');
+        $query->setSearch($filter);
+        $expr = $query->getWhereExpression();
+        $this->assertEquals('((pages.title LIKE :title_1) AND (pages.title LIKE :title_2)) OR ((pages.teaser LIKE :teaser_1) AND (pages.teaser LIKE :teaser_2)) OR ((pages.body LIKE :body_1) AND (pages.body LIKE :body_2)) OR ((pages.chapters LIKE :chapters_1) AND (pages.chapters LIKE :chapters_2))', $expr);
         $params = $query->getWhereParameters();
         $this->assertArrayHasKey('title_1', $params);
         $this->assertArrayHasKey('title_2', $params);
@@ -35,5 +57,12 @@ class SearchQueryTest extends BoltUnitTest
         $this->assertArrayHasKey('chapters_2', $params);
         $this->assertEquals('%lorem%', $params['title_1']);
         $this->assertEquals('%ipsum%', $params['title_2']);
+        $this->assertEquals('%lorem%', $params['teaser_1']);
+        $this->assertEquals('%ipsum%', $params['teaser_2']);
+        $this->assertEquals('%lorem%', $params['body_1']);
+        $this->assertEquals('%ipsum%', $params['body_2']);
+        $this->assertEquals('%lorem%', $params['chapters_1']);
+        $this->assertEquals('%ipsum%', $params['chapters_2']);
+        
     }
 }

--- a/tests/phpunit/unit/Storage/Query/SearchWeighterTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchWeighterTest.php
@@ -19,6 +19,7 @@ class SearchWeighterTest extends BoltUnitTest
         $this->addSomeContent();
 
         $results = $app['query']->getContent('pages/first/3');
+        $results = iterator_to_array($results);
         
         $weighter = $app['query.search_weighter'];
         $weighter->setResults($results);
@@ -39,11 +40,8 @@ class SearchWeighterTest extends BoltUnitTest
         $results[1]->setTitle("Lorem Ipsum");  
         $results[1]->setBody("Lorem Ipsum");  
         
-        $newset = new QueryResultset;
-        $newset->add($results);
-        
         $weighter = $app['query.search_weighter'];
-        $weighter->setResults($newset);
+        $weighter->setResults($results);
         $weighter->setSearchWords(['lorem', 'ipsum']);
         $weighter->setContentType('pages');
         $scores = $weighter->weight();

--- a/tests/phpunit/unit/Storage/Query/SearchWeighterTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchWeighterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Bolt\Tests\Storage\Query;
+
+use Bolt\Storage\Query\QueryResultset;
+use Bolt\Storage\Query\SearchWeighter;
+use Bolt\Tests\BoltUnitTest;
+
+/**
+ * Class to test src/Storage/Query/SelectQuery.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class SearchWeighterTest extends BoltUnitTest
+{
+    public function testSimpleWeight()
+    {
+        $app = $this->getApp();
+        $this->addSomeContent();
+
+        $results = $app['query']->getContent('pages/first/3');
+        
+        $weighter = $app['query.search_weighter'];
+        $weighter->setResults($results);
+        $weighter->setSearchWords(['lorem', 'ipsum']);
+        $weighter->setContentType('pages');
+        $scores = $weighter->weight();
+        $this->assertTrue(is_array($scores));
+        $this->assertEquals(count($results), count($scores));
+        
+    }
+    
+    public function testScoring()
+    {
+        $app = $this->getApp();
+        $results = $app['query']->getContent('pages/first/3');
+        $results = iterator_to_array($results);
+        $results[2]->setTitle("Lorem Ipsum title to improve lorem ipsum result");  
+        $results[1]->setTitle("Lorem Ipsum");  
+        $results[1]->setBody("Lorem Ipsum");  
+        
+        $newset = new QueryResultset;
+        $newset->add($results);
+        
+        $weighter = $app['query.search_weighter'];
+        $weighter->setResults($newset);
+        $weighter->setSearchWords(['lorem', 'ipsum']);
+        $weighter->setContentType('pages');
+        $scores = $weighter->weight();
+
+        $this->assertGreaterThan($scores[0], $scores[2], 'message');        
+        $this->assertGreaterThan($scores[2], $scores[1], 'message');        
+    }
+}


### PR DESCRIPTION
This PR covers the search functionality for querying implementing the functionality that was formerly in the `Storage.php` file.

The work is now primarily split out into `SearchConfig` and `SearchWeighter` classes which handle the bulk of the functionality. The `SearchQuery` class extends the `SelectQuery` class from the previous PR and adds a few small modifications.
### Native Fulltext Search

Whilst the search weighting functionality is a good cross-platform solution for smaller corpuses of text, doing this in PHP is significantly slower and lacks some of the more advanced features of native fulltext searches. 

So this PR also introduces a new concept of native searches which developers with more advanced user can specify at query time. The api remains similar `setcontent results='pages/nativesearch', {filter: 'lorem ipsum'}` the `nativesearch` directive will switch into fulltext mode where the database platform supports it and all the weightings from the configuration will be applied to the query. 

Same caveats as with the last PR in that some of the finessing will follow in future PRs including pagination and some improvements to the public query API. Also native search currently only supports Postgres, but MySQL will follow shortly, SQLite will fall back to a standard weighted search.
