### PR TITLE
Prevent exception empty extension config files

### DIFF
--- a/src/Controller/Backend/FileManager.php
+++ b/src/Controller/Backend/FileManager.php
@@ -78,7 +78,7 @@ class FileManager extends BackendBase
         $type = Lib::getExtension($file->getPath());
 
         $contents = null;
-        if (!$file->exists() || !($contents = $file->read())) {
+        if (!$file->exists() || false === $file->read()) {
             $error = Trans::__("The file '%s' doesn't exist, or is not readable.", ['%s' => $file->getPath()]);
             $this->abort(Response::HTTP_NOT_FOUND, $error);
         }


### PR DESCRIPTION
When I want to open a empty extension config file in the backend, I get a exception "The file 'extensions/clientprofiles.bolt.yml' doesn't exist, or is not readable."

$file->read() returns false if file can't be read. At the moment $file->read() returns a empty string and this is checked as false.

Fixes #4636