### PR TITLE
Sort widgets on render() not process()

### DIFF
--- a/src/Asset/Widget/Queue.php
+++ b/src/Asset/Widget/Queue.php
@@ -95,7 +95,7 @@ class Queue implements QueueInterface
     public function process($html)
     {
         /** @var WidgetAssetInterface $widget */
-        foreach ($this->sort($this->queue) as $widget) {
+        foreach ($this->queue as $widget) {
             if ($widget->getType() === 'frontend' && $widget->isDeferred()) {
                 $html = $this->addDeferredJavaScript($widget, $html);
             }
@@ -160,7 +160,8 @@ class Queue implements QueueInterface
     {
         $html = null;
 
-        foreach ($this->queue as $widget) {
+        /** @var WidgetAssetInterface $widget */
+        foreach ($this->sort($this->queue) as $widget) {
             if ($widget->getType() === $type && $widget->getLocation() === $location) {
                 $html .= $this->addWidgetHolder($widget);
             }


### PR DESCRIPTION
Widget::process() only inserts a JavaScript snippet if any of the
widgets are deferred.

Whereas unlike files, the output is done in render() and the sorting
should be done here.