### PR TITLE
[Travis] Require pass from PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.0
     - php: hhvm
 
 services:


### PR DESCRIPTION
We have been passing tests on PHP 7 since PHP 7-RC4 and 7.0.0 is now GA.