### PR TITLE
Redesign/lets do it compleeeeeetely different

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -456,6 +456,7 @@ field:
         allowed-filetypes: "Allowed file types are:"
         select-from-server: "Select from server"
         select-from-stack: "Select from stack"
+        stack: "Stack"
     geolocation:
         label:
             address-lookup: "Address lookup"

--- a/app/src/package.json
+++ b/app/src/package.json
@@ -20,18 +20,18 @@
         "grunt-contrib-jshint": "~0.11.3",
         "grunt-contrib-uglify": "~0.9.2",
         "grunt-contrib-watch": "~0.6.1",
-        "grunt-endline": "~0.3.0",
+        "grunt-endline": "~0.4.0",
         "grunt-eol": "~0.2.0",
         "grunt-html": "~5.0.0",
-        "grunt-jsdoc": "~0.6.8",
+        "grunt-jsdoc": "~1.0.0",
         "grunt-phpdocumentor": "~0.4.1",
-        "grunt-postcss": "~0.6.0",
+        "grunt-postcss": "~0.7.0",
         "grunt-remove": "~0.1.0",
         "load-grunt-config": "~0.17.2",
-        "load-grunt-tasks": "~3.2.0",
-        "modernizr": "~3.0.0",
+        "load-grunt-tasks": "~3.3.0",
+        "modernizr": "~3.1.0",
         "node-sass": "~3.3.2",
         "postcss-single-charset": "~1.0.0",
-        "request": "~2.62.0"
+        "request": "~2.65.0"
     }
 }

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -14,7 +14,7 @@ $boltblue: #204460;
 $boltbluedarker: darken($boltblue, 5);
 $boltbluelighter: lighten($boltblue, 5);
 
-$basebgcolour: #FCFCF8;
+$basebgcolour: #FDFDFA;
 $bodytextcolour: #333;
 
 $lightgrey: #ccc;

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -17,9 +17,9 @@ $boltbluelighter: lighten($boltblue, 5);
 $basebgcolour: #FDFDFA;
 $bodytextcolour: #333;
 
-$lightgrey: #ccc;
+$lightgrey: #CCC;
 // The color of <hr> lines.
-$hr-border: #ccc;
+$hr-border: #CCC;
 
 $linkmain: lighten(saturate($boltblue, 50), 4);
 $linkvisited: $linkmain;
@@ -31,29 +31,29 @@ $padding-base-horizontal: 8px;
 
 // Primary button.
 $btn-primary-color: #FFF;
-$btn-primary-bg: #FB4D08; //#DC6A23;
-$btn-primary-border: darken($btn-primary-bg, 6%);
+$btn-primary-bg: #36934d; // #FB4D08;
+$btn-primary-border: darken($btn-primary-bg, 5%);
 
 // Secondary button.
-$btn-secondary-bg: desaturate(lighten($btn-primary-bg, 7%), 20);
-$btn-secondary-border: darken($btn-secondary-bg, 6%);
+$btn-secondary-bg: #4a8A6e;
+$btn-secondary-border: darken($btn-secondary-bg, 4%);
 
 // Tertiary button.
-$btn-tertiary-bg: desaturate(lighten($boltblue, 35%), 20);
-$btn-tertiary-border: darken($btn-tertiary-bg, 6%);
+$btn-tertiary-bg: #538ebe;
+$btn-tertiary-border: darken($btn-tertiary-bg, 4%);
 
 // Default button.
 $btn-default-color: #666;
 $btn-default-bg: #E0E0E0;
-$btn-default-border: darken($btn-default-bg, 5);
+$btn-default-border: darken($btn-default-bg, 4%);
 
 $btn-danger-color: #FFF;
-$btn-danger-bg: #CC3333;
-$btn-danger-border: darken($btn-danger-bg, 5);
+$btn-danger-bg: #992020;
+$btn-danger-border: darken($btn-danger-bg, 4%);
 
 $btn-silent-danger-color: #555;
 $btn-silent-danger-bg: #F8F8F8;
-$btn-silent-danger-border: darken($btn-danger-bg, 5);
+$btn-silent-danger-border: darken($btn-danger-bg, 4%);
 
 // Special BOLT button.
 $btn-bolt-color: #FFF;

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -14,7 +14,7 @@ $boltblue: #204460;
 $boltbluedarker: darken($boltblue, 5);
 $boltbluelighter: lighten($boltblue, 5);
 
-$basebgcolour: #FDFDF9;
+$basebgcolour: #FBFBF7;
 $bodytextcolour: #333;
 
 $lightgrey: #ccc;
@@ -93,12 +93,13 @@ $nav-tabs-bg: desaturate(lighten($boltblue, 50%), 30);
 /**
  * Colors in _base.scss.
  */
-$sidebarbackground: #181818;
+$sidebarbackground: #33363E;
 $sidebartextcolour: #DDD;
 $sidebartextcolourcollapsed: #AAA;
 
-$sidebarlink: #EEE;
+$sidebarlink: #BBB;
 $sidebarlinkhover: #FFF;
+$sidebarlinkactive: #FFF;
 $sidebarbackgroundactive: lighten(desaturate($boltblue, 20), 7);
 $sidebarbackgroundhover: lighten(desaturate($boltblue, 20), 18);
 
@@ -123,12 +124,12 @@ $nav-secondary-large-width: 180px;
 
 $nav-secondary-top-padding: 16px;
 $nav-secondary-h-padding: 8px;
-$nav-secondary-v-padding: 8px;
+$nav-secondary-v-padding: 9px;
 $nav-secondary-divider-margin: 14px;
 $nav-secondary-divider-padding: 6px;
 $nav-secondary-icon-size: 24px;
 $nav-secondary-icon-margin: 8px;
