### PR TITLE
Issue #4573: added default height of 0 to the navpage secondary outer (2.2)

### DIFF
--- a/app/src/js/modules/secmenu.js
+++ b/app/src/js/modules/secmenu.js
@@ -60,6 +60,8 @@
      * @memberof Bolt.secmenu
      */
     function adjustSidebarHeight() {
+        $('#navpage-secondary').outerHeight(0);
+
         var newHeight = $(document).height() - $('#navpage-secondary').position().top,
             next = 3000;
 


### PR DESCRIPTION
There is an issue where the sidebar resizes larger as the content size increases, but the content size decreasing is not resizing the sidebar. This fix sets the sidebar height to 0 before calculating the sidebar height to ensure that the document height is pulled in correctly for the calculation.

This is a fix for issue #4573 and should be pulled into master, 3.0 and 2.2