### PR TITLE
[2.2] Don't sort getContent in listing view, when the contenttype has a taxonomy that has a sortorder.

### DIFF
--- a/app/view/twig/editfile/editfile.twig
+++ b/app/view/twig/editfile/editfile.twig
@@ -64,13 +64,8 @@
 
             <p class='lastsaved' style='padding-top: 12px;'>
                 {{ __('Saved on:') }}
-<<<<<<< HEAD
-                <strong>{{ context.datechanged|localdate("%b %e, %H:%M") }}</strong>
-                <small>({{ macro.datetime(context.datechanged) }})</small>
-=======
                 <strong>{{ context.datechanged|localdate("%c") }}</strong>
-                ({{ buic.moment(context.datechanged) }})
->>>>>>> 7736b5b... Change used date-time format to a more i18n-friendly format
+                <small>({{ macro.datetime(context.datechanged) }})</small>
             </p>
 
             </form>

--- a/src/Controllers/Frontend.php
+++ b/src/Controllers/Frontend.php
@@ -229,7 +229,30 @@ class Frontend
         // First, get some content
         $page = $query->get($pagerid, $query->get('page', 1));
         $amount = (!empty($contenttype['listing_records']) ? $contenttype['listing_records'] : $app['config']->get('general/listing_records'));
-        $order = (!empty($contenttype['sort']) ? $contenttype['sort'] : $app['config']->get('general/listing_sort'));
+
+        if (!$order = $app['config']->get('theme/listing_sort', false)) {
+            $order = empty($contenttype['sort']) ? null : $contenttype['sort'];
+        }
+
+        // If $order is not set, one of two things can happen: Either we let `getContent()` sort by itself, or we
+        // explicitly set it to sort on the general/listing_sort setting.
+        if ($order === null) {
+            $taxonomies = $app['config']->get('taxonomy');
+            $hassortorder = false;
+            if (!empty($contenttype['taxonomy'])) {
+                foreach($contenttype['taxonomy'] as $contenttypetaxonomy) {
+                    if ($taxonomies[ $contenttypetaxonomy ]['has_sortorder']) {
+                        // We have a taxonomy with a sortorder, so we must keep $order = false, in order
+                        // to let `getContent()` handle it. We skip the fallback that's a few lines below.
+                        $hassortorder = true;
+                    }
+                }
+            }
+            if (!$hassortorder) {
+                $order = $app['config']->get('general/listing_sort');
+            }
+        }
+
         $content = $app['storage']->getContent($contenttype['slug'], array('limit' => $amount, 'order' => $order, 'page' => $page, 'paging' => true));
 
         $template = $app['templatechooser']->listing($contenttype);


### PR DESCRIPTION
Fixes #3977 for `release/2.2`.