### PR TITLE
[2.2] Fixes #4310 – Geolocation fields no longer able to be used in templatefields.

### DIFF
--- a/app/view/twig/editcontent/fields/_geolocation.twig
+++ b/app/view/twig/editcontent/fields/_geolocation.twig
@@ -42,7 +42,7 @@
     snap: {
         checked:     true,
         class:       'snap',
-        name:        name ~ '_snap',
+        name:        name ~ '[snap]',
         type:        'checkbox',
     }
 } %}


### PR DESCRIPTION
Backport of #4312
