### PR TITLE
Twig image handler tests & reorganisation

### DIFF
--- a/src/Helpers/Image/Image.php
+++ b/src/Helpers/Image/Image.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Bolt\Helpers\Image;
+
+use PHPExif\Exif;
+use PHPExif\Reader\Reader as ExifReader;
+
+/**
+ * Image helper class.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class Image implements \ArrayAccess
+{
+    /** @var string */
+    protected $filename;
+    /** @var string */
+    protected $fullpath;
+    /** @var string */
+    protected $url;
+    /** @var integer */
+    protected $width;
+    /** @var integer */
+    protected $height;
+    /** @var string */
+    protected $type;
+    /** @var string */
+    protected $mime;
+    /** @var float */
+    protected $aspectratio;
+    /** @var array */
+    protected $exif;
+    /** @var boolean */
+    protected $landscape;
+    /** @var boolean */
+    protected $portrait;
+    /** @var boolean */
+    protected $square;
+
+    /**
+     * Constructor.
+     *
+     * @param string $fileName
+     * @param string $boltFilesUri
+     * @param string $boltFilesUri
+     */
+    public function __construct($fileName, $boltFilesPath, $boltFilesUri)
+    {
+        $fileFullPath = sprintf('%s/%s', $boltFilesPath, $fileName);
+        $fileFullPath = realpath($fileFullPath);
+        if (!is_readable($fileFullPath)) {
+            return;
+        }
+        $this->filename = basename($fileFullPath);
+        $this->fullpath = $fileFullPath;
+        $this->url = str_replace('//', '/', $boltFilesUri . $this->filename);
+
+        $this->setImageAttributes();
+        $this->setAspectRatio();
+        $this->setImageExifData();
+    }
+
+    public function offsetExists($offset)
+    {
+        return property_exists($this, $offset);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->$offset;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->$offset = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        $this->$offset = null;
+    }
+
+    /**
+     * Set the base image attributes.
+     */
+    protected function setImageAttributes()
+    {
+        $types = [
+            0 => 'unknown',
+            1 => 'gif',
+            2 => 'jpeg',
+            3 => 'png',
+            4 => 'swf',
+            5 => 'psd',
+            6 => 'bmp'
+        ];
+
+        // Get the dimensions of the image
+        $attributes = getimagesize($this->fullpath);
+
+        $this->width = $attributes[0];
+        $this->height = $attributes[1];
+        $this->type = $types[$attributes[2]];
+        $this->mime = $attributes['mime'];
+    }
+
+    /**
+     * Set the aspect ratio for the image.
+     */
+    protected function setAspectRatio()
+    {
+        $this->aspectratio = $this->height > 0 ? $this->width / $this->height : 0;
+
+        // Landscape if aspectratio > 5:4
+        $this->landscape = ($this->aspectratio >= 1.25) ? true : false;
+
+        // Portrait if aspectratio < 4:5
+        $this->portrait = ($this->aspectratio <= 0.8) ? true : false;
+
+        // Square-ish, if neither portrait or landscape
+        $this->square = !$this->landscape && !$this->portrait;
+    }
+
+    /**
+     * Set the EXIF data for the image.
+     */
+    protected function setImageExifData()
+    {
+        $exif = $this->getExif();
+
+        // GPS coordinates
+        $gps = $exif->getGPS();
+        $gps = explode(',', $gps);
+
+        // If the picture is turned by exif, ouput the turned aspectratio
+        if (in_array($exif->getOrientation(), [6, 7, 8])) {
+            $exifturned = $this->height / $this->width;
+        } else {
+            $exifturned = $this->aspectratio;
+        }
+
+        // Output the relevant EXIF info
+        $this->exif = [
+            'latitude'    => isset($gps[0]) ? $gps[0] : false,
+            'longitude'   => isset($gps[1]) ? $gps[1] : false,
+            'datetime'    => $exif->getCreationDate(),
+            'orientation' => $exif->getOrientation(),
+            'aspectratio' => $exifturned ?: false
+        ];
+    }
+
+    /**
+     * Get an EXIF object.
+     *
+     * @return \PHPExif\Exif
+     */
+    protected function getExif()
+    {
+        /** @var $reader \PHPExif\Reader\Reader */
+        $reader = ExifReader::factory(ExifReader::TYPE_NATIVE);
+
+        try {
+            // Get the EXIF data of the image
+            $exif = $reader->read($this->fullpath);
+        } catch (\RuntimeException $e) {
+            // No EXIF data… create an empty object.
+            $exif = new Exif();
+        }
+
+        return $exif;
+    }
+}

