### PR TITLE
Automatically create upload directories for contenttype fields - Fixes #4405

### DIFF
--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -176,6 +176,7 @@ class Edit
 
     /**
      * Test write access for uploadable fields.
+     * Autocreates the desired directory if it does not exist.
      *
      * @param array $fields
      *
@@ -187,7 +188,7 @@ class Edit
 
         foreach ($fields as &$values) {
             if (isset($values['upload'])) {
-                $values['canUpload'] = $filesystem->has($values['upload']) && $filesystem->getVisibility($values['upload']);
+                $values['canUpload'] = ($filesystem->has($values['upload']) || $filesystem->createDir($values['upload'])) && $filesystem->getVisibility($values['upload']);
             } else {
                 $values['canUpload'] = true;
             }


### PR DESCRIPTION
This should remove the need to manually create file upload directories. Before, if the directory did not already exist, the upload button would be disabled for the affected field, with the text "Upload is not allowed". This change will automatically create the needed directory, and only show the "Upload is not allowed" text if creation fails.