### PR TITLE
Add the fieldtype 'time' with an hourly range dropdown menu, issue #3823

### DIFF
--- a/app/config/contenttypes.yml.dist
+++ b/app/config/contenttypes.yml.dist
@@ -142,6 +142,34 @@ showcases:
             type: date
             default: "first day of last month"
             variant: inline
+        time:
+            type: select
+            values:
+              - 12 AM
+              - 1 AM
+              - 2 AM
+              - 3 AM
+              - 4 AM
+              - 5 AM
+              - 6 AM
+              - 7 AM
+              - 8 AM
+              - 9 AM
+              - 10 AM
+              - 11 AM
+              - 12 PM
+              - 1 PM
+              - 2 PM
+              - 3 PM
+              - 4 PM
+              - 5 PM
+              - 6 PM
+              - 7 PM
+              - 8 PM
+              - 9 PM
+              - 10 pm
+              - 11 pm
+            multiple: false
         integerfield:
             type: integer
             index: true
@@ -258,5 +286,6 @@ showcases:
 # select - varchar(256) - select with predefined values
 # templateselect - varchar(256) - select with template filenames
 # checkbox - integer - checkbox-field which is 1 (checked) or 0 (unchecked)
+# time - select - Select with the ability to choose a predefined time.
 
 # number (deprecated) - input type decimal(18,9), useful for storing number that need to be sortable


### PR DESCRIPTION
Suggested by issue #3823 https://github.com/bolt/bolt/issues/3823

A field type that has a drop down of different hourly times to choose from.