### PR TITLE
[2.2] Use hydration for `{{ record.previous() }}` and `{{ record.next() }}`.

### DIFF
--- a/src/Content.php
+++ b/src/Content.php
@@ -1254,7 +1254,7 @@ class Content implements \ArrayAccess
             'limit'        => 1,
             'order'        => $field . $order,
             'returnsingle' => true,
-            'hydrate'      => false
+            'hydrate'      => true
         );
 
         $pager = array();
@@ -1285,7 +1285,7 @@ class Content implements \ArrayAccess
             'limit'        => 1,
             'order'        => $field . $order,
             'returnsingle' => true,
-            'hydrate'      => false
+            'hydrate'      => true
         );
 
         $pager = array();


### PR DESCRIPTION
 Fixes #4075.