### PR TITLE
Fix the info text for imagelist fields

### DIFF
--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -5,7 +5,7 @@
     label:       field.label,
     upload:      field.upload|default(''),
     can_upload:  field.canUpload,
-    info:        field.info|default('info.upload.filelist')
+    info:        field.info|default('info.upload.imagelist')
 } %}
 
 {#=== INIT ===========================================================================================================#}


### PR DESCRIPTION
The info text for `imagelist` fields pointed to the text for `filelist` fields.

I sent a PR for `release/2.2` as well : #4051