--- a/src/Helpers/Image/Thumbnail.php
+++ b/src/Helpers/Image/Thumbnail.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Bolt\Helpers\Image;
+
+/**
+ * Thumbnail helper class.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class Thumbnail
+{
+    /** @var string */
+    protected $fileName;
+    /** @var string */
+    protected $title;
+    /** @var string */
+    protected $altTitle;
+    /** @var integer */
+    protected $height;
+    /** @var integer */
+    protected $width;
+    /** @var string */
+    protected $scale;
+    /** @var array */
+    protected $thumbConf;
+
+    /**
+     * Constructor.
+     *
+     * @param array $thumbConf Values from $app['config']->get('general/thumbnails')
+     */
+    public function __construct(array $thumbConf)
+    {
+        $this->thumbConf = $thumbConf;
+    }
+
+    /**
+     * Get the file name.
+     *
+     * @return string
+     */
+    public function getFileName()
+    {
+        return $this->fileName;
+    }
+
+    /**
+     * Set the file name.
+     *
+     * @param array|string $fileName
+     *
+     * @return Thumbnail
+     */
+    public function setFileName($fileName)
+    {
+        // After v1.5.1 we store image data as an array
+        if (is_array($fileName)) {
+            $rawFileName = isset($fileName['filename']) ? $fileName['filename'] : $fileName['file'];
+            isset($fileName['title']) ? $this->title = $fileName['title'] : $rawFileName;
+            isset($fileName['alt']) ? $this->altTitle = $fileName['alt'] : $rawFileName;
+            $fileName = $rawFileName;
+        }
+        $this->fileName = $fileName;
+
+        return $this;
+    }
+
+    /**
+     * Get the title.
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        if ($this->title) {
+            return $this->title;
+        }
+
+        return $this->altTitle;
+    }
+
+    /**
+     * Set the title.
+     *
+     * @param string $title
+     *
+     * @return Thumbnail
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * Get the alternative title.
+     *
+     * @return string
+     */
+    public function getAltTitle()
+    {
+        if ($this->altTitle) {
+            return $this->altTitle;
+        }
+
+        return $this->title;
+    }
+
+    /**
+     * Set the alternative title.
+     *
+     * @param string $altTitle
+     *
+     * @return Thumbnail
+     */
+    public function setAltTitle($altTitle)
+    {
+        $this->altTitle = $altTitle;
+
+        return $this;
+    }
+    /**
+     * Get the thumbnail width.
+     *
+     * @param boolean $round
+     *
+     * @return integer
+     */
+    public function getWidth($round = true)
+    {
+        if ($round) {
+            return round($this->width);
+        }
+
+        return $this->width;
+    }
+
+    /**
+     * Set the thumbnail width.
+     *
+     * @param integer $width
+     * @param integer $default
+     *
+     * @return Thumbnail
+     */
+    public function setWidth($width, $default = 100)
+    {
+        if (!is_numeric($width)) {
+            $width = empty($this->thumbConf['default_thumbnail'][0])
+                ? $default
+                : $this->thumbConf['default_thumbnail'][0];
+        }
+        $this->width = $width;
+
+        return $this;
+    }
+
+    /**
+     * Get the thumbnail height.
+     *
+     * @param boolean $round
+     *
+     * @return integer
+     */
+    public function getHeight($round = true)
+    {
+        if ($round) {
+            return round($this->height);
+        }
+
+        return $this->height;
+    }
+
+    /**
+     * Set the thumbnail height.
+     *
+     * @param integer $height
+     * @param integer $default
+     *
+     * @return Thumbnail
+     */
+    public function setHeight($height, $default = 100)
+    {
+        if (!is_numeric($height)) {
+            $height = empty($this->thumbConf['default_thumbnail'][1])
+                ? $default
+                : $this->thumbConf['default_thumbnail'][1];
+        }
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * Get the thumbnail scaling method.
+     *
+     * @return string
+     */
+    public function getScale()
+    {
+        return $this->scale;
+    }
+
+    /**
+     * Set the thumbnail scaling method.
+     *
+     * @param string $scale
+     *
+     * @return Thumbnail
+     */
+    public function setScale($scale)
+    {
+        $valid = ['b', 'c', 'f', 'r'];
+        $scale = substr($scale, 0, 1);
+        $scale = in_array($scale, $valid)
+            ? $scale
+            : (!empty($this->thumbConf['cropping']) ? substr($this->thumbConf['cropping'], 0, 1) : 'c');
+
+        $this->scale = $scale;
+
+        return $this;
+    }
+}

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -230,50 +230,39 @@ class ImageHandler
      * Example: {{ content.image|showimage(320, 240) }}
      * Example: {{ showimage(content.image, 320, 240) }}
      *
-     * @param string  $filename Image filename
+     * @param string  $fileName Image filename
      * @param integer $width    Image width
      * @param integer $height   Image height
      * @param string  $crop     Crop image string identifier
      *
      * @return string HTML output
      */
