### PR TITLE
Replace ☰ for ≡ for better supported unicode on Android.

### DIFF
--- a/theme/base-2014/_header.twig
+++ b/theme/base-2014/_header.twig
@@ -38,7 +38,7 @@
         <nav class="top-bar" data-topbar>
             <ul class="title-area">
                 <li class="name"><h1><a href="{{ paths.root }}">{{ app.config.get('general/sitename') }}</a></h1></li>
-                <li class="toggle-topbar menu-icon"><a href="#">☰ menu</a></li>
+                <li class="toggle-topbar menu-icon"><a href="#">≡ menu</a></li>
             </ul>
 
             <section class="top-bar-section">


### PR DESCRIPTION
Fixes #4384.