### PR TITLE
Regex that insert snippets not working when </head> does not starts the line

### DIFF
--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -935,7 +935,7 @@ class Extensions
     public function insertEndOfHead($tag, $html)
     {
         // first, attempt to insert it before the </head> tag, matching indentation.
-        if (preg_match("~^([ \t]*)</head~mi", $html, $matches)) {
+        if (preg_match("~([ \t]*)</head~mi", $html, $matches)) {
 
             // Try to insert it just before </head>
             $replacement = sprintf("%s\t%s\n%s", $matches[1], $tag, $matches[0]);
@@ -961,7 +961,7 @@ class Extensions
     public function insertEndOfBody($tag, $html)
     {
         // first, attempt to insert it before the </body> tag, matching indentation.
-        if (preg_match("~^([ \t]*)</body~mi", $html, $matches)) {
+        if (preg_match("~([ \t]*)</body~mi", $html, $matches)) {
 
             // Try to insert it just before </head>
             $replacement = sprintf("%s\t%s\n%s", $matches[1], $tag, $matches[0]);
@@ -987,7 +987,7 @@ class Extensions
     public function insertEndOfHtml($tag, $html)
     {
         // first, attempt to insert it before the </body> tag, matching indentation.
-        if (preg_match("~^([ \t]*)</html~mi", $html, $matches)) {
+        if (preg_match("~([ \t]*)</html~mi", $html, $matches)) {
 
             // Try to insert it just before </head>
             $replacement = sprintf("%s\t%s\n%s", $matches[1], $tag, $matches[0]);


### PR DESCRIPTION
When the HTML is minified, the regex for the insertion of snippets stops working, my change has been instead of this:

```
preg_match("~^([ \t]*)</head~mi")
```
I have used this:
```
preg_match("~([ \t]*)</head~mi")
```
I removed the caret ^ and the snippets are inserted correctly even if I minify the HTML, if I don't remove the caret the snippets which contain the meta "generator" or the sitemap are inserted after the body, because it is the behaviour it has when the pattern does not match:

````
 if (preg_match("~([ \t]*)</body~mi", $html, $matches)) {
.............................
        } else {

            // Since we're serving tag soup, just append it.
            $html .= $tag . "\n";
        }
```
So that you can see the difference, look at this regex with the current Bolt regex: 
https://regex101.com/r/qU3tX7/2

It works because HTML is not minified, there are many spaces.

Now look here when minified, it doesn't work:
https://regex101.com/r/mJ7jS1/1

Now if I remove the caret , it works:
https://regex101.com/r/qX4nY2/1

The reason is that it is a regex with a multiline attribute,  the caret ^ in this context means, starting from a newline find "</head", when we minified we have not a new line which start with a space, we have a very long line that starts with "<code><!DOCTYPE html></code>".
