### PR TITLE
Schema manager breakout

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -12,7 +12,7 @@ tools:
             level: all
     php_sim:
         enabled: true
-        min_mass: 30             # Defaults to 16
+        min_mass: 50             # Defaults to 16
     php_code_sniffer:
         enabled: true
         config:

--- a/src/Controller/Backend/BackendBase.php
+++ b/src/Controller/Backend/BackendBase.php
@@ -173,7 +173,7 @@ abstract class BackendBase extends Base
     private function checkFirstUser(Application $app, $route)
     {
         // Check the database users table exists
-        $tableExists = $app['schema']->checkUserTableIntegrity();
+        $tableExists = $app['schema']->hasUserTable();
 
         // Test if we have a valid users in our table
         $userCount = 0;
@@ -191,7 +191,7 @@ abstract class BackendBase extends Base
         // If there are no users in the users table, or the table doesn't exist.
         // Repair the DB, and let's add a new user.
         if (!$tableExists || $userCount === 0) {
-            $app['schema']->repairTables();
+            $app['schema']->update();
             $app['logger.flash']->info(Trans::__('There are no users in the database. Please create the first user.'));
 
             return $this->redirectToRoute('userfirst');

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -146,7 +146,7 @@ class Users extends BackendBase
     public function first(Request $request)
     {
         // We should only be here for creating the first user
-        if ($this->app['schema']->checkUserTableIntegrity() && $this->users()->hasUsers()) {
+        if ($this->app['schema']->hasUserTable() && $this->users()->hasUsers()) {
             return $this->redirectToRoute('dashboard');
         }
 
@@ -162,7 +162,7 @@ class Users extends BackendBase
         }
 
         // If we get here, chances are we don't have the tables set up, yet.
-        $this->app['schema']->repairTables();
+        $this->app['schema']->update();
 
         // Grant 'root' to first user by default
         $userEntity->setRoles([Permissions::ROLE_ROOT]);

--- a/src/EventListener/StorageEventListener.php
+++ b/src/EventListener/StorageEventListener.php
@@ -21,11 +21,13 @@ class StorageEventListener implements EventSubscriberInterface
     protected $em;
     /** @var \Bolt\Config */
     protected $config;
-    /** @var \Bolt\Storage\Database\Schema\Manager*/
+    /** @var \Bolt\Storage\Database\Schema\Manager */
     protected $schemaManager;
+    /** @var UrlGeneratorInterface */
+    protected $urlGenerator;
     /** @var \Bolt\Logger\FlashLoggerInterface */
     protected $loggerFlash;
-    /** @var string */
+    /** @var integer */
     protected $hashStrength;
 
     /**

--- a/src/EventListener/StorageEventListener.php
+++ b/src/EventListener/StorageEventListener.php
@@ -2,34 +2,48 @@
 namespace Bolt\EventListener;
 
 use Bolt\Config;
+use Bolt\Storage\Database\Schema\Manager;
 use Bolt\Events\StorageEvent;
 use Bolt\Events\StorageEvents;
+use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Storage\Entity;
 use Bolt\Storage\EntityManager;
+use Bolt\Translation\Translator as Trans;
 use PasswordLib\PasswordLib;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class StorageEventListener implements EventSubscriberInterface
 {
     /** @var \Bolt\Storage\EntityManager */
     protected $em;
-    /** @var \Bolt\Config $config */
+    /** @var \Bolt\Config */
     protected $config;
+    /** @var \Bolt\Storage\Database\Schema\Manager*/
+    protected $schemaManager;
+    /** @var \Bolt\Logger\FlashLoggerInterface */
+    protected $loggerFlash;
     /** @var string */
     protected $hashStrength;
 
     /**
      * Constructor.
      *
-     * @param EntityManager $em
-     * @param Config        $config
+     * @param EntityManager        $em
+     * @param Config               $config
+     * @param Manager              $schemaManager
+     * @param FlashLoggerInterface $loggerFlash
+     * @param integer              $hashStrength
      */
-    public function __construct(EntityManager $em, Config $config, $hashStrength)
+    public function __construct(EntityManager $em, Config $config, Manager $schemaManager, UrlGeneratorInterface $urlGenerator, FlashLoggerInterface $loggerFlash, $hashStrength)
     {
         $this->em = $em;
         $this->config = $config;
+        $this->schemaManager = $schemaManager;
+        $this->urlGenerator = $urlGenerator;
+        $this->loggerFlash = $loggerFlash;
         $this->hashStrength = $hashStrength;
     }
 
@@ -59,15 +73,34 @@ class StorageEventListener implements EventSubscriberInterface
         if (!$event->isMasterRequest()) {
             return;
         }
+        $this->schemaCheck($event);
 
         $contenttypes = $this->config->get('contenttypes', []);
-
         foreach ($contenttypes as $contenttype) {
             $contenttype = $this->em->getContentType($contenttype['slug']);
 
             // Check if we need to 'publish' any 'timed' records, or 'depublish' any expired records.
             $this->em->publishTimedRecords($contenttype);
             $this->em->depublishExpiredRecords($contenttype);
+        }
+    }
+
+    /**
+     * Trigger database schema checks if required.
+     *
+     * @param GetResponseEvent $event
+     */
+    protected function schemaCheck(GetResponseEvent $event)
+    {
+        $session = $event->getRequest()->getSession();
+        $validSession = $session->isStarted() && $session->get('authentication');
+        $expired = $this->schemaManager->isCheckRequired();
+        if ($validSession && $expired && $this->schemaManager->isUpdateRequired()) {
+            $msg = Trans::__(
+                "The database needs to be updated/repaired. Go to 'Configuration' > '<a href=\"%link%\">Check Database</a>' to do this now.",
+                ['%link%' => $this->urlGenerator->generate('dbcheck')]
+                );
+            $this->loggerFlash->error($msg);
         }
     }
 

--- a/src/Events/StorageEvent.php
+++ b/src/Events/StorageEvent.php
@@ -75,7 +75,10 @@ class StorageEvent extends GenericEvent
      */
     public function getContentType()
     {
-        return $this->getSubject()->contenttype['slug'];
+        $contentType = $this->getSubject()->contenttype;
+        if ($contentType!== null && isset($contentType['slug'])) {
+            return $contentType['slug'];
+        }
     }
 
     /**

--- a/src/Nut/DatabaseCheck.php
+++ b/src/Nut/DatabaseCheck.php
@@ -25,7 +25,8 @@ class DatabaseCheck extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $response = $this->app['schema']->checkTablesIntegrity();
+        /** @var $response \Bolt\Storage\Database\Schema\SchemaCheck */
+        $response = $this->app['schema']->check();
 
         if (!$response->hasResponses()) {
             $output->writeln('<info>The database is OK.</info>');

--- a/src/Nut/DatabaseRepair.php
+++ b/src/Nut/DatabaseRepair.php
@@ -25,7 +25,7 @@ class DatabaseRepair extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $response = $this->app['schema']->repairTables();
+        $response = $this->app['schema']->update();
 
         if (!$response->hasResponses()) {
             $output->writeln('<info>Your database is already up to date.</info>');

--- a/src/Provider/DatabaseSchemaProvider.php
+++ b/src/Provider/DatabaseSchemaProvider.php
@@ -1,8 +1,11 @@
 <?php
+
 namespace Bolt\Provider;
 
+use Bolt\Storage\Database\Schema\Builder;
 use Bolt\Storage\Database\Schema\Manager;
 use Bolt\Storage\Database\Schema\Table;
+use Bolt\Storage\Database\Schema\Timer;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -18,6 +21,14 @@ class DatabaseSchemaProvider implements ServiceProviderInterface
         $app['schema'] = $app->share(
             function ($app) {
                 return new Manager($app);
+            }
+        );
+
+        $app['schema.prefix'] = $app->share(
+            function ($app) {
+                $prefix = $app['config']->get('general/database/prefix', 'bolt_');
+
+                return rtrim($prefix, '_') . '_';
             }
         );
 
@@ -37,43 +48,148 @@ class DatabaseSchemaProvider implements ServiceProviderInterface
                 $platform = $app['db']->getDatabasePlatform();
 
                 // @codingStandardsIgnoreStart
-                return new \Pimple(
-                    [
-                        'authtoken'   => $app->share(function () use ($platform) { return new Table\AuthToken($platform); }),
-                        'cron'        => $app->share(function () use ($platform) { return new Table\Cron($platform); }),
-                        'field_value' => $app->share(function () use ($platform) { return new Table\FieldValue($platform); }),
-                        'log_change'  => $app->share(function () use ($platform) { return new Table\LogChange($platform); }),
-                        'log_system'  => $app->share(function () use ($platform) { return new Table\LogSystem($platform); }),
-                        'relations'   => $app->share(function () use ($platform) { return new Table\Relations($platform); }),
-                        'taxonomy'    => $app->share(function () use ($platform) { return new Table\Taxonomy($platform); }),
-                        'users'       => $app->share(function () use ($platform) { return new Table\Users($platform); }),
-                    ]
-                );
+                return new \Pimple([
+                    'authtoken'   => $app->share(function () use ($platform) { return new Table\AuthToken($platform); }),
+                    'cron'        => $app->share(function () use ($platform) { return new Table\Cron($platform); }),
+                    'field_value' => $app->share(function () use ($platform) { return new Table\FieldValue($platform); }),
+                    'log_change'  => $app->share(function () use ($platform) { return new Table\LogChange($platform); }),
+                    'log_system'  => $app->share(function () use ($platform) { return new Table\LogSystem($platform); }),
+                    'relations'   => $app->share(function () use ($platform) { return new Table\Relations($platform); }),
+                    'taxonomy'    => $app->share(function () use ($platform) { return new Table\Taxonomy($platform); }),
+                    'users'       => $app->share(function () use ($platform) { return new Table\Users($platform); }),
+                ]);
                 // @codingStandardsIgnoreEnd
             }
         );
 
-        // Schemas of all Bolt tables.
+        // Schemas of the ContentType tables
+        $app['schema.content_tables'] = $app->share(
+            function (Application $app) {
+                /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
+                $platform = $app['db']->getDatabasePlatform();
+
+                $contenttypes = $app['config']->get('contenttypes');
+                $acne = new \Pimple();
+
+                foreach (array_keys($contenttypes) as $contenttype) {
+                    // @codingStandardsIgnoreStart
+                    $acne[$contenttype] = $app->share(function () use ($platform) { return new Table\ContentType($platform); });
+                    // @codingStandardsIgnoreEnd
+                }
+
+                return $acne;
+            }
+        );
+
+        // Schemas (empty) of the extension tables
+        $app['schema.extension_tables'] = $app->share(
+            function (Application $app) {
+                /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
+                $platform = $app['db']->getDatabasePlatform();
+
+                return new \Pimple([]);
+            }
+        );
+
+        // Combined schemas of all Bolt tables.
         $app['schema.tables'] = $app->share(
             function (Application $app) {
                 $acne = new \Pimple();
 
                 foreach ($app['schema.base_tables']->keys() as $baseName) {
-                    $acne[$baseName] = $app['schema.base_tables'][$baseName];
+                    // @codingStandardsIgnoreStart
+                    $acne[$baseName] = $app->share(function () use ($app, $baseName) { return $app['schema.base_tables'][$baseName]; });
+                    // @codingStandardsIgnoreEnd
                 }
 
-                /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
-                $platform = $app['db']->getDatabasePlatform();
-                foreach ($app['config']->get('contenttypes') as $contenttype) {
-                    $serviceName = 'schema.' . $contenttype['tablename'];
-                    $acne[$serviceName] = $app->share(
-                        function () use ($platform) {
-                            return new Table\ContentType($platform);
-                        }
-                    );
+                foreach ($app['schema.content_tables']->keys() as $baseName) {
+                    // @codingStandardsIgnoreStart
+                    $acne[$baseName] = $app->share(function () use ($app, $baseName) { return $app['schema.content_tables'][$baseName]; });
+                    // @codingStandardsIgnoreEnd
+                }
+
+                foreach ($app['schema.extension_tables']->keys() as $baseName) {
+                    // @codingStandardsIgnoreStart
+                    $acne[$baseName] = $app->share(function () use ($app, $baseName) { return $app['schema.extension_tables'][$baseName]; });
+                    // @codingStandardsIgnoreEnd
                 }
 
                 return $acne;
+            }
+        );
+
+        $app['schema.builder'] = $app->share(
+            function ($app) {
+                return new \Pimple([
+                    'base'       => $app->share(
+                        function () use ($app) {
+                            return new Builder\BaseTables(
+                                $app['db'],
+                                $app['schema'],
+                                $app['schema.base_tables'],
+                                $app['schema.prefix'],
+                                $app['logger.system'],
+                                $app['logger.flash']
+                            );
+                        }
+                    ),
+                    'content'    => $app->share(
+                        function () use ($app) {
+                            return new Builder\ContentTables(
+                                $app['db'],
+                                $app['schema'],
+                                $app['schema.content_tables'],
+                                $app['schema.prefix'],
+                                $app['logger.system'],
+                                $app['logger.flash']
+                            );
+                        }
+                    ),
+                    'extensions' => $app->share(
+                        function () use ($app) {
+                            return new Builder\ExtensionTables(
+                                $app['db'],
+                                $app['schema'],
+                                $app['schema.extension_tables'],
+                                $app['schema.prefix'],
+                                $app['logger.system'],
+                                $app['logger.flash']
+                            );
+                        }
+                    ),
+                ]);
+            }
+        );
+
+        $app['schema.timer'] = $app->share(
+            function ($app) {
+                return new Timer($app['resources']->getPath('cache'));
+            }
+        );
+
+        $app['schema.comparator.factory'] = $app->protect(
+            function () use ($app) {
+                $platforms = [
+                    'mysql'      => '\\Bolt\\Storage\\Database\\Schema\\Comparison\\MySql',
+                    'postgresql' => '\\Bolt\\Storage\\Database\\Schema\\Comparison\\PostgreSql',
+                    'sqlite'     => '\\Bolt\\Storage\\Database\\Schema\\Comparison\\Sqlite',
+                ];
+                $platformName = $app['db']->getDatabasePlatform()->getName();
+
+                return $platforms[$platformName];
+            }
+        );
+
+        $app['schema.comparator'] = $app->share(
+            function ($app) {
+                $comparator = $app['schema.comparator.factory']();
+
+                return new $comparator(
+                    $app['db'],
+                    $app['schema'],
+                    $app['schema.tables'],
+                    $app['logger.system']
+                );
             }
         );
     }

--- a/src/Provider/DatabaseSchemaProvider.php
+++ b/src/Provider/DatabaseSchemaProvider.php
@@ -84,9 +84,6 @@ class DatabaseSchemaProvider implements ServiceProviderInterface
         // Schemas (empty) of the extension tables
         $app['schema.extension_tables'] = $app->share(
             function (Application $app) {
-                /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
-                $platform = $app['db']->getDatabasePlatform();
-
                 return new \Pimple([]);
             }
         );

--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -202,7 +202,7 @@ class StorageServiceProvider implements ServiceProviderInterface
                     $app['logger.change'],
                     $app['logger.system'],
                     $app['logger.flash'],
-                    $app['url_generator']
+                    $app['url_generator.lazy']
                 );
 
                 return $cr;
@@ -214,6 +214,9 @@ class StorageServiceProvider implements ServiceProviderInterface
                 return new StorageEventListener(
                     $app['storage'],
                     $app['config'],
+                    $app['schema'],
+                    $app['url_generator.lazy'],
+                    $app['logger.flash'],
                     $app['access_control.hash.strength']
                 );
             }

