### PR TITLE
Don't insert Bolt meta tags on AJAX requests

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -551,6 +551,13 @@ class Application extends Silex\Application
             $response->headers->set('Frame-Options', 'SAMEORIGIN');
         }
 
+        // Exit now if it's an AJAX call
+        if ($request->isXmlHttpRequest()) {
+            $this['stopwatch']->stop('bolt.app.after');
+
+            return;
+        }
+
         // true if we need to consider adding html snippets
         if (isset($this['htmlsnippets']) && ($this['htmlsnippets'] === true)) {
             // only add when content-type is text/html

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -551,7 +551,7 @@ class ResourceManager
      */
     private function isPagingRequest(Request $request)
     {
-        $matches = [];
+        $matches = array();
         $found = preg_match('/page_[A-Za-z0-9_]+=\d+/', $request->getRequestUri(), $matches);
 
         return (bool) $found;

--- a/tests/phpunit/nutty
+++ b/tests/phpunit/nutty
@@ -18,6 +18,7 @@ if (!is_readable(PHPUNIT_WEBROOT . '/app/cache')) {
     return;
 }
 
-$app = (new Nutty())->getApp();
+$nutty = new Nutty();
+$app = $nutty->getApp();
 $application = $app['nut'];
 $application->run();


### PR DESCRIPTION
Fixes #4295 

**Note:** This is already both done differently, and handled correctly, in `master`