### PR TITLE
[2.2] Backport of #4413: Limit user agent strings to 128 characters on persist

### DIFF
--- a/src/Users.php
+++ b/src/Users.php
@@ -73,7 +73,7 @@ class Users
         $request = Request::createFromGlobals();
         $this->hostName  = $request->getHost();
         $this->remoteIP  = $request->getClientIp() ?: '127.0.0.1';
-        $this->userAgent = $request->server->get('HTTP_USER_AGENT');
+        $this->userAgent = substr($request->server->get('HTTP_USER_AGENT'), 0, 128);
         $this->authToken = $request->cookies->get('bolt_authtoken');
 
         // Set 'validsession', to see if the current session is valid.


### PR DESCRIPTION
Backport of #4413: Limit user agent strings to 128 characters on persist