### PR TITLE
Controller mounting tweaks

### DIFF
--- a/src/Events/MountEvent.php
+++ b/src/Events/MountEvent.php
@@ -21,9 +21,6 @@ class MountEvent extends Event
     /** @var ControllerCollection */
     protected $collection;
 
-    /** @var array Controllers grouped by priorities */
-    protected $priorities = [];
-
     /**
      * @param Application $app
      * @param ControllerCollection $collection
@@ -47,32 +44,11 @@ class MountEvent extends Event
      *
      * @param string                                           $prefix      The route prefix
      * @param ControllerCollection|ControllerProviderInterface $controllers A ControllerCollection or a ControllerProviderInterface instance
-     * @param int                                              $priority    Priority at which they should be mounted
      */
-    public function mount($prefix, $controllers, $priority = 0)
+    public function mount($prefix, $controllers)
     {
         $controllers = $this->verifyCollection($controllers);
-        $this->priorities[$priority][] = [$prefix, $controllers];
-    }
-
-    /**
-     * Finish mounting process by sorting them and mounting them to application
-     */
-    public function finish()
-    {
-        if ($this->isPropagationStopped()) {
-            return;
-        }
-
-        krsort($this->priorities);
-        foreach ($this->priorities as $priority) {
-            foreach ($priority as $list) {
-                list($prefix, $controllers) = $list;
-                $this->collection->mount($prefix, $controllers);
-            }
-        }
-
-        $this->stopPropagation();
+        $this->collection->mount($prefix, $controllers);
     }
 
     /**

--- a/src/Provider/ControllerServiceProvider.php
+++ b/src/Provider/ControllerServiceProvider.php
@@ -101,10 +101,15 @@ class ControllerServiceProvider implements ServiceProviderInterface, EventSubscr
 
         $event = new MountEvent($app, $app['controllers']);
         $dispatcher->dispatch(ControllerEvents::MOUNT, $event);
-        $event->finish();
     }
 
-    public function mount(MountEvent $event)
+    public function onMountFrontend(MountEvent $event)
+    {
+        $app = $event->getApp();
+        $event->mount('', $app['controller.frontend']);
+    }
+
+    public function onMountBackend(MountEvent $event)
     {
         $app = $event->getApp();
 
@@ -145,15 +150,15 @@ class ControllerServiceProvider implements ServiceProviderInterface, EventSubscr
 
         // Mount the 'thumbnail' provider on /thumbs.
         $event->mount('/thumbs', new ThumbnailProvider());
-
-        // Mount the Frontend controller
-        $event->mount('', $app['controller.frontend'], -50);
     }
 
     public static function getSubscribedEvents()
     {
         return [
-            ControllerEvents::MOUNT => 'mount',
+            ControllerEvents::MOUNT => [
+                ['onMountFrontend', -50],
+                ['onMountBackend'],
+            ],
         ];
     }
 }

--- a/src/Provider/ControllerServiceProvider.php
+++ b/src/Provider/ControllerServiceProvider.php
@@ -9,10 +9,6 @@ use Bolt\Thumbs\ThumbnailProvider;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 class ControllerServiceProvider implements ServiceProviderInterface, EventSubscriberInterface
 {
@@ -154,41 +150,10 @@ class ControllerServiceProvider implements ServiceProviderInterface, EventSubscr
         $event->mount('', $app['controller.frontend'], -50);
     }
 
-    /**
-     * Initial request event.
-     *
-     * @param GetResponseEvent $event
-     */
-    public function onKernelRequest(GetResponseEvent $event)
-    {
-    }
-
-    /**
-     * Pre-send response event.
-     *
-     * @param FilterResponseEvent $event
-     */
-    public function onKernelResponse(FilterResponseEvent $event)
-    {
-    }
-
-    /**
-     * Response event upon exception.
-     *
-     * @param GetResponseForExceptionEvent $event
-     */
-    public function onKernelException(GetResponseForExceptionEvent $event)
-    {
-        //$e = $event->getException();
-    }
-
     public static function getSubscribedEvents()
     {
         return [
             ControllerEvents::MOUNT => 'mount',
-            KernelEvents::REQUEST   => ['onKernelRequest', 32], // Higher than 32 and we don't know the controller
-            KernelEvents::RESPONSE  => ['onKernelResponse', -128],
-            KernelEvents::EXCEPTION => ['onKernelException', -128],
         ];
     }
 }

--- a/src/Provider/ControllerServiceProvider.php
+++ b/src/Provider/ControllerServiceProvider.php
@@ -99,7 +99,7 @@ class ControllerServiceProvider implements ServiceProviderInterface, EventSubscr
         /** @deprecated Since 2.3 and will be removed in Bolt v3.0 */
         $dispatcher->addListener(ControllerEvents::MOUNT, [$app, 'initMountpoints'], -10);
 
-        $event = new MountEvent($app);
+        $event = new MountEvent($app, $app['controllers']);
         $dispatcher->dispatch(ControllerEvents::MOUNT, $event);
         $event->finish();
     }


### PR DESCRIPTION
Updated `Application::mount` to forward to our mount event. This ensures low priority (less than 0) controllers are last.

Cleaned up some of the Controller SP as well.