### PR TITLE
Fix/updating slug field

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -474,6 +474,7 @@ field:
             preview: "Preview"
     slug:
         button:
+            copy: "Copy"
             edit: "Edit"
             lock: "Lock"
             unlock: "Unlock"

--- a/app/src/bower.json
+++ b/app/src/bower.json
@@ -19,6 +19,7 @@
         "blueimp-file-upload": "9.11.2",
         "bootbox": "~4.4.0",
         "bootstrap-sass": "~3.3.5",
+        "clipboard": "~1.5.3",
         "font-awesome": "~4.4.0",
         "jquery-ui": "~1.11.4",
         "jquery.cookie": "~1.4.1",

--- a/app/src/grunt/concat.js
+++ b/app/src/grunt/concat.js
@@ -100,7 +100,8 @@ module.exports = function (grunt, option) {
                 '<%= path.tmp %>/bootstrap.min.js',                             //  24 kb
                 '<%= path.src.bower %>/select2/dist/js/select2.min.js',         //  62 kb
                 '<%= path.tmp %>/moment.min.js',                                //  35 kb
-                '<%= path.tmp %>/modernizr-custom.min.js'                       //   5 kb
+                '<%= path.tmp %>/modernizr-custom.min.js',                      //   5 kb
+                '<%= path.src.bower %>/clipboard/dist/clipboard.min.js'         //   8 kb
             ],
             dest: '<%= path.dest.js %>/lib.js'
         },

--- a/app/src/js/.jshintrc
+++ b/app/src/js/.jshintrc
@@ -22,6 +22,7 @@
         "Backbone": true,
         "Bolt": true,
         "CKEDITOR": true,
+        "Clipboard": true,
         "CodeMirror": true,
         "init": true,
         "JSON": true,

