### PR TITLE
Don't list queries in the profiler that are only seen as noise.

### DIFF
--- a/src/Profiler/DatabaseDataCollector.php
+++ b/src/Profiler/DatabaseDataCollector.php
@@ -53,15 +53,23 @@ class DatabaseDataCollector extends DataCollector
 
     private function trim(array $queries)
     {
+        // Skip "PRAGMA .." and other similarly queries, that only cause noise in the overview of used queries.
+        $cruftarray = [
+            'SHOW FULL TABLES WHERE Table_type',
+            'PRAGMA ',
+            'SELECT DISTINCT k.CONSTRAINT_NAME',
+            'SELECT TABLE_NAME AS Table',
+            'SELECT COLUMN_NAME AS Field',
+            'INNER JOIN information_schema',
+            'FROM information_schema'
+        ];
+
         $return = [];
         foreach ($queries as $query) {
-            // Skip "PRAGMA .." and similar queries by SQLITE.
-            if ((strpos($query['sql'], "PRAGMA ") === 0)
-                || (strpos($query['sql'], "SELECT DISTINCT k.CONSTRAINT_NAME") === 0)
-                || (strpos($query['sql'], "SELECT TABLE_NAME AS Table") === 0)
-                || (strpos($query['sql'], "SELECT COLUMN_NAME AS Field") === 0)
-            ) {
-                continue;
+            foreach($cruftarray as $cruft) {
+                if (strpos($query['sql'], $cruft) !== false) {
+                    continue(2);
+                }
             }
             $return[] = $query;
         }

--- a/src/Profiler/DatabaseDataCollector.php
+++ b/src/Profiler/DatabaseDataCollector.php
@@ -66,7 +66,7 @@ class DatabaseDataCollector extends DataCollector
 
         $return = [];
         foreach ($queries as $query) {
-            foreach($cruftarray as $cruft) {
+            foreach ($cruftarray as $cruft) {
                 if (strpos($query['sql'], $cruft) !== false) {
                     continue(2);
                 }


### PR DESCRIPTION
Only the two "information_schema" ones are added. I just moved it around a bit. 

before: 

![screenshot 2015-11-15 14 28 59](https://cloud.githubusercontent.com/assets/1833361/11168956/fef1665e-8ba5-11e5-985e-b01bf73c280c.png)


after: 

![screenshot 2015-11-15 14 21 47](https://cloud.githubusercontent.com/assets/1833361/11168954/faaab7d0-8ba5-11e5-856e-b4bf5b517791.png)
