### PR TITLE
Strip tags from title in editcontent. Fixes #3590

### DIFF
--- a/app/view/twig/editcontent/editcontent.twig
+++ b/app/view/twig/editcontent/editcontent.twig
@@ -16,7 +16,7 @@
     {% endif %}
 {% endblock page_title %}
 
-{% block page_subtitle context.content.title|default('') %}
+{% block page_subtitle context.content.title|default('')|striptags %}
 
 {# clear default messages, because we use them in a different spot, in this template #}
 {% block messages "" %}


### PR DESCRIPTION
Strip tags from title in editcontent. I used striptags instead of escape since this mimics the behaviour in backend listings and the backend menu. Fixes #3590