### PR TITLE
Fix environment view sync for all install types

### DIFF
--- a/src/Composer/BootstrapGenerator.php
+++ b/src/Composer/BootstrapGenerator.php
@@ -11,7 +11,7 @@ class BootstrapGenerator
 {
     public $templateStart = <<<'EOD'
 <?php
-require_once "%s";
+require_once '%s';
 $configuration = new Bolt\Configuration\Composer(%s);
 
 EOD;
@@ -19,7 +19,7 @@ EOD;
     public $templateEnd = <<<'EOD'
 $configuration->getVerifier()->disableApacheChecks();
 $configuration->verify();
-$app = new Bolt\Application(['resources'=>$configuration]);
+$app = new Bolt\Application(['resources' => $configuration]);
 $app->initialize();
 $app->run();
 
@@ -40,10 +40,14 @@ EOD;
      **/
     public $webname;
 
-    public function __construct($webroot = false, $webname = 'public')
+    /** @var string */
+    public $boltWeb;
+
+    public function __construct($webroot = false, $webname = 'public', $boltWeb = 'bolt-public')
     {
         $this->webroot = $webroot;
         $this->webname = $webname;
+        $this->boltWeb = $boltWeb;
     }
 
     /**
@@ -80,6 +84,9 @@ EOD;
             $template .= $this->getPathCode('web', $this->webname);
             $template .= $this->getPathCode('files', $this->webname . '/files');
             $template .= $this->getPathCode('themebase', $this->webname . '/theme');
+            $template .= $this->getPathCode('view', $this->webname . '/' . $this->boltWeb . '/view');
+        } else {
+            $template .= $this->getPathCode('view', $this->boltWeb . '/view');
         }
 
         $template .= $this->templateEnd;

--- a/src/Configuration/Composer.php
+++ b/src/Configuration/Composer.php
@@ -1,8 +1,14 @@
 <?php
+
 namespace Bolt\Configuration;
 
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * Configuration for a Bolt application Composer install.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
 class Composer extends Standard
 {
     /**
@@ -16,6 +22,7 @@ class Composer extends Standard
         parent::__construct($path, $request);
         $this->setPath('composer', realpath(dirname(__DIR__) . '/../'));
         $this->setPath('app', realpath(dirname(__DIR__) . '/../app/'));
+        $this->setPath('view', realpath(dirname(__DIR__) . '/../app/view'));
         $this->setUrl('app', '/bolt-public/');
     }
 

--- a/src/Configuration/Environment.php
+++ b/src/Configuration/Environment.php
@@ -72,6 +72,8 @@ class Environment
                 $this->syncViewDirectory($dir);
             } catch (IOException $e) {
                 $response[] = $e->getMessage();
+            } catch (\UnexpectedValueException $e) {
+                $response[] = $e->getMessage();
             }
         }
 

--- a/src/Configuration/Environment.php
+++ b/src/Configuration/Environment.php
@@ -18,9 +18,11 @@ class Environment
     /** @var Filesystem */
     protected $filesystem;
     /** @var string */
-    protected $srcRoot;
+    protected $rootPath;
     /** @var string */
-    protected $webRoot;
+    protected $appPath;
+    /** @var string */
+    protected $viewPath;
     /** @var string */
     protected $boltName;
     /** @var string */
@@ -29,17 +31,17 @@ class Environment
     /**
      * Constructor.
      *
-     * @param string $srcRoot
-     * @param string $webRoot
+     * @param string $appPath
+     * @param string $viewPath
      * @param Cache  $cache
      * @param string $boltName
      * @param string $boltVersion
      */
-    public function __construct($srcRoot, $webRoot, Cache $cache, $boltName, $boltVersion)
+    public function __construct($appPath, $viewPath, Cache $cache, $boltName, $boltVersion)
     {
         $this->filesystem = new Filesystem();
-        $this->srcRoot = rtrim($srcRoot, '/');
-        $this->webRoot = rtrim($webRoot, '/');
+        $this->appPath = rtrim($appPath, '/');
+        $this->viewPath = rtrim($viewPath, '/');
         $this->cache = $cache;
         $this->boltName = $boltName;
         $this->boltVersion = $boltVersion;
@@ -87,16 +89,14 @@ class Environment
      */
     protected function syncViewDirectory($dir)
     {
-        if ($this->srcRoot === $this->webRoot) {
+        if ($this->viewPath === $this->appPath . '/view') {
             return;
         }
 
-        $source = $this->srcRoot . '/app/view/' . $dir;
-        $target = $this->webRoot . '/app/view/' . $dir;
-        if ($this->filesystem->exists($target)) {
-            return;
-        }
+        $source = $this->appPath . '/view/' . $dir;
+        $target = $this->viewPath . '/' . $dir;
 
+        // Mirror source and destination, overwrite existing file and clean up removed files
         $this->filesystem->mirror($source, $target, null, ['override' => true, 'delete' => true]);
     }
 

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -94,6 +94,7 @@ class ResourceManager
         $this->setPath('src', dirname(__DIR__));
         $this->setPath('database', 'app/database');
         $this->setPath('themebase', 'theme');
+        $this->setPath('view', 'app/view');
     }
 
     /**

--- a/src/Configuration/Standard.php
+++ b/src/Configuration/Standard.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\Configuration;
 
 use Composer\Autoload\ClassLoader;
@@ -6,8 +7,10 @@ use Eloquent\Pathogen\FileSystem\Factory\PlatformFileSystemPathFactory;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Left as a blank extension of ResourceManager for now, this semantically represents a default configuration
- * for a Bolt application.
+ * Left as a blank extension of ResourceManager for now, this semantically
+ * represents a default configuration for a Bolt application.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
  */
 class Standard extends ResourceManager
 {

--- a/src/Provider/ConfigServiceProvider.php
+++ b/src/Provider/ConfigServiceProvider.php
@@ -21,12 +21,12 @@ class ConfigServiceProvider implements ServiceProviderInterface
 
         $app['config.environment'] = $app->share(
             function ($app) {
-                $srcRoot = $app['resources']->getPath('root');
-                $webRoot = $app['resources']->getPath('web');
+                $appPath = $app['resources']->getPath('app');
+                $viewPath = $app['resources']->getPath('view');
 
                 $environment = new Environment(
-                    $srcRoot,
-                    $webRoot,
+                    $appPath,
+                    $viewPath,
                     $app['cache'],
                     $app['bolt_name'],
                     $app['bolt_version']


### PR DESCRIPTION
This PR fixes #4386 by introducing a `view` path into `ResourceManager`, so we now properly sync both composer-install and multi-site set ups back-end assets on a version change. 

Side note… What this fixes bit me when I set up a Composer install to test this. Starting with a 2.2 install,  then updating that to a master via composer leaves 2.2 `lib.min.js` where in 2.3 `lib.js` is needed.

So thank you @Boorj for nagging me, and @rossriley for his suggested approach.