### PR TITLE
Don't break if Jquery is not present.

### DIFF
--- a/app/theme_defaults/widgetjavascript.twig
+++ b/app/theme_defaults/widgetjavascript.twig
@@ -2,8 +2,9 @@
 <script>
 /*<![CDATA[*/
 
-    $(function() {
-        $('div.widget').each(function () {
+if (window.jQuery) {
+    jQuery(function() {
+        jQuery('div.widget').each(function () {
             if (typeof $(this).data('defer') === 'undefined') {
                 return;
             }
@@ -22,6 +23,9 @@
             });
         });
     });
+} else {
+    console.log('Deferred widgets only work when jQuery is present. Sorry.');
+}
 
 /*]]>*/
 </script>


### PR DESCRIPTION
Ideally, we'll make this script "vanilla", so it doesn't require jquery at all. Until that time, this will have to do. At least it doesn't break when JQuery isn't present.