### PR TITLE
Fixes #4310 – Geolocation fields no longer able to be used in templatefields.

### DIFF
--- a/app/view/twig/editcontent/fields/_geolocation.twig
+++ b/app/view/twig/editcontent/fields/_geolocation.twig
@@ -46,7 +46,7 @@
     snap: {
         checked:     true,
         class:       'snap',
-        name:        name ~ '_snap',
+        name:        name ~ '[snap]',
         type:        'checkbox',
     }
 } %}


### PR DESCRIPTION
Fixes #4310 (hopefully)

And I even can't blame the :koala: …or, can I?!