--- a/src/Storage/Database/Schema/Builder/BaseBuilder.php
+++ b/src/Storage/Database/Schema/Builder/BaseBuilder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Builder;
+
+use Bolt\Logger\FlashLoggerInterface;
+use Bolt\Storage\Database\Schema\Manager;
+use Doctrine\DBAL\Connection;
+use Pimple;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Base class for Bolt's table builders.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+abstract class BaseBuilder
+{
+    /** @var \Doctrine\DBAL\Connection */
+    protected $connection;
+    /** @var \Bolt\Storage\Database\Schema\Manager */
+    protected $manager;
+    /** @var \Pimple */
+    protected $tables;
+    /** @var string */
+    protected $prefix;
+    /** @var \Psr\Log\LoggerInterface */
+    protected $systemLog;
+    /** @var \Bolt\Logger\FlashLoggerInterface */
+    protected $flashLogger;
+
+    /**
+     * Constructor.
+     *
+     * @param Connection           $connection
+     * @param Manager              $manager
+     * @param Pimple               $tables
+     * @param string               $prefix
+     * @param LoggerInterface      $systemLog
+     * @param FlashLoggerInterface $flashLogger
+     */
+    public function __construct(Connection $connection, Manager $manager, Pimple $tables, $prefix, LoggerInterface $systemLog, FlashLoggerInterface $flashLogger)
+    {
+        $this->connection = $connection;
+        $this->manager = $manager;
+        $this->tables = $tables;
+        $this->prefix = $prefix;
+        $this->systemLog = $systemLog;
+        $this->flashLogger = $flashLogger;
+    }
+}

--- a/src/Storage/Database/Schema/Builder/BaseTables.php
+++ b/src/Storage/Database/Schema/Builder/BaseTables.php
@@ -28,19 +28,4 @@ class BaseTables extends BaseBuilder
 
         return $tables;
     }
-
-    /**
-     * Check if just the users table is present.
-     *
-     * @return boolean
-     */
-    public function hasUserTable()
-    {
-        $tables = $this->manager->getInstalledTables();
-        if (isset($tables[$this->manager->getTablename('users')])) {
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/src/Storage/Database/Schema/Builder/BaseTables.php
+++ b/src/Storage/Database/Schema/Builder/BaseTables.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Builder;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+
+/**
+ * Builder for Bolt core tables.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class BaseTables extends BaseBuilder
+{
+    /**
+     * Build the schema for base Bolt tables.
+     *
+     * @param Schema $schema
+     *
+     * @return \Doctrine\DBAL\Schema\Table[]
+     */
+    public function getSchemaTables(Schema $schema)
+    {
+        $tables = [];
+        foreach ($this->tables->keys() as $name) {
+            $tables[$name] = $this->tables[$name]->buildTable($schema, $this->prefix. $name, $name);
+        }
+
+        return $tables;
+    }
+
+    /**
+     * Check if just the users table is present.
+     *
+     * @return boolean
+     */
+    public function hasUserTable()
+    {
+        $tables = $this->getInstalledTables();
+        if (isset($tables[$this->getTablename('users')])) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Storage/Database/Schema/Builder/BaseTables.php
+++ b/src/Storage/Database/Schema/Builder/BaseTables.php
@@ -36,8 +36,8 @@ class BaseTables extends BaseBuilder
      */
     public function hasUserTable()
     {
-        $tables = $this->getInstalledTables();
-        if (isset($tables[$this->getTablename('users')])) {
+        $tables = $this->manager->getInstalledTables();
+        if (isset($tables[$this->manager->getTablename('users')])) {
             return true;
         }
 

--- a/src/Storage/Database/Schema/Builder/ContentTables.php
+++ b/src/Storage/Database/Schema/Builder/ContentTables.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Builder;
+
+use Bolt\Config;
+use Bolt\Storage\Database\Schema\Table\ContentType;
+use Bolt\Storage\Field\Manager as FieldManager;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+
+/**
+ * Builder for Bolt content tables.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ContentTables extends BaseBuilder
+{
+    /**
+     * Build the schema for Bolt ContentType tables.
+     *
+     * @param Schema $schema
+     * @param Config $config
+     *
+     * @return \Doctrine\DBAL\Schema\Table[]
+     */
+    public function getSchemaTables(Schema $schema, Config $config)
+    {
+        /** @var $fieldManager FieldManager */
+        $fieldManager = $config->getFields();
+        $contentTypes = $config->get('contenttypes');
+        $tables = [];
+        foreach ($this->tables->keys() as $name) {
+            $contentType = $contentTypes[$name];
+            $tables[$name] = $this->tables[$name]->buildTable($schema, $this->prefix. $name, $name);
+            if (isset($contentType['fields']) && is_array($contentType['fields'])) {
+                $this->addContentTypeTableColumns($this->tables[$name], $tables[$name], $contentType['fields'], $fieldManager);
+            }
+        }
+
+        return $tables;
+    }
+
+    /**
+     * Add the custom columns for the ContentType.
+     *
+     * @param \Bolt\Storage\Database\Schema\Table\ContentType $tableObj
+     * @param \Doctrine\DBAL\Schema\Table                     $table
+     * @param array                                           $fields
+     * @param FieldManager                                    $fieldManager
+     */
+    private function addContentTypeTableColumns(ContentType $tableObj, Table $table, array $fields, FieldManager $fieldManager)
+    {
+        // Check if all the fields are present in the DB.
+        foreach ($fields as $fieldName => $values) {
+            /** @var \Doctrine\DBAL\Platforms\Keywords\KeywordList $reservedList */
+            $reservedList = $this->connection->getDatabasePlatform()->getReservedKeywordsList();
+            if ($reservedList->isKeyword($fieldName)) {
+                $error = sprintf(
+                    "You're using '%s' as a field name, but that is a reserved word in %s. Please fix it, and refresh this page.",
+                    $fieldName,
+                    $this->connection->getDatabasePlatform()->getName()
+                );
+                $this->flashLogger->error($error);
+                continue;
+            }
+
+            $this->addContentTypeTableColumn($tableObj, $table, $fieldName, $values, $fieldManager);
+        }
+    }
+
+    /**
+     * Add a single column to the ContentType table.
+     *
+     * @param \Bolt\Storage\Database\Schema\Table\ContentType $tableObj
+     * @param \Doctrine\DBAL\Schema\Table                     $table
+     * @param string                                          $fieldName
+     * @param array                                           $values
+     * @param FieldManager                                    $fieldManager
+     */
+    private function addContentTypeTableColumn(ContentType $tableObj, Table $table, $fieldName, array $values, FieldManager $fieldManager)
+    {
+        if ($tableObj->isKnownType($values['type'])) {
+            // Use loose comparison on true as 'true' in YAML is a string
+            $addIndex = isset($values['index']) && (boolean) $values['index'] === true;
+            // Add the contenttype's specific fields
+            $tableObj->addCustomFields($fieldName, $this->getContentTypeTableColumnType($values), $addIndex);
+        } elseif ($handler = $fieldManager->getDatabaseField($values['type'])) {
+            // Add template fields
+            /** @var $handler \Bolt\Storage\Field\FieldInterface */
+            $table->addColumn($fieldName, $handler->getStorageType(), $handler->getStorageOptions());
+        }
+    }
+
+    /**
+     * Certain field types can have single or JSON array types, figure it out.
+     *
+     * @param array $values
+     *
+     * @return string
+     */
+    private function getContentTypeTableColumnType(array $values)
+    {
+        // Multi-value selects are stored as JSON arrays
+        if (isset($values['type']) && $values['type'] === 'select' && isset($values['multiple']) && $values['multiple'] === 'true') {
+            return 'selectmultiple';
+        }
+
+        return $values['type'];
+    }
+}

--- a/src/Storage/Database/Schema/Builder/ExtensionTables.php
+++ b/src/Storage/Database/Schema/Builder/ExtensionTables.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Builder;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+
+/**
+ * Builder for Bolt extension tables.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ExtensionTables extends BaseBuilder
+{
+    /** @var callable[] */
+    protected $tableGenerators = [];
+
+    /**
+     * Get all the registered extension tables.
+     *
+     * We need to be prepared for generators returning a single table, as well
+     * as generators returning an array of tables.
+     *
+     * @param Schema $schema
+     *
+     * @return \Doctrine\DBAL\Schema\Table[]
+     */
+    public function getSchemaTables(Schema $schema)
+    {
+        $tables = [];
+        foreach ($this->tableGenerators as $generator) {
+            $table = call_user_func($generator, $schema);
+
+            if (is_array($table)) {
+                foreach ($table as $t) {
+                    $alias = str_replace($this->prefix, '', $t->getName());
+                    $t->addOption('alias', $alias);
+                    $tables[$alias] = $t;
+                }
+            } else {
+                $alias = str_replace($this->prefix, '', $table->getName());
+                $table->addOption('alias', $alias);
+                $tables[$alias] = $table;
+            }
+        }
+
+        return $tables;
+    }
+
+    /**
+     * This method allows extensions to register their own tables.
+     *
+     * @param callable $generator A generator function that takes the Schema
+     *                            instance and returns a table or an array of
+     *                            tables.
+     */
+    public function addTable(callable $generator)
+    {
+        $this->tableGenerators[] = $generator;
+    }
+}

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -128,4 +128,25 @@ abstract class BaseComparator
 
         return $queries;
     }
+
+    /**
+     * Get the table alteration SQL queries.
+     *
+     * @return string[]
+     */
+    public function getAlters()
+    {
+        $queries = [];
+        if ($this->tablesAlter === null) {
+            return $queries;
+        }
+
+        /** @var $tableDiff TableDiff */
+        foreach ($this->tablesAlter as $tableName => $tableDiff) {
+            $queries[$tableName] = $this->connection->getDatabasePlatform()
+                ->getAlterTableSQL($tableDiff);
+        }
+
+        return $queries;
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -217,4 +217,21 @@ abstract class BaseComparator
             }
         }
     }
