### PR TITLE
Prevent exception empty extension config files

### DIFF
--- a/src/Controllers/Backend.php
+++ b/src/Controllers/Backend.php
@@ -1846,7 +1846,7 @@ class Backend implements ControllerProviderInterface
         }
 
         $contents = null;
-        if (!$file->exists() || !($contents = $file->read())) {
+        if (!$file->exists() || false === $file->read()) {
             $error = Trans::__("The file '%s' doesn't exist, or is not readable.", array('%s' => $file->getPath()));
             $app->abort(Response::HTTP_NOT_FOUND, $error);
         }


### PR DESCRIPTION
When I want to open a empty extension config file in the backend, I get a exception "The file 'extensions/clientprofiles.bolt.yml' doesn't exist, or is not readable."

$file->read() returns false if file can't be read. At the moment $file->read() returns a empty string and this is checked as false.

Fixes #4636