### PR TITLE
Don't sort getContent in listing view, when the contenttype has a taxonomy that has a sortorder.

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -256,6 +256,8 @@ class Frontend extends ConfigurableBase
         if (!$order = $this->getOption('theme/listing_sort', false)) {
             $order = empty($contenttype['sort']) ? null : $contenttype['sort'];
         }
+        // If $order is not set, one of two things can happen: Either we let `getContent()` sort by itself, or we
+        // explicitly set it to sort on the general/listing_sort setting.
         if ($order === null) {
             $taxonomies = $this->getOption('taxonomy');
             $hassortorder = false;

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -254,7 +254,23 @@ class Frontend extends ConfigurableBase
             $amount = empty($contenttype['listing_records']) ? $this->getOption('general/listing_records') : $contenttype['listing_records'];
         }
         if (!$order = $this->getOption('theme/listing_sort', false)) {
-            $order = empty($contenttype['sort']) ? $this->getOption('general/listing_sort') : $contenttype['sort'];
+            $order = empty($contenttype['sort']) ? null : $contenttype['sort'];
+        }
+        if ($order === null) {
+            $taxonomies = $this->getOption('taxonomy');
+            $hassortorder = false;
+            if (!empty($contenttype['taxonomy'])) {
+                foreach($contenttype['taxonomy'] as $contenttypetaxonomy) {
+                    if ($taxonomies[ $contenttypetaxonomy ]['has_sortorder']) {
+                        // We have a taxonomy with a sortorder, so we must keep $order = false, in order
+                        // to let `getContent()` handle it. We skip the fallback that's a few lines below.
+                        $hassortorder = true;
+                    }
+                }
+            }
+            if (!$hassortorder) {
+                $order = $this->getOption('general/listing_sort');
+            }
         }
 
         $content = $this->getContent($contenttype['slug'], ['limit' => $amount, 'order' => $order, 'page' => $page, 'paging' => true]);


### PR DESCRIPTION
Fixes #3977 