-    public function showImage($filename = null, $width = 0, $height = 0, $crop = null)
+    public function showImage($fileName = null, $width = null, $height = null, $crop = null)
     {
-        if ($filename === null) {
+        if ($fileName === null) {
             return  '&nbsp;';
         }
+        $thumb = $this->getThumbnail($fileName, $width, $height, $crop);
 
-        $width = intval($width);
-        $height = intval($height);
+        if ($width === null || $height === null) {
+            $info = $this->imageInfo($thumb->getFileName(), false);
 
-        if (isset($filename['alt'])) {
-            $alt = $filename['alt'];
-        } elseif (isset($filename['title'])) {
-            $alt = $filename['title'];
-        } else {
-            $alt = '';
-        }
-
-        if ($width === 0 || $height === 0) {
-            if (is_array($filename)) {
-                $filename = isset($filename['filename']) ? $filename['filename'] : $filename['file'];
-            }
-
-            $info = $this->imageInfo($filename, false);
-
-            if ($width !== 0) {
-                $height = round($width / $info['aspectratio']);
-            } elseif ($height !== 0) {
-                $width = round($height * $info['aspectratio']);
+            if ($width !== null) {
+                $thumb->setHeight(round($width / $info['aspectratio']));
+            } elseif ($height !== null) {
+                $thumb->setWidth(round($height * $info['aspectratio']));
             } else {
-                $width = $info['width'];
-                $height = $info['height'];
+                $thumb->setWidth($info['width']);
+                $thumb->setHeight($info['height']);
             }
         }
 
-        $image = $this->thumbnail($filename, $width, $height, $crop);
-
-        return '<img src="' . $image . '" width="' . $width . '" height="' . $height . '" alt="'. $alt .'">';
+        return sprintf('<img src="%s" width="%s" height="%s" alt="%s">',
+            $this->getThubnailUri($thumb),
+            $thumb->getWidth(),
+            $thumb->getHeight(),
+            $thumb->getAltTitle()
+        );
     }
 
     /**

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -165,57 +165,40 @@ class ImageHandler
      * Note: This function used to be called 'fancybox', but Fancybox was
      * deprecated in favour of the Magnific Popup library.
      *
-     * @param string  $filename Image filename
-     * @param integer $width    Image width
-     * @param integer $height   Image height
-     * @param string  $crop     Crop image string identifier
-     * @param string  $title    Display title for image
+     * @param string|array $fileName Image file name
+     * @param integer      $width    Image width
+     * @param integer      $height   Image height
+     * @param string       $crop     Crop image string identifier
+     * @param string       $title    Display title for image
      *
      * @return string HTML output
      */
-    public function popup($filename = null, $width = 100, $height = 100, $crop = null, $title = null)
+    public function popup($fileName = null, $width = 100, $height = 100, $crop = null, $title = null)
     {
-        if ($filename === null) {
+        if ($fileName === null) {
             return  '&nbsp;';
         }
 
         $thumbconf = $this->app['config']->get('general/thumbnails');
-
         $fullwidth = !empty($thumbconf['default_image'][0]) ? $thumbconf['default_image'][0] : 1000;
         $fullheight = !empty($thumbconf['default_image'][1]) ? $thumbconf['default_image'][1] : 800;
 
-        $thumbnail = $this->thumbnail($filename, $width, $height, $crop);
-        $large = $this->thumbnail($filename, $fullwidth, $fullheight, 'r');
+        $thumb = $this->getThumbnail($fileName, $width, $height, $crop);
+        $largeThumb = $this->getThumbnail($fileName, $fullwidth, $fullheight, 'r');
 
-        if (empty($title)) {
-            // try to get title from filename array
-            if (is_array($filename) && isset($filename['title'])) {
-                $title = $filename['title'];
-            } else {
-                // fallback to filename from array
-                if (is_array($filename) && isset($filename['filename'])) {
-                    $title = $filename['filename'];
-                } else {
-                    // fallback to filename as provided (string)
-                    $title = sprintf('%s: %s', Trans::__('Image'), $filename);
-                }
-            }
-        }
-
-        if (is_array($filename) && isset($filename['alt'])) {
-            $alt = $filename['alt'];
-        } else {
-            $alt = $title;
-        }
+        // BC Nightmare… If we're passed a title, use it, if not we might have
+        // one in the $fileName array, else use the file name
+        $title = $title ?: $thumb->getTitle() ?: sprintf('%s: %s', Trans::__('Image'), $thumb->getFileName());
+        $altTitle = $thumb->getAltTitle() ?: $title;
 
         $output = sprintf(
             '<a href="%s" class="magnific" title="%s"><img src="%s" width="%s" height="%s" alt="%s"></a>',
-            $large,
+            $this->getThubnailUri($largeThumb),
             $title,
-            $thumbnail,
-            $width,
-            $height,
-            $alt
+            $this->getThubnailUri($thumb),
+            $thumb->getWidth(),
+            $thumb->getHeight(),
+            $altTitle
         );
 
         return $output;

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -49,8 +49,8 @@ class ImageHandler
         }
 
         $image = sprintf(
-            '%sfiles/%s',
-            $this->app['resources']->getUrl('root'),
+            '%s%s',
+            $this->app['resources']->getUrl('files'),
             Lib::safeFilename($filename)
         );
 
@@ -197,7 +197,7 @@ class ImageHandler
                     }
                 }
             }
-            
+
             if (is_array($filename) && isset($filename['alt'])) {
                 $alt = $filename['alt'];
             } else {

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -36,9 +36,9 @@ class ImageHandler
      *
      * @return string Image path
      */
-    public function image($filename, $width = '', $height = '', $crop = '')
+    public function image($filename, $width = null, $height = null, $crop = null)
     {
-        if ($width != '' || $height != '') {
+        if ($width || $height) {
             // You don't want the image, you just want a thumbnail.
             return $this->thumbnail($filename, $width, $height, $crop);
         }
@@ -172,7 +172,7 @@ class ImageHandler
      *
      * @return string HTML output
      */
-    public function popup($filename = '', $width = 100, $height = 100, $crop = '', $title = '')
+    public function popup($filename = null, $width = 100, $height = 100, $crop = null, $title = null)
     {
         if (!empty($filename)) {
             $thumbconf = $this->app['config']->get('general/thumbnails');
@@ -236,7 +236,7 @@ class ImageHandler
      *
      * @return string HTML output
      */
-    public function showImage($filename = '', $width = 0, $height = 0, $crop = '')
+    public function showImage($filename = null, $width = 0, $height = 0, $crop = null)
     {
         if (empty($filename)) {
             return '&nbsp;';
@@ -287,7 +287,7 @@ class ImageHandler
      *
      * @return string Thumbnail path
      */
-    public function thumbnail($filename, $width = '', $height = '', $zoomcrop = 'crop')
+    public function thumbnail($filename, $width = null, $height = null, $zoomcrop = 'crop')
     {
         if (!is_numeric($width)) {
             $thumbconf = $this->app['config']->get('general/thumbnails');

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -291,16 +291,8 @@ class ImageHandler
     public function thumbnail($fileName, $width = null, $height = null, $zoomcrop = null)
     {
         $thumb = $this->getThumbnail($fileName, $width, $height, $zoomcrop);
-        $thumbStr = sprintf('%sx%s%s/%s',
-            $thumb->getWidth(),
-            $thumb->getHeight(),
-            $thumb->getScale(),
-            $thumb->getFileName()
-        );
 
-        $path = $this->app['url_generator']->generate('thumb', ['thumb' => $thumbStr]);
-
-        return $path;
+        return $this->getThubnailUri($thumb);
     }
 
     /**
@@ -324,5 +316,24 @@ class ImageHandler
         ;
 
         return $thumb;
+    }
+
+    /**
+     * Get the thumbnail relative URI.
+     *
+     * @param Thumbnail $thumb
+     *
+     * @return string
+     */
+    private function getThubnailUri(Thumbnail $thumb)
+    {
+        $thumbStr = sprintf('%sx%s%s/%s',
+            $thumb->getWidth(),
+            $thumb->getHeight(),
+            $thumb->getScale(),
+            $thumb->getFileName()
+        );
+
+        return $this->app['url_generator']->generate('thumb', ['thumb' => $thumbStr]);
     }
 }

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -288,16 +288,9 @@ class ImageHandler
      *
      * @return string Relative URL of the thumbnail
      */
-    public function thumbnail($fileName, $width = null, $height = null, $zoomcrop = 'crop')
+    public function thumbnail($fileName, $width = null, $height = null, $zoomcrop = null)
     {
-        $thumb = new Thumbnail($this->app['config']->get('general/thumbnails'));
-        $thumb
-            ->setFileName($fileName)
-            ->setWidth($width)
-            ->setHeight($height)
-            ->setScale($zoomcrop)
-        ;
-
+        $thumb = $this->getThumbnail($fileName, $width, $height, $zoomcrop);
         $thumbStr = sprintf('%sx%s%s/%s',
             $thumb->getWidth(),
             $thumb->getHeight(),
@@ -308,5 +301,28 @@ class ImageHandler
         $path = $this->app['url_generator']->generate('thumb', ['thumb' => $thumbStr]);
 
         return $path;
+    }
+
+    /**
+     * Get a thumbnail object.
+     *
+     * @param string|array $fileName
+     * @param integer      $width
+     * @param integer      $height
+     * @param string       $scale
+     *
+     * @return Thumbnail
+     */
+    private function getThumbnail($fileName, $width = null, $height = null, $scale = null)
+    {
+        $thumb = new Thumbnail($this->app['config']->get('general/thumbnails'));
+        $thumb
+            ->setFileName($fileName)
+            ->setWidth($width)
+            ->setHeight($height)
+            ->setScale($scale)
+        ;
+
+        return $thumb;
     }
 }

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -174,48 +174,48 @@ class ImageHandler
      */
     public function popup($filename = null, $width = 100, $height = 100, $crop = null, $title = null)
     {
-        if (!empty($filename)) {
-            $thumbconf = $this->app['config']->get('general/thumbnails');
+        if ($filename === null) {
+            return  '&nbsp;';
+        }
 
-            $fullwidth = !empty($thumbconf['default_image'][0]) ? $thumbconf['default_image'][0] : 1000;
-            $fullheight = !empty($thumbconf['default_image'][1]) ? $thumbconf['default_image'][1] : 800;
+        $thumbconf = $this->app['config']->get('general/thumbnails');
 
-            $thumbnail = $this->thumbnail($filename, $width, $height, $crop);
-            $large = $this->thumbnail($filename, $fullwidth, $fullheight, 'r');
+        $fullwidth = !empty($thumbconf['default_image'][0]) ? $thumbconf['default_image'][0] : 1000;
+        $fullheight = !empty($thumbconf['default_image'][1]) ? $thumbconf['default_image'][1] : 800;
 
-            if (empty($title)) {
-                // try to get title from filename array
-                if (is_array($filename) && isset($filename['title'])) {
-                    $title = $filename['title'];
+        $thumbnail = $this->thumbnail($filename, $width, $height, $crop);
+        $large = $this->thumbnail($filename, $fullwidth, $fullheight, 'r');
+
+        if (empty($title)) {
+            // try to get title from filename array
+            if (is_array($filename) && isset($filename['title'])) {
+                $title = $filename['title'];
+            } else {
+                // fallback to filename from array
+                if (is_array($filename) && isset($filename['filename'])) {
+                    $title = $filename['filename'];
                 } else {
-                    // fallback to filename from array
-                    if (is_array($filename) && isset($filename['filename'])) {
-                        $title = $filename['filename'];
-                    } else {
-                        // fallback to filename as provided (string)
-                        $title = sprintf('%s: %s', Trans::__('Image'), $filename);
-                    }
+                    // fallback to filename as provided (string)
+                    $title = sprintf('%s: %s', Trans::__('Image'), $filename);
                 }
             }
-
-            if (is_array($filename) && isset($filename['alt'])) {
-                $alt = $filename['alt'];
-            } else {
-                $alt = $title;
-            }
-
-            $output = sprintf(
-                '<a href="%s" class="magnific" title="%s"><img src="%s" width="%s" height="%s" alt="%s"></a>',
-                $large,
-                $title,
-                $thumbnail,
-                $width,
-                $height,
-                $alt
-            );
-        } else {
-            $output = '&nbsp;';
         }
+
+        if (is_array($filename) && isset($filename['alt'])) {
+            $alt = $filename['alt'];
+        } else {
+            $alt = $title;
+        }
+
+        $output = sprintf(
+            '<a href="%s" class="magnific" title="%s"><img src="%s" width="%s" height="%s" alt="%s"></a>',
+            $large,
+            $title,
+            $thumbnail,
+            $width,
+            $height,
+            $alt
+        );
 
         return $output;
     }
@@ -238,41 +238,41 @@ class ImageHandler
      */
     public function showImage($filename = null, $width = 0, $height = 0, $crop = null)
     {
-        if (empty($filename)) {
-            return '&nbsp;';
-        } else {
-            $width = intval($width);
-            $height = intval($height);
-
-            if (isset($filename['alt'])) {
-                $alt = $filename['alt'];
-            } elseif (isset($filename['title'])) {
-                $alt = $filename['title'];
-            } else {
-                $alt = '';
-            }
-
-            if ($width === 0 || $height === 0) {
-                if (is_array($filename)) {
-                    $filename = isset($filename['filename']) ? $filename['filename'] : $filename['file'];
-                }
-
-                $info = $this->imageInfo($filename, false);
-
-                if ($width !== 0) {
-                    $height = round($width / $info['aspectratio']);
-                } elseif ($height !== 0) {
-                    $width = round($height * $info['aspectratio']);
-                } else {
-                    $width = $info['width'];
-                    $height = $info['height'];
-                }
-            }
-
-            $image = $this->thumbnail($filename, $width, $height, $crop);
-
-            return '<img src="' . $image . '" width="' . $width . '" height="' . $height . '" alt="'. $alt .'">';
+        if ($filename === null) {
+            return  '&nbsp;';
         }
+
+        $width = intval($width);
+        $height = intval($height);
+
+        if (isset($filename['alt'])) {
+            $alt = $filename['alt'];
+        } elseif (isset($filename['title'])) {
+            $alt = $filename['title'];
+        } else {
+            $alt = '';
+        }
+
+        if ($width === 0 || $height === 0) {
+            if (is_array($filename)) {
+                $filename = isset($filename['filename']) ? $filename['filename'] : $filename['file'];
+            }
+
+            $info = $this->imageInfo($filename, false);
+
+            if ($width !== 0) {
+                $height = round($width / $info['aspectratio']);
+            } elseif ($height !== 0) {
+                $width = round($height * $info['aspectratio']);
+            } else {
+                $width = $info['width'];
+                $height = $info['height'];
+            }
+        }
+
+        $image = $this->thumbnail($filename, $width, $height, $crop);
+
+        return '<img src="' . $image . '" width="' . $width . '" height="' . $height . '" alt="'. $alt .'">';
     }
 
     /**

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -286,7 +286,7 @@ class TwigExtension extends \Twig_Extension
     /**
      * @see \Bolt\Twig\Handler\ImageHandler::image()
      */
-    public function image($filename, $width = '', $height = '', $crop = '')
+    public function image($filename, $width = null, $height = null, $crop = null)
     {
         return $this->handlers['image']->image($filename, $width, $height, $crop);
     }
@@ -400,7 +400,7 @@ class TwigExtension extends \Twig_Extension
     /**
      * @see \Bolt\Twig\Handler\ImageHandler::popup()
      */
-    public function popup($filename = '', $width = 100, $height = 100, $crop = '', $title = '')
+    public function popup($filename = null, $width = 100, $height = 100, $crop = null, $title = null)
     {
         return $this->handlers['image']->popup($filename, $width, $height, $crop, $title);
     }
@@ -480,7 +480,7 @@ class TwigExtension extends \Twig_Extension
     /**
      * @see \Bolt\Twig\Handler\ImageHandler::showImage()
      */
-    public function showImage($filename = '', $width = 0, $height = 0, $crop = '')
+    public function showImage($filename = null, $width = 0, $height = 0, $crop = null)
     {
         return $this->handlers['image']->showImage($filename, $width, $height, $crop);
     }
@@ -536,7 +536,7 @@ class TwigExtension extends \Twig_Extension
     /**
      * @see \Bolt\Twig\Handler\ImageHandler::thumbnail()
      */
-    public function thumbnail($filename, $width = '', $height = '', $zoomcrop = 'crop')
+    public function thumbnail($filename, $width = null, $height = null, $zoomcrop = 'crop')
     {
         return $this->handlers['image']->thumbnail($filename, $width, $height, $zoomcrop);
     }

--- a/tests/phpunit/unit/Twig/BoltTwigHelpersTest.php
+++ b/tests/phpunit/unit/Twig/BoltTwigHelpersTest.php
@@ -195,30 +195,6 @@ class BoltTwigHelpersTest extends BoltUnitTest
         $this->assertNull($twig->ymllink('config.yml'));
     }
 
-    public function testImageInfo()
-    {
-        // Safe mode should return null
-        $app = $this->getApp();
-        $handlers = $this->getTwigHandlers($app);
-        $twig = new TwigExtension($app, $handlers, true);
-        $this->assertNull($twig->imageInfo('nofile'));
-
-        // Test on normal mode
-        $app = $this->getApp();
-        $app['resources']->setPath('files', PHPUNIT_ROOT . '/resources');
-        $handlers = $this->getTwigHandlers($app);
-        $twig = new TwigExtension($app, $handlers, false);
-        $img = 'generic-logo.png';
-        $info = $twig->imageInfo($img);
-        $this->assertEquals(12, count($info));
-
-        // Test non readable image fails
-        $app = $this->getApp();
-        $handlers = $this->getTwigHandlers($app);
-        $twig = new TwigExtension($app, $handlers, false);
-        $this->assertFalse($twig->imageInfo('nothing'));
-    }
-
     public function testSlug()
     {
         $app = $this->getApp();

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -45,7 +45,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->image(['filename' => 'generic-logo.png'], 20);
-        $this->assertSame('/thumbs/20x120crop/generic-logo.png', $result);
+        $this->assertSame('/thumbs/20x120c/generic-logo.png', $result);
     }
 
     public function testImageFileNameHeightOnly()
@@ -54,7 +54,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->image(['filename' => 'generic-logo.png'], '', 20);
-        $this->assertSame('/thumbs/160x20crop/generic-logo.png', $result);
+        $this->assertSame('/thumbs/160x20c/generic-logo.png', $result);
     }
 
     public function testImageFileNameWidthHeight()
@@ -167,7 +167,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup('generic-logo.png', null, 50);
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x50crop/generic-logo.png" width="" height="50" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x50c/generic-logo.png" width="" height="50" alt="Image: generic-logo.png"></a>', $result);
     }
 
     public function testPopupCrop()
@@ -202,7 +202,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup(['title' => 'Koala', 'filename' => 'generic-logo.png'], null, null, null, null);
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120crop/generic-logo.png" width="" height="" alt="Koala"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="Koala"></a>', $result);
     }
 
     public function testPopupFileNameArrayWithoutTitle()
@@ -211,7 +211,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup(['filename' => 'generic-logo.png'], null, null, null, null);
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="generic-logo.png"><img src="/thumbs/160x120crop/generic-logo.png" width="" height="" alt="generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="generic-logo.png"></a>', $result);
     }
 
     public function testPopupFileNameArrayWithAlt()
@@ -220,7 +220,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup(['title' => 'Koala', 'alt' => 'Gum Leaves', 'filename' => 'generic-logo.png'], null, null, null, null);
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120crop/generic-logo.png" width="" height="" alt="Gum Leaves"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="Gum Leaves"></a>', $result);
     }
 
     public function testShowImageEmptyFileName()

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -107,7 +107,19 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->imageInfo('koala.jpg', false);
-        $this->assertFalse($result);
+        $this->assertInstanceOf('Bolt\Helpers\Image\Image', $result);
+        $this->assertNull($result['filename']);
+        $this->assertNull($result['fullpath']);
+        $this->assertNull($result['url']);
+        $this->assertNull($result['width']);
+        $this->assertNull($result['height']);
+        $this->assertNull($result['type']);
+        $this->assertNull($result['mime']);
+        $this->assertNull($result['aspectratio']);
+        $this->assertNull($result['exif']);
+        $this->assertNull($result['landscape']);
+        $this->assertNull($result['portrait']);
+        $this->assertNull($result['square']);
     }
 
     public function testImageInfo()

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -133,4 +133,93 @@ class ImageHandlerTest extends BoltUnitTest
         $this->assertFalse($result['portrait']);
         $this->assertFalse($result['square']);
     }
+
+    public function testPopupEmptyFileName()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->popup();
+        $this->assertSame('&nbsp;', $result);
+    }
+
+    public function testPopupFileNameOnly()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->popup('generic-logo.png');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/100x100c/generic-logo.png" width="100" height="100" alt="Image: generic-logo.png"></a>', $result);
+    }
+
+    public function testPopupWidth()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->popup('generic-logo.png', 50);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/50x100c/generic-logo.png" width="50" height="100" alt="Image: generic-logo.png"></a>', $result);
+    }
+
+    public function testPopupHeight()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->popup('generic-logo.png', null, 50);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x50crop/generic-logo.png" width="" height="50" alt="Image: generic-logo.png"></a>', $result);
+    }
+
+    public function testPopupCrop()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->popup('generic-logo.png', null, null, 'f');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120f/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $result = $handler->popup('generic-logo.png', null, null, 'fit');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120f/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+
+        $result = $handler->popup('generic-logo.png', null, null, 'r');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120r/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $result = $handler->popup('generic-logo.png', null, null, 'resize');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120r/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+
+        $result = $handler->popup('generic-logo.png', null, null, 'b');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120b/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $result = $handler->popup('generic-logo.png', null, null, 'borders');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120b/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+
+        $result = $handler->popup('generic-logo.png', null, null, 'c');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $result = $handler->popup('generic-logo.png', null, null, 'crop');
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+    }
+
+    public function testPopupFileNameArrayWithTitle()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->popup(['title' => 'Koala', 'filename' => 'generic-logo.png'], null, null, null, null);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120crop/generic-logo.png" width="" height="" alt="Koala"></a>', $result);
+    }
+
+    public function testPopupFileNameArrayWithoutTitle()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->popup(['filename' => 'generic-logo.png'], null, null, null, null);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="generic-logo.png"><img src="/thumbs/160x120crop/generic-logo.png" width="" height="" alt="generic-logo.png"></a>', $result);
+    }
+
+    public function testPopupFileNameArrayWithAlt()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->popup(['title' => 'Koala', 'alt' => 'Gum Leaves', 'filename' => 'generic-logo.png'], null, null, null, null);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120crop/generic-logo.png" width="" height="" alt="Gum Leaves"></a>', $result);
+    }
 }

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Bolt\Tests\Twig;
+
+use Bolt\Tests\BoltUnitTest;
+use Bolt\Twig\Handler\ImageHandler;
+
+/**
+ * Class to test Bolt\Twig\Handler\ImageHandler
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ImageHandlerTest extends BoltUnitTest
+{
+    public function testImageFileNameLegacy()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->image('generic-logo.png');
+        $this->assertSame('/files/generic-logo.png', $result);
+    }
+
+    public function testImageFileNameArray()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->image(['filename' => 'generic-logo.png']);
+        $this->assertSame('/files/generic-logo.png', $result);
+    }
+
+    public function testImageFileNameWidthOnly()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20);
+        $this->assertSame('/thumbs/20x120crop/generic-logo.png', $result);
+    }
+
+    public function testImageFileNameHeightOnly()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->image(['filename' => 'generic-logo.png'], '', 20);
+        $this->assertSame('/thumbs/160x20crop/generic-logo.png', $result);
+    }
+
+    public function testImageFileNameWidthHeight()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20);
+        $this->assertSame('/thumbs/20x20c/generic-logo.png', $result);
+    }
+
+    public function testImageFileNameCrop()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'f');
+        $this->assertSame('/thumbs/20x20f/generic-logo.png', $result);
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'fit');
+        $this->assertSame('/thumbs/20x20f/generic-logo.png', $result);
+
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'r');
+        $this->assertSame('/thumbs/20x20r/generic-logo.png', $result);
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'resize');
+        $this->assertSame('/thumbs/20x20r/generic-logo.png', $result);
+
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'b');
+        $this->assertSame('/thumbs/20x20b/generic-logo.png', $result);
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'borders');
+        $this->assertSame('/thumbs/20x20b/generic-logo.png', $result);
+
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'c');
+        $this->assertSame('/thumbs/20x20c/generic-logo.png', $result);
+        $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'crop');
+        $this->assertSame('/thumbs/20x20c/generic-logo.png', $result);
+    }
+}

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -222,4 +222,93 @@ class ImageHandlerTest extends BoltUnitTest
         $result = $handler->popup(['title' => 'Koala', 'alt' => 'Gum Leaves', 'filename' => 'generic-logo.png'], null, null, null, null);
         $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120crop/generic-logo.png" width="" height="" alt="Gum Leaves"></a>', $result);
     }
+
+    public function testShowImageEmptyFileName()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->showImage();
+        $this->assertSame('&nbsp;', $result);
+    }
+
+    public function testShowImageFileNameOnly()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->showImage('generic-logo.png');
+        $this->assertSame('<img src="/thumbs/624x351c/generic-logo.png" width="624" height="351" alt="">', $result);
+    }
+
+    public function testShowImageWidth()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->showImage('generic-logo.png', 50);
+        $this->assertSame('<img src="/thumbs/50x28c/generic-logo.png" width="50" height="28" alt="">', $result);
+    }
+
+    public function testShowImageHeight()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->showImage('generic-logo.png', null, 50);
+        $this->assertSame('<img src="/thumbs/89x50c/generic-logo.png" width="89" height="50" alt="">', $result);
+    }
+
+    public function testShowImageCrop()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->showImage('generic-logo.png', null, null, 'f');
+        $this->assertSame('<img src="/thumbs/624x351f/generic-logo.png" width="624" height="351" alt="">', $result);
+        $result = $handler->showImage('generic-logo.png', null, null, 'fit');
+        $this->assertSame('<img src="/thumbs/624x351f/generic-logo.png" width="624" height="351" alt="">', $result);
+
+        $result = $handler->showImage('generic-logo.png', null, null, 'r');
+        $this->assertSame('<img src="/thumbs/624x351r/generic-logo.png" width="624" height="351" alt="">', $result);
+        $result = $handler->showImage('generic-logo.png', null, null, 'resize');
+        $this->assertSame('<img src="/thumbs/624x351r/generic-logo.png" width="624" height="351" alt="">', $result);
+
+        $result = $handler->showImage('generic-logo.png', null, null, 'b');
+        $this->assertSame('<img src="/thumbs/624x351b/generic-logo.png" width="624" height="351" alt="">', $result);
+        $result = $handler->showImage('generic-logo.png', null, null, 'borders');
+        $this->assertSame('<img src="/thumbs/624x351b/generic-logo.png" width="624" height="351" alt="">', $result);
+
+        $result = $handler->showImage('generic-logo.png', null, null, 'c');
+        $this->assertSame('<img src="/thumbs/624x351c/generic-logo.png" width="624" height="351" alt="">', $result);
+        $result = $handler->showImage('generic-logo.png', null, null, 'crop');
+        $this->assertSame('<img src="/thumbs/624x351c/generic-logo.png" width="624" height="351" alt="">', $result);
+    }
+
+    public function testShowImageFileNameArrayWithTitle()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->showImage(['title' => 'Koala', 'filename' => 'generic-logo.png'], null, null, null, null);
+        $this->assertSame('<img src="/thumbs/624x351c/generic-logo.png" width="624" height="351" alt="Koala">', $result);
+    }
+
+    public function testShowImageFileNameArrayWithoutTitle()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->showImage(['filename' => 'generic-logo.png'], null, null, null, null);
+        $this->assertSame('<img src="/thumbs/624x351c/generic-logo.png" width="624" height="351" alt="">', $result);
+    }
+
+    public function testShowImageFileNameArrayWithAlt()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->showImage(['title' => 'Koala', 'alt' => 'Gum Leaves', 'filename' => 'generic-logo.png'], null, null, null, null);
+        $this->assertSame('<img src="/thumbs/624x351c/generic-logo.png" width="624" height="351" alt="Gum Leaves">', $result);
+    }
 }

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -167,7 +167,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup('generic-logo.png', null, 50);
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x50c/generic-logo.png" width="" height="50" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x50c/generic-logo.png" width="160" height="50" alt="Image: generic-logo.png"></a>', $result);
     }
 
     public function testPopupCrop()
@@ -176,24 +176,24 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup('generic-logo.png', null, null, 'f');
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120f/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120f/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
         $result = $handler->popup('generic-logo.png', null, null, 'fit');
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120f/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120f/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
 
         $result = $handler->popup('generic-logo.png', null, null, 'r');
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120r/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120r/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
         $result = $handler->popup('generic-logo.png', null, null, 'resize');
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120r/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120r/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
 
         $result = $handler->popup('generic-logo.png', null, null, 'b');
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120b/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120b/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
         $result = $handler->popup('generic-logo.png', null, null, 'borders');
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120b/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120b/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
 
         $result = $handler->popup('generic-logo.png', null, null, 'c');
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
         $result = $handler->popup('generic-logo.png', null, null, 'crop');
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="Image: generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
     }
 
     public function testPopupFileNameArrayWithTitle()
@@ -202,7 +202,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup(['title' => 'Koala', 'filename' => 'generic-logo.png'], null, null, null, null);
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="Koala"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120c/generic-logo.png" width="160" height="120" alt="Koala"></a>', $result);
     }
 
     public function testPopupFileNameArrayWithoutTitle()
@@ -211,7 +211,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup(['filename' => 'generic-logo.png'], null, null, null, null);
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="generic-logo.png"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Image: generic-logo.png"><img src="/thumbs/160x120c/generic-logo.png" width="160" height="120" alt="Image: generic-logo.png"></a>', $result);
     }
 
     public function testPopupFileNameArrayWithAlt()
@@ -220,7 +220,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup(['title' => 'Koala', 'alt' => 'Gum Leaves', 'filename' => 'generic-logo.png'], null, null, null, null);
-        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120c/generic-logo.png" width="" height="" alt="Gum Leaves"></a>', $result);
+        $this->assertSame('<a href="/thumbs/1000x750r/generic-logo.png" class="magnific" title="Koala"><img src="/thumbs/160x120c/generic-logo.png" width="160" height="120" alt="Gum Leaves"></a>', $result);
     }
 
     public function testShowImageEmptyFileName()

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Twig;
 
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Handler\ImageHandler;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Class to test Bolt\Twig\Handler\ImageHandler
@@ -12,6 +13,14 @@ use Bolt\Twig\Handler\ImageHandler;
  */
 class ImageHandlerTest extends BoltUnitTest
 {
+    protected function setUp()
+    {
+        $app = $this->getApp();
+        $files = $app['resources']->getPath('filespath');
+        $fs = new Filesystem();
+        $fs->copy(PHPUNIT_ROOT . '/resources/generic-logo.png', $files . '/generic-logo.png', true);
+    }
+
     public function testImageFileNameLegacy()
     {
         $app = $this->getApp();
@@ -81,5 +90,47 @@ class ImageHandlerTest extends BoltUnitTest
         $this->assertSame('/thumbs/20x20c/generic-logo.png', $result);
         $result = $handler->image(['filename' => 'generic-logo.png'], 20, 20, 'crop');
         $this->assertSame('/thumbs/20x20c/generic-logo.png', $result);
+    }
+
+    public function testImageInfoSafe()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->imageInfo('generic-logo.png', true);
+        $this->assertNull($result);
+    }
+
+    public function testImageInfoNotReadable()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->imageInfo('koala.jpg', false);
+        $this->assertFalse($result);
+    }
+
+    public function testImageInfo()
+    {
+        $app = $this->getApp();
+        $handler = new ImageHandler($app);
+
+        $result = $handler->imageInfo('generic-logo.png', false);
+        $this->assertSame(624, $result['width']);
+        $this->assertSame(351, $result['height']);
+        $this->assertSame('jpeg', $result['type']);
+        $this->assertSame('image/jpeg', $result['mime']);
+        $this->assertRegExp('#1.7777#', (string) $result['aspectratio']);
+        $this->assertSame('generic-logo.png', $result['filename']);
+        $this->assertRegExp('#tests/phpunit/web-root/files/generic-logo.png#', $result['fullpath']);
+        $this->assertSame('/files/generic-logo.png', $result['url']);
+        $this->assertSame('', $result['exif']['latitude']);
+        $this->assertFalse($result['exif']['longitude']);
+        $this->assertFalse($result['exif']['datetime']);
+        $this->assertFalse($result['exif']['orientation']);
+        $this->assertRegExp('#1.7777#', (string) $result['exif']['aspectratio']);
+        $this->asserttrue($result['landscape']);
+        $this->assertFalse($result['portrait']);
+        $this->assertFalse($result['square']);
     }
 }


### PR DESCRIPTION
This brings `\Bolt\Twig\Handler\ImageHandler` to 100% test coverage and breaks out the logic into a couple of `\Bolt\Helper` classes along the way.
![coverage](https://cloud.githubusercontent.com/assets/1427081/10606473/08bc1c5e-772b-11e5-81f4-5a3985434285.png)
