### PR TITLE
Updated nut.commands.add shortcut to accept callable. Also added example usage.

### DIFF
--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -3,6 +3,7 @@ namespace Bolt\Provider;
 
 use Bolt\Nut;
 use Bolt\Nut\NutApplication;
+use LogicException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Console\Command\Command;
@@ -54,15 +55,50 @@ class NutServiceProvider implements ServiceProviderInterface
             }
         );
 
+        /**
+         * This is a shortcut to add commands to nut lazily.
+         *
+         * Add a single command:
+         *
+         *     $app['nut.commands.add'](function ($app) {
+         *         return new Command1($app);
+         *     });
+         *
+         * Or add multiple commands:
+         *
+         *     $app['nut.commands.add'](function ($app) {
+         *         return [
+         *             new Command1($app),
+         *             new Command2($app),
+         *         ];
+         *     });
+         *
+         * Commands can also be passed in directly. However,
+         * this is NOT recommended because commands are created
+         * even when they are not used, e.g. web requests.
+         *
+         *     $app['nut.commands.add'](new Command1($app));
+         */
         $app['nut.commands.add'] = $app->protect(
-            function (Command $command) use ($app) {
+            function ($commandsToAdd) use ($app) {
                 $app['nut.commands'] = $app->share(
                     $app->extend(
                         'nut.commands',
-                        function ($commands) use ($command) {
-                            $commands[] = $command;
+                        function ($existingCommands, $app) use ($commandsToAdd) {
+                            if (is_callable($commandsToAdd)) {
+                                $commandsToAdd = $commandsToAdd($app);
+                            }
+                            $commandsToAdd = is_array($commandsToAdd) ? $commandsToAdd : [$commandsToAdd];
+                            foreach ($commandsToAdd as $command) {
+                                if (!$command instanceof Command) {
+                                    throw new LogicException(
+                                        'Nut commands must be instances of \Symfony\Component\Console\Command\Command'
+                                    );
+                                }
+                                $existingCommands[] = $command;
+                            }
 
-                            return $commands;
+                            return $existingCommands;
                         }
                     )
                 );

--- a/tests/phpunit/unit/Extensions/BaseExtensionTest.php
+++ b/tests/phpunit/unit/Extensions/BaseExtensionTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Extensions;
 
 use Bolt\Provider\NutServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * Class to test src/BaseExtension.
@@ -561,12 +561,11 @@ class BaseExtensionTest extends AbstractExtensionsUnitTest
     public function testAddNutCommand()
     {
         $app = $this->makeApp();
+        $app->register(new NutServiceProvider());
+
         $ext = $this->getMockForAbstractClass('Bolt\BaseExtension', [$app]);
-        $command = $this->getMock('Symfony\Component\Console\Command\Command', null, ['mockCommand']);
-        $provider = new NutServiceProvider($app);
-        $app->register($provider);
-        $app->boot();
-        $ext->addConsoleCommand($command);
-        $this->assertTrue(in_array($command, $app['nut.commands']));
+        $ext->addConsoleCommand(new Command('test_command'));
+
+        $this->assertTrue($app['nut']->has('test_command'));
     }
 }

--- a/tests/phpunit/unit/Provider/NutServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/NutServiceProviderTest.php
@@ -3,33 +3,76 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\NutServiceProvider;
 use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\Console\Command\Command;
 
 /**
  * Class to test src/Provider/NutServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
+ * @author Carson Full <carsonfull@gmail.com>
  */
 class NutServiceProviderTest extends BoltUnitTest
 {
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new NutServiceProvider($app);
-        $app->register($provider);
+        $app->register(new NutServiceProvider());
+        $app->boot();
+
         $this->assertInstanceOf('Symfony\Component\Console\Application', $app['nut']);
         $this->assertInstanceOf('Symfony\Component\Console\Application', $app['console']);
         $this->assertTrue(is_array($app['nut.commands']));
-        $app->boot();
     }
 
-    public function testAddCommand()
+    public function testAddCommandCallableSingle()
     {
-        $app = $this->makeApp();
-        $provider = new NutServiceProvider($app);
-        $app->register($provider);
-        $app->boot();
-        $command = $this->getMock('Symfony\Component\Console\Command\Command', null, ['mockCommand']);
-        $app['nut.commands.add']($command);
-        $this->assertTrue(in_array($command, $app['nut.commands']));
+        $app = $this->getApp();
+        $app->register(new NutServiceProvider());
+
+        $app['nut.commands.add'](function ($app) {
+            return new Command('command1');
+        });
+
+        $this->assertTrue($app['nut']->has('command1'));
+    }
+
+    public function testAddCommandCallableMultiple()
+    {
+        $app = $this->getApp();
+        $app->register(new NutServiceProvider());
+
+        $app['nut.commands.add'](function ($app) {
+            return [
+                new Command('command1'),
+                new Command('command2'),
+            ];
+        });
+
+        $this->assertTrue($app['nut']->has('command1'));
+        $this->assertTrue($app['nut']->has('command2'));
+    }
+
+    public function testAddCommandSingle()
+    {
+        $app = $this->getApp();
+        $app->register(new NutServiceProvider());
+
+        $command1 = new Command('command1');
+        $app['nut.commands.add']($command1);
+
+        $this->assertTrue($app['nut']->has('command1'));
+    }
+
+    public function testAddCommandMultiple()
+    {
+        $app = $this->getApp();
+        $app->register(new NutServiceProvider());
+
+        $command1 = new Command('command1');
+        $command2 = new Command('command2');
+        $app['nut.commands.add']([$command1, $command2]);
+
+        $this->assertTrue($app['nut']->has('command1'));
+        $this->assertTrue($app['nut']->has('command2'));
     }
 }


### PR DESCRIPTION
Updated nut.commands.add shortcut to accept callable. Also added example usage.

```php
$app['nut.commands.add'](function ($app) {
    return new Command1($app);
});

$app['nut.commands.add'](function ($app) {
    return [
        new Command1($app),
        new Command2($app),
    ];
});
```