+
+    /**
+     * Add required changes to the response object.
+     *
+     * NOTE: This must be run after adjustDiffs() so that the user response
+     * doesn't contain ignored changes.
+     */
+    protected function addAlterResponses()
+    {
+        foreach ($this->diffs as $tableName => $tableDiff) {
+            $this->pending = true;
+            $this->tablesAlter[$tableName] = $tableDiff;
+            $this->getResponse()->addTitle($tableName, sprintf('Table `%s` is not the correct schema:', $tableName));
+            $this->getResponse()->checkDiff($tableName, $tableDiff);
+            $this->systemLog->debug('Database update required', $this->connection->getDatabasePlatform()->getAlterTableSQL($tableDiff));
+        }
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -108,4 +108,24 @@ abstract class BaseComparator
         }
         return $this->response = new SchemaCheck();
     }
+
+    /**
+     * Get the table creation SQL queries.
+     *
+     * @return string[]
+     */
+    public function getCreates()
+    {
+        if ($this->tablesCreate === null) {
+            return [];
+        }
+
+        $queries = [];
+        foreach ($this->tablesCreate as $tableName => $table) {
+            $queries[$tableName] = $this->connection->getDatabasePlatform()
+                ->getCreateTableSQL($table, AbstractPlatform::CREATE_INDEXES | AbstractPlatform::CREATE_FOREIGNKEYS);
+        }
+
+        return $queries;
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -71,4 +71,28 @@ abstract class BaseComparator
 
         return $this->pending;
     }
+
+    /**
+     * Run the update checks and flag if we need an update.
+     *
+     * @param boolean $force
+     *
+     * @return SchemaCheck
+     */
+    public function compare($force = false)
+    {
+        if ($this->response !== null && $force === false) {
+            return $this->getResponse();
+        }
+
+        $this->checkTables();
+
+        // If we have diffs, check if they need to be modified
+        if ($this->diffs !== null) {
+            $this->adjustDiffs();
+            $this->addAlterResponses();
+        }
+
+        return $this->getResponse();
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -95,4 +95,17 @@ abstract class BaseComparator
 
         return $this->getResponse();
     }
+
+    /**
+     * Get the schema check response object.
+     *
+     * @return \Bolt\Storage\Database\Schema\SchemaCheck
+     */
+    public function getResponse()
+    {
+        if ($this->response !== null) {
+            return $this->response;
+        }
+        return $this->response = new SchemaCheck();
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -56,4 +56,19 @@ abstract class BaseComparator
         $this->schemaTables = $schemaTables;
         $this->systemLog = $systemLog;
     }
+
+    /**
+     * Are database updates required.
+     *
+     * @return boolean
+     */
+    public function hasPending()
+    {
+        if ($this->pending !== null) {
+            return $this->pending;
+        }
+        $this->compare();
+
+        return $this->pending;
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -185,4 +185,19 @@ abstract class BaseComparator
             $this->checkTable($fromTable, $toTable);
         }
     }
+
+    /**
+     * Check that a single table's columns and indices are valid.
+     *
+     * @param Table $fromTable
+     * @param Table $toTable
+     */
+    protected function checkTable(Table $fromTable, Table $toTable)
+    {
+        $tableName = $fromTable->getName();
+        $diff = (new Comparator())->diffTable($fromTable, $toTable);
+        if ($diff !== false) {
+            $this->diffs[$tableName] = $diff;
+        }
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -149,4 +149,12 @@ abstract class BaseComparator
 
         return $queries;
     }
+
+    /**
+     * Remove table/column diffs that for verious reasons aren't supported on a
+     * platform.
+     *
+     * @param TableDiff $diff
+     */
+    abstract protected function removeIgnoredChanges(TableDiff $diff);
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -200,4 +200,21 @@ abstract class BaseComparator
             $this->diffs[$tableName] = $diff;
         }
     }
+
+    /**
+     * Platform specific adjustments to table/column diffs.
+     */
+    protected function adjustDiffs()
+    {
+        $diffUpdater = new DiffUpdater($this->ignoredChanges);
+
+        /** @var $diff TableDiff */
+        foreach ($this->diffs as $tableName => $tableDiff) {
+            $this->diffs[$tableName] = $diffUpdater->adjustDiff($tableDiff);
+            if ($this->diffs[$tableName] === false) {
+                unset($this->diffs[$tableName]);
+                continue;
+            }
+        }
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Comparison;
+
+use Bolt\Storage\Database\Schema\Manager;
+use Bolt\Storage\Database\Schema\SchemaCheck;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
+use Pimple;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Base class for handling table comparison.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+abstract class BaseComparator
+{
+    /** @var \Doctrine\DBAL\Connection */
+    protected $connection;
+    /** @var \Bolt\Storage\Database\Schema\Manager */
+    protected $manager;
+    /** @var \Pimple */
+    protected $schemaTables;
+    /** @var \Psr\Log\LoggerInterface */
+    protected $systemLog;
+
+    /** @var \Doctrine\DBAL\Schema\TableDiff[] */
+    protected $diffs;
+    /** @var \Doctrine\DBAL\Schema\Table[] */
+    protected $tablesCreate;
+    /** @var \Doctrine\DBAL\Schema\TableDiff[] */
+    protected $tablesAlter;
+    /** @var array */
+    protected $ignoredChanges = [];
+    /** @var boolean */
+    protected $pending;
+    /** @var \Bolt\Storage\Database\Schema\SchemaCheck */
+    protected $response;
+
+    /**
+     * Constructor.
+     *
+     * @param Connection      $connection
+     * @param Manager         $manager
+     * @param Pimple          $schemaTables
+     * @param LoggerInterface $systemLog
+     */
+    public function __construct(Connection $connection, Manager $manager, Pimple $schemaTables, LoggerInterface $systemLog)
+    {
+        $this->connection = $connection;
+        $this->manager = $manager;
+        $this->schemaTables = $schemaTables;
+        $this->systemLog = $systemLog;
+    }
+}

--- a/src/Storage/Database/Schema/Comparison/DiffUpdater.php
+++ b/src/Storage/Database/Schema/Comparison/DiffUpdater.php
@@ -85,4 +85,22 @@ class DiffUpdater
             }
         }
     }
+
+    /**
+     * Do checks for columns.
+     *
+     * @param Column $column
+     * @param array  $alterData
+     *
+     * @return boolean
+     */
+    protected function checkColumn(Column $column, array $alterData)
+    {
+        // Not needed to be implemented yet
+        if ($alterData['propertyName'] !== $column->getName()) {
+            return false;
+        }
+
+        return false;
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/DiffUpdater.php
+++ b/src/Storage/Database/Schema/Comparison/DiffUpdater.php
@@ -65,4 +65,24 @@ class DiffUpdater
 
         return $this->updateDiffTable($tableDiff);
     }
+
+    /**
+     * Check individual diff properties.
+     *
+     * @param TableDiff $tableDiff
+     * @param array     $schemaUpdateType
+     * @param string    $alterKey
+     * @param array     $alterData
+     */
+    protected function checkChangedProperties(TableDiff $tableDiff, array $schemaUpdateType, $alterKey, array $alterData)
+    {
+        foreach ($schemaUpdateType as $columnName => $changeObject) {
+            // Function name we need to call
+            $func = $this->paramMap[$alterKey];
+            $needsUnset = call_user_func_array([$this, $func], [$changeObject, $alterData]);
+            if ($needsUnset) {
+                unset($tableDiff->{$alterKey}[$columnName]);
+            }
+        }
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/DiffUpdater.php
+++ b/src/Storage/Database/Schema/Comparison/DiffUpdater.php
@@ -144,4 +144,22 @@ class DiffUpdater
 
         return false;
     }
