### PR TITLE
Restore Symfony fluent-interface chained call syntax

### DIFF
--- a/src/AccessControl/Password.php
+++ b/src/AccessControl/Password.php
@@ -186,7 +186,8 @@ class Password
             ->setReplyTo($from)
             ->setTo([$userEntity['email'] => $userEntity['displayname']])
             ->setBody(strip_tags($mailhtml))
-            ->addPart($mailhtml, 'text/html');
+            ->addPart($mailhtml, 'text/html')
+        ;
 
         $failed = true;
         $failedRecipients = [];

--- a/src/Application.php
+++ b/src/Application.php
@@ -70,14 +70,16 @@ class Application extends Silex\Application
     protected function initConfig()
     {
         $this->register(new Provider\DatabaseSchemaServiceProvider())
-            ->register(new Provider\ConfigServiceProvider());
+            ->register(new Provider\ConfigServiceProvider())
+        ;
     }
 
     protected function initSession()
     {
         $this
             ->register(new Provider\TokenServiceProvider())
-            ->register(new Provider\SessionServiceProvider());
+            ->register(new Provider\SessionServiceProvider())
+        ;
     }
 
     public function initialize()
@@ -226,7 +228,8 @@ class Application extends Silex\Application
             ->register(new Provider\EventListenerServiceProvider())
             ->register(new Provider\AssetServiceProvider())
             ->register(new Provider\FormServiceProvider())
-            ->register(new Provider\MailerServiceProvider());
+            ->register(new Provider\MailerServiceProvider())
+        ;
 
         $this['paths'] = $this['resources']->getPaths();
 

--- a/src/Asset/Snippet/Queue.php
+++ b/src/Asset/Snippet/Queue.php
@@ -81,7 +81,8 @@ class Queue implements QueueInterface
             ->setLocation($location)
             ->setCallback($callback)
             ->setExtension($extensionName)
