### PR TITLE
Document cookies_no_frontend in config.yml.dist

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -355,6 +355,10 @@ cookies_lifetime: 1209600
 # to '.example.org'.
 cookies_domain:
 
+# Disable cookies in frontent requests default (enabled by default)
+# See :  https://github.com/bolt/bolt/issues/3425
+# cookies_no_frontend: true
+
 # If your system is using a custom session configuration (such as a Redis
 # handler from a PHP extension) then we need to disable our session storage
 # handler. In that case, set this setting to false.


### PR DESCRIPTION
The parameter cookies_no_frontend added in bolt#3425 is not documented in config.yml.dist