### PR TITLE
Nut password handling

### DIFF
--- a/src/Nut/UserAdd.php
+++ b/src/Nut/UserAdd.php
@@ -32,46 +32,40 @@ class UserAdd extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $username = $input->getArgument('username');
-        $password = $input->getArgument('password');
-        $email = $input->getArgument('email');
-        $displayname = $input->getArgument('displayname');
-        $role = $input->getArgument('role');
+        /** @var \Bolt\Storage\Repository\UsersRepository $repo */
+        $repo = $this->app['storage']->getRepository('Bolt\Storage\Entity\Users');
+        $user = new Entity\Users([
+            'username'    => $input->getArgument('username'),
+            'password'    => $input->getArgument('password'),
+            'email'       => $input->getArgument('email'),
+            'displayname' => $input->getArgument('displayname'),
+            'roles'       => (array) $input->getArgument('role'),
+        ]);
 
-        $data = [
-            'username'    => $username,
-            'password'    => $password,
-            'email'       => $email,
-            'displayname' => $displayname,
-            'roles'       => [$role],
-        ];
-
-        $user = new Entity\Users($data);
-
+        $message = [];
         $valid = true;
-        if (!$this->app['users']->checkAvailability('username', $user->getUsername())) {
+        if ($repo->getUser($user->getEmail())) {
             $valid = false;
-            $output->writeln("<error>Error creating user: username {$user->getUsername()} already exists</error>");
+            $message[] = ("<error>    * Email address '{$user->getEmail()}' already exists</error>");
         }
-        if (!$this->app['users']->checkAvailability('email', $user->getEmail())) {
+        if ($repo->getUser($user->getUsername())) {
             $valid = false;
-            $output->writeln("<error>Error creating user: email {$user->getEmail()} exists</error>");
+            $message[] = ("<error>    * User name '{$user->getUsername()}' already exists</error>");
         }
-        if (!$this->app['users']->checkAvailability('displayname', $user->getDisplayname())) {
-            $valid = false;
-            $output->writeln("<error>Error creating user: display name {$user->getDisplayname()} already exists</error>");
+        if ($valid === false) {
+            $message[] = ("<error>Error creating user:</error>");
+            $output->write(array_reverse($message), true);
+            return;
         }
 
-        if ($valid) {
+        try {
             // Boot all service providers manually as, we're not handling a request
             $this->app->boot();
-            $res = $this->app['users']->saveUser($user);
-            if ($res) {
-                $this->auditLog(__CLASS__, "User created: {$user['username']}");
-                $output->writeln("<info>Successfully created user: {$user['username']}</info>");
-            } else {
-                $output->writeln("<error>Error creating user: {$user['username']}</error>");
-            }
+            $this->app['storage']->getRepository('Bolt\Storage\Entity\Users')->save($user);
+            $this->auditLog(__CLASS__, "User created: {$user->getUsername()}");
+            $output->writeln("<info>Successfully created user: {$user->getUsername()}</info>");
+        } catch (\Exception $e) {
+            $output->writeln("<error>Error creating user: {$user->getUsername()}</error>");
         }
     }
 }

--- a/src/Nut/UserAdd.php
+++ b/src/Nut/UserAdd.php
@@ -49,20 +49,22 @@ class UserAdd extends BaseCommand
         $user = new Entity\Users($data);
 
         $valid = true;
-        if (! $this->app['users']->checkAvailability('username', $user->getUsername())) {
+        if (!$this->app['users']->checkAvailability('username', $user->getUsername())) {
             $valid = false;
             $output->writeln("<error>Error creating user: username {$user->getUsername()} already exists</error>");
         }
-        if (! $this->app['users']->checkAvailability('email', $user->getEmail())) {
+        if (!$this->app['users']->checkAvailability('email', $user->getEmail())) {
             $valid = false;
             $output->writeln("<error>Error creating user: email {$user->getEmail()} exists</error>");
         }
-        if (! $this->app['users']->checkAvailability('displayname', $user->getDisplayname())) {
+        if (!$this->app['users']->checkAvailability('displayname', $user->getDisplayname())) {
             $valid = false;
             $output->writeln("<error>Error creating user: display name {$user->getDisplayname()} already exists</error>");
         }
 
         if ($valid) {
+            // Boot all service providers manually as, we're not handling a request
+            $this->app->boot();
             $res = $this->app['users']->saveUser($user);
             if ($res) {
                 $this->auditLog(__CLASS__, "User created: {$user['username']}");

--- a/src/Nut/UserResetPassword.php
+++ b/src/Nut/UserResetPassword.php
@@ -23,7 +23,7 @@ class UserResetPassword extends BaseCommand
             ->addArgument(
                 'username',
                 InputArgument::REQUIRED,
-                'The username (loginname or e-mail address) you wish to reset the password for.'
+                'The username (login name or e-mail address) you wish to reset the password for.'
             )
             ->addOption(
                 'no-interaction',
@@ -43,12 +43,14 @@ class UserResetPassword extends BaseCommand
         /** @var \Symfony\Component\Console\Helper\DialogHelper $dialog */
         $dialog = $this->getHelperSet()->get('dialog');
         $confirm = $input->getOption('no-interaction');
-        $question = "<question>Are you sure you want to reset the password for \"{$username}\"?</question>";
+        $question = "<question>Are you sure you want to reset the password for '$username'?</question> ";
 
         if (!$confirm && !$dialog->askConfirmation($output, $question, false)) {
             return false;
         }
 
+        // Boot all service providers manually as, we're not handling a request
+        $this->app->boot();
         $password = $this->app['access_control.password']->setRandomPassword($username);
 
         if ($password !== false) {

--- a/src/Nut/UserResetPassword.php
+++ b/src/Nut/UserResetPassword.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * Nut command to reset a user password
@@ -40,12 +41,11 @@ class UserResetPassword extends BaseCommand
     {
         $username = $input->getArgument('username');
 
-        /** @var \Symfony\Component\Console\Helper\DialogHelper $dialog */
-        $dialog = $this->getHelperSet()->get('dialog');
+        /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
+        $helper = $this->getHelper('question');
         $confirm = $input->getOption('no-interaction');
-        $question = "<question>Are you sure you want to reset the password for '$username'?</question> ";
-
-        if (!$confirm && !$dialog->askConfirmation($output, $question, false)) {
+        $question = new ConfirmationQuestion("<question>Are you sure you want to reset the password for '$username'?</question> ");
+        if (!$confirm && !$helper->ask($input, $output, $question)) {
             return false;
         }
 

--- a/tests/phpunit/unit/Nut/UserResetPasswordTest.php
+++ b/tests/phpunit/unit/Nut/UserResetPasswordTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace Bolt\Tests\Nut;
+
+use Bolt\Nut\UserResetPassword;
+use Bolt\Tests\BoltUnitTest;
+use Bolt\Storage\Entity;
+use PasswordLib\PasswordLib;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class to test src/Nut/UserResetPassword.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class UserResetPasswordTest extends BoltUnitTest
+{
+    public function testRun()
+    {
+        $this->resetDb();
+        $app = $this->getApp();
+        $repo = $app['storage']->getRepository('Bolt\Storage\Entity\Users');
+        $user = new Entity\Users([
+            'username'    => 'koala',
+            'password'    => 'GumL3@ve$',
+            'email'       => 'koala@drop.bear.com.au',
+            'displayname' => 'Drop Bear',
+            'roles'       => ['root'],
+        ]);
+        $repo->save($user);
+
+        $command = new UserResetPassword($app);
+        $tester = new CommandTester($command);
+
+        $helper = $this->getMock('\Symfony\Component\Console\Helper\QuestionHelper', ['ask']);
+        $helper->expects($this->once())
+            ->method('ask')
+            ->will($this->returnValue(true));
+        $set = new HelperSet(['question' => $helper]);
+        $command->setHelperSet($set);
+
+        $tester->execute(['username' => 'koala'], ['interactive' => false]);
+        $result = $tester->getDisplay();
+        $this->assertRegExp('#New password for koala is #', trim($result));
+        $this->assertSame(38, strlen(trim($result)));
+
+        // Test that the saved value matches the hash
+        $repo = $app['storage']->getRepository('Bolt\Storage\Entity\Users');
+        $userEntity = $repo->getUser('koala');
+        $crypt = new PasswordLib();
+
+        // Check the old password isn't valid
+        $auth = $crypt->verifyPasswordHash('GumL3@ve$', $userEntity->getPassword());
+        $this->assertFalse($auth);
+
+        // Check the new password is valid
+        $bits = explode(' ', trim($result));
+        $auth = $crypt->verifyPasswordHash($bits[5], $userEntity->getPassword());
+        $this->assertTrue($auth);
+    }
+}


### PR DESCRIPTION
Neither  `nut user:add` or `nut user:reset-password` currently work… this fixes that and add tests (and a tiny deprecation refactor)

Oh and user name and email address duplication messages work now:
```
$ ./app/nut user:add koala "Drop Bear" drop.bear@koala.com.au GumL3@ve$ root
Successfully created user: koala
$ ./app/nut user:add koala "Drop Bear" drop.bear@koala.com.au GumL3@ve$ root
Error creating user:
    * User name 'koala' already exists
    * Email address 'drop.bear@koala.com.au' already exists
```