### PR TITLE
[2.2] Fix the info text for imagelist fields

### DIFF
--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -5,7 +5,7 @@
     label:       field.label|default(''),
     upload:      field.upload|default(''),
     can_upload:  field.canUpload,
-    info:        field.info|default('info.upload.filelist')
+    info:        field.info|default('info.upload.imagelist')
 } %}
 
 {#=== INIT ===========================================================================================================#}


### PR DESCRIPTION
The info text for `imagelist` fields pointed to the text for `filelist` fields.

I sent a PR for `master` as well : #4052