### PR TITLE
Move echo out of constructor into shutdown function

### DIFF
--- a/src/Exception/LowlevelException.php
+++ b/src/Exception/LowlevelException.php
@@ -72,6 +72,7 @@ HTML;
      */
     public function __construct($message, $code = null, $previous = null)
     {
+        parent::__construct(strip_tags($message), $code, $previous);
         $html = self::$html;
         $info = self::$info;
 

--- a/src/Exception/LowlevelException.php
+++ b/src/Exception/LowlevelException.php
@@ -58,6 +58,8 @@ HTML;
     out. Be sure to include the exact error message you're getting!</p>
 HTML;
 
+    public static $screen;
+
     /**
      * Print a 'low level' error page, and quit. The user has to fix something.
      *
@@ -94,7 +96,7 @@ HTML;
             $output = self::cleanHTML($output);
         }
 
-        echo $output;
+        self::$screen = $output;
     }
 
     /**
@@ -190,6 +192,8 @@ HTML;
 
             echo str_replace($app['resources']->getPath('rootpath'), '', $html);
         }
+
+        echo self::$screen;
     }
 
     /**

--- a/src/Library.php
+++ b/src/Library.php
@@ -205,7 +205,7 @@ class Library
      */
     public static function loadSerialize($filename, $silent = false)
     {
-        if (! is_readable($filename)) {
+        if (!is_readable($filename)) {
             if ($silent) {
                 return false;
             }
@@ -218,7 +218,7 @@ class Library
                 '<pre>' . htmlspecialchars($filename) . '</pre>' .
                 '<p>' . str_replace('<a>', '<a href="javascript:history.go(-1)">', $part) . '</p>';
 
-            throw new LowlevelException(Translator::__('File is not readable!'), $message);
+            throw new LowlevelException(Translator::__('File is not readable!' . $message));
         }
 
         $serializedData = trim(implode('', file($filename)));
@@ -289,7 +289,7 @@ class Library
 
                     $message = 'Error opening file<br/><br/>' .
                         'The file <b>' . $filename . '</b> could not be written! <br /><br />' .
-                        'Try logging in with your ftp-client and check to see if it is chmodded to be readable by ' .
+                        'Try logging in with your FTP client and check to see if it is chmodded to be readable by ' .
                         'the webuser (ie: 777 or 766, depending on the setup of your server). <br /><br />' .
                         'Current path: ' . getcwd() . '.';
                     throw new LowlevelException($message);
@@ -299,7 +299,7 @@ class Library
 
                 $message = 'Error opening file<br/><br/>' .
                     'Could not lock <b>' . $filename . '</b> for writing! <br /><br />' .
-                    'Try logging in with your ftp-client and check to see if it is chmodded to be readable by the ' .
+                    'Try logging in with your FTP client and check to see if it is chmodded to be readable by the ' .
                     'webuser (ie: 777 or 766, depending on the setup of your server). <br /><br />' .
                     'Current path: ' . getcwd() . '.';
                 throw new LowlevelException($message);
@@ -307,7 +307,7 @@ class Library
         } else {
             $message = 'Error opening file<br/><br/>' .
                 'The file <b>' . $filename . '</b> could not be opened for writing! <br /><br />' .
-                'Try logging in with your ftp-client and check to see if it is chmodded to be readable by the ' .
+                'Try logging in with your FTP client and check to see if it is chmodded to be readable by the ' .
                 'webuser (ie: 777 or 766, depending on the setup of your server). <br /><br />' .
                 'Current path: ' . getcwd() . '.';
             throw new LowlevelException($message);

--- a/tests/phpunit/unit/Configuration/LowlevelChecksTest.php
+++ b/tests/phpunit/unit/Configuration/LowlevelChecksTest.php
@@ -107,27 +107,42 @@ class LowlevelChecksTest extends BoltUnitTest
     {
         $check = $this->getCleanChecker();
         $check->magicQuotes = true;
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doChecks();
+
+        try {
+            $check->doChecks();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/Bolt requires 'Magic Quotes' to be off/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testSafeModeException()
     {
         $check = $this->getCleanChecker();
         $check->safeMode = true;
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doChecks();
+
+        try {
+            $check->doChecks();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/Bolt requires 'Safe mode' to be off/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testApacheChecks()
     {
         $check = $this->getCleanChecker();
         $check->isApache = true;
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doChecks();
+
+        try {
+            $check->doChecks();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/.htaccess doesn't exist. Make sure it's present and readable to the user that the webserver is using./", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testApacheCheckCanBeDisabled()
@@ -142,9 +157,14 @@ class LowlevelChecksTest extends BoltUnitTest
     {
         $check = $this->getMockedChecker('mockMysql');
         $check->mysqlLoaded = false;
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doDatabaseCheck();
+
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/MySQL was selected as the database type, but the driver does not exist or is not loaded/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testGoodMysql()
@@ -172,26 +192,41 @@ class LowlevelChecksTest extends BoltUnitTest
     {
         $check = $this->getMockedChecker('mockPostgres');
         $check->postgresLoaded = false;
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doDatabaseCheck();
+
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/PostgreSQL was selected as the database type, but the driver does not exist or is not loaded/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testPlatformFailsSqlite()
     {
         $check = $this->getMockedChecker('mockSqlite');
         $check->sqliteLoaded = false;
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doDatabaseCheck();
+
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/SQLite was selected as the database type, but the driver does not exist or is not loaded/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testPlatformUnsupported()
     {
         $check = $this->getMockedChecker('mockUnsupportedPlatform');
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/database type, but it is not supported/");
-        $check->doDatabaseCheck();
+
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/was selected as the database type, but it is not supported/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testGoodSqliteFile()
@@ -249,9 +284,13 @@ class LowlevelChecksTest extends BoltUnitTest
             ->with('test/bolt.db')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/is not writable/");
-        $check->doDatabaseCheck();
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/The database file test\/bolt.db is not writable. Make sure it's present and writable to the user that the webserver is using./", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testSqliteNonexistentDir()
@@ -269,9 +308,13 @@ class LowlevelChecksTest extends BoltUnitTest
             ->with('test')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/does not exist/");
-        $check->doDatabaseCheck();
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/The database folder test does not exist. Make sure it's present and writable to the user that the webserver is using./", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testSqliteUnwritableDir()
@@ -295,33 +338,52 @@ class LowlevelChecksTest extends BoltUnitTest
             ->with('test')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/is not writable/");
-        $check->doDatabaseCheck();
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/The database folder test is not writable. Make sure it's present and writable to the user that the webserver is using./", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testDbFailsAsRootWithoutPassword()
     {
         $check = $this->getMockedChecker('mockRoot');
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt will stubbornly refuse to run until you've set a password/");
-        $check->doDatabaseCheck();
+
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/There is no password set for the database connection, and you're using user 'root'. That must surely be a mistake, right\? Bolt will stubbornly refuse to run until you've set a password for 'root'./", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testEmptyDb()
     {
         $check = $this->getMockedChecker('mockEmptyDb');
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doDatabaseCheck();
+
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/There is no databasename set for your database/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testEmptyDbUser()
     {
         $check = $this->getMockedChecker('mockEmptyUser');
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doDatabaseCheck();
+
+        try {
+            $check->doDatabaseCheck();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/There is no username set for your database/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testCoreFatalErrorCatch()
@@ -379,9 +441,14 @@ class LowlevelChecksTest extends BoltUnitTest
     {
         $badDir = "/path/to/nowhere";
         $check = $this->getCleanChecker();
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->assertWritableDir($badDir);
+
+        try {
+            $check->assertWritableDir($badDir);
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/The folder \/path\/to\/nowhere doesn't exist. Make sure it is present and writable to the user that the webserver is using./", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     public function testConfigFileAlreadyExistsSoIgnore()
@@ -425,9 +492,13 @@ class LowlevelChecksTest extends BoltUnitTest
             ->method('is_readable')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('Bolt\Exception\LowlevelException');
-        $this->expectOutputRegex("/Bolt - Fatal Error/");
-        $check->doChecks();
+        try {
+            $check->doChecks();
+            $this->fail('Bolt\Exception\LowlevelException not thrown');
+        } catch (LowlevelException $e) {
+            $this->assertRegExp("/Couldn't read config.yml/", $e->getMessage());
+            $this->assertRegExp('/Bolt - Fatal Error/', $e::$screen);
+        }
     }
 
     // This helper provides a mocked checker object with the config values preset


### PR DESCRIPTION
This prevents multiple exceptions being output in a single request cycle… Bring on the lifting of feature freeze.

![screenshot from 2015-11-20 06-12-48](https://cloud.githubusercontent.com/assets/1427081/11282323/cdf85692-8f52-11e5-8c1f-b114deefcc17.png)
