### PR TITLE
Not found using a template instead of a database record

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -86,6 +86,7 @@ homepage_template: index.twig
 # Note 1: The record specified in this parameter must be set to 'published'
 # Note 2: If you are logged on, and debug is set to 'true', you will NOT see the
 #         404 page!
+# Note 3: This may also point to a template without a record, eg error404.twig
 notfound: page/not-found
 
 # The default template and amount of records to use for listing-pages on the

--- a/src/Application.php
+++ b/src/Application.php
@@ -629,13 +629,17 @@ class Application extends Silex\Application
 
         $end = $this['config']->getWhichEnd();
         if (($exception instanceof HttpException) && ($end == 'frontend')) {
-            $content = $this['storage']->getContent($this['config']->get('general/notfound'), array('returnsingle' => true));
+            if (substr($this['config']->get('general/notfound'), -5) == '.twig') {
+                return $this['render']->render($this['config']->get('general/notfound'));
+            } else {
+                $content = $this['storage']->getContent($this['config']->get('general/notfound'), array('returnsingle' => true));
 
-            // Then, select which template to use, based on our 'cascading templates rules'
-            if ($content instanceof Content && !empty($content->id)) {
-                $template = $this['templatechooser']->record($content);
+                // Then, select which template to use, based on our 'cascading templates rules'
+                if ($content instanceof Content && !empty($content->id)) {
+                    $template = $this['templatechooser']->record($content);
 
-                return $this['render']->render($template, $content->getTemplateContext());
+                    return $this['render']->render($template, $content->getTemplateContext());
+                }
             }
 
             $message = "The page could not be found, and there is no 'notfound' set in 'config.yml'. Sorry about that.";


### PR DESCRIPTION
I think relying on some magic content in the database for a not found page is a bad thing. The error404 page should work, especially when the database is empty (for whatever eason). So working with a template seems the better option since it will always work.

A default template may also be added if desired, something like:

```
{% include '_header.twig' %}

<article>
    <h1>Page not found</h1>
    <p>The requested URL "{{ app.request.getRequestUri }}" was not found.</p>
</article>

{% include '_footer.twig' %}
```

This is just for 2.2 since I don't have a master/2.3 setup and notfound handling seems changed in master.