### PR TITLE
Fixes #3868 - Taxonomies being wiped on status change using grouped taxonomy

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -2359,19 +2359,22 @@ class Storage
      * @see https://github.com/bolt/bolt/issues/3908
      *
      * @param Content $content
+     * @param string  $taxonomytype
      * @param array   $taxonomy
      *
      * @return array
      */
-    private function getIndexedTaxonomy($content, $taxonomy)
+    private function getIndexedTaxonomy($content, $taxonomytype, $taxonomy)
     {
+        $configTaxonomies = $this->app['config']->get('taxonomy');
+
         if (Arr::isIndexedArray($taxonomy)) {
             return $taxonomy;
         }
 
         $ret = array();
         foreach ($taxonomy as $key) {
-            if ($content->group !== null) {
+            if ($configTaxonomies[$taxonomytype]['behaves_like'] == 'grouping' && $content->group !== null) {
                 $ret[] = $content->group['slug'] . '#' . $content->group['order'];
             } else {
                 $ret[] = $key;
@@ -2409,7 +2412,7 @@ class Storage
         foreach ($contenttype['taxonomy'] as $taxonomytype) {
             // Set 'newvalues to 'empty array' if not defined
             if (!empty($taxonomy[$taxonomytype])) {
-                $newslugs = $this->getIndexedTaxonomy($content, $taxonomy[$taxonomytype]);
+                $newslugs = $this->getIndexedTaxonomy($content, $taxonomytype, $taxonomy[$taxonomytype]);
             } else {
                 $newslugs = array();
             }


### PR DESCRIPTION
When using status updates with contenttypes with multiple taxonomies
and one taxonomy is defined with `grouping` all taxonomy values are set
to the value of the `grouping` taxonomy.  By passing the taxonomy type
to `getIndexedTaxonomy()` non-grouped item values are preserved.

Example to replicate.  Consider a taxonomy as follows:

```
region:
    name: Region
    slug: region
    multiple: false
    behaves_like: categories
    options: [ North, South, East, West ]
    listing_template: listing.twig

types:
    name: Types
    slug: types
    singular_name: type
    singular_slug: type
    behaves_like: grouping
    multiple: false
    options: [ Article, Gallery, Video, Event ]
    listing_template: listing.twig
```

If a contenttype refers to both taxonomies and the status is changed via the dashboard or article list, all taxonomies are set to the value of `types`.