### PR TITLE
Fix record retrieval for ownership checking

### DIFF
--- a/src/Permissions.php
+++ b/src/Permissions.php
@@ -666,7 +666,7 @@ class Permissions
                 // If content was not passed but our rule contains the content
                 // we need, lets fetch the Content object @see #3909
                 if (is_string($content) || ($contenttype && $contentId)) {
-                    $content = $this->app['storage']->getContent("$contenttype/$contentId", array('hydrate' => false));
+                    $content = $this->app['storage']->getContent("$contenttype/$contentId", array('hydrate' => false, 'status' => '!undefined'));
                 }
 
                 if (intval($content['ownerid']) && (intval($content['ownerid']) === intval($user['id']))) {


### PR DESCRIPTION
The missing parameter was preventing `Bolt\Storage::getContent()` to bypass the forced `published` status for retrieved records.

I've seen this "trick" being used in `Bolt\Controllers\Backend` for example.

Please see #3466 for the full discussion.