### PR TITLE
Use db charset and collate set in config file to generate table creation sql

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -909,6 +909,7 @@ class Config
                 'dbname'         => 'bolt',
                 'prefix'         => 'bolt_',
                 'charset'        => 'utf8',
+                'collate'        => 'utf8_unicode_ci',
                 'randomfunction' => '',
             ],
             'sitename'                    => 'Default Bolt site',

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -355,13 +355,13 @@ class Users extends BackendBase
         }
 
         $login = $this->login()->login($request, $userEntity->getUsername(), $form->get('password')->getData());
-
         $token = $this->session()->get('authentication');
         if ($login && $token) {
             $this->flashes()->clear();
             $this->flashes()->info(Trans::__('Welcome to your new Bolt site, %USER%.', ['%USER%' => $userEntity->getDisplayname()]));
 
             $response = $this->setAuthenticationCookie($this->redirectToRoute('dashboard'), (string) $token);
+
             return $response;
         }
 

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -355,13 +355,13 @@ class Users extends BackendBase
         }
 
         $login = $this->login()->login($request, $userEntity->getUsername(), $form->get('password')->getData());
+
         $token = $this->session()->get('authentication');
         if ($login && $token) {
             $this->flashes()->clear();
             $this->flashes()->info(Trans::__('Welcome to your new Bolt site, %USER%.', ['%USER%' => $userEntity->getDisplayname()]));
 
             $response = $this->setAuthenticationCookie($this->redirectToRoute('dashboard'), (string) $token);
-
             return $response;
         }
 

--- a/src/Provider/DatabaseSchemaServiceProvider.php
+++ b/src/Provider/DatabaseSchemaServiceProvider.php
@@ -37,6 +37,18 @@ class DatabaseSchemaServiceProvider implements ServiceProviderInterface
             return "/^$prefix.+/";
         };
 
+        $app['schema.charset'] = $app->share(
+            function ($app) {
+                return $app['config']->get('general/database/charset', 'utf8');
+            }
+        );
+
+        $app['schema.collate'] = $app->share(
+            function ($app) {
+                return $app['config']->get('general/database/collate', 'utf8_unicode_ci');
+            }
+        );
+
         /** @deprecated Will be removed in Bolt 3 */
         $app['integritychecker'] = $app->share(
             function ($app) {
@@ -130,6 +142,8 @@ class DatabaseSchemaServiceProvider implements ServiceProviderInterface
                                 $app['schema'],
                                 $app['schema.base_tables'],
                                 $app['schema.prefix'],
+                                $app['schema.charset'],
+                                $app['schema.collate'],
                                 $app['logger.system'],
                                 $app['logger.flash']
                             );
@@ -142,6 +156,8 @@ class DatabaseSchemaServiceProvider implements ServiceProviderInterface
                                 $app['schema'],
                                 $app['schema.content_tables'],
                                 $app['schema.prefix'],
+                                $app['schema.charset'],
+                                $app['schema.collate'],
                                 $app['logger.system'],
                                 $app['logger.flash']
                             );
@@ -154,6 +170,8 @@ class DatabaseSchemaServiceProvider implements ServiceProviderInterface
                                 $app['schema'],
                                 $app['schema.extension_tables'],
                                 $app['schema.prefix'],
+                                $app['schema.charset'],
+                                $app['schema.collate'],
                                 $app['logger.system'],
                                 $app['logger.flash']
                             );

--- a/src/Storage/Database/Schema/Builder/BaseBuilder.php
+++ b/src/Storage/Database/Schema/Builder/BaseBuilder.php
@@ -23,6 +23,10 @@ abstract class BaseBuilder
     protected $tables;
     /** @var string */
     protected $prefix;
+    /** @var string */
+    protected $charset;
+    /** @var string */
+    protected $collate;
     /** @var \Psr\Log\LoggerInterface */
     protected $systemLog;
     /** @var \Bolt\Logger\FlashLoggerInterface */
@@ -35,15 +39,19 @@ abstract class BaseBuilder
      * @param Manager              $manager
      * @param Pimple               $tables
      * @param string               $prefix