+
+    /**
+     * Do checks for foreignKey constraints.
+     *
+     * @param ForeignKeyConstraint $foreignKeyConstraint
+     * @param array                $alterData
+     *
+     * @return boolean
+     */
+    protected function checkForeignKeyConstraint(ForeignKeyConstraint $foreignKeyConstraint, array $alterData)
+    {
+        // Not needed to be implemented yet
+        if ($alterData['propertyName'] !== $foreignKeyConstraint->getName()) {
+            return false;
+        }
+
+        return false;
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/DiffUpdater.php
+++ b/src/Storage/Database/Schema/Comparison/DiffUpdater.php
@@ -126,4 +126,22 @@ class DiffUpdater
         }
         return false;
     }
+
+    /**
+     * Do checks for indexes.
+     *
+     * @param Index $index
+     * @param array $alterData
+     *
+     * @return boolean
+     */
+    protected function checkIndex(Index $index, array $alterData)
+    {
+        // Not needed to be implemented yet
+        if ($alterData['propertyName'] !== $index->getName()) {
+            return false;
+        }
+
+        return false;
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/DiffUpdater.php
+++ b/src/Storage/Database/Schema/Comparison/DiffUpdater.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Comparison;
+
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\ColumnDiff;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\TableDiff;
+
+/**
+ * Processor for \Doctrine\DBAL\Schema\TableDiff objects.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class DiffUpdater
+{
+    /** @var array */
+    protected $ignoredChanges;
+    /** @var array */
+    protected $paramMap = [
+        'addedColumns'       => 'checkColumn',
+        'changedColumns'     => 'checkColumnDiff',
+        'removedColumns'     => 'checkColumn',
+        'renamedColumns'     => 'checkColumn',
+        'addedIndexes'       => 'checkIndex',
+        'changedIndexes'     => 'checkIndex',
+        'removedIndexes'     => 'checkIndex',
+        'renamedIndexes'     => 'checkIndex',
+        'addedForeignKeys'   => 'checkForeignKeyConstraint',
+        'changedForeignKeys' => 'checkForeignKeyConstraint',
+        'removedForeignKeys' => 'checkForeignKeyConstraint',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param array $ignoredChanges
+     */
+    public function __construct(array $ignoredChanges)
+    {
+        $this->ignoredChanges = $ignoredChanges;
+    }
+}

--- a/src/Storage/Database/Schema/Comparison/DiffUpdater.php
+++ b/src/Storage/Database/Schema/Comparison/DiffUpdater.php
@@ -162,4 +162,23 @@ class DiffUpdater
 
         return false;
     }
