### PR TITLE
hide viewless from record browser popup #4120

### DIFF
--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -232,14 +232,16 @@ class FilesystemManager extends AsyncBase
         $results = [];
 
         foreach ($this->storage()->getContentTypes() as $contenttype) {
-            $records = $this->getContent($contenttype, ['published' => true, 'hydrate' => false]);
+            if(!$this->app['config']->get("contenttypes/{$contenttype}/viewless")){
+                $records = $this->getContent($contenttype, ['published' => true, 'hydrate' => false]);
 
-            foreach ($records as $record) {
-                $results[$contenttype][] = [
-                    'title' => $record->getTitle(),
-                    'id'    => $record->id,
-                    'link'  => $record->link()
-                ];
+                foreach ($records as $record) {
+                    $results[$contenttype][] = [
+                        'title' => $record->getTitle(),
+                        'id' => $record->id,
+                        'link' => $record->link()
+                    ];
+                }
             }
         }
 


### PR DESCRIPTION
Check each record type that appears in the record browser popup to make sure it's not viewless before adding its links to the list. Prevents appearance of brown M&Ms.

**Edit**
Fixes #4120