### PR TITLE
Deprecated App::getVersion in favor of container parameter

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -30,6 +30,9 @@ class Application extends Silex\Application
         $values['bolt_version'] = '2.3.0';
         $values['bolt_name'] = 'alpha 1';
         $values['bolt_released'] = false; // `true` for stable releases, `false` for alpha, beta and RC.
+        $values['bolt_long_version'] = function($app) {
+            return $app['bolt_version'] . ' ' . $app['bolt_name'];
+        };
 
         /** @internal Parameter to track a deprecated PHP version */
         $values['deprecated.php'] = version_compare(PHP_VERSION, '5.5.9', '<');
@@ -432,14 +435,13 @@ class Application extends Silex\Application
      * @param boolean $long TRUE returns 'version name', FALSE 'version'
      *
      * @return string
+     *
+     * @deprecated since 2.3, will be removed in 3.0
+     *             Use parameters in application instead
      */
     public function getVersion($long = true)
     {
-        if ($long) {
-            return trim($this['bolt_version'] . ' ' . $this['bolt_name']);
-        }
-
-        return $this['bolt_version'];
+        return $this[$long ? 'bolt_long_version' : 'bolt_version'];
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -1047,7 +1047,7 @@ class Config
 
             // Check to make sure the version is still the same. If not, effectively invalidate the
             // cached config to force a reload.
-            if (!isset($this->data['version']) || ($this->data['version'] != $this->app->getVersion())) {
+            if (!isset($this->data['version']) || ($this->data['version'] != $this->app['bolt_long_version'])) {
                 // The logger and the flashbags aren't available yet, so we set a flag to notify the user later.
                 $this->notify_update = true;
                 return false;
@@ -1069,7 +1069,7 @@ class Config
     protected function saveCache()
     {
         // Store the version number along with the config.
-        $this->data['version'] = $this->app->getVersion();
+        $this->data['version'] = $this->app['bolt_long_version'];
 
         if ($this->get('general/caching/config')) {
             Lib::saveSerialize($this->app['resources']->getPath('cache/config_cache.php'), $this->data);

--- a/src/DataCollector/BoltDataCollector.php
+++ b/src/DataCollector/BoltDataCollector.php
@@ -36,9 +36,9 @@ class BoltDataCollector extends DataCollector
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         $this->data = [
-            'version'     => $this->app->getVersion(false),
+            'version'     => $this->app['bolt_version'],
             'name'        => $this->app['bolt_name'],
-            'fullversion' => 'Version: ' . $this->app->getVersion(true),
+            'fullversion' => 'Version: ' . $this->app['bolt_long_version'],
             'payoff'      => 'Sophisticated, lightweight & simple CMS',
             'aboutlink'   => sprintf('<a href="%s">%s</a>', $this->app->generatePath('about'), 'About'),
             'branding'    => null,

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -17,7 +17,7 @@ class NutServiceProvider implements ServiceProviderInterface
 
                 $console->setName('Bolt console tool - Nut');
                 if ($app instanceof \Bolt\Application) {
-                    $console->setVersion($app->getVersion());
+                    $console->setVersion($app['bolt_long_version']);
                 }
 
                 $console->addCommands($app['nut.commands']);


### PR DESCRIPTION
This is in an effort to not couple our code to `Bolt\Application`