### PR TITLE
Update .htaccess 78 characters for terminal

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -39,7 +39,8 @@ Options -Indexes
 # =============================================
 # if you don't set your own mimetypes or you aren't using
 # HTML5 Boilerplate Server Configs https://github.com/h5bp/server-configs-apache
-# then you can uncomment (delete the hash/pound/octothorpe/number symbol) the section below:
+# then you can uncomment (delete the hash/pound/octothorpe/number symbol)
+# the section below:
 
 #<IfModule mod_mime.c>
 #  AddType application/font-woff2    woff2


### PR DESCRIPTION
If you copy paste this in a standard terminal it will put the text "the section below" to a new line. This will result in a fault in .htaccess. That's why "the section below" is maby better on a new line.