### PR TITLE
[Tests] Bolt\Events

### DIFF
--- a/tests/phpunit/unit/Events/ControllerEventsTest.php
+++ b/tests/phpunit/unit/Events/ControllerEventsTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace Bolt\Tests\Events;
+
+use Bolt\Events\ControllerEvents;
+use Bolt\Tests\BoltUnitTest;
+
+/**
+ * Class to test Bolt\Events\ControllerEvents
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ControllerEventsTest extends BoltUnitTest
+{
+    public function testConstant()
+    {
+        $this->assertSame('controller.mount', ControllerEvents::MOUNT);
+    }
+
+    public function testSingletonConstructor()
+    {
+        $reflection = new \ReflectionClass('Bolt\Events\ControllerEvents');
+        $method = $reflection->getMethod ('__construct');
+
+        $this->assertTrue($method->isConstructor());
+        $this->assertTrue($method->isPrivate());
+    }
+}

--- a/tests/phpunit/unit/Events/CronEventTest.php
+++ b/tests/phpunit/unit/Events/CronEventTest.php
@@ -11,22 +11,25 @@ use Symfony\Component\Console\Output\BufferedOutput;
  * Class to test src/Events/CronEvent.
  *
  * @author Ross Riley <riley.ross@gmail.com>
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
 class CronEventTest extends BoltUnitTest
 {
     public function testCronCalls()
     {
-        /*
         $app = $this->getApp();
 
-        $app['cache'] = $this->getMock('Bolt\Cache');
-        $app['logger.manager'] = $this->getMock('Bolt\Logger\Manager', ['trim'], [$app]);
+        $app['cache'] = $this->getMock('Bolt\Cache', [], [$app['resources']->getPath('cache'), $app]);
+        $app['cache']
+            ->expects($this->exactly(1))
+            ->method('clearCache');
 
-        $app['cache']->expects($this->exactly(1))
-                  ->method('clearCache');
-
-        $app['logger.manager']->expects($this->exactly(2))
-                  ->method('trim');
+        $changeRepository = $app['storage']->getRepository('Bolt\Storage\Entity\LogChange');
+        $systemRepository = $app['storage']->getRepository('Bolt\Storage\Entity\LogSystem');
+        $app['logger.manager'] = $this->getMock('Bolt\Logger\Manager', ['trim'], [$app, $changeRepository, $systemRepository]);
+        $app['logger.manager']
+            ->expects($this->exactly(2))
+            ->method('trim');
 
         $output = new BufferedOutput();
 
@@ -42,6 +45,5 @@ class CronEventTest extends BoltUnitTest
         $out = $listeningEvent->output->fetch();
         $this->assertRegExp('/Clearing cache/', $out);
         $this->assertRegExp('/Trimming logs/', $out);
-*/
     }
 }

--- a/tests/phpunit/unit/Events/MountEventTest.php
+++ b/tests/phpunit/unit/Events/MountEventTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Bolt\Tests\Events;
+
+use Bolt\Events\MountEvent;
+use Bolt\Tests\BoltUnitTest;
+use Silex\Application;
+use Silex\ControllerCollection;
+use Silex\ControllerProviderInterface;
+use Silex\Route;
+
+/**
+ * Class to test Bolt\Events\MountEvent
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class MountEventTest extends BoltUnitTest
+{
+    public function testConstructor()
+    {
+        $app = $this->getApp();
+        $controllers = new ControllerCollection(new Route('/'));
+        $mountEvent = new MountEvent($app, $controllers);
+
+        $this->assertInstanceOf('Bolt\Events\MountEvent', $mountEvent);
+        $this->assertInstanceOf('Silex\Application', $mountEvent->getApp());
+    }
+
+    public function testMount()
+    {
+        $app = $this->getApp();
+
+        $route = new Route('/');
+        $controllers = $this->getMock('Silex\ControllerCollection', ['mount'], [$route]);
+        $controllers
+            ->expects($this->once())
+            ->method('mount')
+        ;
+
+        $mountEvent = new MountEvent($app, $controllers);
+        $mountEvent->mount('/', $controllers);
+    }
+
+    public function testMountInvalidCollection()
+    {
+        $app = $this->getApp();
+
+        $route = new Route('/');
+        $controllers = $this->getMock('Silex\ControllerCollection', ['connect', 'mount'], [$route]);
+        $controllers
+            ->expects($this->never())
+            ->method('mount')
+        ;
+
+        $this->setExpectedException('LogicException', 'The "mount" method takes either a "ControllerCollection" or a "ControllerProviderInterface" instance.');
+        $mountEvent = new MountEvent($app, $controllers);
+        $mountEvent->mount('/', $route);
+    }
+
+    public function testMountInvalidCollectionConnect()
+    {
+        $app = $this->getApp();
+
+        $route = new Route('/');
+        $controllers = $this->getMock('Silex\ControllerCollection', ['connect', 'mount'], [$route]);
+        $controllers
+            ->expects($this->never())
+            ->method('mount')
+        ;
+
+        $this->setExpectedException('LogicException', 'The method "Bolt\Tests\Events\ControllerMock::connect" must return a "ControllerCollection" instance. Got: "Bolt\Tests\Events\ClippyKoala"');
+
+        $mountEvent = new MountEvent($app, $controllers);
+        $mountEvent->mount('/', new ControllerMock($route));
+    }
+}
+
+class ControllerMock implements ControllerProviderInterface
+{
+    public function connect(Application $app)
+    {
+        return new ClippyKoala();
+    }
+}
+
+class ClippyKoala {}

--- a/tests/phpunit/unit/Events/StorageEventTest.php
+++ b/tests/phpunit/unit/Events/StorageEventTest.php
@@ -33,4 +33,19 @@ class StorageEventTest extends BoltUnitTest
         $this->assertEquals(5, $event->getId());
         $this->assertEquals('pages', $event->getContentType());
     }
+
+    public function testIsCreate()
+    {
+        $app = $this->getApp();
+        $content = new Content($app, 'pages');
+        $content->setValue('id', 5);
+
+        $event = new StorageEvent($content);
+
+        $event->setArgument('create', true);
+        $this->assertTrue($event->isCreate());
+
+        $event->setArgument('create', false);
+        $this->assertFalse($event->isCreate());
+    }
 }


### PR DESCRIPTION
Missing (single) line of code is ControllerEvents being singleton, which is tested, but can't show up in PHPUnit coverage… 'cause… no further comment… :stuck_out_tongue_winking_eye: 

![coverage](https://cloud.githubusercontent.com/assets/1427081/10715802/57c706b2-7b1b-11e5-9780-d07cd523bb09.png)