### PR TITLE
Fix: Don't show notice about `mailoptions` when not logged on. 

### DIFF
--- a/src/EventListener/GeneralListener.php
+++ b/src/EventListener/GeneralListener.php
@@ -74,7 +74,7 @@ class GeneralListener implements EventSubscriberInterface
             return;
         }
 
-        if (!$this->app['config']->get('general/mailoptions') && $this->app['extensions']->hasMailSenders()) {
+        if ($this->app['users']->getCurrentuser() && !$this->app['config']->get('general/mailoptions') && $this->app['extensions']->hasMailSenders()) {
             $error = "One or more installed extensions need to be able to send email. Please set up the 'mailoptions' in config.yml.";
             $this->app['logger.flash']->error(Trans::__($error));
         }


### PR DESCRIPTION
Only show notice when logged on. Fixes #4126. Fixes #3905.