### PR TITLE
[NotFoundListener] Check if template exists instead of string ending with ".twig"

### DIFF
--- a/src/EventListener/NotFoundListener.php
+++ b/src/EventListener/NotFoundListener.php
@@ -54,18 +54,21 @@ class NotFoundListener implements EventSubscriberInterface
             return;
         }
 
-        if (substr($this->notFoundPage, -5) === '.twig') {
+        // If $notFoundPage is referencing a template, render it and be done.
+        if ($this->render->hasTemplate($this->notFoundPage)) {
             $response = $this->render->render($this->notFoundPage);
-        } else {
-            $content = $this->storage->getContent($this->notFoundPage, ['returnsingle' => true]);
-
-            if (!$content instanceof Content || empty($content->id)) {
-                return;
-            }
-
-            $template = $this->templateChooser->record($content);
-            $response = $this->render->render($template, $content->getTemplateContext());
+            $event->setResponse($response);
+            return;
         }
+
+        // Next try for referencing DB content.
+        $content = $this->storage->getContent($this->notFoundPage, ['returnsingle' => true]);
+        if (!$content instanceof Content || empty($content->id)) {
+            return;
+        }
+
+        $template = $this->templateChooser->record($content);
+        $response = $this->render->render($template, $content->getTemplateContext());
 
         $event->setResponse($response);
     }

--- a/src/Render.php
+++ b/src/Render.php
@@ -65,6 +65,37 @@ class Render
     }
 
     /**
+     * Check if the template exists.
+     *
+     * @param string $template The name of the template.
+     *
+     * @return bool
+     */
+    public function hasTemplate($template)
+    {
+        /** @var \Twig_Environment $env */
+        $env = $this->app[$this->twigKey];
+        $loader = $env->getLoader();
+
+        /*
+         * Twig_ExistsLoaderInterface is getting merged into
+         * Twig_LoaderInterface in Twig 2.0. Check for this
+         * instead once we are there, and remove getSource() check.
+         */
+        if ($loader instanceof \Twig_ExistsLoaderInterface) {
+            return $loader->exists($template);
+        }
+
+        try {
+            $loader->getSource($template);
+        } catch (\Twig_Error_Loader $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Postprocess the rendered HTML: insert the snippets, and stuff.
      *
      * @param Response $response


### PR DESCRIPTION
Can't find where @Boorj was complaining about this, but this is less hacky.