### PR TITLE
[2.2] Making _sub_menu.twig more legible.

### DIFF
--- a/app/theme_defaults/_sub_menu.twig
+++ b/app/theme_defaults/_sub_menu.twig
@@ -1,24 +1,46 @@
-{% macro display_menu_item(item, loop) %}
-<li class="index-{{ loop.index }}{% if loop.first %} first{% endif %}{% if loop.last %} last{% endif %}">
-    <a href="{{ item.link }}" {% if item.title is defined %}title='{{ item.title|escape }}'{% endif %}
-       class='{% if item|current %}current {% endif %}{% if item.class is defined %}{{item.class}}{% endif %}'>
-       {% if item.label is defined %}{{item.label}}{% else %} - {% endif %}
-    </a>
+{% spaceless %}
+{# This file might seem a little complex, because of the high density of tags.
+   It uses Twig macros and ternary selectors. Read up on them, if required:
+   macros: http://twig.sensiolabs.org/doc/templates.html#macros
+   ternary operators: http://twig.sensiolabs.org/doc/templates.html#other-operators
+#}
 
-    {% if item.submenu is defined %}
-        <ul>
-            {% for submenu in item.submenu %}
-                {{ _self.display_menu_item(submenu, loop) }}
-            {% endfor %}
-        </ul>
-    {% endif %}
-</li>
+{# The 'recursive' macro, for inserting one menu item. If it has a submenu, it
+   invokes itself to insert the items of the submenus. #}
+{% macro display_menu_item(item, loop) %}
+
+    {% from _self import display_menu_item %}
+
+    <li class="index-{{ loop.index }}
+        {{ loop.first ? ' first' -}}
+        {{ loop.last ? ' last' -}}
+        {{ item.submenu|default(false) ? ' has-dropdown' -}}
+        {{ item|current ? ' active' }}">
+
+        <a href="{{ item.link }}" title='{{ item.title|default('')|escape }}' class='{{ item.class|default('') }}'>
+            {{ item.label|default('-') }}
+        </a>
+
+        {% if item.submenu is defined %}
+            <ul>
+                {% for submenu in item.submenu %}
+                    {{ display_menu_item(submenu, loop) }}
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </li>
 {% endmacro %}
 
+{# Make the macro available for use #}
+{% from _self import display_menu_item %}
+
+{# The main menu loop: Iterates over the items, calling `display_menu_item` #}
 <nav class="{{name}}">
     <ul class="bolt-menu">
     {% for item in menu %}
-        {{ _self.display_menu_item(item, loop) }}
+        {{ display_menu_item(item, loop) }}
     {% endfor %}
     </ul>
 </nav>
+
+{% endspaceless %}

--- a/theme/base-2014/_sub_menu.twig
+++ b/theme/base-2014/_sub_menu.twig
@@ -1,24 +1,45 @@
+{% spaceless %}
+{# This file might seem a little complex, because of the high density of tags.
+   It uses Twig macros and ternary selectors. Read up on them, if required:
+   macros: http://twig.sensiolabs.org/doc/templates.html#macros
+   ternary operators: http://twig.sensiolabs.org/doc/templates.html#other-operators
+#}
+
+{# The 'recursive' macro, for inserting one menu item. If it has a submenu, it
+   invokes itself to insert the items of the submenus. #}
 {% macro display_menu_item(item, loop) %}
+
     {% from _self import display_menu_item %}
-    <li class="index-{{ loop.index }}{% if loop.first %} first{% endif %}{% if loop.last %} last{% endif %}{% if item.submenu is defined %} has-dropdown{% endif %}{% if item|current %} active{% endif %}">
-        <a href="{{ item.link }}" {% if item.title is defined %}title='{{ item.title|escape }}'{% endif %}
-            class='{% if item.class is defined %}{{item.class}}{% endif %}'>
-            {% if item.label is defined %}{{item.label}}{% else %} - {% endif %}
+
+    <li class="index-{{ loop.index -}}
+        {{ loop.first ? ' first' -}}
+        {{ loop.last ? ' last' -}}
+        {{ item.submenu|default(false) ? ' has-dropdown' -}}
+        {{ item|current ? ' active' }}">
+
+        <a href="{{ item.link }}" title='{{ item.title|default('')|escape }}' class='{{ item.class|default('') }}'>
+            {{ item.label|default('-') }}
         </a>
+
         {% if item.submenu is defined %}
             <ul class="dropdown">
-            {% for submenu in item.submenu %}
-                {{ display_menu_item(submenu, loop) }}
-            {% endfor %}
+                {% for submenu in item.submenu %}
+                    {{ display_menu_item(submenu, loop) }}
+                {% endfor %}
             </ul>
         {% endif %}
+
     </li>
 {% endmacro %}
 
+{# Make the macro available for use #}
 {% from _self import display_menu_item %}
 
+{# The main menu loop: Iterates over the items, calling `display_menu_item` #}
 {% for item in menu %}
     {% if item.label is defined %}
         {{ display_menu_item(item, loop) }}
     {% endif %}
 {% endfor %}
+
+{% endspaceless %}


### PR DESCRIPTION
Making the default _sub_menu.twig templates a bit more legible.

 - Added comments
 - Added whitespace
 - Uses way less {% ifs %}
 - Removed deprecated _self
 - Works with strict_variables: true now.

Funtionality-wise nothing has changed.