-            ->setCallbackArguments($callbackArguments);
+            ->setCallbackArguments($callbackArguments)
+        ;
     }
 
     /**
@@ -161,7 +162,8 @@ class Queue implements QueueInterface
             $jqueryfile = $this->resources->getPath('app/view/js/jquery-2.1.4.min.js');
             $asset = (new Snippet())
                 ->setLocation(Target::BEFORE_JS)
-                ->setCallback('<script src="' . $jqueryfile . '"></script>');
+                ->setCallback('<script src="' . $jqueryfile . '"></script>')
+            ;
             $html = $this->injector->inject($asset, $asset->getLocation(), $html);
         }
 

--- a/src/Asset/Widget/Queue.php
+++ b/src/Asset/Widget/Queue.php
@@ -239,7 +239,8 @@ class Queue implements QueueInterface
         );
         $snippet = (new Snippet())
             ->setLocation(Target::AFTER_BODY_JS)
-            ->setCallback((string) $javaScript);
+            ->setCallback((string) $javaScript)
+        ;
 
         $this->deferAdded = true;
 

--- a/src/Configuration/Check/EmailSetup.php
+++ b/src/Configuration/Check/EmailSetup.php
@@ -110,7 +110,8 @@ class EmailSetup extends BaseCheck implements ConfigurationCheckInterface
                 ->setReplyTo([$senderMail                => $senderName])
                 ->setTo([$this->options['user']['email'] => $this->options['user']['displayname']])
                 ->setBody(strip_tags($mailhtml))
-                ->addPart($mailhtml, 'text/html');
+                ->addPart($mailhtml, 'text/html')
+            ;
 
             $this->app['swiftmailer.use_spool'] = false;
             if ($this->app['mailer']->send($message) > 0) {

--- a/src/Controller/Async/Records.php
+++ b/src/Controller/Async/Records.php
@@ -3,7 +3,6 @@
 namespace Bolt\Controller\Async;
 
 use Bolt\Storage\ContentRequest\ListingOptions;
-use Bolt\Translation\Translator as Trans;
 use Silex\ControllerCollection;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -90,7 +89,8 @@ class Records extends AsyncBase
             ->setOrder($referer->query->get('order'))
             ->setPage($referer->query->get('page_' . $contentType))
             ->setFilter($referer->query->get('filter'))
-            ->setTaxonomies($taxonomy);
+            ->setTaxonomies($taxonomy)
+        ;
 
         $context = [
             'contenttype'     => $this->getContentType($contentType),

--- a/src/Controller/Async/SystemChecks.php
+++ b/src/Controller/Async/SystemChecks.php
@@ -35,7 +35,8 @@ class SystemChecks extends AsyncBase
 
         $results = $this->getCheck('DirectoryAccess')
             ->setOptions($options)
-            ->runCheck();
+            ->runCheck()
+        ;
 
         return $this->json($results);
     }
@@ -57,7 +58,8 @@ class SystemChecks extends AsyncBase
 
         $results = $this->getCheck('EmailSetup')
             ->setOptions($options)
-            ->runCheck();
+            ->runCheck()
+        ;
 
         return $this->json($results);
     }
@@ -75,7 +77,8 @@ class SystemChecks extends AsyncBase
 
         $results = $this->getCheck('PhpExtensions')
             ->setOptions($options)
-            ->runCheck();
+            ->runCheck()
+        ;
 
         return $this->json($results);
     }

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -5,7 +5,6 @@ use Bolt\Storage\ContentRequest\Edit;
 use Bolt\Storage\ContentRequest\Listing;
 use Bolt\Storage\ContentRequest\ListingOptions;
 use Bolt\Storage\ContentRequest\Save;
-use Bolt\Storage\Entity\Content;
 use Bolt\Translation\Translator as Trans;
 use Silex\ControllerCollection;
 use Symfony\Component\HttpFoundation\Request;
@@ -127,7 +126,8 @@ class Records extends BackendBase
             ->setOrder($request->query->get('order'))
             ->setPage($request->query->get('page_' . $contenttypeslug))
             ->setFilter($request->query->get('filter'))
-            ->setTaxonomies($taxonomy);
+            ->setTaxonomies($taxonomy)
+        ;
 
         $context = [
             'contenttype'     => $this->getContentType($contenttypeslug),

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -444,7 +444,8 @@ class Users extends BackendBase
                     'label'       => Trans::__('page.edit-users.label.display-name'),
                     'attr'        => ['placeholder' => Trans::__('page.edit-users.placeholder.displayname')],
                 ]
-            );
+            )
+        ;
 
         return $form;
     }

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1138,7 +1138,8 @@ class Storage
                 ->update($tablename)
                 ->set('status', ':newstatus')
                 ->set('datechanged', ':datechanged')
-                ->setParameter('datechanged', date('Y-m-d H:i:s'));
+                ->setParameter('datechanged', date('Y-m-d H:i:s'))
+            ;
 
             $this->timedWhere($query, $type);
 
@@ -1185,7 +1186,8 @@ class Storage
             ->from($tablename)
             ->set('status', ':newstatus')
             ->set('datechanged', ':datechanged')
-            ->setParameter('datechanged', date('Y-m-d H:i:s'));
+            ->setParameter('datechanged', date('Y-m-d H:i:s'))
+        ;
 
         $this->timedWhere($query, $type);
 
@@ -1206,7 +1208,8 @@ class Storage
                 ->andWhere('datepublish < :currenttime')
                 ->setParameter('oldstatus', 'timed')
                 ->setParameter('newstatus', 'published')
-                ->setParameter('currenttime', new \DateTime(), \Doctrine\DBAL\Types\Type::DATETIME);
+                ->setParameter('currenttime', new \DateTime(), \Doctrine\DBAL\Types\Type::DATETIME)
+            ;
         } else {
             $query
                 ->where('status = :oldstatus')
@@ -1216,7 +1219,8 @@ class Storage
                 ->setParameter('oldstatus', 'published')
                 ->setParameter('newstatus', 'held')
                 ->setParameter('zeroday', '1900-01-01 00:00:01')
-                ->setParameter('currenttime', new \DateTime(), \Doctrine\DBAL\Types\Type::DATETIME);
+                ->setParameter('currenttime', new \DateTime(), \Doctrine\DBAL\Types\Type::DATETIME)
+            ;
         }
     }
 

--- a/src/Nut/CacheClear.php
+++ b/src/Nut/CacheClear.php
@@ -17,7 +17,8 @@ class CacheClear extends BaseCommand
     {
         $this
             ->setName('cache:clear')
-            ->setDescription('Clear the cache');
+            ->setDescription('Clear the cache')
+        ;
     }
 
     /**

--- a/src/Nut/ConfigGet.php
+++ b/src/Nut/ConfigGet.php
@@ -25,7 +25,8 @@ class ConfigGet extends BaseCommand
             ->setName('config:get')
             ->setDescription('Get a value from config.yml.')
             ->addArgument('key', InputArgument::REQUIRED, 'The key you wish to get.')
-            ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'Specify config file to use');
+            ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'Specify config file to use')
+        ;
     }
 
     /**

--- a/src/Nut/ConfigSet.php
+++ b/src/Nut/ConfigSet.php
@@ -27,7 +27,8 @@ class ConfigSet extends BaseCommand
             ->addArgument('key', InputArgument::REQUIRED, 'The key you wish to get.')
             ->addArgument('value', InputArgument::REQUIRED, 'The value you wish to set it to.')
             ->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'Specify config file to use')
-            ->addOption('backup', 'b', InputOption::VALUE_NONE, 'Make a backup of the config file');
+            ->addOption('backup', 'b', InputOption::VALUE_NONE, 'Make a backup of the config file')
+        ;
     }
 
     /**

--- a/src/Nut/CronRunner.php
+++ b/src/Nut/CronRunner.php
@@ -23,7 +23,8 @@ class CronRunner extends BaseCommand
         $this
             ->setName('cron')
             ->setDescription('Cron virtual daemon')
-            ->addOption('run', null, InputOption::VALUE_REQUIRED, "Run a particular interim's jobs:\n" . implode("\n", $interims));
+            ->addOption('run', null, InputOption::VALUE_REQUIRED, "Run a particular interim's jobs:\n" . implode("\n", $interims))
+        ;
     }
 
     /**

--- a/src/Nut/DatabaseCheck.php
+++ b/src/Nut/DatabaseCheck.php
@@ -17,7 +17,8 @@ class DatabaseCheck extends BaseCommand
     {
         $this
             ->setName('database:check')
-            ->setDescription('Check the database for missing tables and/or columns.');
+            ->setDescription('Check the database for missing tables and/or columns.')
+        ;
     }
 
     /**

--- a/src/Nut/DatabaseExport.php
+++ b/src/Nut/DatabaseExport.php
@@ -22,7 +22,8 @@ class DatabaseExport extends BaseCommand
             ->setDescription('[EXPERIMENTAL] Export the database records to a YAML or JSON file.')
             ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
             ->addOption('contenttypes',   'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'One or more contenttypes to export records for.')
-            ->addOption('file',           'f', InputOption::VALUE_REQUIRED, 'A YAML or JSON file to use for export data. Must end with .yml, .yaml or .json');
+            ->addOption('file',           'f', InputOption::VALUE_REQUIRED, 'A YAML or JSON file to use for export data. Must end with .yml, .yaml or .json')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -51,7 +52,8 @@ class DatabaseExport extends BaseCommand
             ->checkMigrationFilesExist('export')
             ->checkMigrationFilesWriteable()
             ->checkContenttypeValid($input->getOption('contenttypes'))
-            ->exportContenttypesRecords();
+            ->exportContenttypesRecords()
+        ;
 
         if ($export->getError()) {
             foreach ($export->getErrorMessages() as $error) {

--- a/src/Nut/DatabaseImport.php
+++ b/src/Nut/DatabaseImport.php
@@ -21,7 +21,8 @@ class DatabaseImport extends BaseCommand
             ->setName('database:import')
             ->setDescription('[EXPERIMENTAL] Import database records from a YAML or JSON file')
             ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
-            ->addOption('file',           'f', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A YAML or JSON file to use for import data. Must end with .yml, .yaml or .json');
+            ->addOption('file',           'f', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A YAML or JSON file to use for import data. Must end with .yml, .yaml or .json')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -47,7 +48,8 @@ class DatabaseImport extends BaseCommand
             ->setMigrationFiles($files)
             ->checkMigrationFilesValid(true)
             ->checkMigrationFilesExist('import')
-            ->importMigrationFiles();
+            ->importMigrationFiles()
+        ;
 
         if ($import->getError()) {
             foreach ($import->getErrorMessages() as $error) {

--- a/src/Nut/DatabasePrefill.php
+++ b/src/Nut/DatabasePrefill.php
@@ -24,7 +24,8 @@ class DatabasePrefill extends BaseCommand
             ->setName('database:prefill')
             ->setDescription('Pre-fill the database Lorem Ipsum records')
             ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
-            ->addArgument('contenttypes', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'A list of Contentypes to pre-fill. If this argument is empty, all Contenttypes are used.');
+            ->addArgument('contenttypes', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'A list of Contentypes to pre-fill. If this argument is empty, all Contenttypes are used.')
+        ;
     }
 
     /**

--- a/src/Nut/DatabaseRepair.php
+++ b/src/Nut/DatabaseRepair.php
@@ -17,7 +17,8 @@ class DatabaseRepair extends BaseCommand
     {
         $this
             ->setName('database:update')
-            ->setDescription('Repair and/or update the database.');
+            ->setDescription('Repair and/or update the database.')
+        ;
     }
 
     /**

--- a/src/Nut/Extensions.php
+++ b/src/Nut/Extensions.php
@@ -17,7 +17,8 @@ class Extensions extends BaseCommand
     {
         $this
             ->setName('extensions')
-            ->setDescription('Lists all installed extensions');
+            ->setDescription('Lists all installed extensions')
+        ;
     }
 
     /**

--- a/src/Nut/ExtensionsAutoloader.php
+++ b/src/Nut/ExtensionsAutoloader.php
@@ -18,7 +18,8 @@ class ExtensionsAutoloader extends BaseCommand
     {
         $this
             ->setName('extensions:autoloader')
-            ->setDescription('Update the extensions autoloader.');
+            ->setDescription('Update the extensions autoloader.')
+        ;
     }
 
     /**

--- a/src/Nut/ExtensionsDisable.php
+++ b/src/Nut/ExtensionsDisable.php
@@ -22,7 +22,8 @@ class ExtensionsDisable extends BaseCommand
             ->setName('extensions:disable')
             ->setAliases(['extensions:uninstall'])
             ->setDescription('Uninstalls an extension.')
-            ->addArgument('name', InputArgument::REQUIRED, 'Name of the extension to uninstall');
+            ->addArgument('name', InputArgument::REQUIRED, 'Name of the extension to uninstall')
+        ;
     }
 
     /**

--- a/src/Nut/ExtensionsEnable.php
+++ b/src/Nut/ExtensionsEnable.php
@@ -23,7 +23,8 @@ class ExtensionsEnable extends BaseCommand
             ->setAliases(['extensions:install'])
             ->setDescription('Installs an extension by name and version.')
             ->addArgument('name', InputArgument::REQUIRED, 'Name of the extension to enable')
-            ->addArgument('version', InputArgument::REQUIRED, 'Version of the extension to enable');
+            ->addArgument('version', InputArgument::REQUIRED, 'Version of the extension to enable')
+        ;
     }
 
     /**

--- a/src/Nut/Info.php
+++ b/src/Nut/Info.php
@@ -17,7 +17,8 @@ class Info extends BaseCommand
     {
         $this
             ->setName('info')
-            ->setDescription('Display phpinfo().');
+            ->setDescription('Display phpinfo().')
+        ;
     }
 
     /**

--- a/src/Nut/LogClear.php
+++ b/src/Nut/LogClear.php
@@ -20,7 +20,8 @@ class LogClear extends BaseCommand
         $this
             ->setName('log:clear')
             ->setDescription('Clear (truncate) the system & change logs.')
-            ->addOption('force', 'f', InputOption::VALUE_NONE, 'If set, no confirmation will be required');
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'If set, no confirmation will be required')
+        ;
     }
 
     /**

--- a/src/Nut/LogTrim.php
+++ b/src/Nut/LogTrim.php
@@ -17,7 +17,8 @@ class LogTrim extends BaseCommand
     {
         $this
             ->setName('log:trim')
-            ->setDescription('Trim the system & change logs.');
+            ->setDescription('Trim the system & change logs.')
+        ;
     }
 
     /**

--- a/src/Nut/SetupSync.php
+++ b/src/Nut/SetupSync.php
@@ -20,7 +20,8 @@ class SetupSync extends BaseCommand
     {
         $this
             ->setName('setup:sync')
-            ->setDescription('Synchronise a Bolt install private asset directories with the web root.');
+            ->setDescription('Synchronise a Bolt install private asset directories with the web root.')
+        ;
     }
 
     /**

--- a/src/Nut/TestRunner.php
+++ b/src/Nut/TestRunner.php
@@ -17,7 +17,8 @@ class TestRunner extends BaseCommand
     {
         $this
             ->setName('tests:run')
-            ->setDescription('Runs all available tests');
+            ->setDescription('Runs all available tests')
+        ;
     }
 
     /**

--- a/src/Nut/UserAdd.php
+++ b/src/Nut/UserAdd.php
@@ -24,7 +24,8 @@ class UserAdd extends BaseCommand
             ->addArgument('displayname', InputArgument::REQUIRED, 'The display name for the new user.')
             ->addArgument('email', InputArgument::REQUIRED, 'The email address for the new user.')
             ->addArgument('password', InputArgument::REQUIRED, 'The password for the new user.')
-            ->addArgument('role', InputArgument::REQUIRED, 'The role you wish to give them.');
+            ->addArgument('role', InputArgument::REQUIRED, 'The role you wish to give them.')
+        ;
     }
 
     /**

--- a/src/Nut/UserResetPassword.php
+++ b/src/Nut/UserResetPassword.php
@@ -21,17 +21,9 @@ class UserResetPassword extends BaseCommand
         $this
             ->setName('user:reset-password')
             ->setDescription('Reset a user password.')
-            ->addArgument(
-                'username',
-                InputArgument::REQUIRED,
-                'The username (login name or e-mail address) you wish to reset the password for.'
-            )
-            ->addOption(
-                'no-interaction',
-                'n',
-                InputOption::VALUE_NONE,
-                'Do not ask for confirmation'
-            );
+            ->addArgument('username', InputArgument::REQUIRED, 'The username (login name or e-mail address) you wish to reset the password for.')
+            ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
+        ;
     }
 
     /**

--- a/src/Nut/UserRoleAdd.php
+++ b/src/Nut/UserRoleAdd.php
@@ -20,7 +20,8 @@ class UserRoleAdd extends BaseCommand
             ->setName('role:add')
             ->setDescription('Add a certain role to a user.')
             ->addArgument('username', InputArgument::REQUIRED, 'The username (loginname) you wish to add a role to.')
-            ->addArgument('role', InputArgument::REQUIRED, 'The role you wish to give them.');
+            ->addArgument('role', InputArgument::REQUIRED, 'The role you wish to give them.')
+        ;
     }
 
     /**

--- a/src/Nut/UserRoleRemove.php
+++ b/src/Nut/UserRoleRemove.php
@@ -20,7 +20,8 @@ class UserRoleRemove extends BaseCommand
             ->setName('role:remove')
             ->setDescription('Remove a certain role from a user.')
             ->addArgument('username', InputArgument::REQUIRED, 'The username (loginname) you wish to remove the role from.')
-            ->addArgument('role', InputArgument::REQUIRED, 'The role you wish to remove.');
+            ->addArgument('role', InputArgument::REQUIRED, 'The role you wish to remove.')
+        ;
     }
 
     /**

--- a/src/Session/Handler/FileHandler.php
+++ b/src/Session/Handler/FileHandler.php
@@ -147,7 +147,8 @@ class FileHandler implements \SessionHandlerInterface
         $files = $finder->files()
             ->in($this->savePath)
             ->name('/\.sess$/')
-            ->date("< now - $maxlifetime seconds");
+            ->date("< now - $maxlifetime seconds")
+        ;
 
         foreach ($files as $file) {
             try {

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -208,7 +208,8 @@ class ImageHandler
             ->setFileName($fileName)
             ->setWidth($width)
             ->setHeight($height)
-            ->setScale($scale);
+            ->setScale($scale)
+        ;
 
         return $thumb;
     }

--- a/src/Twig/Handler/RecordHandler.php
+++ b/src/Twig/Handler/RecordHandler.php
@@ -3,7 +3,6 @@
 namespace Bolt\Twig\Handler;
 
 use Bolt\Helpers\Html;
-use Bolt\Legacy\Content;
 use Silex;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\Glob;
@@ -192,7 +191,8 @@ class RecordHandler
             ->notPath('.sass-cache')
             ->depth('<2')
             ->path($name)
-            ->sortByName();
+            ->sortByName()
+        ;
 
         foreach ($finder as $file) {
             $name = $file->getRelativePathname();


### PR DESCRIPTION
This restores the :scream: inflicted in #4378 and brings calm to Symfony addicts and their war on anti-perfection!

@rarila: I have updated the code sniffer rules so this won't increase the count :+1: 
@CarsonF: Any Belgian :beers: are fine :grin: 

**No :koala: were harmed in the making of this PR.**