### PR TITLE
Fixes problem of web profiler bundle template location by using reflection. Fixes #4431

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -292,8 +292,10 @@ class Application extends Silex\Application
             $this->extend(
                 'twig.loader.filesystem',
                 function (\Twig_Loader_Filesystem $filesystem, Application $app) {
+                    $refProfilerClass = new \ReflectionClass('Symfony\Bundle\WebProfilerBundle\WebProfilerBundle');
+                    $webProfilerPath = dirname($refProfilerClass->getFileName());
                     $filesystem->addPath(
-                        $app['resources']->getPath('root') . '/vendor/symfony/web-profiler-bundle/Symfony/Bundle/WebProfilerBundle/Resources/views',
+                        $webProfilerPath . '/Resources/views',
                         'WebProfiler'
                     );
                     $filesystem->addPath($app['resources']->getPath('app') . '/view', 'BoltProfiler');

--- a/src/Application.php
+++ b/src/Application.php
@@ -292,8 +292,8 @@ class Application extends Silex\Application
             $this->extend(
                 'twig.loader.filesystem',
                 function (\Twig_Loader_Filesystem $filesystem, Application $app) {
-                    $refProfilerClass = new \ReflectionClass('Symfony\Bundle\WebProfilerBundle\WebProfilerBundle');
-                    $webProfilerPath = dirname($refProfilerClass->getFileName());
+                    $refProfilerClass = new \ReflectionClass('Symfony\Bundle\WebProfilerBundle\DependencyInjection\WebProfilerExtension');
+                    $webProfilerPath = dirname(dirname($refProfilerClass->getFileName()));
                     $filesystem->addPath(
                         $webProfilerPath . '/Resources/views',
                         'WebProfiler'

--- a/src/Application.php
+++ b/src/Application.php
@@ -292,7 +292,7 @@ class Application extends Silex\Application
             $this->extend(
                 'twig.loader.filesystem',
                 function (\Twig_Loader_Filesystem $filesystem, Application $app) {
-                    $refProfilerClass = new \ReflectionClass('Symfony\Bundle\WebProfilerBundle\DependencyInjection\WebProfilerExtension');
+                    $refProfilerClass = new \ReflectionClass('Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension');
                     $webProfilerPath = dirname(dirname($refProfilerClass->getFileName()));
                     $filesystem->addPath(
                         $webProfilerPath . '/Resources/views',


### PR DESCRIPTION
Use reflection to determine the location of the web profiler bundle, thereby removing the guesswork of configuring twig with the location of the web profiler bundle's templates.

I also don't like brown M&Ms.