### PR TITLE
Fix for save / overwrite error on repeating fields

### DIFF
--- a/src/Storage/Field/Collection/RepeatingFieldCollection.php
+++ b/src/Storage/Field/Collection/RepeatingFieldCollection.php
@@ -189,7 +189,7 @@ class RepeatingFieldCollection extends ArrayCollection
     {
         $flat = [];
         foreach ($this as $collection => $vals) {
-            $flat = array_merge($flat, $vals->toArray());
+            $flat = array_merge($flat, array_values($vals->toArray()));
         }
 
         return $flat;


### PR DESCRIPTION
When flattening the existing values, index the array keys numerically so that subsequent groups dont overwrite the previous.