+
+    /**
+     * After post-processing a diff, check if we have anything left and respond
+     * as Comparator::diffTable() would.
+     *
+     * @param TableDiff $diff
+     *
+     * @return TableDiff|false
+     */
+    private function updateDiffTable(TableDiff $diff)
+    {
+        foreach (array_keys($this->paramMap) as $param) {
+            if (!empty($diff->{$param})) {
+                return $diff;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/DiffUpdater.php
+++ b/src/Storage/Database/Schema/Comparison/DiffUpdater.php
@@ -103,4 +103,27 @@ class DiffUpdater
 
         return false;
     }
+
+    /**
+     * Do checks for column diffs.
+     *
+     * @param ColumnDiff $columnDiff
+     * @param array      $alterData
+     *
+     * @return boolean
+     */
+    protected function checkColumnDiff(ColumnDiff $columnDiff, array $alterData)
+    {
+        if (count($columnDiff->changedProperties) !== 1 && !$columnDiff->hasChanged($alterData['propertyName'])) {
+            return false;
+        }
+
+        foreach ($alterData['ignoredChanges'] as $keys) {
+            if ($keys['before'] === $columnDiff->fromColumn->getType()->getName() &&
+                $keys['after'] === $columnDiff->column->getType()->getName()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/DiffUpdater.php
+++ b/src/Storage/Database/Schema/Comparison/DiffUpdater.php
@@ -42,4 +42,27 @@ class DiffUpdater
     {
         $this->ignoredChanges = $ignoredChanges;
     }
+
+    /**
+     * Platform specific adjustments to table/column diffs.
+     *
+     * @param TableDiff $tableDiff
+     *
+     * @return TableDiff|false
+     */
+    public function adjustDiff(TableDiff $tableDiff)
+    {
+        foreach ($this->ignoredChanges as $alterKey => $alterData) {
+            // Array from something like 'changedColumns', 'changedIndexes',
+            // or 'changedForeignKeys'
+            $schemaUpdateType = $tableDiff->$alterKey;
+
+            if (empty($schemaUpdateType)) {
+                continue;
+            }
+            $this->checkChangedProperties($tableDiff, $schemaUpdateType, $alterKey, $alterData);
+        }
+
+        return $this->updateDiffTable($tableDiff);
+    }
 }

--- a/src/Storage/Database/Schema/Comparison/MySql.php
+++ b/src/Storage/Database/Schema/Comparison/MySql.php
@@ -31,7 +31,7 @@ class MySql extends BaseComparator
     protected function removeIgnoredChanges(TableDiff $diff)
     {
         // Work around reserved column name removal
-        if ($diff->fromTable->getName() === $this->getTablename('cron')) {
+        if ($diff->fromTable->getName() === $this->manager->getTablename('cron')) {
             foreach ($diff->renamedColumns as $key => $col) {
                 if ($col->getName() === 'interim') {
                     $diff->addedColumns[] = $col;

--- a/src/Storage/Database/Schema/Comparison/MySql.php
+++ b/src/Storage/Database/Schema/Comparison/MySql.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Comparison;
+
+use Doctrine\DBAL\Schema\TableDiff;
+
+/**
+ * Comparison handling for MySQL/MariaDB platforms.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class MySql extends BaseComparator
+{
+    /** @var string */
+    protected $platform = 'mysql';
+    /** @var array */
+    protected $ignoredChanges = [
+        'changedColumns' => [
+            'propertyName'   => 'type',
+            'ignoredChanges' => [
+                ['before' => 'date', 'after' => 'date'],
+                ['before' => 'datetime', 'after' => 'datetime'],
+                ['before' => 'text', 'after' => 'json_array'],
+            ],
+        ]
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function removeIgnoredChanges(TableDiff $diff)
+    {
+        // Work around reserved column name removal
+        if ($diff->fromTable->getName() === $this->getTablename('cron')) {
+            foreach ($diff->renamedColumns as $key => $col) {
+                if ($col->getName() === 'interim') {
+                    $diff->addedColumns[] = $col;
+                    unset($diff->renamedColumns[$key]);
+                }
+            }
+        }
+    }
+}

--- a/src/Storage/Database/Schema/Comparison/PostgreSql.php
+++ b/src/Storage/Database/Schema/Comparison/PostgreSql.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Comparison;
+
+use Doctrine\DBAL\Schema\TableDiff;
+
+/**
+ * Comparison handling for PostgreSQL platforms.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class PostgreSql extends BaseComparator
+{
+    /** @var string */
+    protected $platform = 'postgresql';
+    /** @var array */
+    protected $ignoredChanges = [
+        'changedColumns' => [
+            'propertyName'   => 'type',
+            'ignoredChanges' => [
+                ['before' => 'date', 'after' => 'date'],
+                ['before' => 'datetime', 'after' => 'datetime'],
+                ['before' => 'string', 'after' => 'json_array'],
+                ['before' => 'text', 'after' => 'json_array'],
+            ],
+        ]
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function removeIgnoredChanges(TableDiff $diff)
+    {
+    }
+}

--- a/src/Storage/Database/Schema/Comparison/Sqlite.php
+++ b/src/Storage/Database/Schema/Comparison/Sqlite.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema\Comparison;
+
+use Doctrine\DBAL\Schema\TableDiff;
+
+/**
+ * Comparison handling for Sqlite platforms.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class Sqlite extends BaseComparator
+{
+    /** @var string */
+    protected $platform = 'sqlite';
+    /** @var array */
+    protected $ignoredChanges = [
+        'changedColumns' => [
+            'propertyName'   => 'type',
+            'ignoredChanges' => [
+                ['before' => 'date', 'after' => 'date'],
+                ['before' => 'datetime', 'after' => 'datetime'],
+                ['before' => 'text', 'after' => 'json_array'],
+            ],
+        ]
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function removeIgnoredChanges(TableDiff $diff)
+    {
+    }
+}

--- a/src/Storage/Database/Schema/Manager.php
+++ b/src/Storage/Database/Schema/Manager.php
@@ -1,112 +1,141 @@
 <?php
+
 namespace Bolt\Storage\Database\Schema;
 
-use Bolt\Storage\Database\Schema\Table\BaseTable;
-use Bolt\Storage\Database\Schema\Table\ContentType;
-use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Doctrine\DBAL\Schema\Comparator;
+use Bolt\Exception\StorageException;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\DBAL\Schema\TableDiff;
 use Silex\Application;
-use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * Manager class for Bolt database schema.
+ *
+ * Based on on parts of the monolithic Bolt\Database\IntegrityChecker class.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
 class Manager
 {
+    /** @var \Doctrine\DBAL\Connection */
+    protected $connection;
+    /** @var \Bolt\Config */
+    protected $config;
+    /** @var \Doctrine\DBAL\Schema\Schema */
+    protected $schema;
+    /** @var \Doctrine\DBAL\Schema\Table[] */
+    protected $schemaTables;
+    /** @var \Doctrine\DBAL\Schema\Table[] */
+    protected $installedTables;
+
     /** @var \Silex\Application */
     private $app;
-    /** @var string */
-    private $prefix;
-    /** @var \Doctrine\DBAL\Schema\Table[] Current tables. */
-    private $tables;
 
-    /** @var array Array of callables that produce table definitions. */
-    protected $extension_table_generators = [];
-    /** @var string */
-    protected $integrityCachePath;
-
+    /** @deprecated Will be removed in v3 */
     const INTEGRITY_CHECK_INTERVAL    = 1800; // max. validity of a database integrity check, in seconds
     const INTEGRITY_CHECK_TS_FILENAME = 'dbcheck_ts'; // filename for the check timestamp file
 
-    public $tableMap = [];
-
+    /**
+     * Constructor.
+     *
+     * @param Application $app
+     */
     public function __construct(Application $app)
     {
         $this->app = $app;
+        $this->connection = $app['db'];
+        $this->config = $app['config'];
     }
 
     /**
-     * Invalidate our database check by removing the timestamp file from cache.
-     *
-     * @return void
+     * @deprecated Will be removed in v3. This is a place holder to prevent fatal errors.
      */
-    public function invalidate()
+    public function __call($name, $args)
     {
-        $fileName = $this->getValidityTimestampFilename();
+        $this->app['logger.system']->warning('[DEPRECATED]: An extension is called an invalid or removed integrity checker function: ' . $name, ['event' => 'deprecated']);
+    }
 
-        // delete the cached dbcheck-ts
-        if (is_writable($fileName)) {
-            unlink($fileName);
-        } elseif (file_exists($fileName)) {
-            $message = sprintf(
-                "The file '%s' exists, but couldn't be removed. Please remove this file manually, and try again.",
-                $fileName
-            );
-            $this->app->abort(Response::HTTP_UNAUTHORIZED, $message);
+    /**
+     * @deprecated Will be removed in v3. This is a place holder to prevent fatal errors.
+     */
+    public function __get($name)
+    {
+        $this->app['logger.system']->warning('[DEPRECATED]: An extension is called an invalid or removed integrity checker property: ' . $name, ['event' => 'deprecated']);
+    }
+
+    /**
+     * Get the database name of a table from an alias.
+     *
+     * @param string $name
+     *
+     * @return string|null
+     */
+    public function getTableName($name)
+    {
+        if (isset($this->app['schema.tables'][$name])) {
+            return $this->app['schema.tables'][$name]->getTableName();
         }
     }
 
     /**
-     * Set our state as valid by writing the current date/time to the
-     * app/cache/dbcheck-ts file.
-     *
-     * @return void
-     */
-    public function markValid()
-    {
-        $timestamp = time();
-        file_put_contents($this->getValidityTimestampFilename(), $timestamp);
-    }
-
-    /**
-     * Check if our state is known valid by comparing app/cache/dbcheck-ts to
-     * the current timestamp.
+     * Check to see if we have past the time to re-check our schema.
      *
      * @return boolean
      */
-    public function isValid()
+    public function isCheckRequired()
     {
-        if (is_readable($this->getValidityTimestampFilename())) {
-            $validityTS = intval(file_get_contents($this->getValidityTimestampFilename()));
-        } else {
-            $validityTS = 0;
-        }
-
-        return ($validityTS >= time() - self::INTEGRITY_CHECK_INTERVAL);
+        return $this->getSchemaTimer()->isCheckRequired();
     }
 
     /**
-     * Get an associative array with the bolt_tables tables as Doctrine Table objects.
+     * Check to see if there is a mismatch in installed versus configured
+     * schemas.
      *
-     * @return \Doctrine\DBAL\Schema\Table[]
+     * @return boolean
      */
-    protected function getTableObjects()
+    public function isUpdateRequired()
     {
-        if (!empty($this->tables)) {
-            return $this->tables;
+        return $this->getSchemaComparator()->hasPending();
+    }
+
+    /**
+     * Run a check against current and configured schemas.
+     *
+     * @return SchemaCheck
+     */
+    public function check()
+    {
+        $response = $this->getSchemaComparator()->compare();
+        if (!$response->hasResponses()) {
+            $this->getSchemaTimer()->setCheckExpiry();
         }
 
-        /** @var $sm \Doctrine\DBAL\Schema\AbstractSchemaManager */
-        $sm = $this->app['db']->getSchemaManager();
+        return $response;
+    }
 
-        $this->tables = [];
+    /**
+     * Run database table updates.
+     *
+     * @return \Bolt\Storage\Database\Schema\SchemaCheck
+     */
+    public function update()
+    {
+        // Do the initial check
+        $this->getSchemaComparator()->compare();
+        $response = $this->getSchemaComparator()->getResponse();
+        $creates = $this->getSchemaComparator()->getCreates();
+        $alters = $this->getSchemaComparator()->getAlters();
 
-        foreach ($sm->listTables() as $table) {
-            $this->tables[$table->getName()] = $table;
+        $modifier = new TableModifier($this->connection, $this->app['logger.system'], $this->app['logger.flash']);
+        $modifier->createTables($creates, $response);
+        $modifier->alterTables($alters, $response);
+
+        // Recheck now that we've processed
+        $this->getSchemaComparator()->compare();
+        if (!$this->getSchemaComparator()->hasPending()) {
+            $this->getSchemaTimer()->setCheckExpiry();
         }
 
-        return $this->tables;
+        return $response;
     }
 
     /**
@@ -114,228 +143,28 @@ class Manager
      *
      * @return boolean
      */
-    public function checkUserTableIntegrity()
+    public function hasUserTable()
     {
-        $tables = $this->getTableObjects();
-
-        // Check the users table.
-        if (!isset($tables[$this->getTablename('users')])) {
-            return false;
+        $tables = $this->getInstalledTables();
+        if (isset($tables['users'])) {
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     /**
-     * Check if all required tables and columns are present in the DB.
+     * Get the built schema.
      *
-     * @param boolean $hinting Return hints if true
-     *
-     * @return CheckResponse
+     * @return \Doctrine\DBAL\Schema\Schema
      */
-    public function checkTablesIntegrity($hinting = false)
+    public function getSchema()
     {
-        $response = new CheckResponse($hinting);
-        $tables = $this->getTablesSchema();
-        $valid = true;
-
-        /** @var $table Table */
-        foreach ($tables as $table) {
-            // Set the valid flag via bitwise
-            $valid = $valid & $this->checkTableIntegrity($table, $response);
+        if ($this->schema === null) {
+            $this->getSchemaTables();
         }
 
-        // If there were no messages, update the timer, so we don't check it again.
-        // If there _are_ messages, keep checking until it's fixed.
-        if ($valid) {
-            $this->markValid();
-        }
-
-        return $response;
-    }
-
-    /**
-     * Check that a single table's columns and indices are present in the DB.
-     *
-     * @param Table         $table
-     * @param CheckResponse $response
-     *
-     * @return boolean
-     */
-    protected function checkTableIntegrity(Table $table, CheckResponse $response)
-    {
-        $comparator = new Comparator();
-        $currentTables = $this->getTableObjects();
-        $tableName = $table->getName();
-
-        // Create the users table.
-        if (!isset($currentTables[$tableName])) {
-            $response->addTitle($tableName, sprintf('Table `%s` is not present.', $tableName));
-        } else {
-            $diff = $comparator->diffTable($currentTables[$tableName], $table);
-            $this->addResponseDiff($tableName, $diff, $response);
-        }
-
-        // If we are using the debug logger, log the diffs
-        foreach ($response->getDiffDetails() as $diff) {
-            $this->app['logger.system']->debug('Database update required', $diff);
-        }
-
-        // If a table still has messages return a false to flick the validity check
-        return !$response->hasResponses();
-    }
-
-    /**
-     * Add details of the table differences to the response object.
-     *
-     * @param string          $tableName
-     * @param TableDiff|false $diff
-     * @param CheckResponse   $response
-     */
-    protected function addResponseDiff($tableName, $diff, CheckResponse $response)
-    {
-        if ($diff === false) {
-            return;
-        }
-
-        $diff = $this->cleanupTableDiff($diff);
-        if ($details = $this->app['db']->getDatabasePlatform()->getAlterTableSQL($diff)) {
-            $response->addTitle($tableName, sprintf('Table `%s` is not the correct schema:', $tableName));
-            $response->checkDiff($tableName, $diff);
-
-            // For debugging we keep the diffs
-            $response->addDiffDetail($details);
-        }
-    }
-
-    /**
-     * Determine if we need to check the table integrity. Do this only once per
-     * hour, per session, since it's pretty time consuming.
-     *
-     * @return boolean TRUE if a check is needed
-     */
-    public function needsCheck()
-    {
-        return !$this->isValid();
-    }
-
-    /**
-     * Check if there are pending updates to the tables.
-     *
-     * @return boolean
-     */
-    public function needsUpdate()
-    {
-        $response = $this->checkTablesIntegrity();
-
-        return $response->hasResponses() ? true : false;
-    }
-
-    /**
-     * Check and repair tables.
-     *
-     * @return CheckResponse
-     */
-    public function repairTables()
-    {
-        // When repairing tables we want to start with an empty flashbag. Otherwise we get another
-        // 'repair your DB'-notice, right after we're done repairing.
-        $this->app['logger.flash']->clear();
-
-        $response = new CheckResponse();
-        $currentTables = $this->getTableObjects();
-        /** @var $schemaManager AbstractSchemaManager */
-        $schemaManager = $this->app['db']->getSchemaManager();
-        $comparator = new Comparator();
-        $tables = $this->getTablesSchema();
-
-        /** @var $table Table */
-        foreach ($tables as $table) {
-            $tableName = $table->getName();
-
-            // Create the users table.
-            if (!isset($currentTables[$tableName])) {
-                /** @var $platform AbstractPlatform */
-                $platform = $this->app['db']->getDatabasePlatform();
-                $queries = $platform->getCreateTableSQL($table, AbstractPlatform::CREATE_INDEXES | AbstractPlatform::CREATE_FOREIGNKEYS);
-                foreach ($queries as $query) {
-                    $this->app['db']->query($query);
-                }
-
-                $response->addTitle($tableName, sprintf('Created table `%s`.', $tableName));
-            } else {
-                $diff = $comparator->diffTable($currentTables[$tableName], $table);
-                if ($diff) {
-                    $diff = $this->cleanupTableDiff($diff);
-                    // diff may be just deleted columns which we have reset above
-                    // only exec and add output if does really alter anything
-                    if ($this->app['db']->getDatabasePlatform()->getAlterTableSQL($diff)) {
-                        $schemaManager->alterTable($diff);
-                        $response->addTitle($tableName, sprintf('Updated `%s` table to match current schema.', $tableName));
-                    }
-                }
-            }
-        }
-
-        return $response;
-    }
-
-    /**
-     * Cleanup a table diff, remove changes we want to keep or fix platform
-     * specific issues.
-     *
-     * @param TableDiff $diff
-     *
-     * @return \Doctrine\DBAL\Schema\TableDiff
-     */
-    protected function cleanupTableDiff(TableDiff $diff)
-    {
-        $baseTables = $this->getBoltTablesNames();
-
-        // Work around reserved column name removal
-        if ($diff->fromTable->getName() === $this->getTablename('cron')) {
-            foreach ($diff->renamedColumns as $key => $col) {
-                if ($col->getName() === 'interim') {
-                    $diff->addedColumns[] = $col;
-                    unset($diff->renamedColumns[$key]);
-                }
-            }
-        }
-
-        // Some diff changes can be ignored… Because… DBAL.
-        $alias = $this->getTableAlias($diff->fromTable->getName());
-        if (isset($this->app['schema.tables'][$alias]) && $ignored = $this->app['schema.tables'][$alias]->ignoredChanges()) {
-            $this->removeIgnoredChanges($this->app['schema.tables'][$alias], $diff, $ignored);
-        }
-
-        // Don't remove fields from contenttype tables to prevent accidental data removal
-        if (!in_array($diff->fromTable->getName(), $baseTables)) {
-            $diff->removedColumns = [];
-        }
-
-        return $diff;
-    }
-
-    /**
-     * Woraround for the json_array types on SQLite. If only the type has
-     * changed, we ignore to prevent multiple schema warnings.
-     *
-     * @param BaseTable $boltTable
-     * @param TableDiff $diff
-     * @param array     $ignored
-     */
-    protected function removeIgnoredChanges(BaseTable $boltTable, TableDiff $diff, array $ignored)
-    {
-        if ($diff->fromTable->getName() !== $boltTable->getTableName()) {
-            return;
-        }
-
-        foreach ($ignored as $ignore) {
-            if (isset($diff->changedColumns[$ignore['column']])
-                && $diff->changedColumns[$ignore['column']]->changedProperties === [$ignore['property']]) {
-                unset($diff->changedColumns[$ignore['column']]);
-            }
-        }
+        return $this->schema;
     }
 
     /**
@@ -343,294 +172,69 @@ class Manager
      *
      * @return \Doctrine\DBAL\Schema\Table[]
      */
-    public function getTablesSchema()
+    public function getSchemaTables()
     {
-        $schema = new Schema();
-
-        $tables = array_merge(
-            $this->getBoltTablesSchema($schema),
-            $this->getContentTypeTablesSchema($schema),
-            $this->getExtensionTablesSchema($schema)
-        );
-
-        foreach ($tables as $index => $table) {
-            if (strpos($table->getName(), $this->getTablenamePrefix()) === false) {
-                unset($tables[$index]);
-            }
+        if ($this->schemaTables !== null) {
+            return $this->schemaTables;
         }
 
+        $schema = new Schema();
+        $tables = array_merge(
+            $this->app['schema.builder']['base']->getSchemaTables($schema),
+            $this->app['schema.builder']['content']->getSchemaTables($schema, $this->config),
+            $this->app['schema.builder']['extensions']->getSchemaTables($schema)
+        );
+        $this->schema = $schema;
+
         return $tables;
+    }
+
+    /**
+     * Get the installed table list from Doctrine.
+     *
+     * @return \Doctrine\DBAL\Schema\Table[]
+     */
+    public function getInstalledTables()
+    {
+        if ($this->installedTables !== null) {
+            return $this->installedTables;
+        }
+
+        /** @var $tables \Doctrine\DBAL\Schema\Table[] */
+        $tables = $this->connection->getSchemaManager()->listTables();
+        foreach ($tables as $table) {
+            $alias = str_replace($this->app['schema.prefix'], '', $table->getName());
+            $this->installedTables[$alias] = $table;
+        }
+
+        return $this->installedTables;
     }
 
     /**
      * This method allows extensions to register their own tables.
      *
-     * @param Callable $generator A generator function that takes the Schema
-     *                            instance and returns a table or an array of tables.
+     * @param callable $generator A generator function that takes the Schema
+     *                            instance and returns a table or an array of
+     *                            tables.
      */
-    public function registerExtensionTable($generator)
+    public function registerExtensionTable(callable $generator)
     {
-        $this->extension_table_generators[] = $generator;
+        $this->app['schema.builder']['extensions']->addTable($generator);
     }
 
     /**
-     * Get all the registered extension tables.
-     *
-     * @param Schema $schema
-     *
-     * @return \Doctrine\DBAL\Schema\Table[]
+     * @return \Bolt\Storage\Database\Schema\Timer
      */
-    protected function getExtensionTablesSchema(Schema $schema)
+    private function getSchemaTimer()
     {
-        $tables = [];
-        foreach ($this->extension_table_generators as $generator) {
-            $table = call_user_func($generator, $schema);
-            // We need to be prepared for generators returning a single table,
-            // as well as generators returning an array of tables.
-            if (is_array($table)) {
-                foreach ($table as $t) {
-                    $tables[] = $t;
-                }
-            } else {
-                $tables[] = $table;
-            }
-        }
-
-        return $tables;
+        return $this->app['schema.timer'];
     }
 
     /**
-     * Get an array of Bolt's internal tables
-     *
-     * @return \Doctrine\DBAL\Schema\Table[]
+     * @return \Bolt\Storage\Database\Schema\Comparison\BaseComparator
      */
-    protected function getBoltTablesNames()
+    private function getSchemaComparator()
     {
-        $baseTables = [];
-        /** @var $table Table */
-        foreach ($this->getBoltTablesSchema(new Schema()) as $table) {
-            $baseTables[] = $table->getName();
-        }
-
-        return $baseTables;
-    }
-
-    /**
-     * Build the schema for base Bolt tables.
-     *
-     * @param Schema $schema
-     *
-     * @return \Doctrine\DBAL\Schema\Table[]
-     */
-    protected function getBoltTablesSchema(Schema $schema)
-    {
-        $tables = [];
-        foreach ($this->app['schema.base_tables']->keys() as $name) {
-            $tables[] = $this->app['schema.base_tables'][$name]->buildTable($schema, $this->getTablename($name));
-        }
-
-        return $tables;
-    }
-
-    /**
-     * Build the schema for Bolt ContentType tables.
-     *
-     * @param Schema $schema
-     *
-     * @return \Doctrine\DBAL\Schema\Table[]
-     */
-    protected function getContentTypeTablesSchema(Schema $schema)
-    {
-        $tables = [];
-
-        // Now, iterate over the contenttypes, and create the tables if they don't exist.
-        foreach ($this->app['config']->get('contenttypes') as $contenttype) {
-            $tableObj = $this->getContentTypeTableObject($contenttype['tablename']);
-            $tableName = $this->getTablename($contenttype['tablename']);
-            $this->mapTableName($tableName, $contenttype['tablename']);
-            $myTable = $tableObj->buildTable($schema, $tableName);
-
-            if (isset($contenttype['fields']) && is_array($contenttype['fields'])) {
-                $this->addContentTypeTableColumns($tableObj, $myTable, $contenttype['fields']);
-            }
-
-            $tables[] = $myTable;
-        }
-
-        return $tables;
-    }
-
-    /**
-     * Ensure any late added ContentTypes have a valid table object in the provider.
-     *
-     * @param string $contenttype
-     *
-     * @return \Bolt\Storage\Database\Schema\Table\ContentType
-     */
-    private function getContentTypeTableObject($contenttype)
-    {
-        if (!isset($this->app['schema.tables'][$contenttype])) {
-            $platform = $this->app['db']->getDatabasePlatform();
-            $this->app['schema.tables'][$contenttype] = $this->app->share(
-                function () use ($platform) {
-                    return new ContentType($platform);
-                }
-            );
-        }
-
-        return $this->app['schema.tables'][$contenttype];
-    }
-
-    /**
-     * Add the custom columns for the ContentType.
-     *
-     * @param \Bolt\Storage\Database\Schema\Table\ContentType $tableObj
-     * @param \Doctrine\DBAL\Schema\Table                     $table
-     * @param array                                           $fields
-     */
-    private function addContentTypeTableColumns(ContentType $tableObj, Table $table, array $fields)
-    {
-        // Check if all the fields are present in the DB.
-        foreach ($fields as $fieldName => $values) {
-            /** @var \Doctrine\DBAL\Platforms\Keywords\KeywordList $reservedList */
-            $reservedList = $this->app['db']->getDatabasePlatform()->getReservedKeywordsList();
-            if ($reservedList->isKeyword($fieldName)) {
-                $error = sprintf(
-                    "You're using '%s' as a field name, but that is a reserved word in %s. Please fix it, and refresh this page.",
-                    $fieldName,
-                    $this->app['db']->getDatabasePlatform()->getName()
-                );
-                $this->app['logger.flash']->error($error);
-                continue;
-            }
-
-            $this->addContentTypeTableColumn($tableObj, $table, $fieldName, $values);
-        }
-    }
-
-    /**
-     * Add a single column to the ContentType table.
-     *
-     * @param \Bolt\Storage\Database\Schema\Table\ContentType $tableObj
-     * @param \Doctrine\DBAL\Schema\Table                     $table
-     * @param string                                          $fieldName
-     * @param array                                           $values
-     */
-    private function addContentTypeTableColumn(ContentType $tableObj, Table $table, $fieldName, array $values)
-    {
-        if ($tableObj->isKnownType($values['type'])) {
-            // Use loose comparison on true as 'true' in YAML is a string
-            $addIndex = isset($values['index']) && $values['index'] == 'true';
-            // Add the contenttype's specific fields
-            $tableObj->addCustomFields($fieldName, $this->getContentTypeTableColumnType($values), $addIndex);
-        } elseif ($handler = $this->app['config']->getFields()->getDatabaseField($values['type'])) {
-            // Add template fields
-            /** @var $handler \Bolt\Storage\Field\FieldInterface */
-            $table->addColumn($fieldName, $handler->getStorageType(), $handler->getStorageOptions());
-        }
-    }
-
-    /**
-     * Certain field types can have single or JSON array types, figure it out.
-     *
-     * @param array $values
-     *
-     * @return string
-     */
-    private function getContentTypeTableColumnType(array $values)
-    {
-        // Multi-value selects are stored as JSON arrays
-        if (isset($values['type']) && $values['type'] === 'select' && isset($values['multiple']) && $values['multiple'] === 'true') {
-            return 'selectmultiple';
-        }
-
-        return $values['type'];
-    }
-
-    /**
-     * Get the tablename with prefix from a given $name.
-     *
-     * @param $name
-     *
-     * @return string
-     */
-    public function getTablename($name)
-    {
-        $name = str_replace('-', '_', $this->app['slugify']->slugify($name));
-        $tablename = sprintf('%s%s', $this->getTablenamePrefix(), $name);
-
-        return $tablename;
-    }
-
-    /**
-     * Get the table alias name.
-     *
-     * @param $name
-     *
-     * @return string
-     */
-    protected function getTableAlias($tableName)
-    {
-        return str_replace($this->getTablenamePrefix(), '', $tableName);
-    }
-
-    /**
-     * Get the tablename prefix.
-     *
-     * @return string
-     */
-    protected function getTablenamePrefix()
-    {
-        if ($this->prefix !== null) {
-            return $this->prefix;
-        }
-
-        $this->prefix = $this->app['config']->get('general/database/prefix', 'bolt_');
-
-        // Make sure prefix ends in '_'. Prefixes without '_' are lame.
-        if ($this->prefix[strlen($this->prefix) - 1] != '_') {
-            $this->prefix .= '_';
-        }
-
-        return $this->prefix;
-    }
-
-    /**
-     * Get the 'validity' timestamp's file name.
-     *
-     * @return string
-     */
-    private function getValidityTimestampFilename()
-    {
-        if (empty($this->integrityCachePath)) {
-            $this->integrityCachePath = $this->app['resources']->getPath('cache');
-        }
-
-        return $this->integrityCachePath . '/' . self::INTEGRITY_CHECK_TS_FILENAME;
-    }
-
-    /**
-     * Map a table name's value.
-     *
-     * @param string $from
-     * @param string $to
-     */
-    protected function mapTableName($from, $to)
-    {
-        $this->tableMap[$from] = $to;
-    }
-
-    /**
-     * Get the stored table name key.
-     *
-     * @param string $table
-     *
-     * @return string
-     */
-    public function getKeyForTable($table)
-    {
-        if (isset($this->tableMap[$table])) {
-            return $this->tableMap[$table];
-        }
+        return $this->app['schema.comparator'];
     }
 }

--- a/src/Storage/Database/Schema/SchemaCheck.php
+++ b/src/Storage/Database/Schema/SchemaCheck.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\Storage\Database\Schema;
 
 use Doctrine\DBAL\Schema\TableDiff;
@@ -8,7 +9,7 @@ use Doctrine\DBAL\Schema\TableDiff;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class CheckResponse
+class SchemaCheck
 {
     /** @var array */
     private $pending = [];
@@ -20,13 +21,6 @@ class CheckResponse
     private $hints = [];
     /** @var array */
     private $diffs = [];
-    /** @var boolean */
-    private $hinting;
-
-    public function __construct($hinting = false)
-    {
-        $this->hinting = $hinting;
-    }
 
     /**
      * Add a diff detail.
@@ -113,8 +107,9 @@ class CheckResponse
             if (!empty($this->messages[$tableName])) {
                 $message .= implode(', ', $this->messages[$tableName]);
             }
-            $response[] = $message;
+            $response[$tableName] = $message;
         }
+        ksort($response);
 
         return $response;
     }
@@ -177,9 +172,9 @@ class CheckResponse
         $this->getRemovedIndexes($tableName, $diff);
         $this->getRemovedForeignKeys($tableName, $diff);
 
-        if ($this->hinting && count($diff->removedColumns) > 0) {
+        if (count($diff->removedColumns) > 0) {
             $hint = sprintf(
-                'The following fields in the `%s` table are not defined in your configuration. You can safely delete them manually if they are no longer needed: ',
+                'The following fields in the `%s` table are not defined in your configuration. You can safely delete them manually if they are no longer needed: `%s`',
                 $tableName,
                 join('`, `', array_keys($diff->removedColumns))
             );

--- a/src/Storage/Database/Schema/SchemaCheck.php
+++ b/src/Storage/Database/Schema/SchemaCheck.php
@@ -3,6 +3,7 @@
 namespace Bolt\Storage\Database\Schema;
 
 use Doctrine\DBAL\Schema\TableDiff;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 
 /**
  * A response class for a single table's check.
@@ -285,16 +286,8 @@ class SchemaCheck
      */
     private function getAddedForeignKeys($tableName, TableDiff $diff)
     {
-        foreach ($diff->addedForeignKeys as $index) {
-            $this->addMessage(
-                $tableName,
-                sprintf(
-                    'missing foreign key on `%s` related to `%s.%s`',
-                    implode(', ', $index->getUnquotedLocalColumns()),
-                    $index->getForeignTableName(),
-                    implode(', ' . $index->getForeignTableName() . '.', $index->getUnquotedForeignColumns())
-                )
-            );
+        foreach ($diff->addedForeignKeys as $foreignKey) {
+            $this->addForeignKeysMessage($tableName, $foreignKey, 'missing foreign key on `%s` related to `%s.%s`');
         }
     }
 
@@ -306,17 +299,29 @@ class SchemaCheck
      */
     private function getChangedForeignKeys($tableName, TableDiff $diff)
     {
-        foreach ($diff->changedForeignKeys as $index) {
-            $this->addMessage(
-                $tableName,
-                sprintf(
-                    'changed foreign key on `%s`, it is now related to `%s.%s`',
-                    implode(', ', $index->getUnquotedLocalColumns()),
-                    $index->getForeignTableName(),
-                    implode(', ' . $index->getForeignTableName() . '.', $index->getUnquotedForeignColumns())
-                )
-            );
+        foreach ($diff->changedForeignKeys as $foreignKey) {
+            $this->addForeignKeysMessage($tableName, $foreignKey, 'changed foreign key on `%s`, it is now related to `%s.%s`');
         }
+    }
+
+    /**
+     * Add a message for a foreign key change.
+     *
+     * @param string               $tableName
+     * @param ForeignKeyConstraint $index
+     * @param string               $format
+     */
+    private function addForeignKeysMessage($tableName, ForeignKeyConstraint $foreignKey, $format)
+    {
+        $this->addMessage(
+            $tableName,
+            sprintf(
+                $format,
+                implode(', ', $foreignKey->getUnquotedLocalColumns()),
+                $foreignKey->getForeignTableName(),
+                implode(', ' . $foreignKey->getForeignTableName() . '.', $foreignKey->getUnquotedForeignColumns())
+            )
+        );
     }
 
     /**

--- a/src/Storage/Database/Schema/Table/AuthToken.php
+++ b/src/Storage/Database/Schema/Table/AuthToken.php
@@ -40,15 +40,4 @@ class AuthToken extends BaseTable
     {
         $this->table->setPrimaryKey(['id']);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function ignoredChanges()
-    {
-        return [
-            ['column' => 'lastseen', 'property' => 'type'],
-            ['column' => 'validity', 'property' => 'type'],
-        ];
-    }
 }

--- a/src/Storage/Database/Schema/Table/ContentType.php
+++ b/src/Storage/Database/Schema/Table/ContentType.php
@@ -82,22 +82,6 @@ class ContentType extends BaseTable
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function ignoredChanges()
-    {
-        $ignoredChanges = [
-            ['column' => 'datecreated', 'property' => 'type'],
-            ['column' => 'datechanged', 'property' => 'type'],
-            ['column' => 'datepublish', 'property' => 'type'],
-            ['column' => 'datedepublish', 'property' => 'type'],
-            ['column' => 'templatefields', 'property' => 'type'],
-        ];
-
-        return array_merge($this->ignoredChanges, $ignoredChanges);
-    }
-
-    /**
      * Check if the field type is valid.
      *
      * @param string $type
@@ -122,10 +106,6 @@ class ContentType extends BaseTable
 
         if ($addIndex) {
             $this->table->addIndex([$fieldName]);
-        }
-
-        if ($this->typeMap[$type] === 'columnDate' || $this->typeMap[$type] === 'columnDateTime' || $this->typeMap[$type] === 'columnJson') {
-            $this->ignoredChanges[] = ['column' => $fieldName, 'property' => 'type'];
         }
     }
 

--- a/src/Storage/Database/Schema/Table/ContentType.php
+++ b/src/Storage/Database/Schema/Table/ContentType.php
@@ -102,7 +102,9 @@ class ContentType extends BaseTable
      */
     public function addCustomFields($fieldName, $type, $addIndex)
     {
-        $this->{$this->typeMap[$type]}($fieldName);
+        if (!$this->table->hasColumn($fieldName)) {
+            $this->{$this->typeMap[$type]}($fieldName);
+        }
 
         if ($addIndex) {
             $this->table->addIndex([$fieldName]);

--- a/src/Storage/Database/Schema/Table/Cron.php
+++ b/src/Storage/Database/Schema/Table/Cron.php
@@ -35,14 +35,4 @@ class Cron extends BaseTable
     {
         $this->table->setPrimaryKey(['id']);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function ignoredChanges()
-    {
-        return [
-            ['column' => 'lastrun', 'property' => 'type'],
-        ];
-    }
 }

--- a/src/Storage/Database/Schema/Table/FieldValue.php
+++ b/src/Storage/Database/Schema/Table/FieldValue.php
@@ -47,16 +47,4 @@ class FieldValue extends BaseTable
     {
         $this->table->setPrimaryKey(['id']);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function ignoredChanges()
-    {
-        return [
-            ['column' => 'value_date', 'property' => 'type'],
-            ['column' => 'value_datetime', 'property' => 'type'],
-            ['column' => 'value_json_array', 'property' => 'type'],
-        ];
-    }
 }

--- a/src/Storage/Database/Schema/Table/LogChange.php
+++ b/src/Storage/Database/Schema/Table/LogChange.php
@@ -45,15 +45,4 @@ class LogChange extends BaseTable
     {
         $this->table->setPrimaryKey(['id']);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function ignoredChanges()
-    {
-        return [
-            ['column' => 'date', 'property' => 'type'],
-            ['column' => 'diff', 'property' => 'type'],
-        ];
-    }
 }

--- a/src/Storage/Database/Schema/Table/LogSystem.php
+++ b/src/Storage/Database/Schema/Table/LogSystem.php
@@ -45,15 +45,4 @@ class LogSystem extends BaseTable
     {
         $this->table->setPrimaryKey(['id']);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function ignoredChanges()
-    {
-        return [
-            ['column' => 'date', 'property' => 'type'],
-            ['column' => 'source', 'property' => 'type'],
-        ];
-    }
 }

--- a/src/Storage/Database/Schema/Table/Users.php
+++ b/src/Storage/Database/Schema/Table/Users.php
@@ -50,18 +50,4 @@ class Users extends BaseTable
     {
         $this->table->setPrimaryKey(['id']);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function ignoredChanges()
-    {
-        return [
-            ['column' => 'lastseen', 'property' => 'type'],
-            ['column' => 'roles', 'property' => 'type'],
-            ['column' => 'shadowvalidity', 'property' => 'type'],
-            ['column' => 'stack', 'property' => 'type'],
-            ['column' => 'throttleduntil', 'property' => 'type'],
-        ];
-    }
 }

--- a/src/Storage/Database/Schema/Table/Users.php
+++ b/src/Storage/Database/Schema/Table/Users.php
@@ -21,14 +21,14 @@ class Users extends BaseTable
         $this->table->addColumn('lastseen',       'datetime',   ['notnull' => false, 'default' => null]);
         $this->table->addColumn('lastip',         'string',     ['length' => 32, 'default' => '']);
         $this->table->addColumn('displayname',    'string',     ['length' => 32]);
-        $this->table->addColumn('stack',          'json_array', ['length' => 1024, 'notnull' => false]);
+        $this->table->addColumn('stack',          'json_array', ['notnull' => false]);
         $this->table->addColumn('enabled',        'boolean',    ['default' => true]);
         $this->table->addColumn('shadowpassword', 'string',     ['length' => 128, 'default' => '']);
         $this->table->addColumn('shadowtoken',    'string',     ['length' => 128, 'default' => '']);
         $this->table->addColumn('shadowvalidity', 'datetime',   ['notnull' => false, 'default' => null]);
         $this->table->addColumn('failedlogins',   'integer',    ['default' => 0]);
         $this->table->addColumn('throttleduntil', 'datetime',   ['notnull' => false, 'default' => null]);
-        $this->table->addColumn('roles',          'json_array', ['length' => 1024]);
+        $this->table->addColumn('roles',          'json_array', []);
         // @codingStandardsIgnoreEnd
     }
 

--- a/src/Storage/Database/Schema/TableModifier.php
+++ b/src/Storage/Database/Schema/TableModifier.php
@@ -48,4 +48,17 @@ class TableModifier
             $this->createTable($tableName, $tableCreate, $response);
         }
     }
+
+    /**
+     * Process a group of tables alter queries.
+     *
+     * @param array       $tableAlters
+     * @param SchemaCheck $response
+     */
+    public function alterTables(array $tableAlters, SchemaCheck $response)
+    {
+        foreach ($tableAlters as $tableName => $tableAlter) {
+            $this->alterTable($tableName, $tableAlter, $response);
+        }
+    }
 }

--- a/src/Storage/Database/Schema/TableModifier.php
+++ b/src/Storage/Database/Schema/TableModifier.php
@@ -35,4 +35,17 @@ class TableModifier
         $this->loggerSystem = $loggerSystem;
         $this->loggerFlash = $loggerFlash;
     }
+
+    /**
+     * Process a group of tables create queries.
+     *
+     * @param array       $tableCreates
+     * @param SchemaCheck $response
+     */
+    public function createTables(array $tableCreates, SchemaCheck $response)
+    {
+        foreach ($tableCreates as $tableName => $tableCreate) {
+            $this->createTable($tableName, $tableCreate, $response);
+        }
+    }
 }

--- a/src/Storage/Database/Schema/TableModifier.php
+++ b/src/Storage/Database/Schema/TableModifier.php
@@ -77,4 +77,20 @@ class TableModifier
             }
         }
     }
+
+    /**
+     * Process a single table alter queries.
+     *
+     * @param string      $tableName
+     * @param array       $tableAlter
+     * @param SchemaCheck $response
+     */
+    protected function alterTable($tableName, array $tableAlter, SchemaCheck $response)
+    {
+        foreach ($tableAlter as $query) {
+            if ($this->runQuery($tableName, $query)) {
+                $response->addTitle($tableName, sprintf('Updated `%s` table to match current schema.', $tableName));
+            }
+        }
+    }
 }

--- a/src/Storage/Database/Schema/TableModifier.php
+++ b/src/Storage/Database/Schema/TableModifier.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema;
+
+use Bolt\Logger\FlashLoggerInterface;
+use Bolt\Translation\Translator as Trans;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Table modification handler class.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class TableModifier
+{
+    /** @var \Doctrine\DBAL\Connection */
+    protected $connection;
+    /** @var \Psr\Log\LoggerInterface */
+    protected $loggerSystem;
+    /** @var \Bolt\Logger\FlashLoggerInterface */
+    protected $loggerFlash;
+
+    /**
+     * Constructor.
+     *
+     * @param Connection           $connection
+     * @param LoggerInterface      $loggerSystem
+     * @param FlashLoggerInterface $loggerFlash
+     */
+    public function __construct(Connection $connection, LoggerInterface $loggerSystem, FlashLoggerInterface $loggerFlash)
+    {
+        $this->connection = $connection;
+        $this->loggerSystem = $loggerSystem;
+        $this->loggerFlash = $loggerFlash;
+    }
+}

--- a/src/Storage/Database/Schema/TableModifier.php
+++ b/src/Storage/Database/Schema/TableModifier.php
@@ -61,4 +61,20 @@ class TableModifier
             $this->alterTable($tableName, $tableAlter, $response);
         }
     }
+
+    /**
+     * Process a single table create query.
+     *
+     * @param string      $tableName
+     * @param array       $tableCreate
+     * @param SchemaCheck $response
+     */
+    protected function createTable($tableName, array $tableCreate, SchemaCheck $response)
+    {
+        foreach ($tableCreate as $query) {
+            if ($this->runQuery($tableName, $query)) {
+                $response->addTitle($tableName, sprintf('Created table `%s`.', $tableName));
+            }
+        }
+    }
 }

--- a/src/Storage/Database/Schema/TableModifier.php
+++ b/src/Storage/Database/Schema/TableModifier.php
@@ -93,4 +93,25 @@ class TableModifier
             }
         }
     }
+
+    /**
+     * Run the create/alter query.
+     *
+     * @param string $tableName
+     * @param string $query
+     *
+     * @return \Doctrine\DBAL\Driver\Statement|null
+     */
+    protected function runQuery($tableName, $query)
+    {
+        try {
+            return $this->connection->query($query);
+        } catch (DBALException $e) {
+            $this->loggerSystem->critical($e->getMessage(), ['event' => 'exception', 'exception' => $e]);
+            $this->loggerFlash->error(
+                Trans::__('An error occured while updating `%TABLE%`. The error is %ERROR%',
+                ['%TABLE%' => $tableName, '%ERROR%' => $e->getMessage()]
+            ));
+        }
+    }
 }

--- a/src/Storage/Database/Schema/Timer.php
+++ b/src/Storage/Database/Schema/Timer.php
@@ -50,4 +50,23 @@ class Timer
 
         return $this->expired = $ts->isPast();
     }
+
+    /**
+     * Invalidate our database check by removing the timestamp file from cache.
+     *
+     * @throws \RuntimeException
+     */
+    public function setCheckRequired()
+    {
+        try {
+            $this->expired = true;
+            $this->filesystem->remove($this->timestampFile);
+        } catch (IOException $e) {
+            $message = sprintf(
+                "The file '%s' exists, but couldn't be removed. Please remove this file manually, and try again.",
+                $this->timestampFile
+            );
+            throw new StorageException($message);
+        }
+    }
 }

--- a/src/Storage/Database/Schema/Timer.php
+++ b/src/Storage/Database/Schema/Timer.php
@@ -29,4 +29,25 @@ class Timer
         $this->timestampFile = $cachePath . '/dbcheck.ts';
         $this->filesystem = new Filesystem();
     }
+
+    /**
+     * Check if we have determined that we need to do a database check.
+     *
+     * @return boolean
+     */
+    public function isCheckRequired()
+    {
+        if ($this->expired !== null) {
+            return $this->expired;
+        }
+
+        if ($this->filesystem->exists($this->timestampFile)) {
+            $expiryTimestamp = (integer) file_get_contents($this->timestampFile);
+        } else {
+            $expiryTimestamp = 0;
+        }
+        $ts = Carbon::createFromTimeStamp($expiryTimestamp + self::CHECK_INTERVAL);
+
+        return $this->expired = $ts->isPast();
+    }
 }

--- a/src/Storage/Database/Schema/Timer.php
+++ b/src/Storage/Database/Schema/Timer.php
@@ -69,4 +69,21 @@ class Timer
             throw new StorageException($message);
         }
     }
