### PR TITLE
Asset handling fixes/tweaks

### DIFF
--- a/src/Asset/File/FileAssetBase.php
+++ b/src/Asset/File/FileAssetBase.php
@@ -22,6 +22,16 @@ abstract class FileAssetBase implements FileAssetInterface
     protected $cacheHash;
 
     /**
+     * Constructor.
+     *
+     * @param string $fileName
+     */
+    public function __construct($fileName = null)
+    {
+        $this->fileName = $fileName;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getType()

--- a/src/Asset/File/FileAssetBase.php
+++ b/src/Asset/File/FileAssetBase.php
@@ -16,7 +16,7 @@ abstract class FileAssetBase implements FileAssetInterface
     protected $late;
     /** @var integer */
     protected $priority;
-    /** @var string */
+    /** @var array */
     protected $attributes;
     /** @var string */
     protected $cacheHash;
@@ -86,17 +86,31 @@ abstract class FileAssetBase implements FileAssetInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes($raw = false)
     {
-        return $this->attributes;
+        if ($raw) {
+            return $this->attributes;
+        }
+
+        return implode(' ', (array) $this->attributes);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setAttributes($attributes)
+    public function setAttributes(array $attributes)
     {
         $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttribute($attribute)
+    {
+        $this->attributes[] = $attribute;
 
         return $this;
     }

--- a/src/Asset/File/FileAssetInterface.php
+++ b/src/Asset/File/FileAssetInterface.php
@@ -53,18 +53,29 @@ interface FileAssetInterface extends AssetInterface
     /**
      * Get the asset's attributes.
      *
-     * @return string
+     * @param boolean $raw
+     *
+     * @return string|array
      */
-    public function getAttributes();
+    public function getAttributes($raw = false);
 
     /**
      * Set the asset's attributes.
      *
-     * @param string $attributes
+     * @param array $attributes
      *
      * @return FileAssetInterface
      */
-    public function setAttributes($attributes);
+    public function setAttributes(array $attributes);
+
+    /**
+     * Add and attributes for the asset.
+     *
+     * @param string $attribute
+     *
+     * @return FileAssetInterface
+     */
+    public function addAttribute($attribute);
 
     /**
      * Get the cache hash string.

--- a/src/Asset/File/JavaScript.php
+++ b/src/Asset/File/JavaScript.php
@@ -18,6 +18,6 @@ class JavaScript extends FileAssetBase
     {
         $hash = $this->cacheHash ? '?v=' . $this->cacheHash : $this->cacheHash;
 
-        return sprintf('<script src="%s%s" %s></script>', $this->fileName, $hash, $this->attributes);
+        return sprintf('<script src="%s%s" %s></script>', $this->fileName, $hash, $this->getAttributes());
     }
 }

--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -59,7 +59,7 @@ abstract class BaseExtension implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getApp()
+    protected function getApp()
     {
         return $this->app;
     }

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -52,7 +52,7 @@ class Extensions
     /**
      * {@inheritdoc}
      */
-    public function getApp()
+    protected function getApp()
     {
         return $this->app;
     }

--- a/src/Extensions/AssetTrait.php
+++ b/src/Extensions/AssetTrait.php
@@ -26,7 +26,7 @@ trait AssetTrait
      *
      * @param FileAssetInterface|string $fileAsset Asset object, or file name
      */
-    public function addCss($fileAsset, $options = [])
+    public function addCss($fileAsset)
     {
         if (!$fileAsset instanceof FileAssetInterface) {
             $fileAsset = $this->setupAsset(new Stylesheet(), $fileAsset, func_get_args());
@@ -40,7 +40,7 @@ trait AssetTrait
      *
      * @param FileAssetInterface|string $fileAsset File name
      */
-    public function addJavascript($fileAsset, $options = [])
+    public function addJavascript($fileAsset)
     {
         if (!$fileAsset instanceof FileAssetInterface) {
             $fileAsset = $this->setupAsset(new JavaScript(), $fileAsset, func_get_args());

--- a/src/Extensions/AssetTrait.php
+++ b/src/Extensions/AssetTrait.php
@@ -13,12 +13,12 @@ use Bolt\Asset\File\Stylesheet;
  */
 trait AssetTrait
 {
-    /** @return \Silex\Application */
-    abstract public function getApp();
     /** @return string */
     abstract public function getBaseUrl();
     /** @return string */
     abstract public function getBasePath();
+    /** @return \Silex\Application */
+    abstract protected function getApp();
 
     /**
      * Add a particular CSS file to the output. This will be inserted before the

--- a/src/Extensions/AssetTrait.php
+++ b/src/Extensions/AssetTrait.php
@@ -88,7 +88,7 @@ trait AssetTrait
             [
                 'late'     => false,
                 'priority' => 0,
-                'attrib'   => null,
+                'attrib'   => [],
             ],
             $this->getCompatibleArgs($options)
         );
@@ -110,7 +110,7 @@ trait AssetTrait
      * Where options were:
      *   'late'     - True to add to the end of the HTML <body>
      *   'priority' - Loading priority
-     *   'attrib'   - A string containing either/or 'defer', and 'async'
+     *   'attrib'   - A string containing either/both 'defer', and 'async'
      *
      * Passed in $args array can be:
      * - args[0] always the file name
@@ -127,10 +127,15 @@ trait AssetTrait
             return [
                 'late'     => isset($args[1]) ? $args[1] : false,
                 'priority' => isset($args[2]) ? $args[2] : 0,
-                'attrib'   => false
+                'attrib'   => []
             ];
         }
 
-        return $args[1];
+        $options = $args[1];
+        if (isset($options['attrib'])) {
+            $options['attrib'] = explode(' ', $options['attrib']);
+        }
+
+        return $options;
     }
 }

--- a/src/Extensions/AssetTrait.php
+++ b/src/Extensions/AssetTrait.php
@@ -31,6 +31,7 @@ trait AssetTrait
         if (!$fileAsset instanceof FileAssetInterface) {
             $fileAsset = $this->setupAsset(new Stylesheet(), $fileAsset, func_get_args());
         }
+        $fileAsset->setFileName($this->getAssetPath($fileAsset->getFileName()));
         $this->getApp()['asset.queue.file']->add($fileAsset);
     }
 
@@ -45,6 +46,7 @@ trait AssetTrait
         if (!$fileAsset instanceof FileAssetInterface) {
             $fileAsset = $this->setupAsset(new JavaScript(), $fileAsset, func_get_args());
         }
+        $fileAsset->setFileName($this->getAssetPath($fileAsset->getFileName()));
         $this->getApp()['asset.queue.file']->add($fileAsset);
     }
 
@@ -63,15 +65,17 @@ trait AssetTrait
             return $this->getApp()['resources']->getUrl('theme') . $fileName;
         } elseif ($this instanceof \Bolt\Extensions) {
             return $fileName;
-        } else {
-            $message = sprintf(
-                "Couldn't add file asset '%s': File does not exist in either %s or %s directories.",
-                $fileName,
-                $this->getBaseUrl(),
-                $this->getApp()['resources']->getUrl('theme')
-            );
-            $this->getApp()['logger.system']->error($message, ['event' => 'extensions']);
         }
+
+        $message = sprintf(
+            "Couldn't add file asset '%s': File does not exist in either %s or %s directories.",
+            $fileName,
+            $this->getBaseUrl(),
+            $this->getApp()['resources']->getUrl('theme')
+        );
+        $this->getApp()['logger.system']->error($message, ['event' => 'extensions']);
+
+        return $fileName;
     }
 
     /**
@@ -83,7 +87,6 @@ trait AssetTrait
      */
     private function setupAsset(FileAssetInterface $asset, $fileName, array $options)
     {
-        $fileName = $this->getAssetPath($fileName);
         $options = array_merge(
             [
                 'late'     => false,

--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -39,6 +39,8 @@ class AssetServiceProvider implements ServiceProviderInterface
                 return substr(md5($app['asset.salt'] . $fullPath . (string) filemtime($fullPath)), 0, 10);
             } elseif (is_readable($fileName)) {
                 return substr(md5($app['asset.salt'] . $fileName . (string) filemtime($fileName)), 0, 10);
+            } else {
+                return substr(md5($app['asset.salt'] . $fileName . mt_rand()), 0, 10);
             }
         });
 


### PR DESCRIPTION
**Summary**
* Fixes #4332
* Allows file asset objects to be created with file name, skipping fluency if desired

**Documentation**
This cleans up and fixes some derps from the asset refactor, and widget implementation branches. Below is an example of what now **can** be done, 2.0 & 2.2 behaviour is still valid.

* In the front-end "zone" we simply inject a JavaScript and CSS files with default options, exactly the same as `addCss('assets/css/foo.css')` `addJavascript('assets/js/foo.js')` 
* In the back-end "zone" we create the object and set whatever other options we do/don't want.

```php
use Bolt\Asset\File\JavaScript;
use Bolt\Asset\File\Stylesheet;
use Bolt\BaseExtension;
use Bolt\Controller\Zone;

class Extension extends BaseExtension
{
    public function initialize()
    {
        $this->app->before([$this, 'before']);
    }

    public function before(Request $request, Application $app)
    {
        // Simple asset injection
        if (Zone::isFrontend($request)) {
            $this->addCss(new Stylesheet('assets/css/foo.css'));
            $this->addJavascript(new JavaScript('assets/js/foo.js'));
        }

        // With all the bells and whistles!
        if (Zone::isBackend($request)) {
            $css = new Stylesheet();
            $css
                ->setFileName('assets/css/bar.css')
                ->setPriority(7)
            ;
            $this->addCss($css);

            $js = new JavaScript();
            $js
                ->setFileName('assets/js/bar.js')
                ->setLate(true)
                ->setPriority(99)
                ->addAttribute('defer')
                ->addAttribute('async')
            ;
            $this->addJavascript($js);
        }
    }
}
```
**Note:** Using objects is optional for convenience, calling the functions with 2.0/2.2 signatures will still work *exactly* the same as we just build the objects before adding them to the queue. 
