### PR TITLE
Enhancement - Added the ability to allow for Multi Sort Functionality in getContent

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1871,21 +1871,43 @@ class Storage
      */
     private function isValidColumn($name, $contenttype, $allowVariants = false)
     {
-        // Strip the minus in '-title' if allowed.
-        if ($allowVariants) {
-            if ((strlen($name) > 0) && ($name[0] == "-")) {
-                $name = substr($name, 1);
+        $isValidColumn = false;
+
+        if ($this->isMultiOrderQuery($name)) {
+            $separatedOrders = $this->getOrderBys($name);
+        } else {
+            $separatedOrders = [$name];
+        }
+
+        //Loop through each term if multiple
+        foreach ($separatedOrders as $index => $name) {
+
+            $name = trim($name);
+
+            // Strip the minus in '-title' if allowed.
+            if ($allowVariants) {
+                if ((strlen($name) > 0) && ($name[0] == "-")) {
+                    $name = substr($name, 1);
+                }
+                $name = $this->getFieldName($name);
             }
-            $name = $this->getFieldName($name);
+
+            // Check if the $name is in the contenttype's fields.
+            if (isset($contenttype['fields'][$name])) {
+                $isValidColumn = true;
+            }
+
+            if (in_array($name, Content::getBaseColumns())) {
+                $isValidColumn = true;
+            }
+
+            if (! $isValidColumn) {
+                return false;
+            }
+
         }
-        // Check if the $name is in the contenttype's fields.
-        if (isset($contenttype['fields'][$name])) {
-            return true;
-        }
-        if (in_array($name, Content::getBaseColumns())) {
-            return true;
-        }
-        return false;
+
+        return true;
     }
 
     /**

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1878,16 +1878,13 @@ class Storage
             }
             $name = $this->getFieldName($name);
         }
-
         // Check if the $name is in the contenttype's fields.
         if (isset($contenttype['fields'][$name])) {
             return true;
         }
-
         if (in_array($name, Content::getBaseColumns())) {
             return true;
         }
-
         return false;
     }
 
@@ -1940,8 +1937,9 @@ class Storage
                 $order .= ' DESC';
             }
 
-            if ($this->isNotLastItemInArray($totalOrderByElements, $index))
+            if ($this->isNotLastItemInArray($totalOrderByElements, $index)) {
                 $order .= ',';
+            }
         }
 
         return $order;
@@ -1963,7 +1961,7 @@ class Storage
      */
     protected function getOrderBys($order)
     {
-        $separatedOrders[] = $order;
+        $separatedOrders = [$order];
 
         if ($this->isMultiOrderQuery($order))
             $separatedOrders = explode(",", $order);
@@ -1977,7 +1975,7 @@ class Storage
      */
     protected function isMultiOrderQuery($order)
     {
-        return ( strpos($order, ',') !== false ? true : false );
+        return strpos($order, ',') !== false;
     }
 
     /**

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1977,7 +1977,7 @@ class Storage
      */
     protected function isMultiOrderQuery($order)
     {
-        return ( strpos($order, ',') !== FALSE ? TRUE : FALSE );
+        return ( strpos($order, ',') !== false ? true : false );
     }
 
     /**

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1915,25 +1915,69 @@ class Storage
      */
     private function getEscapedSortorder($name, $prefix = 'r')
     {
-        list($name, $asc) = $this->getSortOrder($name);
+        $order = '';
 
-        // If we don't have a name, we can't determine a sortorder.
-        if (empty($name)) {
-            return false;
-        }
-        if (strpos($name, 'RAND') !== false) {
-            $order = $name;
-        } elseif ($prefix !== false) {
-            $order = $this->app['db']->quoteIdentifier($prefix . '.' . $name);
-        } else {
-            $order = $this->app['db']->quoteIdentifier($name);
-        }
+        $separatedOrders = $this->getOrderBys($name);
 
-        if (! $asc) {
-            $order .= ' DESC';
+        $totalOrderByElements = count($separatedOrders);
+
+        foreach ($separatedOrders as $index => $name) {
+            list($name, $asc) = $this->getSortOrder($name);
+
+            // If we don't have a name, we can't determine a sortorder.
+            if (empty($name)) {
+                return false;
+            }
+            if (strpos($name, 'RAND') !== false) {
+                $order .= $name;
+            } elseif ($prefix !== false) {
+                $order .= $this->app['db']->quoteIdentifier($prefix . '.' . $name);
+            } else {
+                $order .= $this->app['db']->quoteIdentifier($name);
+            }
+
+            if (! $asc) {
+                $order .= ' DESC';
+            }
+
+            if ($this->isNotLastItemInArray($totalOrderByElements, $index))
+                $order .= ',';
         }
 
         return $order;
+    }
+
+    /**
+     * @param $totalOrderByElements
+     * @param $index
+     * @return bool
+     */
+    protected function isNotLastItemInArray($totalOrderByElements, $index)
+    {
+        return $totalOrderByElements !== ($index+1);
+    }
+
+    /**
+     * @param $order
+     * @return array
+     */
+    protected function getOrderBys($order)
+    {
+        $separatedOrders[] = $order;
+
+        if ($this->isMultiOrderQuery($order))
+            $separatedOrders = explode(",", $order);
+
+        return $separatedOrders;
+    }
+
+    /**
+     * @param $order
+     * @return bool
+     */
+    protected function isMultiOrderQuery($order)
+    {
+        return ( strpos($order, ',') !== FALSE ? TRUE : FALSE );
     }
 
     /**

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1922,7 +1922,7 @@ class Storage
         $totalOrderByElements = count($separatedOrders);
 
         foreach ($separatedOrders as $index => $name) {
-            list($name, $asc) = $this->getSortOrder($name);
+            list($name, $asc) = $this->getSortOrder(trim($name));
 
             // If we don't have a name, we can't determine a sortorder.
             if (empty($name)) {

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1963,8 +1963,9 @@ class Storage
     {
         $separatedOrders = [$order];
 
-        if ($this->isMultiOrderQuery($order))
+        if ($this->isMultiOrderQuery($order)) {
             $separatedOrders = explode(",", $order);
+        }
 
         return $separatedOrders;
     }

--- a/src/Storage/Query/Handler/OrderHandler.php
+++ b/src/Storage/Query/Handler/OrderHandler.php
@@ -17,12 +17,40 @@ class OrderHandler
      */
     public function __invoke(QueryInterface $query, $order)
     {
-        if (strpos($order, '-') === 0) {
-            $direction = 'DESC';
-            $order = substr($order, 1);
-        } else {
-            $direction = null;
+        $separatedOrders = $this->getOrderBys($order);
+
+        foreach ($separatedOrders as $order) {
+            if (strpos($order, '-') === 0) {
+                $direction = 'DESC';
+                $order = substr($order, 1);
+            } else {
+                $direction = null;
+            }
+            $query->getQueryBuilder()->orderBy($order, $direction);
         }
-        $query->getQueryBuilder()->orderBy($order, $direction);
+
+    }
+
+    /**
+     * @param $order
+     * @return array
+     */
+    protected function getOrderBys($order)
+    {
+        $separatedOrders[] = $order;
+
+        if ($this->isMultiOrderQuery($order))
+            $separatedOrders = explode(",", $order);
+
+        return $separatedOrders;
+    }
+
+    /**
+     * @param $order
+     * @return bool
+     */
+    protected function isMultiOrderQuery($order)
+    {
+        return ( strpos($order, ',') !== FALSE ? TRUE : FALSE );
     }
 }

--- a/src/Storage/Query/Handler/OrderHandler.php
+++ b/src/Storage/Query/Handler/OrderHandler.php
@@ -20,6 +20,7 @@ class OrderHandler
         $separatedOrders = $this->getOrderBys($order);
 
         foreach ($separatedOrders as $order) {
+            $order = trim($order);
             if (strpos($order, '-') === 0) {
                 $direction = 'DESC';
                 $order = substr($order, 1);

--- a/src/Storage/Query/Handler/OrderHandler.php
+++ b/src/Storage/Query/Handler/OrderHandler.php
@@ -38,10 +38,11 @@ class OrderHandler
      */
     protected function getOrderBys($order)
     {
-        $separatedOrders[] = $order;
+        $separatedOrders = [$order];
 
-        if ($this->isMultiOrderQuery($order))
+        if ($this->isMultiOrderQuery($order)) {
             $separatedOrders = explode(",", $order);
+        }
 
         return $separatedOrders;
     }
@@ -52,6 +53,6 @@ class OrderHandler
      */
     protected function isMultiOrderQuery($order)
     {
-        return ( strpos($order, ',') !== false ? true : false );
+        return strpos($order, ',') !== false;
     }
 }

--- a/src/Storage/Query/Handler/OrderHandler.php
+++ b/src/Storage/Query/Handler/OrderHandler.php
@@ -52,6 +52,6 @@ class OrderHandler
      */
     protected function isMultiOrderQuery($order)
     {
-        return ( strpos($order, ',') !== FALSE ? TRUE : FALSE );
+        return ( strpos($order, ',') !== false ? true : false );
     }
 }


### PR DESCRIPTION
Modified the legacy and upcoming storage system to allow for multi sort in the setcontent query. Now queries can be used as follows to sort on multiple columns. 

Ex.:
```twig
{% setcontent 'entity' orderby('-name, title') %}
```

**Edit**
Fixes #1255
Fixes #2234