+
+    /**
+     * Set our state as valid by writing the current date/time to the
+     * app/cache/dbcheck.ts file.
+     *
+     * We only want to do these checks once per hour, per session, since it's
+     * pretty time consuming… Unless specifically requested.
+     */
+    public function setCheckExpiry()
+    {
+        try {
+            $this->expired = false;
+            $this->filesystem->dumpFile($this->timestampFile, time());
+        } catch (IOException $e) {
+            // Something went wrong
+        }
+    }
 }

--- a/src/Storage/Database/Schema/Timer.php
+++ b/src/Storage/Database/Schema/Timer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Bolt\Storage\Database\Schema;
+
+use Bolt\Exception\StorageException;
+use Carbon\Carbon;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Schema validation check functionality.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class Timer
+{
+    /** @var \Symfony\Component\Filesystem\Filesystem */
+    protected $filesystem;
+    /** @var string */
+    protected $timestampFile;
+    /** @var boolean */
+    protected $expired;
+
+    const CHECK_INTERVAL = 1800;
+
+    public function __construct($cachePath)
+    {
+        $this->timestampFile = $cachePath . '/dbcheck.ts';
+        $this->filesystem = new Filesystem();
+    }
+}

--- a/src/Users.php
+++ b/src/Users.php
@@ -484,7 +484,7 @@ class Users
         // Make sure the DB is updated. Note, that at this point we currently don't have
         // the permissions to do so, but if we don't, update the DB, we can never add the
         // role 'root' to the current user.
