### PR TITLE
Fix codeception tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_script:
   - git clone https://github.com/bolt/composer-install.git .tmp
   # - cd .tmp
   # Add requires
-  - composer require --working-dir=.tmp/ --no-update bolt/bolt:dev-master phpunit/phpunit:^4.5 codeception/codeception:2.1.2 lstrojny/phpunit-function-mocker:dev-master guzzlehttp/guzzle:^5.3 composer/composer:dev-master@dev passwordlib/passwordlib:1.0.x-dev@dev
+  - composer require --working-dir=.tmp/ --no-update bolt/bolt:dev-master phpunit/phpunit:^4.5 codeception/codeception:^2.1 lstrojny/phpunit-function-mocker:dev-master guzzlehttp/guzzle:^5.3 composer/composer:dev-master@dev passwordlib/passwordlib:1.0.x-dev@dev
   # Create the project
   - composer create-project --working-dir=.tmp/ --no-interaction --prefer-dist
   # Update the Composer Bolt install with the PR files

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "require-dev" : {
         "bolt/codingstyle" : "~1.0",
-        "codeception/codeception" : "2.1.2",
+        "codeception/codeception" : "^2.1",
         "lstrojny/phpunit-function-mocker" : "dev-master@dev",
         "phpmd/phpmd" : "~2.2",
         "phpunit/dbunit" : "~1.3",

--- a/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
+++ b/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
@@ -275,7 +275,7 @@ class BackendEditorCest
          * properly handle URL queries parameters in POSTs. For now we'll just
          * pretend that seeing the data is good enough…
          */
-        $I->see('This is the contact text');
+        $I->seeInSource('This is the contact text');
 //         $I->seeInField('#templatefields-section_1', 'This is the contact text');
     }
 }

--- a/tests/codeception/acceptance/103-BackendManager/BackendManagerCest.php
+++ b/tests/codeception/acceptance/103-BackendManager/BackendManagerCest.php
@@ -111,7 +111,7 @@ class BackendManagerCest
         $I->setCookie($this->tokenNames['session'], $this->cookies[$this->tokenNames['session']]);
         $I->amOnPage('/bolt/editcontent/pages/3');
 
-        $I->see('This is the contact text');
+        $I->seeInSource('This is the contact text');
 
         $I->selectOption('#statusselect', 'published');
 

--- a/tests/codeception/acceptance/200-Frontend/FrontendCest.php
+++ b/tests/codeception/acceptance/200-Frontend/FrontendCest.php
@@ -91,7 +91,7 @@ class FrontendCest
 
         $I->amOnPage('/contact');
 
-        $I->see("This is the contact text");
+        $I->seeInSource('This is the contact text');
     }
 
     /**


### PR DESCRIPTION
We were asserting that we **see** text which is in an `<input value="">`.
These started getting stripped https://github.com/Codeception/Codeception/issues/2249 https://github.com/Codeception/Codeception/issues/2461.
**seeInSource** doesn't strip tags https://github.com/Codeception/Codeception/pull/2465