-$nav-secondary-indent: ($nav-secondary-icon-size + $nav-secondary-icon-margin + 4px);
+$nav-secondary-indent: ($nav-secondary-icon-size + $nav-secondary-icon-margin + 8px);
 $nav-secondary-collapsed-width: ($nav-secondary-h-padding + $nav-secondary-indent + 1);
 
 /**

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -31,15 +31,15 @@ $padding-base-horizontal: 8px;
 
 // Primary button.
 $btn-primary-color: #FFF;
-$btn-primary-bg: #107a30; // Or perhaps a nice dark blue: #1d4268;
+$btn-primary-bg: #5d9f11; // Or perhaps a nice dark blue: #1d4268;
 $btn-primary-border: darken($btn-primary-bg, 5%);
 
 // Secondary button.
-$btn-secondary-bg: #4a8A6e;
+$btn-secondary-bg: #206bbb;
 $btn-secondary-border: darken($btn-secondary-bg, 4%);
 
 // Tertiary button.
-$btn-tertiary-bg: #538ebe;
+$btn-tertiary-bg: desaturate(lighten(#42627B, 20), 12);
 $btn-tertiary-border: darken($btn-tertiary-bg, 4%);
 
 // Default button.
@@ -88,7 +88,7 @@ $nav-tabs-bg: desaturate(lighten($boltblue, 50%), 30);
 
 
 // The color of the tabs, in the 'edit content' screen.
-$filtertabs: desaturate(mix($basebgcolour, $btn-tertiary-bg, 70), 20);
+$filtertabs: mix($basebgcolour, $btn-tertiary-bg, 70);
 $filtertab-color: darken($filtertabs, 40);
 $filtertab-active-color: #555;
 

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -14,7 +14,7 @@ $boltblue: #204460;
 $boltbluedarker: darken($boltblue, 5);
 $boltbluelighter: lighten($boltblue, 5);
 
-$basebgcolour: #FBFBF7;
+$basebgcolour: #FAFAF8;
 $bodytextcolour: #333;
 
 $lightgrey: #ccc;
@@ -73,9 +73,6 @@ $panel-border-radius: 0;
 // Table border color: mostly used for the contenttype 'overviews'
 $table-border-color: #CCC;
 $table-bg-accent: #F6F6F9;
-
-// Width of the gutter in the grid. Bit wider than default, because whitespace is free.
-$grid-gutter-width: 40px;
 
 // Pagination.
 $pagination-color: lighten(desaturate($boltblue, 35), 6);

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -14,7 +14,7 @@ $boltblue: #204460;
 $boltbluedarker: darken($boltblue, 5);
 $boltbluelighter: lighten($boltblue, 5);
 
-$basebgcolour: #FAFAF8;
+$basebgcolour: #FCFCF8;
 $bodytextcolour: #333;
 
 $lightgrey: #ccc;

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -18,6 +18,7 @@ $basebgcolour: #FDFDFA;
 $bodytextcolour: #333;
 
 $lightgrey: #CCC;
+$light-border: #E8E8E8;
 // The color of <hr> lines.
 $hr-border: #CCC;
 
@@ -32,10 +33,10 @@ $padding-base-horizontal: 8px;
 // Primary button.
 $btn-primary-color: #FFF;
 $btn-primary-bg: #5d9f11; // Or perhaps a nice dark blue: #1d4268;
-$btn-primary-border: darken($btn-primary-bg, 5%);
+$btn-primary-border: darken($btn-primary-bg, 4%);
 
 // Secondary button.
-$btn-secondary-bg: #206bbb;
+$btn-secondary-bg: #2A78CB;
 $btn-secondary-border: darken($btn-secondary-bg, 4%);
 
 // Tertiary button.
@@ -48,7 +49,7 @@ $btn-default-bg: #E0E0E0;
 $btn-default-border: darken($btn-default-bg, 4%);
 
 $btn-danger-color: #FFF;
-$btn-danger-bg: #992020;
+$btn-danger-bg: #AA1010;
 $btn-danger-border: darken($btn-danger-bg, 4%);
 
 $btn-silent-danger-color: #555;
@@ -67,7 +68,7 @@ $dropdown-link-hover-bg: #DDD;
 
 // Sidebar panel headings.
 $panel-default-heading-bg: #DDD;
-$panel-default-border: #E2E2E2;
+$panel-default-border: $light-border;
 $panel-border-radius: 0;
 
 // Table border color: mostly used for the contenttype 'overviews'

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -31,7 +31,7 @@ $padding-base-horizontal: 8px;
 
 // Primary button.
 $btn-primary-color: #FFF;
-$btn-primary-bg: #36934d; // #FB4D08;
+$btn-primary-bg: #107a30; // Or perhaps a nice dark blue: #1d4268;
 $btn-primary-border: darken($btn-primary-bg, 5%);
 
 // Secondary button.

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -97,11 +97,11 @@ $sidebarbackground: #33363E;
 $sidebartextcolour: #DDD;
 $sidebartextcolourcollapsed: #AAA;
 
-$sidebarlink: #BBB;
+$sidebarlink: #CCC;
 $sidebarlinkhover: #FFF;
 $sidebarlinkactive: #FFF;
-$sidebarbackgroundactive: lighten(desaturate($boltblue, 20), 7);
-$sidebarbackgroundhover: lighten(desaturate($boltblue, 20), 18);
+$sidebarbackgroundactive: lighten(desaturate($boltblue, 20), 12);
+$sidebarbackgroundhover: lighten(desaturate($boltblue, 30), 6);
 
 /**
  * Fonts.
@@ -122,7 +122,7 @@ $nav-primary-min-height: 50px;
 $nav-secondary-small-width: 280px;
 $nav-secondary-large-width: 180px;
 
-$nav-secondary-top-padding: 16px;
+$nav-secondary-top-padding: 17px;
 $nav-secondary-h-padding: 8px;
 $nav-secondary-v-padding: 9px;
 $nav-secondary-divider-margin: 14px;

--- a/app/src/sass/_base.scss
+++ b/app/src/sass/_base.scss
@@ -87,6 +87,11 @@ $nav-tabs-active-link-hover-border-color: $nav-tabs-border-color;
 $nav-tabs-bg: desaturate(lighten($boltblue, 50%), 30);
 
 
+// The color of the tabs, in the 'edit content' screen.
+$filtertabs: desaturate(mix($basebgcolour, $btn-tertiary-bg, 70), 20);
+$filtertab-color: darken($filtertabs, 40);
+$filtertab-active-color: #555;
+
 /**
  * Colors in _base.scss.
  */

