### PR TITLE
Template bugfix for backend menu

### DIFF
--- a/app/view/twig/nav/_macros.twig
+++ b/app/view/twig/nav/_macros.twig
@@ -42,9 +42,9 @@
     {% set class = ((wide ? ' menu-pop-wide' : '') ~ (active ? ' active' : ''))|trim %}
 
     {# Show stuff! #}
-    {% if allowedany and not force_submenu|default(false)  %}
+    {% if allowedany %}
         <li{% if class %} class="{{ class }}"{% endif %}>
-            {% if allowedamount == 1 %}
+            {% if allowedamount == 1 and not force_submenu|default(false) %}
                 {% set item = allowedsingle %}
                 <a href="{{ item.link }}">
                     {{ icon(item.icon, "icon") }}{{ item.label|default("<em>(" ~ __("no content …") ~ ")</em>")|raw }}


### PR DESCRIPTION
Fix: submenu is missing if `show_in_menu` is set

![bildschirmfoto vom 2015-12-29 21 23 22](https://cloud.githubusercontent.com/assets/5207145/12041754/c3dd1a62-ae74-11e5-87bd-2a13c4c17891.png)

A little bugfix for 2.2.15 - have a happy new year! :boom: :tada: :beers: 