### PR TITLE
Environment update handling

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -104,6 +104,9 @@ class Application extends Silex\Application
         // Initialize the rest of the Providers.
         $this->initProviders();
 
+        // Do a version check
+        $this['config.environment']->checkVersion();
+
         // Calling for BC. Controllers are mounted in ControllerServiceProvider now.
         $this->initMountpoints();
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -53,11 +53,6 @@ class Cache extends FilesystemCache
 
         try {
             parent::__construct($cacheDir, $this->extension);
-
-            // If the Bolt version has changed, flush our cache
-            if (!$this->checkCacheVersion()) {
-                $this->clearCache();
-            }
         } catch (\Exception $e) {
             $app['logger.system']->critical($e->getMessage(), ['event' => 'exception', 'exception' => $e]);
             throw $e;
@@ -168,30 +163,6 @@ class Cache extends FilesystemCache
         $dir->close();
 
         $this->updateCacheVersion();
-    }
-
-    /**
-     * Check if the cache version matches Bolt's current version
-     *
-     * @return boolean TRUE  - versions match
-     *                 FALSE - versions don't match
-     */
-    private function checkCacheVersion()
-    {
-        $file = $this->getDirectory() . '/.version';
-
-        if (!file_exists($file)) {
-            return false;
-        }
-
-        $version = md5($this->app['bolt_version'].$this->app['bolt_name']);
-        $cached  = file_get_contents($file);
-
-        if ($version === $cached) {
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/src/Configuration/Environment.php
+++ b/src/Configuration/Environment.php
@@ -3,7 +3,6 @@
 namespace Bolt\Configuration;
 
 use Bolt\Cache;
-use Silex\Application;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -30,16 +29,20 @@ class Environment
     /**
      * Constructor.
      *
-     * @param ResourceManager $resourceManager
+     * @param string $srcRoot
+     * @param string $webRoot
+     * @param Cache  $cache
+     * @param string $boltName
+     * @param string $boltVersion
      */
-    public function __construct(Application $app)
+    public function __construct($srcRoot, $webRoot, Cache $cache, $boltName, $boltVersion)
     {
         $this->filesystem = new Filesystem();
-        $this->srcRoot = realpath($app['resources']->getPath('root'));
-        $this->webRoot = realpath($app['resources']->getPath('web'));
-        $this->cache = $app['cache'];
-        $this->boltName = $app['bolt_name'];
-        $this->boltVersion = $app['bolt_version'];
+        $this->srcRoot = $srcRoot;
+        $this->webRoot = $webRoot;
+        $this->cache = $cache;
+        $this->boltName = $boltName;
+        $this->boltVersion = $boltVersion;
     }
 
     /**

--- a/src/Configuration/Environment.php
+++ b/src/Configuration/Environment.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Bolt\Configuration;
+
+use Bolt\Cache;
+use Silex\Application;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Environment set up and management class.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class Environment
+{
+    /** @var Cache */
+    protected $cache;
+    /** @var Filesystem */
+    protected $filesystem;
+    /** @var string */
+    protected $srcRoot;
+    /** @var string */
+    protected $webRoot;
+    /** @var string */
+    protected $boltName;
+    /** @var string */
+    protected $boltVersion;
+
+    /**
+     * Constructor.
+     *
+     * @param ResourceManager $resourceManager
+     */
+    public function __construct(Application $app)
+    {
+        $this->filesystem = new Filesystem();
+        $this->srcRoot = realpath($app['resources']->getPath('root'));
+        $this->webRoot = realpath($app['resources']->getPath('web'));
+        $this->cache = $app['cache'];
+        $this->boltName = $app['bolt_name'];
+        $this->boltVersion = $app['bolt_version'];
+    }
+
+    /**
+     * Check Bolt's version against a cached key. If there is a change we flush
+     * the cache data and if required synchronise asset directories.
+     */
+    public function checkVersion()
+    {
+        if ($this->checkCacheVersion()) {
+            return;
+        }
+        $this->syncView();
+        $this->cache->clearCache();
+    }
+
+    /**
+     * Perform a synchronisation of files in specific app/view/ subdirectories.
+     */
+    public function syncView()
+    {
+        $views = ['css', 'fonts', 'img', 'js'];
+        foreach ($views as $dir) {
+            $this->syncViewDirectory($dir);
+        }
+    }
+
+    /**
+     * Synchronise the files in an app/view/ subdirectory.
+     *
+     * @param string $dir
+     */
+    protected function syncViewDirectory($dir)
+    {
+        if ($this->srcRoot === $this->webRoot) {
+            return;
+        }
+
+        $source = $this->srcRoot . '/app/view/' . $dir;
+        $target = $this->webRoot . '/app/view/' . $dir;
+        if ($this->filesystem->exists($target)) {
+            return;
+        }
+
+        try {
+            $this->filesystem->mirror($source, $target, null, ['override' => true, 'delete' => true]);
+        } catch (IOException $e) {
+            // Apparently not.
+            trigger_error($e->getMessage(), E_USER_WARNING);
+        }
+    }
+
+    /**
+     * Check if the cache version matches Bolt's current version
+     *
+     * @return boolean TRUE  - versions match
+     *                 FALSE - versions don't match
+     */
+    protected function checkCacheVersion()
+    {
+        $file = $this->cache->getDirectory() . '/.version';
+
+        if (!file_exists($file)) {
+            return false;
+        }
+
+        $version = md5($this->boltVersion . $this->boltName);
+        $cached  = file_get_contents($file);
+
+        if ($version === $cached) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Configuration/Environment.php
+++ b/src/Configuration/Environment.php
@@ -60,13 +60,22 @@ class Environment
 
     /**
      * Perform a synchronisation of files in specific app/view/ subdirectories.
+     *
+     * @return array|null
      */
     public function syncView()
     {
         $views = ['css', 'fonts', 'img', 'js'];
+        $response = null;
         foreach ($views as $dir) {
-            $this->syncViewDirectory($dir);
+            try {
+                $this->syncViewDirectory($dir);
+            } catch (IOException $e) {
+                $response[] = $e->getMessage();
+            }
         }
+
+        return $response;
     }
 
     /**
@@ -86,12 +95,7 @@ class Environment
             return;
         }
 
-        try {
-            $this->filesystem->mirror($source, $target, null, ['override' => true, 'delete' => true]);
-        } catch (IOException $e) {
-            // Apparently not.
-            trigger_error($e->getMessage(), E_USER_WARNING);
-        }
+        $this->filesystem->mirror($source, $target, null, ['override' => true, 'delete' => true]);
     }
 
     /**

--- a/src/Nut/SetupSync.php
+++ b/src/Nut/SetupSync.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Bolt\Configuration\Environment;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut command to perform Bolt web asset sync.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class SetupSync extends BaseCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('setup:sync')
+            ->setDescription('Synchronise a Bolt install private asset directories with the web root.');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        /** @var \Bolt\Configuration\Environment $environment */
+        $environment = $this->app['config.environment'];
+
+        $response = $environment->syncView();
+        if ($response === null) {
+            $output->writeln('<info>​Directory synchronisation succeeded​.</info>');
+        } else {
+            $output->writeln('<comment>​Directory synchronisation encountered problems:</comment>');
+            foreach ($response as $message) {
+                $output->writeln('<comment>' . $message . '</comment>');
+            }
+        }
+    }
+}

--- a/src/Provider/ConfigServiceProvider.php
+++ b/src/Provider/ConfigServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Bolt\Provider;
 
 use Bolt\Config;
+use Bolt\Configuration\Environment;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -15,6 +16,23 @@ class ConfigServiceProvider implements ServiceProviderInterface
                 $config = new Config($app);
 
                 return $config;
+            }
+        );
+
+        $app['config.environment'] = $app->share(
+            function ($app) {
+                $srcRoot = realpath($app['resources']->getPath('root'));
+                $webRoot = realpath($app['resources']->getPath('web'));
+
+                $environment = new Environment(
+                    $srcRoot,
+                    $webRoot,
+                    $app['cache'],
+                    $app['bolt_name'],
+                    $app['bolt_version']
+                );
+
+                return $environment;
             }
         );
     }

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -51,6 +51,7 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\UserResetPassword($app),
                     new Nut\UserRoleAdd($app),
                     new Nut\UserRoleRemove($app),
+                    new Nut\SetupSync($app),
                 ];
             }
         );


### PR DESCRIPTION
* New class to manage install environment/checks
* Moved version check / cache flush from `Bolt\Cache`
* If web root is writeable the relevant `app/view/` directories are synchonised
* Added nut command where web user has no write access:
* Multi-site set up just got a lot easier and smoother updates.
* Fixes #3551 for composer install updates
