### PR TITLE
[RFC] Change used date-time format to a more i18n-friendly format

### DIFF
--- a/app/view/twig/editcontent/_aside-status.twig
+++ b/app/view/twig/editcontent/_aside-status.twig
@@ -10,7 +10,7 @@
 
 <p class="lastsaved">
     {% if context.content.id is not empty %}
-    {{ __('Saved on:') }} <strong>{{ context.content.datechanged|localdate("%b %e, %H:%M") }}</strong>
+    {{ __('Saved on:') }} <strong>{{ context.content.datechanged|localdate("%c") }}</strong>
     <small>({{ buic.moment(context.content.datechanged) }})</small>
 {% else %}
     {{ __('contenttypes.generic.not-saved-yet', {'%contenttype%': context.contenttype.slug}) }}

--- a/app/view/twig/editcontent/_buttons.twig
+++ b/app/view/twig/editcontent/_buttons.twig
@@ -61,7 +61,7 @@
         <p class="lastsaved form-control-static">
             {% if context.content.id != 0 %}
                 {{ __('Saved on:') }}
-                <strong>{{ context.content.datechanged|localdate("%b %e, %H:%M") }}</strong>
+                <strong>{{ context.content.datechanged|localdate("%c") }}</strong>
                 <small>({{ buic.moment(context.content.datechanged) }})</small>
             {% else %}
                 {{ __('contenttypes.generic.not-saved-yet', {'%contenttype%': context.contenttype.slug}) }}

--- a/app/view/twig/editfile/editfile.twig
+++ b/app/view/twig/editfile/editfile.twig
@@ -65,7 +65,7 @@
 
             <p class="lastsaved" style="padding-top: 12px;">
                 {{ __('Saved on:') }}
-                <strong>{{ context.datechanged|localdate("%b %e, %H:%M") }}</strong>
+                <strong>{{ context.datechanged|localdate("%c") }}</strong>
                 ({{ buic.moment(context.datechanged) }})
             </p>
 


### PR DESCRIPTION
Hey folks,

I don't consider this a bug or an improvement, it's just some proposed changes.

Basically, the `%b %e, %H:%M` date-time format is used throughout the backend. The "problem" is that it puts the month number before the day number, which is not the way to go in French for example, as we normally put the day number before the month number. I personally don't mind this so much, but I can see how this can be a problem for some of my picky clients.

So I propose to use the `%c` format instead, even though I know it's not ideal, because it's a bit verbose, but it's the only _l10n-friendly_ format available for `strftime()`.

What do you think?