### PR TITLE
Fixes for field persistence errors

### DIFF
--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -137,7 +137,7 @@ class Edit
             'allowed_status'     => $allowedStatuses,
             'contentowner'       => $contentowner,
             'fields'             => $this->config->fields->fields(),
-            'fieldtemplates'     => $this->getTempateFieldTemplates($contentType, $content),
+            'fieldtemplates'     => $this->getTemplateFieldTemplates($contentType, $content),
             'fieldtypes'         => $this->getUsedFieldtypes($contentType, $content, $contextHas),
             'groups'             => $this->createGroupTabs($contentType, $contextHas),
             'can'                => $contextCan,
@@ -205,7 +205,7 @@ class Edit
      *
      * @return array
      */
-    private function getTempateFieldTemplates(array $contentType, Content $content)
+    private function getTemplateFieldTemplates(array $contentType, Content $content)
     {
         $templateFieldTemplates = [];
         $templateFieldsConfig = $this->config->get('theme/templatefields');
@@ -217,7 +217,7 @@ class Edit
             foreach ($contentType['fields'] as $name => $field) {
                 if ($field['type'] === 'templateselect' && !empty($content->values[$name])) {
                     $toRepair[$name] = $content->values[$name];
-                    $content->setValue($name, '');
+                    $content->set($name, '');
                 }
             }
             if ($content->hasTemplateFields()) {
@@ -225,7 +225,7 @@ class Edit
             }
 
             foreach ($toRepair as $name => $value) {
-                $content->setValue($name, $value);
+                $content->set($name, $value);
             }
         }
 

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -63,11 +63,11 @@ class Content extends Entity
      * Setter for content values.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      */
     public function set($key, $value)
     {
-        $setter = 'set'.ucfirst($key);
+        $setter = 'set' . ucfirst($key);
         if (is_array($value)) {
             $value = array_filter($value);
         }

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -67,12 +67,13 @@ class Content extends Entity
      */
     public function set($key, $value)
     {
-        $this->$key = $value;
+        $setter = 'set'.ucfirst($key);
+        $this->$setter($value);
     }
 
     /**
      * Helper to set an array of values
-     * 
+     *
      * @param array $values
      */
     public function setValues(array $values)

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -68,6 +68,9 @@ class Content extends Entity
     public function set($key, $value)
     {
         $setter = 'set'.ucfirst($key);
+        if (is_array($value)) {
+            $value = array_filter($value);
+        }
         $this->$setter($value);
     }
 
@@ -79,8 +82,7 @@ class Content extends Entity
     public function setValues(array $values)
     {
         foreach($values as $key => $value) {
-            $setter = 'set'.ucfirst($key);
-            $this->$setter($value);
+            $this->set($key, $value);
         }
     }
 

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -81,7 +81,7 @@ class Content extends Entity
      */
     public function setValues(array $values)
     {
-        foreach($values as $key => $value) {
+        foreach ($values as $key => $value) {
             $this->set($key, $value);
         }
     }

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -71,6 +71,19 @@ class Content extends Entity
     }
 
     /**
+     * Helper to set an array of values
+     * 
+     * @param array $values
+     */
+    public function setValues(array $values)
+    {
+        foreach($values as $key => $value) {
+            $setter = 'set'.ucfirst($key);
+            $this->$setter($value);
+        }
+    }
+
+    /**
      * Getter for a record's 'title' field.
      *
      * If there is no field called 'title' then we just return the first text

--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -115,6 +115,9 @@ abstract class FieldTypeBase implements FieldTypeInterface
     public function set($entity, $value)
     {
         $key = $this->mapping['fieldname'];
+        if (is_array($value)) {
+            $value = array_filter($value);
+        }
         if (!$value && isset($this->mapping['data']['default'])) {
             $value = $this->mapping['data']['default'];
         }

--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -115,9 +115,6 @@ abstract class FieldTypeBase implements FieldTypeInterface
     public function set($entity, $value)
     {
         $key = $this->mapping['fieldname'];
-        if (is_array($value)) {
-            $value = array_filter($value);
-        }
         if (!$value && isset($this->mapping['data']['default'])) {
             $value = $this->mapping['data']['default'];
         }


### PR DESCRIPTION
Fixes #4563 and also restores the `$entity->setValues` method as a helper for setting an array of values.