### PR TITLE
[Tests] Deprecation notices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "phpunit/php-code-coverage" : "~2.0",
         "phpunit/phpunit" : "~4.4",
         "sebastian/phpcpd" : "~2.0",
-        "squizlabs/php_codesniffer" : "~2.0"
+        "squizlabs/php_codesniffer" : "~2.0",
+        "symfony/phpunit-bridge" : "^2.7"
     },
     "minimum-stability" : "beta",
     "config" : {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,7 @@
     <php>
         <server name="HTTP_HOST" value="bolt.dev" />
         <server name="REQUEST_URI" value="/bolt" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     </php>
     <listeners>
         <listener file="tests/phpunit/BoltListener.php" class="Bolt\Tests\BoltListener">


### PR DESCRIPTION
As [described here](http://symfony.com/doc/current/cookbook/upgrade/major_version.html) and [announced here](http://symfony.com/blog/new-in-symfony-2-7-phpunit-bridge).

This is some more awesome by Nicolas to enable notifications on deprecations… presently master only gives us:
```
$ php70 vendor/bin/phpunit 
New value for theme: base-2014 was successful. File updated.
Deleted 1 files from cache.

Cache cleared!
PHPUnit 4.8.16 by Sebastian Bergmann and contributors.

.....I..S......................................................  63 / 933 (  6%)
............................................................... 126 / 933 ( 13%)
......................................................SS....... 189 / 933 ( 20%)
............................................................... 252 / 933 ( 27%)
..................................................S............ 315 / 933 ( 33%)
............................................................... 378 / 933 ( 40%)
............................................................... 441 / 933 ( 47%)
.....SS........................................................ 504 / 933 ( 54%)
............................................................... 567 / 933 ( 60%)
............................................................... 630 / 933 ( 67%)
............................................................... 693 / 933 ( 74%)
............................................................... 756 / 933 ( 81%)
............................................................... 819 / 933 ( 87%)
...............................................S............... 882 / 933 ( 94%)
...................................................

Time: 1.36 minutes, Memory: 640.00Mb

OK, but incomplete, skipped, or risky tests!
Tests: 933, Assertions: 1865, Skipped: 7, Incomplete: 1.

THE ERROR HANDLER HAS CHANGED!
```

Longer term though this will give us more advance warning so we hopefully don't have the 2.2.0 release "fun" all over again :grin: 