### PR TITLE
Fix secondary nav element's class not being output in certain cases

### DIFF
--- a/app/view/twig/nav/_macros.twig
+++ b/app/view/twig/nav/_macros.twig
@@ -43,15 +43,13 @@
 
     {# Show stuff! #}
     {% if allowedany %}
-        {% if allowedamount == 1 and not force_submenu|default(false) %}
-            {% set item = allowedsingle %}
-            <li>
+        <li{% if class %} class="{{ class }}"{% endif %}>
+            {% if allowedamount == 1 and not force_submenu|default(false) %}
+                {% set item = allowedsingle %}
                 <a href="{{ item.link }}">
                     {{ icon(item.icon, "icon") }}{{ item.label|default("<em>(" ~ __("no content …") ~ ")</em>")|raw }}
                 </a>
-            </li>
-        {% else %}
-            <li{% if class %} class="{{ class }}"{% endif %}>
+            {% else %}
                 <a  href="{% if popoveritems %}{{ popoveritems.0.link }}{% else %}#{% endif %}" class="menu-pop">
                     {{ label(icon, label) }}
                 </a>
@@ -70,8 +68,8 @@
                         {% endif %}
                     {% endfor %}
                 </ul>
-            </li>
-        {% endif %}
+            {% endif %}
+        </li>
     {% endif %}
 
 {% endmacro %}


### PR DESCRIPTION
So, I don't know if there was a reason for the element's `class` not being output when `allowedamount == 1`, but it produces the following visual bug:

![Illustrative screenshot](https://cloud.githubusercontent.com/assets/8007715/10207051/6e7a74ca-67ca-11e5-908b-6f3559c64378.png)

This fixes it, but I hope it doesn't have any side effects?

I sent a PR for `release/2.2` as well: #4173