--- a/app/src/js/modules/fields/slug.js
+++ b/app/src/js/modules/fields/slug.js
@@ -84,11 +84,11 @@
         });
 
         field.unlock.on('click', function () {
-            unlock(field);
+            unlock(field, true);
         });
 
         field.group.on('dblclick', function () {
-            unlock(field);
+            unlock(field, false);
         });
 
         field.edit.on('click', function () {
@@ -141,11 +141,13 @@
      * @param {FieldData} field - Field data.
      * @param {boolean} wasEmpty - Slug is currently empty
      */
-    function unlock(field) {
+    function unlock(field, needsconfirmation) {
         // "unlock" if it's currently empty.
         // Note: We don't ask for confirmation anymore. Too many clicks.
-        field.group.removeClass('locked').addClass('unlocked');
-        startAutoGeneration(field);
+        if (!needsconfirmation || confirm(bolt.data('field.slug.message.unlock'))) {
+            field.group.removeClass('locked').addClass('unlocked');
+            startAutoGeneration(field);
+        }
         return false;
     }
 

--- a/app/src/js/modules/fields/slug.js
+++ b/app/src/js/modules/fields/slug.js
@@ -6,8 +6,9 @@
  *
  * @param {Object} bolt - The Bolt module.
  * @param {Object} $ - jQuery.
+ * @param {Object} Clipboard.
  */
-(function (bolt, $) {
+(function (bolt, $, Clipboard) {
     'use strict';
 
     /**
@@ -253,4 +254,4 @@
     // Apply mixin container
     bolt.fields.slug = slug;
 
-})(Bolt || {}, jQuery);
+})(Bolt || {}, jQuery, Clipboard);

--- a/app/src/js/modules/fields/slug.js
+++ b/app/src/js/modules/fields/slug.js
@@ -36,6 +36,7 @@
      * @property {Object} lock - Lock button.
      * @property {Object} unlock - Unlock button.
      * @property {Object} edit - Edit button.
+     * @property {Object} copy - Copy button.
      * @property {string} key - The field key
      * @property {Array} uses - Fields used to automatically generate a slug.
      * @property {string} slug - Content slug.
@@ -68,6 +69,7 @@
                 lock: $(fieldset).find('li.lock a'),
                 unlock: $(fieldset).find('li.unlock a'),
                 edit: $(fieldset).find('li.edit a'),
+                copy: $(fieldset).find('li.copy a'),
                 key: fconf.key,
                 uses: fconf.uses,
                 slug: fconf.slug,
@@ -89,6 +91,17 @@
         if (fconf.isEmpty) {
             field.unlock.trigger('click');
         }
+
+        var clipboard = new Clipboard(field.copy);
+
+        clipboard.on('success', function(e) {
+            console.info('Action:', e.action);
+            console.info('Text:', e.text);
+            console.info('Trigger:', e.trigger);
+
+            e.clearSelection();
+        });
+
     };
 
     /**

--- a/app/src/js/modules/fields/slug.js
+++ b/app/src/js/modules/fields/slug.js
@@ -142,8 +142,7 @@
      * @param {boolean} wasEmpty - Slug is currently empty
      */
     function unlock(field, needsconfirmation) {
-        // "unlock" if it's currently empty.
-        // Note: We don't ask for confirmation anymore. Too many clicks.
+        // Only ask for confirmation anymore when using the button. Not on doubleclick.
         if (!needsconfirmation || confirm(bolt.data('field.slug.message.unlock'))) {
             field.group.removeClass('locked').addClass('unlocked');
             startAutoGeneration(field);

--- a/app/src/js/modules/fields/slug.js
+++ b/app/src/js/modules/fields/slug.js
@@ -33,6 +33,7 @@
      *
      * @property {Object} group - Group container.
      * @property {Object} show - Slug display.
+     * @property {Object} prefix - URL prefix (like `/contenttype/` ).
      * @property {Object} data - Data field.
      * @property {Object} lock - Lock button.
      * @property {Object} unlock - Unlock button.
@@ -66,11 +67,12 @@
         var field = {
                 group: $(fieldset).find('.input-group'),
                 show: $(fieldset).find('em'),
+                prefix: $(fieldset).find('span.prefix'),
                 data: $(fieldset).find('input'),
                 lock: $(fieldset).find('li.lock a'),
                 unlock: $(fieldset).find('li.unlock a'),
                 edit: $(fieldset).find('li.edit a'),
-                copy: $(fieldset).find('li.copy a'),
+                copy: $(fieldset).find('li.copy'),
                 key: fconf.key,
                 uses: fconf.uses,
                 slug: fconf.slug,
@@ -93,13 +95,10 @@
             field.unlock.trigger('click');
         }
 
-        var clipboard = new Clipboard(field.copy);
+        var clipboard = new Clipboard('.copy');
 
         clipboard.on('success', function(e) {
-            console.info('Action:', e.action);
-            console.info('Text:', e.text);
-            console.info('Trigger:', e.trigger);
-
+            console.info('Copied:', e.text);
             e.clearSelection();
         });
 
@@ -189,6 +188,7 @@
             success: function (uri) {
                 field.data.val(uri);
                 field.show.html(uri);
+                field.copy.attr('data-clipboard-text', field.prefix.text() + uri);
             },
             error: function () {
                 console.log('failed to get an URI');

--- a/app/src/js/modules/fields/slug.js
+++ b/app/src/js/modules/fields/slug.js
@@ -84,7 +84,11 @@
         });
 
         field.unlock.on('click', function () {
-            unlock(field, fconf.isEmpty);
+            unlock(field);
+        });
+
+        field.group.on('dblclick', function () {
+            unlock(field);
         });
 
         field.edit.on('click', function () {
@@ -137,12 +141,12 @@
      * @param {FieldData} field - Field data.
      * @param {boolean} wasEmpty - Slug is currently empty
      */
-    function unlock(field, wasEmpty) {
-        // "unlock" if it's currently empty, _or_ we've confirmed that we want to do so.
-        if (wasEmpty || confirm(bolt.data('field.slug.message.unlock'))) {
-            field.group.removeClass('locked').addClass('unlocked');
-            startAutoGeneration(field);
-        }
+    function unlock(field) {
+        // "unlock" if it's currently empty.
+        // Note: We don't ask for confirmation anymore. Too many clicks.
+        field.group.removeClass('locked').addClass('unlocked');
+        startAutoGeneration(field);
+        return false;
     }
 
     /**

--- a/app/src/sass/fieldsets/_slug.scss
+++ b/app/src/sass/fieldsets/_slug.scss
@@ -72,6 +72,7 @@
             width: 100%;
             height: 32px;
             text-indent: -$icon-width - $icon-right-margin;
+            padding-top: 5px;
             padding-left: $icon-width + $padding-base-vertical + $icon-right-margin;
             white-space: normal;
             word-break: break-all;

--- a/app/src/sass/fieldsets/_slug.scss
+++ b/app/src/sass/fieldsets/_slug.scss
@@ -16,7 +16,7 @@
                 color: black;
                 font-style: normal;
                 font-weight: normal;
-                line-height: 1.4;
+                line-height: 22px;
             }
         }
 
@@ -67,8 +67,10 @@
 
         span.input-group-addon {
             display: inline-block;
+            overflow: hidden;
             margin: 1px 0;
             width: 100%;
+            height: 32px;
             text-indent: -$icon-width - $icon-right-margin;
             padding-left: $icon-width + $padding-base-vertical + $icon-right-margin;
             white-space: normal;

--- a/app/view/twig/editcontent/fields/_slug.twig
+++ b/app/view/twig/editcontent/fields/_slug.twig
@@ -44,6 +44,7 @@
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right">
+                    <li class="copy"><a href="#"><i class="fa fa-fw fa-copy"></i> {{ __('field.slug.button.copy') }}</a></li>
                     <li class="lock"><a href="#"><i class="fa fa-fw fa-lock"></i> {{ __('field.slug.button.lock') }}</a></li>
                     <li class="unlock"><a href="#"><i class="fa fa-fw fa-unlock-alt"></i> {{ __('field.slug.button.unlock') }}</a></li>
                     <li class="edit"><a href="#"><i class="fa fa-fw fa-pencil"></i> {{ __('field.slug.button.edit') }}</a></li>

--- a/app/view/twig/editcontent/fields/_slug.twig
+++ b/app/view/twig/editcontent/fields/_slug.twig
@@ -32,10 +32,10 @@
 {% block fieldset_type 'slug' %}
 
 {% block fieldset_label_text  option.viewless ? __('Unique Alias') : __('field.slug.permalink') %}
-{% block fieldset_label_class 'col-sm-3' %}
+{% block fieldset_label_class 'col-sm-12' %}
 
 {% block fieldset_controls %}
-    <div class="col-sm-9">
+    <div class="col-sm-12">
         <div class="input-group locked">
             <span class="input-group-addon">/{{ context.content.contenttype }}/<em>{{ context.content.get(contentkey) }}</em></span>
             <input{{ macro.attr(attributes.slug) }}>

--- a/app/view/twig/editcontent/fields/_slug.twig
+++ b/app/view/twig/editcontent/fields/_slug.twig
@@ -31,23 +31,31 @@
 
 {% block fieldset_type 'slug' %}
 
-{% block fieldset_label_text  option.viewless ? __('Unique Alias') : __('field.slug.permalink') %}
+{% block fieldset_label_text option.viewless ? __('Unique Alias') : __('field.slug.permalink') %}
 {% block fieldset_label_class 'col-sm-12' %}
 
 {% block fieldset_controls %}
     <div class="col-sm-12">
         <div class="input-group locked">
-            <span class="input-group-addon">/{{ context.content.contenttype }}/<em>{{ context.content.get(contentkey) }}</em></span>
+            <span class="input-group-addon"><span class="prefix">/{{ context.content.contenttype }}/</span><em>{{ context.content.get(contentkey) }}</em></span>
             <input{{ macro.attr(attributes.slug) }}>
             <div class="input-group-btn">
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right">
-                    <li class="copy"><a href="#"><i class="fa fa-fw fa-copy"></i> {{ __('field.slug.button.copy') }}</a></li>
-                    <li class="lock"><a href="#"><i class="fa fa-fw fa-lock"></i> {{ __('field.slug.button.lock') }}</a></li>
-                    <li class="unlock"><a href="#"><i class="fa fa-fw fa-unlock-alt"></i> {{ __('field.slug.button.unlock') }}</a></li>
-                    <li class="edit"><a href="#"><i class="fa fa-fw fa-pencil"></i> {{ __('field.slug.button.edit') }}</a></li>
+                    <li class="copy" data-clipboard-text="/{{ context.content.contenttype }}/{{ context.content.get(contentkey) }}">
+                        <a href="#"><i class="fa fa-fw fa-copy"></i> {{ __('field.slug.button.copy') }}</a>
+                    </li>
+                    <li class="lock">
+                        <a href="#"><i class="fa fa-fw fa-lock"></i> {{ __('field.slug.button.lock') }}</a>
+                    </li>
+                    <li class="unlock">
+                        <a href="#"><i class="fa fa-fw fa-unlock-alt"></i> {{ __('field.slug.button.unlock') }}</a>
+                    </li>
+                    <li class="edit">
+                        <a href="#"><i class="fa fa-fw fa-pencil"></i> {{ __('field.slug.button.edit') }}</a>
+                    </li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
There's no easily implementable way to make the slug look good, when wrapped over two lines: 

 - Either it looks "weird", because the button is _way_ too high, and it looks out of place
 - The CSS would need to be hacky, and wonky browsers interpret the hacky css differently.

To circumvent this, I'm proposing to make the 'slug' field take up the full width, and no longer allowing it to wrap over more than one line. 

 - Wrapping is an edgecase, so doesn't occur often.
 - Not that it's full width, it can be a fair bit longer before wrapping happens.

![screen shot 2015-11-06 at 10 47 35](https://cloud.githubusercontent.com/assets/1833361/10994029/d7d5e902-8473-11e5-8d14-3dfbd742d92f.png)

New features: 

  - Doubleclick the slug to unlock
  - Added a 'copy to clipboard' option in the drop down.