### PR TITLE
Renamed example repeat field.

### DIFF
--- a/app/config/contenttypes.yml.dist
+++ b/app/config/contenttypes.yml.dist
@@ -165,7 +165,7 @@ showcases:
             type: templateselect
             filter: '*.twig'
             group: meta
-        repeat:
+        repeater:
             type: repeater
             limit: 3
             fields:

--- a/tests/phpunit/unit/Storage/FieldLoadTest.php
+++ b/tests/phpunit/unit/Storage/FieldLoadTest.php
@@ -49,9 +49,9 @@ class FieldLoadTest extends BoltUnitTest
         $this->addSomeFields();
         $repo = $em->getRepository('showcases');
         $record = $repo->find(1);
-        $this->assertInstanceOf('Bolt\Storage\Field\Collection\RepeatingFieldCollection', $record->repeat);
-        $this->assertEquals(2, count($record->repeat));
-        foreach ($record->repeat as $collection) {
+        $this->assertInstanceOf('Bolt\Storage\Field\Collection\RepeatingFieldCollection', $record->repeater);
+        $this->assertEquals(2, count($record->repeater));
+        foreach ($record->repeater as $collection) {
             $this->assertInstanceOf('Bolt\Storage\Field\Collection\FieldCollection', $collection);
             foreach ($collection as $fieldValue) {
                 $this->assertInstanceOf('Bolt\Storage\Entity\FieldValue', $fieldValue);
@@ -90,7 +90,7 @@ class FieldLoadTest extends BoltUnitTest
             ['repeattitle' => 'Test', 'repeatimage' => ['file' => 'example.jpg', 'title' => 'Test Image']],
             ['repeattitle' => 'Test 2', 'repeatimage' => ['file' => 'example2.jpg', 'title' => 'Test Image 2']],
         ];
-        $content->setRepeat($repeat);
+        $content->setRepeater($repeat);
 
         $repo->save($content);
     }


### PR DESCRIPTION
This was causing errors to be thrown on the dashboard, due to the fact
that "repeat" is a reserved word in MySQL.

Fixes #4272.

Mentioning brown M&Ms, as per the contributing doc!