### PR TITLE
fix wrong guzzle curl options

### DIFF
--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -395,7 +395,7 @@ class PackageManager
         }
 
         try {
-            $this->app['guzzle.client']->head($uri, [], ['query' => $query, 'exceptions' => true, 'connect_timeout' => 5]);
+            $this->app['guzzle.client']->head($uri, ['query' => $query, 'exceptions' => true, 'connect_timeout' => 5, 'timeout' => 10]);
 
             $this->app['extend.online'] = true;
         } catch (ClientException $e) {

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -327,7 +327,7 @@ class General extends AsyncBase
             $this->app['logger.system']->info('Fetching from remote server: ' . $source, ['event' => 'news']);
 
             try {
-                $fetchedNewsData = $this->app['guzzle.client']->get($curl['url'], [], $curl['options'])->getBody(true);
+                $fetchedNewsData = $this->app['guzzle.client']->get($curl['url'], ['config' => ['curl' => $curl['options']]])->getBody(true);
                 if ($this->getOption('general/branding/news_variable')) {
                     $newsVariable = $this->getOption('general/branding/news_variable');
                     $fetchedNewsItems = json_decode($fetchedNewsData)->$newsVariable;
@@ -388,14 +388,14 @@ class General extends AsyncBase
         );
 
         // Standard option(s)
-        $options = ['CURLOPT_CONNECTTIMEOUT' => 5];
+        $options = [CURLOPT_CONNECTTIMEOUT => 5, CURLOPT_TIMEOUT => 10];
 
         // Options valid if using a proxy
         if ($this->getOption('general/httpProxy')) {
             $proxies = [
-                'CURLOPT_PROXY'        => $this->getOption('general/httpProxy/host'),
-                'CURLOPT_PROXYTYPE'    => 'CURLPROXY_HTTP',
-                'CURLOPT_PROXYUSERPWD' => $this->getOption('general/httpProxy/user') . ':' .
+                CURLOPT_PROXY        => $this->getOption('general/httpProxy/host'),
+                CURLOPT_PROXYTYPE    => CURLPROXY_HTTP,
+                CURLOPT_PROXYUSERPWD => $this->getOption('general/httpProxy/user') . ':' .
                 $this->getOption('general/httpProxy/password'),
             ];
         }


### PR DESCRIPTION
When news.bolt.cm is unreachable, php-fpm timeouts because connection_timeout of curl options does not work.

according to guzzlehttp 5.3 documents, it shoule be set like this:
http://docs.guzzlephp.org/en/5.3/http-messages.html#request-config

and curl options should be constants instead of string.

Fixed :D


Also I found in PackageManager.php it uses guzzle request options to set timeout time, but when fetch bolt news it use raw curl options, maybe should be consistent?