--- a/app/src/sass/buic/_listing.scss
+++ b/app/src/sass/buic/_listing.scss
@@ -6,10 +6,10 @@ table.buic-listing {
      * Striping.
      */
     tbody {
-        $background-normal:          #fff;
-        $background-normal-stripe:   #f9f9f9;
-        $background-selected:        mix(#fff, #7b9db8, 90%);
-        $background-selected-stripe: mix(#fff, #7b9db8, 80%);
+        $background-normal:          $basebgcolour;
+        $background-normal-stripe:   darken($basebgcolour, 4);
+        $background-selected:        mix($background-normal, #7b9db8, 90%);
+        $background-selected-stripe: mix($background-normal-stripe, #7b9db8, 80%);
 
         // No striping.
         tr {
@@ -45,7 +45,7 @@ table.buic-listing {
     tr.heading {
         th {
             padding: 1em 0.2em 0.1em 0.2em;
-            background: #fff !important;
+            background: $basebgcolour !important;
 
             font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
             font-size: $font-size-h3;

--- a/app/src/sass/buic/_listing.scss
+++ b/app/src/sass/buic/_listing.scss
@@ -71,7 +71,7 @@ table.buic-listing {
             $symbol-color:          #ddd;
             $symbol-color-selected: #888;
             $symbol-color-hover:    #00c;
-            $symbol-spacing:        0.3em;
+            $symbol-spacing:        0.4em;
 
             color: $text-color;
             vertical-align: middle;

--- a/app/src/sass/buic/_listing.scss
+++ b/app/src/sass/buic/_listing.scss
@@ -7,9 +7,9 @@ table.buic-listing {
      */
     tbody {
         $background-normal:          $basebgcolour;
-        $background-normal-stripe:   darken($basebgcolour, 4);
-        $background-selected:        mix($background-normal, #7b9db8, 90%);
-        $background-selected-stripe: mix($background-normal-stripe, #7b9db8, 80%);
+        $background-normal-stripe:   mix($background-normal, #7389a1, 92%);
+        $background-selected:        mix($background-normal, #555, 85%);
+        $background-selected-stripe: mix($background-normal-stripe, #555, 85%);
 
         // No striping.
         tr {
@@ -151,9 +151,6 @@ table.buic-listing {
             @extend .btn;
             @extend .btn-default;
             @extend .btn-xs;
-
-            padding-top: 0;
-            padding-bottom: 0;
 
             &.danger {
                 @extend .btn-silent-danger;

--- a/app/src/sass/fieldsets/_generic.scss
+++ b/app/src/sass/fieldsets/_generic.scss
@@ -8,7 +8,7 @@ div[data-fieldtype] {
 // The last container, just before save buttons.
 div[data-fieldtype]:last-child,
 div[data-fieldtype="meta"] {
-    border-bottom: 1px solid #bbb;
+    border-bottom: 1px solid $light-border;
     padding-bottom: 20px;
     margin-bottom: 15px;
 }

--- a/app/src/sass/fieldsets/_generic.scss
+++ b/app/src/sass/fieldsets/_generic.scss
@@ -1,7 +1,7 @@
 /*** Fieldset container ***/
 
 div[data-fieldtype] {
-    border-bottom: 1px dashed #eee;
+    border-bottom: 1px solid transparent; // Transparent line, to keep spacing intact.
     margin-bottom: 10px;
 }
 
@@ -21,15 +21,17 @@ fieldset[data-bolt-field] {
     /*** Label ***/
 
     label, .control-label {
-        font-weight: bold;
+        font-weight: normal;
         font-size: 13px;
-        color: lighten(black, 30%);
+        color: #777;
     }
 
     // Main label.
     label.main {
-        color: desaturate(lighten($boltblue, 35%), 20);
-        font-size: 15px;
+        color: #333;
+        font-weight: normal;
+        font-size: 16px;
+        margin-bottom: 6px;
     }
 
     /*** Info popup ***/

--- a/app/src/sass/fieldsets/_geolocation.scss
+++ b/app/src/sass/fieldsets/_geolocation.scss
@@ -29,8 +29,8 @@
         }
 
         .matched, .latitude, .longitude {
-            background: #fafafa;
-            border: none;
+            // background: #fafafa;
+            // border: none;
             box-shadow: none;
             font-size: 1em;
             line-height: 1em;

--- a/app/src/sass/fieldsets/_slug.scss
+++ b/app/src/sass/fieldsets/_slug.scss
@@ -10,6 +10,7 @@
             text-align: left;
             font-family: $fonts-family-monospace;
             color: #aaa;
+            font-size: 13px;
 
             em {
                 color: black;

--- a/app/src/sass/fieldsets/_video.scss
+++ b/app/src/sass/fieldsets/_video.scss
@@ -13,4 +13,9 @@ fieldset[data-bolt-field="video"] {
         width: 100%;
         vertical-align: middle;
     }
+
+    .label-pixels {
+        display: inline;
+    }
+
 }

--- a/app/src/sass/modules/_aside.scss
+++ b/app/src/sass/modules/_aside.scss
@@ -28,6 +28,7 @@ aside {
 
     .panel {
         border-radius: 0;
+        margin-left: 12px;
     }
 
     .panel-body > ul {

--- a/app/src/sass/modules/_aside.scss
+++ b/app/src/sass/modules/_aside.scss
@@ -29,6 +29,7 @@ aside {
     .panel {
         border-radius: 0;
         margin-left: 12px;
+        border-color: $panel-default-border;
     }
 
     .panel-body > ul {
@@ -69,4 +70,12 @@ aside {
     code {
         letter-spacing: -0.5px;
     }
+}
+
+@media (max-width: 640px) {
+
+    aside .panel {
+        margin-left: 0;
+    }
+
 }

--- a/app/src/sass/modules/_aside.scss
+++ b/app/src/sass/modules/_aside.scss
@@ -52,7 +52,7 @@ aside {
     }
 
     .btn-group {
-        margin-bottom: 14px;
+        margin: 0 6px 12px 0;
     }
 
     .dropdown-menu .btn-link {

--- a/app/src/sass/modules/_bolt.scss
+++ b/app/src/sass/modules/_bolt.scss
@@ -3,6 +3,7 @@ html {
 }
 
 body {
+    background: $basebgcolour;
     color: $bodytextcolour;
     font-size: 13px;
     min-height: 100%;

--- a/app/src/sass/modules/_dashboard.scss
+++ b/app/src/sass/modules/_dashboard.scss
@@ -40,6 +40,10 @@
         border-bottom: 1px solid #E7E7E7;
     }
 
+    th.listthumb {
+        padding: 0;
+    }
+
     th h2 {
         margin: 0.4em 0 0.1em;
         color: #666;
@@ -77,12 +81,12 @@
         text-align: left;
     }
 
-    td.listthumb {
-        padding: 9px 2px 2px;
-    }
-
     td.check {
         /* padding-top: 10px; */
+    }
+
+    td.listthumb {
+        padding: 9px 0 2px;
     }
 
     td.listthumb img {
@@ -148,12 +152,18 @@
 }
 
 @media (max-width: 640px) {
-    .dashboardlisting td.listthumb img {
-        margin-top:  42px;
-        margin-bottom: 4px;
+
+    .dashboardlisting td.listthumb {
+        padding: 4px 0 0 0;
     }
 
-    .dashboardlisting td.actions .btn-group {
-        margin-top: 2px;
+    .dashboardlisting td.listthumb img {
+        margin-left: 0px;
+
     }
+
+    .dashboardlisting td.excerpt {
+        padding: 6px 6px 6px 2px;
+    }
+
 }

--- a/app/src/sass/modules/_dashboard.scss
+++ b/app/src/sass/modules/_dashboard.scss
@@ -16,105 +16,113 @@
     margin-bottom: 10px;
     width: 100%;
     padding: 1px;
-}
 
-.dashboardlisting tbody {
-    border-top: 0px !important;
-}
-
-.dashboardlisting th,
-.dashboardlisting td {
-    border-bottom: 1px solid $table-border-color;
-    font-size: 13px;
-    line-height: $line-height-base;
-    vertical-align: top;
-    padding: 8px;
-}
-
-.dashboardlisting th {
-    background-color: #F2F2F2 !important;
-    text-align: left;
-    font-weight: bold;
-    color: #888;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    border-bottom: 1px solid #E7E7E7;
-}
-
-.dashboardlisting th h2 {
-    margin: 0.4em 0 0.1em;
-    color: #666;
-}
-
-.dashboardlisting tr {
-    background-color: #FFF;
-}
-
-.dashboardlisting tr.dim td.id,
-.dashboardlisting tr.dim td.excerpt,
-.dashboardlisting tr.dim td.listthumb,
-.dashboardlisting tr.dim td.username
-{
-    opacity: 0.8;
-    filter: grayscale(0.5);
-}
-
-.dashboardlisting tr.dim img {
-    filter: grayscale(0.6) blur(1px);
-}
-
-.dashboardlisting td.id,
-.dashboardlisting td.username,
-.dashboardlisting td.actions,
-.dashboardlisting td.listthumb  {
-    white-space: nowrap;
-    color: #666;
-    padding: 8px;
-}
-.dashboardlisting td.username {
-    text-align: left;
-}
-
-.dashboardlisting td.listthumb {
-    padding: 4px 2px 2px;
-}
-
-.dashboardlisting td.check {
-    /* padding-top: 10px; */
-}
-
-.dashboardlisting td.listthumb img {
-    max-width: inherit; /* correcting an issue that first popped up in Chrome-dev 30. */
-}
-
-.dashboardlisting td.actions {
-    text-align: right;
-
-    .btn-group {
-        display: inline-flex;
-        -webkit-align-self: auto;
-        padding-left: 6px;
+    tbody {
+        border-top: 0px !important;
     }
-}
 
-.dashboardlisting .btn-group > .btn + .dropdown-toggle {
-  padding-left: 3px;
-  padding-right: 6px;
-}
+    th,
+    td {
+        border-bottom: 1px solid $table-border-color;
+        font-size: 13px;
+        line-height: $line-height-base;
+        vertical-align: top;
+        padding: 10px 8px;
+    }
 
-.dashboardlisting td.excerpt span {
-    max-height: 38px;
-    /* padding-top: 3px; */
-    display: block;
-    line-height: $line-height-base;
-    color: #777;
-    overflow: hidden;
-    word-wrap: break-word;
-    word-break: break-all;
-}
+    th {
+        background-color: #F2F2F2 !important;
+        text-align: left;
+        font-weight: bold;
+        color: #888;
+        padding-top: 5px;
+        padding-bottom: 5px;
+        border-bottom: 1px solid #E7E7E7;
+    }
 
-.dashboardlisting td.excerpt.large span {
-    max-height: 54px;
+    th h2 {
+        margin: 0.4em 0 0.1em;
+        color: #666;
+    }
+
+    tr {
+        background-color: #FFF;
+    }
+
+    td {
+        border-color: $light-border;
+    }
+
+    tr.dim td.id,
+    tr.dim td.excerpt,
+    tr.dim td.listthumb,
+    tr.dim td.username
+    {
+        opacity: 0.8;
+        filter: grayscale(0.5);
+    }
+
+    tr.dim img {
+        filter: grayscale(0.6) blur(1px);
+    }
+
+    td.id,
+    td.username,
+    td.actions,
+    td.listthumb  {
+        white-space: nowrap;
+        color: #666;
+    }
+    td.username {
+        text-align: left;
+    }
+
+    td.listthumb {
+        padding: 9px 2px 2px;
+    }
+
+    td.check {
+        /* padding-top: 10px; */
+    }
+
+    td.listthumb img {
+        max-width: inherit; /* correcting an issue that first popped up in Chrome-dev 30. */
+    }
+
+    td.actions {
+        text-align: right;
+
+        .btn-group {
+            display: inline-flex;
+            -webkit-align-self: auto;
+            padding-left: 6px;
+        }
+    }
+
+    .btn-group > .btn + .dropdown-toggle {
+      padding-left: 3px;
+      padding-right: 6px;
+    }
+
+    td.excerpt {
+        padding-top: 9px;
+    }
+
+    td.excerpt span {
+        max-height: 40px;
+        /* padding-top: 3px; */
+        display: block;
+        line-height: 19px;
+        color: #777;
+        overflow: hidden;
+        word-wrap: break-word;
+        word-break: break-all;
+    }
+
+    td.excerpt.large span {
+        max-height: 58px;
+    }
+
 }
 
 @media (max-width: 767px) {

--- a/app/src/sass/modules/_editcontent.scss
+++ b/app/src/sass/modules/_editcontent.scss
@@ -161,7 +161,7 @@
 
     .fileselectbuttongroup {
         & > * {
-            margin: 0 4px 4px 0;
+            margin: 8px 4px 4px 0;
             float: left;
         }
         .caret {

--- a/app/src/sass/modules/_forms.scss
+++ b/app/src/sass/modules/_forms.scss
@@ -35,6 +35,12 @@ label {
     .form-group {
         margin-top: 24px;
         margin-bottom: 10px;
+
+        @media (max-width: 640px) {
+            margin-top: 16px;
+            margin-bottom: 4px;
+        }
+
     }
 
     .form-group-first {
@@ -122,10 +128,7 @@ fieldset.checkbox {
 #filtertabs {
     margin-bottom: 16px;
     border: 0;
-
-    @include respond-to(medium-screens) {
-        border-bottom: 1px solid darken($filtertabs, 10);;
-    }
+    border-bottom: 1px solid darken($filtertabs, 10);;
 
     a {
         color: $filtertab-color;
@@ -139,6 +142,10 @@ fieldset.checkbox {
             color: #444;
             background-color: #FFF !important;
             border-bottom: 0;
+        }
+
+        @media (max-width: 767px) {
+            padding: 4px 6px;
         }
     }
 

--- a/app/src/sass/modules/_forms.scss
+++ b/app/src/sass/modules/_forms.scss
@@ -124,15 +124,16 @@ fieldset.checkbox {
     border: 0;
 
     @include respond-to(medium-screens) {
-        border-bottom: 1px solid #BBB;
+        border-bottom: 1px solid darken($filtertabs, 10);;
     }
 
     a {
-        color: #666;
-        background-color: desaturate(lighten($boltblue, 60%), 30);
-        border: 1px solid #BBB;
+        color: $filtertab-color;
+        background-color: $filtertabs; // desaturate(lighten($boltblue, 60%), 30);
+        border: 1px solid darken($filtertabs, 10);
         cursor: pointer;
         padding: 5px 12px;
+        font-weight: normal;
 
         &:hover {
             color: #444;
@@ -142,15 +143,15 @@ fieldset.checkbox {
     }
 
     li {
-        margin-left: -3px;
+        margin-right: 2px;
 
         &.active {
-            margin-top: -5px;
 
             a {
-                background-color: #F8F8F8;
-                color: #333;
-                padding: 7px 12px 8px 12px;
+                background-color: $basebgcolour;
+                border: 1px solid darken($filtertabs, 20);
+                border-bottom: 1px solid $basebgcolour;
+                color: $filtertab-active-color;
             }
         }
     }

--- a/app/src/sass/modules/_forms.scss
+++ b/app/src/sass/modules/_forms.scss
@@ -31,13 +31,14 @@ label {
         margin-bottom: 5px;
         padding-top: 4px;
     }
-}
-
-.form-group {
-    margin-bottom: 20px;
 
     .form-group {
+        margin-top: 24px;
         margin-bottom: 10px;
+    }
+
+    .form-group-first {
+        margin-top: 0;
     }
 }
 

--- a/app/src/sass/modules/custom/_bootstrap.scss
+++ b/app/src/sass/modules/custom/_bootstrap.scss
@@ -89,6 +89,11 @@
     padding-bottom: 16px;
     margin: 6px 0 20px;
     border-bottom: 0;
+
+    @media (max-width: 640px) {
+        padding-bottom: 0;
+    }
+
 }
 
 // Enhance center-block
@@ -140,6 +145,10 @@
     font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     margin: 0;
     padding: 8px 8px 8px 2px;
+
+    @media (max-width: 640px) {
+       padding: 10px 8px 8px 6px;
+   }
 }
 
 .navbar .navbar-brand img {
@@ -241,7 +250,7 @@
 
 .navbar-toggle {
     float: left;
-    margin: 11px 0 0 15px;
+    margin: 11px 0 0 -8px;
     padding: 5px 8px 4px 5px;
     background-color: desaturate(lighten($boltblue, 45), 35);
     border: 0px solid #FFF !important;

--- a/app/src/sass/modules/custom/_bootstrap.scss
+++ b/app/src/sass/modules/custom/_bootstrap.scss
@@ -90,7 +90,7 @@
 
 // Override page-header
 .page-header {
-    padding-bottom: 14px;
+    padding-bottom: 16px;
     margin: 6px 0 20px;
 }
 
@@ -119,6 +119,7 @@
     background-color: $boltblue;
     background-repeat: repeat-x;
     border-bottom: 0;
+    box-shadow: 0 -5px 0 rgba(0, 0, 0, 0.15) inset;
 
     div.navbar-collapse {
         float: right;

--- a/app/src/sass/modules/custom/_bootstrap.scss
+++ b/app/src/sass/modules/custom/_bootstrap.scss
@@ -137,13 +137,12 @@
 .navbar .navbar-brand {
     display: inline-block;
     top: 0px;
-    left: 20px;
     color: #FFF;
     font-size: 28px;
     line-height: 28px;
     font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     margin: 0;
-    padding: 10px 8px 8px 10px;
+    padding: 8px 8px 8px 33px;
 }
 
 .navbar .navbar-brand img {
@@ -157,7 +156,7 @@
     color: #ccc !important;
     font-size: 22px;
     line-height: 30px;
-    margin-top: 10px;
+    margin-top: 8px;
     padding: 1px 5px 0 5px;
     float: left;
     font-weight: normal;

--- a/app/src/sass/modules/custom/_bootstrap.scss
+++ b/app/src/sass/modules/custom/_bootstrap.scss
@@ -142,7 +142,7 @@
     line-height: 28px;
     font-family: 'Source Sans Pro', 'Helvetica Neue', Helvetica, Arial, sans-serif;
     margin: 0;
-    padding: 8px 8px 8px 33px;
+    padding: 8px 8px 8px 2px;
 }
 
 .navbar .navbar-brand img {

--- a/app/src/sass/modules/custom/_bootstrap.scss
+++ b/app/src/sass/modules/custom/_bootstrap.scss
@@ -88,6 +88,7 @@
 .page-header {
     padding-bottom: 16px;
     margin: 6px 0 20px;
+    border-bottom: 0;
 }
 
 // Enhance center-block
@@ -311,17 +312,17 @@ ul.dropdown-menu li a.nolink {
     &>li {
 
         &>a {
-            color: $linkmain;
+            color: darken($btn-tertiary-bg, 5);
         }
 
         &>span {
-            color: #666;
+            color: #888;
         }
     }
 
     .active a {
-        background-color: $linkmain;
-        border-color: $linkmain;
+        background-color: $btn-tertiary-bg;
+        border-color: $btn-tertiary-bg;
     }
 
 }

--- a/app/src/sass/modules/custom/_bootstrap.scss
+++ b/app/src/sass/modules/custom/_bootstrap.scss
@@ -116,10 +116,9 @@
 
 .navbar-bolt {
     background: transparent;
-    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 80%, rgba(0, 0, 0, .2) 100%);
     background-color: $boltblue;
     background-repeat: repeat-x;
-    // box-shadow: 0 4px 0px rgba(0, 0, 0, .2);
+    border-bottom: 0;
 
     div.navbar-collapse {
         float: right;

--- a/app/src/sass/modules/custom/_bootstrap.scss
+++ b/app/src/sass/modules/custom/_bootstrap.scss
@@ -17,17 +17,13 @@
 .btn-sm {
   font-size: 13px;
   line-height: 16px;
-  padding: 4px 7px;
+  padding: 4px 9px;
 }
 
 .btn-group > a.btn-sm,
 .btn-group > a.btn-xs {
     font-weight: normal;
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-}
-
-.btn-group + .btn-group {
-    margin-left: 4px;
 }
 
 // Primary button for Bolt:

--- a/app/src/sass/nav/_content.scss
+++ b/app/src/sass/nav/_content.scss
@@ -1,6 +1,6 @@
 /**** MODE: Hidden + Shown ****/
 #navpage-content {
-    padding: 16px 24px 60px 8px;
+    padding: 12px 16px 60px 6px;
     transition: left 0.3s;
     position: absolute;
     left: 0;
@@ -10,6 +10,7 @@
 @include respond-to(medium-screens) {
     /**** MODE: Expanded ****/
     #navpage-content {
+        padding-top: 16px;
         padding-left: 42px;
         left: $nav-secondary-large-width;
     }

--- a/app/src/sass/nav/_content.scss
+++ b/app/src/sass/nav/_content.scss
@@ -1,6 +1,6 @@
 /**** MODE: Hidden + Shown ****/
 #navpage-content {
-    padding: 16px 16px 60px 8px;
+    padding: 16px 24px 60px 8px;
     transition: left 0.3s;
     position: absolute;
     left: 0;
@@ -10,14 +10,14 @@
 @include respond-to(medium-screens) {
     /**** MODE: Expanded ****/
     #navpage-content {
-        padding-left: 30px;
+        padding-left: 42px;
         left: $nav-secondary-large-width;
     }
 
     /**** MODE: Collapsed ****/
     #navpage-wrapper.nav-secondary-collapsed {
         #navpage-content {
-            padding-left: 30px;
+            padding-left: 42px;
             left: $nav-secondary-collapsed-width;
         }
     }

--- a/app/src/sass/nav/_nav.scss
+++ b/app/src/sass/nav/_nav.scss
@@ -1,7 +1,6 @@
 #navpage-wrapper {
     width: 100%;
     height: 100%;
-    background: $basebgcolour;
 }
 
 @import "primary";

--- a/app/src/sass/nav/_primary.scss
+++ b/app/src/sass/nav/_primary.scss
@@ -2,7 +2,7 @@
     .navbar-form {
         border: 0;
         box-shadow: none !important;
-        font-size: 120%;
+        font-size: 100%;
         margin-right: 8px;
         padding: 0 15px 8px 6px;
     }
@@ -83,6 +83,7 @@
 .navbar-static-top .nav > li {
     & > a {
         color: $sidebarlink;
+        font-weight: normal;
     }
     &:hover > a,
     :focus {

--- a/app/src/sass/nav/_secondary.scss
+++ b/app/src/sass/nav/_secondary.scss
@@ -45,6 +45,10 @@
             color: $sidebarlink;
             font-weight: normal;
 
+            @media (max-width: 640px) {
+                padding: ($nav-secondary-v-padding - 2px) $nav-secondary-h-padding ($nav-secondary-v-padding - 2px) ($nav-secondary-h-padding + $nav-secondary-indent);
+            }
+
             i {
                 width: $nav-secondary-icon-size;
                 margin-right: $nav-secondary-icon-margin;
@@ -127,7 +131,8 @@
         display: block;
         //text-indent: -$nav-secondary-indent;
         font-weight: normal;
-        max-height: 4.8em;
+        max-height: 3.6em;
+        overflow: hidden;
         cursor: pointer;
     }
     &.nav-secondary-dashboard {
@@ -190,6 +195,7 @@
 
         form {
             margin: 0;
+            padding-top: 0;
             border: none;
             box-shadow: none;
         }

--- a/app/src/sass/nav/_secondary.scss
+++ b/app/src/sass/nav/_secondary.scss
@@ -21,7 +21,7 @@
     height: 100%;
     left: -$nav-secondary-small-width;
     transition: left 0.1s, width 0.1s;
-    box-shadow: -5px 0 0 rgba(0, 0, 0, 0.2) inset;
+    box-shadow: -5px 0 0 rgba(0, 0, 0, 0.15) inset;
     background: $sidebarbackground;
     color: $sidebartextcolour;
     font-size: 120%;
@@ -157,6 +157,9 @@
     a:focus {
         color: $sidebarlinkhover;
         background: $sidebarbackgroundhover;
+        i.icon {
+            background: $sidebarlinkhover;
+        }
     }
 
     & > em {
@@ -167,13 +170,16 @@
         i.icon {
             background: none;
             color: lighten($sidebarbackgroundactive, 40);
-            top:15px;
+            top: 17px;
         }
     }
 
     &.active {
-        background-color: $sidebarbackgroundactive;
-        color: #fff;
+        color: $sidebarlinkactive;
+        background: $sidebarbackgroundactive;
+        i.icon {
+            background: $sidebarlinkactive;
+        }
     }
 
     &.divider {
@@ -226,9 +232,9 @@
         border-radius: 3px;
         font-size: ($nav-secondary-icon-size - 8px);
         color: #333;
-        position:absolute;
-        left:10px;
-        top:9px;
+        position: absolute;
+        left: 12px;
+        top: 10px;
 
         &:before {
             font-weight: normal;

--- a/app/src/sass/nav/_secondary.scss
+++ b/app/src/sass/nav/_secondary.scss
@@ -25,7 +25,6 @@
     background: $sidebarbackground;
     color: $sidebartextcolour;
     font-size: 120%;
-    //overflow-y: auto;
 
     ul.submenu {
         @include hide();
@@ -174,7 +173,7 @@
         }
     }
 
-    &.active {
+    &.active > a {
         color: $sidebarlinkactive;
         background: $sidebarbackgroundactive;
         i.icon {

--- a/app/view/twig/_base/_fieldset.twig
+++ b/app/view/twig/_base/_fieldset.twig
@@ -21,6 +21,6 @@
 
 <fieldset{{ macro.attr(attributes_fieldset) }}>
     <legend class="sr-only">{% block fieldset_label_text %}{% endblock fieldset_label_text %}</legend>
-    <label{{ macro.attr(attributes_label) }}>{{ block('fieldset_label_text') }}{{ field_info|default('') }}</label>
+    <label{{ macro.attr(attributes_label) }}>{{ block('fieldset_label_text') }}: {{ field_info|default('') }}</label>
     {% block fieldset_controls %}{% endblock fieldset_controls %}
 </fieldset>

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -112,7 +112,7 @@
             <th class="hidden-xs">{{ sortable_link('id', __('Id'))}}</th>
 
             {# COLUMN: Content #}
-            <th style="width:80%">{{ sortable_link(content.TitleColumnName()|first, __('Title') ~ '/' ~ __('Excerpt')) }}</th>
+            <th style="width:80%">{{ sortable_link(content.TitleColumnName()|first, __('Title') ~ ' / ' ~ __('Excerpt')) }}</th>
 
             {# COLUMN: Thumbnail #}
             <th>&nbsp;</th>

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -115,13 +115,13 @@
             <th style="width:80%">{{ sortable_link(content.TitleColumnName()|first, __('Title') ~ ' / ' ~ __('Excerpt')) }}</th>
 
             {# COLUMN: Thumbnail #}
-            <th>&nbsp;</th>
+            <th class="listthumb"></th>
 
             {# COLUMN: Meta #}
             <th class="username hidden-xs">{{ sortable_link('datecreated', __('Meta'))}}</th>
 
             {# COLUMN: Action #}
-            <th>{{ __('Actions') }}</th>
+            <th class="hidden-xs">{{ __('Actions') }}</th>
         {% endblock %}
     </tr>
 {% endif %}
@@ -207,7 +207,7 @@
     {### BLOCK: ACTIONS ###}
     {% block listing_actions %}
         {# COLUMN: Action #}
-        <td class="actions">
+        <td class="actions hidden-xs">
             <div class="btn-group">
                 {% if modifiable %}
                     <a class="btn btn-default btn-xs" href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id}) }}">

--- a/app/view/twig/_macro/_macro.twig
+++ b/app/view/twig/_macro/_macro.twig
@@ -186,7 +186,7 @@
 
         {# Button: Upload #}
         {% if canUpload %}
-            <span class="btn btn-secondary btn-sm fileinput-button">
+            <span class="btn btn-tertiary btn-sm fileinput-button">
             	<i class="fa fa-upload"></i>
             	<span>{{ (type == 'image') ? __('Upload image') : __('Upload file') }}</span>
             	<input{{ attr(attr_upload) }}>

--- a/app/view/twig/_macro/_macro.twig
+++ b/app/view/twig/_macro/_macro.twig
@@ -186,13 +186,13 @@
 
         {# Button: Upload #}
         {% if canUpload %}
-            <span class="btn btn-secondary fileinput-button">
+            <span class="btn btn-secondary btn-sm fileinput-button">
             	<i class="fa fa-upload"></i>
             	<span>{{ (type == 'image') ? __('Upload image') : __('Upload file') }}</span>
             	<input{{ attr(attr_upload) }}>
         	</span>
         {% else %}
-            <button type="button" class="btn" disabled="disabled">
+            <button type="button" class="btn btn-sm" disabled="disabled">
                 {{ __('Upload not allowed') }}
                 {# creating a dummy stub, instead of the uploader. Needed (currently) to attach events to #}
                 {% set attr_upload = attr_upload|merge({'type' : 'hidden'}) %}
@@ -201,7 +201,7 @@
         {% endif %}
 
         {# Button: Select from Server #}
-        <button type="button" class="btn btn-tertiary" data-target="#selectModal-{{ key }}" data-remote="{{ href }}" data-toggle="modal">
+        <button type="button" class="btn btn-tertiary btn-sm" data-target="#selectModal-{{ key }}" data-remote="{{ href }}" data-toggle="modal">
             <i class="fa fa-download"></i>
             {{ __('field.general.select-from-server') }}
         </button>
@@ -209,9 +209,9 @@
         {# Button: Select from Stack #}
         {% if not app.config.get('general/backend/stack/disable', false) and items %}
             <div class="btn-group">
-                <button type="button" class="btn btn-tertiary dropdown-toggle" data-toggle="dropdown">
+                <button type="button" class="btn btn-tertiary btn-sm dropdown-toggle" data-toggle="dropdown">
                     <i class="fa fa-paperclip"></i>
-                    {{ __('field.general.select-from-stack') }}
+                    {{ __('field.general.stack') }}
                     <span class="caret"></span>
                 </button>
 

--- a/app/view/twig/editcontent/_aside-live-editor.twig
+++ b/app/view/twig/editcontent/_aside-live-editor.twig
@@ -1,6 +1,6 @@
 {% if context.contenttype.liveeditor is not defined or context.contenttype.liveeditor %}{# don't show for viewless contenttypes. #}
 <div class="btn-group">
-    <button type="button" class="btn btn-tertiary" id="sidebar-live-editor-button">
+    <button type="button" class="btn btn-secondary" id="sidebar-live-editor-button">
         <i class="fa fa-pencil"></i> {{ __('Live Edit') }}
     </button>
 </div>

--- a/app/view/twig/editcontent/_aside-live-editor.twig
+++ b/app/view/twig/editcontent/_aside-live-editor.twig
@@ -1,5 +1,5 @@
 {% if context.contenttype.liveeditor is not defined or context.contenttype.liveeditor %}{# don't show for viewless contenttypes. #}
-<div class="btn-group">
+<div class="btn-group hidden-xs">
     <button type="button" class="btn btn-secondary" id="sidebar-live-editor-button">
         <i class="fa fa-pencil"></i> {{ __('Live Edit') }}
     </button>

--- a/app/view/twig/editcontent/_buttons.twig
+++ b/app/view/twig/editcontent/_buttons.twig
@@ -1,4 +1,4 @@
-<div class="form-group">
+<div class="form-group hidden-xs">
     <div class="col-xs-12">
 
         {# Save Contentype #}

--- a/app/view/twig/editcontent/_buttons.twig
+++ b/app/view/twig/editcontent/_buttons.twig
@@ -28,7 +28,7 @@
         {# Live Edit #}
         {% if context.contenttype.liveeditor is not defined or context.contenttype.liveeditor %}
             <div class="btn-group">
-                <button type="button" class="btn btn-tertiary" id="live-editor-button">
+                <button type="button" class="btn btn-secondary" id="live-editor-button">
                     <i class="fa fa-pencil"></i> {{ __('Live Edit') }}
                 </button>
             </div>

--- a/app/view/twig/editcontent/fielddata/_imagelist.twig
+++ b/app/view/twig/editcontent/fielddata/_imagelist.twig
@@ -14,7 +14,7 @@
             <img src="%PATH%../thumbs/60x40/%FNAME%" width="60" height="40">
         </a>
         <input type="text" value="%VAL%">
-        <a href="#" class="remove-button"><i class="fa fa-times"></i></a>
+        <a href="#" class="remove-button btm-sm"><i class="fa fa-times"></i></a>
     </div>
 {% endset %}
 

--- a/app/view/twig/editcontent/fielddata/_imagelist.twig
+++ b/app/view/twig/editcontent/fielddata/_imagelist.twig
@@ -14,7 +14,7 @@
             <img src="%PATH%../thumbs/60x40/%FNAME%" width="60" height="40">
         </a>
         <input type="text" value="%VAL%">
-        <a href="#" class="remove-button btm-sm"><i class="fa fa-times"></i></a>
+        <a href="#" class="remove-button"><i class="fa fa-times"></i></a>
     </div>
 {% endset %}
 

--- a/app/view/twig/editcontent/fields/_file.twig
+++ b/app/view/twig/editcontent/fields/_file.twig
@@ -65,7 +65,7 @@
 
         {# Infotext #}
         {% if not ismobileclient() %}
-            <div class="infotext hidden-xs">{{ app.translator.trans('info.upload.filesmall', {}, 'infos') }}</div>
+            <div class="hidden-xs"><label>{{ app.translator.trans('info.upload.filesmall', {}, 'infos') }}</label></div>
         {% endif %}
     </div>
 {% endblock fieldset_controls %}

--- a/app/view/twig/editcontent/fields/_filelist.twig
+++ b/app/view/twig/editcontent/fields/_filelist.twig
@@ -55,10 +55,12 @@
         <div class="clearfix">
             {{ macro.upload_buttons('file', key, attributes.fileupload, option.upload, can_upload) }}
 
-            <button type="button" class="btn btn-default remove-selected-button">
-                <i class="fa fa-trash"></i>
-                <span>{{ __('Remove selected') }}</span>
-            </button>
+            <div class="button-wrap fileselectbuttongroup">
+                <button type="button" class="btn btn-default btn-sm remove-selected-button">
+                    <i class="fa fa-trash"></i>
+                    <span>{{ __('Remove selected') }}</span>
+                </button>
+            </div>
         </div>
 
         {# Progress info #}

--- a/app/view/twig/editcontent/fields/_geolocation.twig
+++ b/app/view/twig/editcontent/fields/_geolocation.twig
@@ -36,7 +36,7 @@
     },
 
     formatted: {
-        class:      'matched',
+        class:      'form-control matched',
         name:        name ~ '[formatted_address]',
         placeholder: '—',
         readonly:    true,
@@ -55,7 +55,7 @@
     {% from '@bolt/_macro/_macro.twig' import attr %}
 
     <div class="col-sm-8">
-        <div class="form-group">
+        <div class="form-group form-group-first">
             <div class="col-sm-12">
                 <label>{{ __('field.geolocation.label.address-lookup') }}</label>
                 <input{{ attr(attributes.address) }} value="{{ geolocation.address|default('') }}">

--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -105,7 +105,7 @@
     <div class="col-xs-12 dropzone" id="dropzone-{{ key }}">
         <div class="row">
             <div class="col-xs-8">
-                <div class="form-group">
+                <div class="form-group form-group-first">
                     <div class="col-sm-12">
                         {{ block.imagepath(labelkey, option, image, attributes.inp) }}
                     </div>

--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -66,10 +66,12 @@
 
             <textarea name="{{ name }}" id="{{ key }}" class="hide">{{ list_json }}</textarea>
 
-            <span class="btn btn-default btn-sm remove-selected-button">
-                <i class="fa fa-trash"></i>
-                <span>{{ __('Remove selected') }}</span>
-            </span>
+            <div class="button-wrap fileselectbuttongroup">
+                <span class="btn btn-default btn-sm remove-selected-button">
+                    <i class="fa fa-trash"></i>
+                    <span>{{ __('Remove selected') }}</span>
+                </span>
+            </div>
         </div>
 
         <p class="uploading-list"></p>

--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -66,7 +66,7 @@
 
             <textarea name="{{ name }}" id="{{ key }}" class="hide">{{ list_json }}</textarea>
 
-            <span class="btn btn-default remove-selected-button">
+            <span class="btn btn-default btn-sm remove-selected-button">
                 <i class="fa fa-trash"></i>
                 <span>{{ __('Remove selected') }}</span>
             </span>

--- a/app/view/twig/editcontent/fields/_video.twig
+++ b/app/view/twig/editcontent/fields/_video.twig
@@ -93,7 +93,7 @@
 
 {% block fieldset_controls %}
     <div class="col-sm-8">
-        <div class="form-group">
+        <div class="form-group form-group-first">
             <div class="col-sm-12">
                 <label>{{ __('field.video.label.url') }}</label>
                 <input{{ macro.attr(attributes.url) }}>
@@ -107,7 +107,7 @@
                 <input{{ macro.attr(attributes.width) }}> ×
                 <label for="{{ 'video-' ~ key ~ '-height' }}" class="sr-only">{{ __('field.video.height') }}</label>
                 <input{{ macro.attr(attributes.height) }}>
-                <label>{{ __('field.video.pixel') }}</label>
+                <label class='label-pixels'>{{ __('field.video.pixel') }}</label>
             </div>
         </div>
 

--- a/app/view/twig/editcontent/fields/_video.twig
+++ b/app/view/twig/editcontent/fields/_video.twig
@@ -107,13 +107,13 @@
                 <input{{ macro.attr(attributes.width) }}> ×
                 <label for="{{ 'video-' ~ key ~ '-height' }}" class="sr-only">{{ __('field.video.height') }}</label>
                 <input{{ macro.attr(attributes.height) }}>
-                {{ __('field.video.pixel') }}
+                <label>{{ __('field.video.pixel') }}</label>
             </div>
         </div>
 
         <div class="form-group">
             <div class="col-sm-9">
-                <span><b>{{ __('field.video.matched-video') }}</b></span>
+                <label>{{ __('field.video.matched-video') }}</label>
                 <p id="video-{{ key }}-text">{{ videotitle|raw }}</p>
             </div>
 


### PR DESCRIPTION
I've made a lot of small changes in the backend UI. Just a pixel more margin here, a slight color change there.. No great changes anywhere, but altogether i think this makes the backend feel a bit more balanced out. 

Oh, and the "orange" for the primary buttons is gone :fire: 

Some screenshots, for side-by-side comparison:

New dashboard:
![dashboard-new](https://cloud.githubusercontent.com/assets/1833361/10714737/c4a0ae4c-7afc-11e5-88ca-17d63f21ed30.png)

Old dashboard:
![dashboard-old](https://cloud.githubusercontent.com/assets/1833361/10714739/c4a51e64-7afc-11e5-9b05-6a7a8d98fa25.png)

New Edit content: 
![edit-new](https://cloud.githubusercontent.com/assets/1833361/10714740/c4a56860-7afc-11e5-9192-add7084587a8.png)

Old: Edit content:
![edit-old](https://cloud.githubusercontent.com/assets/1833361/10714741/c4a5c760-7afc-11e5-925a-84a3889ad14b.png)

New Listing:
![listing-new](https://cloud.githubusercontent.com/assets/1833361/10714738/c4a452c2-7afc-11e5-84d3-2d3b0537eac9.png)

Old Listing: 
![listing-old](https://cloud.githubusercontent.com/assets/1833361/10714742/c4a787c6-7afc-11e5-85a3-d32d5a3dab2c.png)

New mobile edit: 
![mobile-edit-new](https://cloud.githubusercontent.com/assets/1833361/10714743/c4b59f46-7afc-11e5-96fb-f28c6bfae1a5.png)

Old mobile edit: 
![mobile-edit-old](https://cloud.githubusercontent.com/assets/1833361/10714744/c4b7bb50-7afc-11e5-8c45-e16703e60447.png)

New mobile listing:
![mobile-listing-new](https://cloud.githubusercontent.com/assets/1833361/10714745/c4bd28c4-7afc-11e5-84ac-873ab46d7fff.png)

Old mobile listing: 
![mobile-listing-old](https://cloud.githubusercontent.com/assets/1833361/10714746/c4bd5fba-7afc-11e5-87d6-e457d0149d57.png)

As soon as the PR is merged, we should recompile and commit all js / css. 