### PR TITLE
Ignore theme directory except for base-* and default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ extensions/*
 thumbs/
 vendor/
 phpunit.xml
+theme/*
+!theme/base-*
+!theme/default
 
 # Unless you want to store vendor's "state" in your Git repo.
 composer.phar


### PR DESCRIPTION
This prevents the :koala: from committing a theme when working on a core repo… 