### PR TITLE
Make 'required' for `type: select` fields work. 

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -5,7 +5,8 @@
     label:     field.label|default(''),
     multiple:  (field.multiple is defined and field.multiple),
     values:    field.values|default([]),
-    info:      field.info|default('')
+    info:      field.info|default(''),
+    required:  field.required|default(false)
 } %}
 
 {#=== INIT ===========================================================================================================#}
@@ -42,6 +43,7 @@
     class:     option.class,
     id:        key,
     multiple:  option.multiple,
+    required:  option.required,
     name:      (option.multiple) ? name ~ '[]' : name,
 } %}
 
@@ -62,7 +64,7 @@
 
                 {% set is_array = (value is iterable and (value | length) > 1) %}
                 {% set attr_opt = {
-                    value:     id,
+                    value:     (id == 0) ? '' : id,
                     selected:  id in selection or (not onlyids and (is_array ? value[0] : value) in selection),
                 } %}
 

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -64,7 +64,7 @@
 
                 {% set is_array = (value is iterable and (value | length) > 1) %}
                 {% set attr_opt = {
-                    value:     (id == 0) ? '' : id,
+                    value:     (id == 0 and option.required) ? '' : id,
                     selected:  id in selection or (not onlyids and (is_array ? value[0] : value) in selection),
                 } %}
 

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -64,7 +64,7 @@
 
                 {% set is_array = (value is iterable and (value | length) > 1) %}
                 {% set attr_opt = {
-                    value:     (id == 0 and option.required) ? '' : id,
+                    value:     id,
                     selected:  id in selection or (not onlyids and (is_array ? value[0] : value) in selection),
                 } %}
 

--- a/src/Twig/Handler/RecordHandler.php
+++ b/src/Twig/Handler/RecordHandler.php
@@ -309,7 +309,7 @@ class RecordHandler
         if ($startempty) {
             $retval = array();
         } else {
-            $retval = array('');
+            $retval = array('' => '');
         }
         foreach ($content as $c) {
             if (is_array($fieldname)) {


### PR DESCRIPTION
As @rarila pointed out: 

> The first child option element of a select element with a required attribute and without a multiple attribute, and whose size is “1”, must have either an empty value attribute, or must have no text content.

This PR should fix that. Fixes #4353 