### PR TITLE
Fixed missing variable permissions in _relations.twig. [2.2]

### DIFF
--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -21,7 +21,7 @@
                 {% setcontent record = reltype ~ '/' ~ id %}
                 {% if record %}
                     {% set editable = isallowed('edit', record) %}
-                    {% include ['_sub/_listing.twig'] with {'excerptlength': 280, 'thumbsize': 54, 'compact': true, 'content': record} %}
+                    {% include ['_sub/_listing.twig'] with {'excerptlength': 280, 'thumbsize': 54, 'compact': true, 'content': record, 'permissions': context.permissions} %}
                 {% endif %}
             {% endfor %}
         </table>

--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1051,6 +1051,7 @@ class Backend implements ControllerProviderInterface
             'contentowner'   => $contentowner,
             'fields'         => $app['config']->fields->fields(),
             'fieldtemplates' => $templateFieldTemplates,
+            'permissions'    => $this->getContentTypeUserPermissions($app, $contenttypeslug, $app['users']->getCurrentUser()),
             'can_upload'     => $app['users']->isAllowed('files:uploads'),
             'groups'         => $groups,
             'has'            => array(


### PR DESCRIPTION
This is a nasty bug that only reveals itself if you have `strict_variables: true`. It appears to have been introduced in 2.2.9 or 10.

How to reproduce:

* Set `strict_variables: true` in `config.yml`.
* Add a relation to `pages` in the `entries` content type.
* Create a page.
* Create an entry that references the page.
* Edit the page. You should get *Variable "permissions" does not exist in "_base/_listing.twig" at line 3*.

I actually haven't tested this in master, so I don't know if it needs to be ported.

Happy friday!