### PR TITLE
Use tag names instead of slugs for autocomplete and tag cloud [2.2]

### DIFF
--- a/app/view/twig/editcontent/_taxonomies.twig
+++ b/app/view/twig/editcontent/_taxonomies.twig
@@ -49,7 +49,7 @@
                         success: function(data) {
                             var results = [];
                             $.each(data, function(index, item){
-                                results.push( item.slug );
+                                results.push( item.name );
                             });
                             $('#taxonomy-{{ taxonomy.slug }}').select2({tags: results, minimumInputLength: 1, tokenSeparators: [",", " "]});
                         },
@@ -67,7 +67,7 @@
                         success: function(data) {
                             if (data.length > 0) {
                                 $.each(data, function(index, item){
-                                    $("#tagcloud-{{ taxonomy.slug }}").append('<a href="#" rel="' + item.count + '">' + item.slug + '</a>');
+                                    $("#tagcloud-{{ taxonomy.slug }}").append('<a href="#" rel="' + item.count + '">' + item.name + '</a>');
                                 });
                                 $("#tagcloud-{{ taxonomy.slug }} a").on('click', function (e) {
                                     e.preventDefault();

--- a/src/Controllers/Async.php
+++ b/src/Controllers/Async.php
@@ -341,7 +341,7 @@ class Async implements ControllerProviderInterface
         $table .= 'taxonomy';
 
         $query = $app['db']->createQueryBuilder()
-            ->select("DISTINCT $table.slug")
+            ->select("DISTINCT $table.name")
             ->from($table)
             ->where('taxonomytype = :taxonomytype')
             ->orderBy('slug', 'ASC')
@@ -369,7 +369,7 @@ class Async implements ControllerProviderInterface
         $table .= 'taxonomy';
 
         $query = $app['db']->createQueryBuilder()
-            ->select('slug, COUNT(slug) AS count')
+            ->select('name, COUNT(slug) AS count')
             ->from($table)
             ->where('taxonomytype = :taxonomytype')
             ->groupBy('slug')
@@ -384,11 +384,11 @@ class Async implements ControllerProviderInterface
         usort(
             $results,
             function ($a, $b) {
-                if ($a['slug'] == $b['slug']) {
+                if ($a['name'] == $b['name']) {
                     return 0;
                 }
 
-                return ($a['slug'] < $b['slug']) ? -1 : 1;
+                return ($a['name'] < $b['name']) ? -1 : 1;
             }
         );
 


### PR DESCRIPTION
Backport of #4125 for 2.2

Not sure if you want to merge this in 2.2 or not. To me this seems like a fix that anybody would want, but it does change the way the tagging widgets work.