### PR TITLE
Set composer/composer to dev stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "bolt/thumbs" : "~2.0",
         "brandonwamboldt/utilphp" : "~1.0",
         "cocur/slugify" : "~1.0",
-        "composer/composer" : "dev-master",
+        "composer/composer" : "dev-master@dev",
         "doctrine/dbal" : "2.5.1",
         "erusev/parsedown-extra" : "~0.2",
         "ext-mbstring" : "*",
@@ -70,11 +70,9 @@
         "sebastian/phpcpd" : "~2.0",
         "squizlabs/php_codesniffer" : "~2.0"
     },
-    "minimum-stability" : "beta",
     "config" : {
         "preferred-install" : "dist"
     },
-    "prefer-stable" : true,
     "autoload" : {
         "psr-4" : {
             "Bolt\\" : "src"


### PR DESCRIPTION
Fixes #4265

I changed the global _minimum stability_ to stable, because it's way easier to see which packages need a lower stability. At this point, `composer/composer` is the only one.

Because our _minimum stability_ in stable now, _prefer-stable_ isn't needed