### PR TITLE
DBALException logging tweaks

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -165,6 +165,8 @@ class Application extends Silex\Application
             $this['db']->connect();
         // A ConnectionException or DriverException could be thrown, we'll catch DBALException to be safe.
         } catch (DBALException $e) {
+            $this['logger.system']->debug($e->getMessage(), ['event' => 'exception', 'exception' => $e]);
+
             // Trap double exceptions caused by throwing a new LowlevelException
             set_exception_handler(['\Bolt\Exception\LowlevelException', 'nullHandler']);
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -184,7 +184,7 @@ class Application extends Silex\Application
                      "&nbsp;&nbsp;&nbsp;&nbsp;* Database name is correct\n" .
                      "&nbsp;&nbsp;&nbsp;&nbsp;* User name has access to the named database\n" .
                      "&nbsp;&nbsp;&nbsp;&nbsp;* Password is correct\n";
-            throw new LowlevelException($error);
+            throw new LowlevelException($error, $e->getCode(), $e);
         }
 
         // Resume normal error handling

--- a/src/Exception/LowlevelException.php
+++ b/src/Exception/LowlevelException.php
@@ -85,7 +85,11 @@ HTML;
         // expose the information to hosts on the whitelist.
 
         // Determine if we're on the command line. If so, don't output HTML.
-        if (php_sapi_name() == 'cli') {
+        if (php_sapi_name() === 'cli') {
+            if ($previous instanceof \Exception) {
+                $output .= "\n\nException message:\n" . $previous->getMessage() . "\n\n";
+            }
+
             $output = self::cleanHTML($output);
         }
 
@@ -209,6 +213,7 @@ HTML;
         $output = preg_replace('/<style>.*<\/style>/smi', "", $output);
         $output = strip_tags($output);
         $output = preg_replace('/(\n+)(\s+)/smi', "\n", $output);
+        $output = preg_replace('/&nbsp;/smi', " ", $output);
 
         return $output;
     }


### PR DESCRIPTION
I had a problem this morning setting up a PostgreSQL install. I was able to use `psql` from the CLI and access the configured database, and the HBA access was set liberally… 

Why couldn't I access my database? Bolt would just tell me to check my connection… and I had! :stuck_out_tongue_winking_eye: 

With this PR, if you have debug logging enabled, something similar to this will end up in `app/cache/bolt-debug.log`
```
[2015-10-30 05:10:16] logger.system.DEBUG: An exception occured in driver: SQLSTATE[08006] [7] FATAL:  no pg_hba.conf entry for host "46.17.0.55", user "koala", database "bolt_master", SSL off {"event":"exception","exception":"[object] (Doctrine\\DBAL\\Exception\\ConnectionException(code: 0): An exception occured in driver: SQLSTATE[08006] [7] FATAL:  no pg_hba.conf entry for host \"46.17.0.55\", user \"koala\", database \"bolt_master\", SSL off at [snip]/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractPostgreSQLDriver.php:85, Doctrine\\DBAL\\Driver\\PDOException(code: 7): SQLSTATE[08006] [7] FATAL:  no pg_hba.conf entry for host \"46.17.0.55\", user \"koala\", database \"bolt_master\", SSL off at [snip]/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:47, PDOException(code: 7): SQLSTATE[08006] [7] FATAL:  no pg_hba.conf entry for host \"46.17.0.55\", user \"koala\", database \"bolt_master\", SSL off at [snip]/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:43)"} []
```

Also if you're on the CLI, this:
```
Bolt - Fatal Error
Bolt could not connect to the configured database.
Things to check:
&nbsp;&nbsp;* Ensure the pgsql database is running
&nbsp;&nbsp;* Check the database: parameters are configured correctly in app/config/config.yml
&nbsp;&nbsp;&nbsp;&nbsp;* Database name is correct
&nbsp;&nbsp;&nbsp;&nbsp;* User name has access to the named database
&nbsp;&nbsp;&nbsp;&nbsp;* Password is correct
This is a fatal error. Please fix the error, and refresh the page.
Bolt can not run, until this error has been corrected. 
Make sure you've read the instructions in the documentation for help. If you
can't get it to work, post a message on our forum, and we'll try to help you
out. Be sure to include the exact error message you're getting!
* http://docs.bolt.cm/installation - Bolt documentation - Setup
* http://stackoverflow.com/questions/tagged/bolt-cms - Bolt questions on Stack Overflow
```
Becomes this (note the last two lines):
```
Bolt - Fatal Error
Bolt could not connect to the configured database.
Things to check:
  * Ensure the pgsql database is running
  * Check the database: parameters are configured correctly in app/config/config.yml
    * Database name is correct
    * User name has access to the named database
    * Password is correct
This is a fatal error. Please fix the error, and refresh the page.
Bolt can not run, until this error has been corrected. 
Make sure you've read the instructions in the documentation for help. If you
can't get it to work, post a message on our forum, and we'll try to help you
out. Be sure to include the exact error message you're getting!
* http://docs.bolt.cm/installation - Bolt documentation - Setup
* http://stackoverflow.com/questions/tagged/bolt-cms - Bolt questions on Stack Overflow
Exception message:
An exception occured in driver: SQLSTATE[08006] [7] FATAL:  no pg_hba.conf entry for host "46.17.0.55", user "koala", database "bolt_master", SSL off
```