### PR TITLE
[2.2] Silence warning notice

### DIFF
--- a/tests/phpunit/unit/DataCollector/TwigDataCollectorTest.php
+++ b/tests/phpunit/unit/DataCollector/TwigDataCollectorTest.php
@@ -68,7 +68,7 @@ class TwigDataCollectorTest extends BoltUnitTest
             ->method('getFunctions')
             ->will($this->returnValue(array('func' => $func)));
 
-        $app['twig']->addExtension($ext);
+        @$app['twig']->addExtension($ext);
         $data->collect($request, $response);
     }
 }


### PR DESCRIPTION
Our unit tests are throwing this warning, which is a distraction.
```
PHP Warning:  filemtime(): stat failed for vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php(290) : 
eval()'d code in vendor/twig/twig/lib/Twig/Environment.php on line 769
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:44
PHP   3. PHPUnit_TextUI_Command->run() vendor/phpunit/phpunit/src/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_TestRunner->doRun() vendor/phpunit/phpunit/src/TextUI/Command.php:149
PHP   5. PHPUnit_Framework_TestSuite->run() vendor/phpunit/phpunit/src/TextUI/TestRunner.php:440
PHP   6. PHPUnit_Framework_TestSuite->run() vendor/phpunit/phpunit/src/Framework/TestSuite.php:747
PHP   7. PHPUnit_Framework_TestCase->run() vendor/phpunit/phpunit/src/Framework/TestSuite.php:747
PHP   8. PHPUnit_Framework_TestResult->run() vendor/phpunit/phpunit/src/Framework/TestCase.php:724
PHP   9. PHPUnit_Framework_TestCase->runBare() vendor/phpunit/phpunit/src/Framework/TestResult.php:612
PHP  10. PHPUnit_Framework_TestCase->runTest() vendor/phpunit/phpunit/src/Framework/TestCase.php:768
PHP  11. ReflectionMethod->invokeArgs() vendor/phpunit/phpunit/src/Framework/TestCase.php:909
PHP  12. Bolt\Tests\DataCollector\TwigDataCollectorTest->testCollectWithMocks() vendor/phpunit/phpunit/src/Framework/TestCase.php:909
PHP  13. Twig_Environment->addExtension() tests/phpunit/unit/DataCollector/TwigDataCollectorTest.php:71
PHP  14. filemtime() vendor/twig/twig/lib/Twig/Environment.php:769
```