### PR TITLE
[2.2] Fix: Don't show notice about `mailoptions` when not logged on.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -448,7 +448,7 @@ class Application extends Silex\Application
      */
     public function initMailCheck()
     {
-        if (!$this['config']->get('general/mailoptions') && $this['extensions']->hasMailSenders()) {
+        if ($this['users']->getCurrentuser() && !$this['config']->get('general/mailoptions') && $this['extensions']->hasMailSenders()) {
             $error = "One or more installed extensions need to be able to send email. Please set up the 'mailoptions' in config.yml.";
             $this['session']->getFlashBag()->add('error', Trans::__($error));
         }


### PR DESCRIPTION
Only show notice when logged on. Fixes #4126. Fixes #3905.