### PR TITLE
Fixed priority issue in assets. Fixes #4319

### DIFF
--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -548,7 +548,7 @@ class Extensions
 
             $options = array(
                 'late'     => isset($args[1]) ? isset($args[1]) : false,
-                'priority' => isset($args[2]) ? isset($args[2]) : 0,
+                'priority' => isset($args[2]) ? $args[2] : 0,
                 'attrib'   => false
             );
         }
@@ -578,7 +578,7 @@ class Extensions
 
             $options = array(
                 'late'     => isset($args[1]) ? isset($args[1]) : false,
-                'priority' => isset($args[2]) ? isset($args[2]) : 0,
+                'priority' => isset($args[2]) ? $args[2] : 0,
                 'attrib'   => false
             );
         }


### PR DESCRIPTION
Priority did not work because it was converted to boolean if the variable priority was set. The methods affected are addCss and addJavascript. 

A dump of the variable $files in the method  processAssets shows  this:
```
array:2 [▼
  "ebb081dd3fe3d1e6b08d5f11c5e01ac3" => array:4 [▼
    "filename" => "/extensions/vendor/bolt/editable/assets//ckeditor/ckeditor.js"
    "late" => true
    "priority" => true
    "attrib" => false
  ]
  "dcb1cb7e3145c3508a7ee333d2803159" => array:4 [▼
    "filename" => "/extensions/vendor/bolt/editable/assets//ckeditor/startup.js"
    "late" => true
    "priority" => true
    "attrib" => false
  ]
]
```