-        $this->app['schema']->repairTables();
+        $this->app['schema']->update();
 
         // Show a helpful message to the user.
         $this->app['logger.flash']->info(Trans::__("There should always be at least one 'root' user. You have just been promoted. Congratulations!"));

--- a/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
+++ b/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
@@ -2,6 +2,7 @@
 namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Configuration\ResourceManager;
+use Bolt\Storage\Database\Schema\SchemaCheck;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,10 +21,10 @@ class DatabaseTest extends ControllerUnitTest
     public function testCheck()
     {
         $this->allowLogin($this->getApp());
-        $checkResponse = new \Bolt\Storage\Database\Schema\CheckResponse();
-        $check = $this->getMock('Bolt\Storage\Database\Schema\Manager', ['checkTablesIntegrity'], [$this->getApp()]);
+        $checkResponse = new SchemaCheck();
+        $check = $this->getMock('Bolt\Storage\Database\Schema\Manager', ['check'], [$this->getApp()]);
         $check->expects($this->atLeastOnce())
-            ->method('checkTablesIntegrity')
+            ->method('check')
             ->will($this->returnValue($checkResponse));
 
         $this->setService('schema', $check);
@@ -36,29 +37,15 @@ class DatabaseTest extends ControllerUnitTest
     public function testUpdate()
     {
         $this->allowLogin($this->getApp());
-        $checkResponse = new \Bolt\Storage\Database\Schema\CheckResponse();
-        $check = $this->getMock('Bolt\Storage\Database\Schema\Manager', ['repairTables'], [$this->getApp()]);
+        $checkResponse = new SchemaCheck();
+        $check = $this->getMock('Bolt\Storage\Database\Schema\Manager', ['update'], [$this->getApp()]);
 
         $check->expects($this->any())
-            ->method('repairTables')
+            ->method('update')
             ->will($this->returnValue($checkResponse));
 
         $this->setService('schema', $check);
         ResourceManager::$theApp = $this->getApp();
-
-        $this->setRequest(Request::create('/bolt/dbupdate', 'POST', ['return' => 'edit']));
-        $response = $this->controller()->update($this->getRequest());
-
-        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
-        $this->assertEquals('/bolt/file/edit/config/contenttypes.yml', $response->getTargetUrl());
-        $this->assertNotEmpty($this->getFlashBag()->get('success'));
-
-        $this->setRequest(Request::create('/bolt/dbupdate', 'POST', ['return' => 'edit']));
-        $response = $this->controller()->update($this->getRequest());
-
-        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
-        $this->assertEquals('/bolt/file/edit/config/contenttypes.yml', $response->getTargetUrl());
-        $this->assertNotEmpty($this->getFlashBag()->get('success'));
 
         $this->setRequest(Request::create('/bolt/dbupdate', 'POST'));
         $response = $this->controller()->update($this->getRequest());

--- a/tests/phpunit/unit/Storage/FieldLoadTest.php
+++ b/tests/phpunit/unit/Storage/FieldLoadTest.php
@@ -17,7 +17,7 @@ class FieldLoadTest extends BoltUnitTest
     {
         $this->resetDb();
         $app = $this->getApp();
-        $app['schema']->repairTables();
+        $app['schema']->update();
         $this->addDefaultUser($app);
         $this->addSomeContent();
         $em = $app['storage'];

--- a/tests/phpunit/unit/Storage/FieldSaveTest.php
+++ b/tests/phpunit/unit/Storage/FieldSaveTest.php
@@ -16,7 +16,7 @@ class FieldSaveTest extends BoltUnitTest
     public function testRelationsSave()
     {
         $app = $this->getApp();
-        $app['schema']->repairTables();
+        $app['schema']->update();
         $this->addSomeContent();
         $em = $app['storage'];
         $repo = $em->getRepository('showcases');


### PR DESCRIPTION
* Fixes #4043
* Gives us discrete control over columns ignore per platform, per type, per lots…
* Lays the **foundation** for extensions to define their own ContentTypes… The database layer works now, but the config needs adjusting. e.g.
```php
    public function initialize()
    {
        $this->addContentType();
    }

    private function addContentType()
    {
        $this->app['config']->set('contenttypes/koalas', [
            'tablename' => 'koalas',
            'fields'    => [
                'title' => ['type' => 'text'],
                'slug'  => ['type' => 'text', 'uses' => 'title'],
                'body'  => ['type' => 'html', 'height' => '300px'],
            ]
        ]);
        /** @var \Doctrine\DBAL\Platforms\AbstractPlatform $platform */
        $platform = $this->app['db']->getDatabasePlatform();
        $this->app['schema.content_tables']['my_extension_contenttype'] = $this->app->share(
            function () use ($platform) {
                return new \Bolt\Storage\Database\Schema\Table\ContentType($platform);
            }
        );
    }
```

…lots of other stuff, and bugs that were as yet unidentified…

![](http://static.tvtropes.org/pmwiki/pub/images/the-4400-main_a.jpg)