+     * @param string               $charset
+     * @param string               $collate
      * @param LoggerInterface      $systemLog
      * @param FlashLoggerInterface $flashLogger
      */
-    public function __construct(Connection $connection, Manager $manager, Pimple $tables, $prefix, LoggerInterface $systemLog, FlashLoggerInterface $flashLogger)
+    public function __construct(Connection $connection, Manager $manager, Pimple $tables, $prefix, $charset, $collate, LoggerInterface $systemLog, FlashLoggerInterface $flashLogger)
     {
         $this->connection = $connection;
         $this->manager = $manager;
         $this->tables = $tables;
         $this->prefix = $prefix;
+        $this->charset = $charset;
+        $this->collate = $collate;
         $this->systemLog = $systemLog;
         $this->flashLogger = $flashLogger;
     }

--- a/src/Storage/Database/Schema/Builder/BaseTables.php
+++ b/src/Storage/Database/Schema/Builder/BaseTables.php
@@ -22,7 +22,7 @@ class BaseTables extends BaseBuilder
     {
         $tables = [];
         foreach ($this->tables->keys() as $name) {
-            $tables[$name] = $this->tables[$name]->buildTable($schema, $this->prefix. $name, $name);
+            $tables[$name] = $this->tables[$name]->buildTable($schema, $this->prefix. $name, $name, $this->charset, $this->collate);
         }
 
         return $tables;

--- a/src/Storage/Database/Schema/Builder/ContentTables.php
+++ b/src/Storage/Database/Schema/Builder/ContentTables.php
@@ -31,7 +31,7 @@ class ContentTables extends BaseBuilder
         $tables = [];
         foreach ($this->tables->keys() as $name) {
             $contentType = $contentTypes[$name];
-            $tables[$name] = $this->tables[$name]->buildTable($schema, $this->prefix. $name, $name);
+            $tables[$name] = $this->tables[$name]->buildTable($schema, $this->prefix. $name, $name, $this->charset, $this->collate);
             if (isset($contentType['fields']) && is_array($contentType['fields'])) {
                 $this->addContentTypeTableColumns($this->tables[$name], $tables[$name], $contentType['fields'], $fieldManager);
             }

--- a/src/Storage/Database/Schema/Builder/ExtensionTables.php
+++ b/src/Storage/Database/Schema/Builder/ExtensionTables.php
@@ -35,11 +35,15 @@ class ExtensionTables extends BaseBuilder
                 foreach ($table as $t) {
                     $alias = str_replace($this->prefix, '', $t->getName());
                     $t->addOption('alias', $alias);
+                    $t->addOption('charset', $this->charset);
+                    $t->addOption('collate', $this->collate);
                     $tables[$alias] = $t;
                 }
             } else {
                 $alias = str_replace($this->prefix, '', $table->getName());
                 $table->addOption('alias', $alias);
+                $table->addOption('charset', $this->charset);
+                $table->addOption('collate', $this->collate);
                 $tables[$alias] = $table;
             }
         }

--- a/src/Storage/Database/Schema/Table/BaseTable.php
+++ b/src/Storage/Database/Schema/Table/BaseTable.php
@@ -55,13 +55,17 @@ abstract class BaseTable
      * @param Schema $schema
      * @param string $tableName
      * @param string $aliasName
+     * @param string $charset
+     * @param string $collate
      *
      * @return \Doctrine\DBAL\Schema\Table
      */
-    public function buildTable(Schema $schema, $tableName, $aliasName)
+    public function buildTable(Schema $schema, $tableName, $aliasName, $charset, $collate)
     {
         $this->table = $schema->createTable($tableName);
         $this->table->addOption('alias', $aliasName);
+        $this->table->addOption('charset', $charset);
+        $this->table->addOption('collate', $collate);
         $this->aliasName = $aliasName;
         $this->tableName = $this->table->getName();
         $this->addColumns();


### PR DESCRIPTION
No matter what charset was set in config, bolt created tables in utf8 and utf8_unicode_ci in mysql during installation, because it's doctrine dbal default:

https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php#L478

btw utf8mb4 and utf8mb4_xxx_ci works fine.