### PR TITLE
Fix selects with empty values

### DIFF
--- a/app/view/twig/_macro/_buic.twig
+++ b/app/view/twig/_macro/_buic.twig
@@ -135,10 +135,6 @@
             <div>
                 <div>
                     <select{{ hattr(attributes) }}>
-                        {% if not conf.multiple %}
-                            <option value="" label="–"></option>
-                        {% endif %}
-
                         {% set last_optgroup = false %}
 
                         {% for option in conf.options %}
@@ -155,8 +151,13 @@
                             {% endif %}
 
                             {# option #}
-                            {% set optattr = {'value': option.value, 'selected': option.selected|default(false) } %}
-                            <option{{ hattr(optattr) }}>{{ option.text|default(option.value)|striptags|e }}</option>
+                            {% set opttext = option.text|default(option.value)|striptags|e %}
+                            {% set optattr = {
+                                'value!':   option.value,
+                                'selected': option.selected|default(false),
+                                'label':    option.value == '' and opttext == '' ? '-' : false,
+                            } %}
+                            <option{{ hattr(optattr) }}>{{ opttext }}</option>
                         {% endfor %}
 
                         {# Close open optgroup #}

--- a/app/view/twig/_macro/_buic.twig
+++ b/app/view/twig/_macro/_buic.twig
@@ -89,15 +89,37 @@
  #}
 {% macro select(opt) %}
     {% spaceless %}
+        {% set options = opt.options|default([]) %}
+        {% set multiple = opt.multiple|default(false) %}
+
+        {# Add an empty option for non multiple selects if not already there #}
+        {% if not multiple %}
+            {% set has_empty_val = false %}
+            {% set has_selected_val = false %}
+
+            {% for option in options %}
+                {% if option.value == '' %}
+                    {% set has_empty_val = true %}
+                {% endif %}
+                {% if option.selected %}
+                    {% set has_selected_val = true %}
+                {% endif %}
+            {% endfor %}
+
+            {% if not has_empty_val %}
+                {% set options = [{value: '', text: '', selected: not has_selected_val}]|merge(options) %}
+            {% endif %}
+        {% endif %}
+
         {% set conf = {
             'all':       opt.all|default(false),
             'class':     opt.class|default(),
             'clear':     opt.clear|default(false),
             'disabled':  opt.disabled|default(false),
             'id':        opt.id|default(opt['name+id']|default('')),
-            'multiple':  opt.multiple|default(false),
+            'multiple':  multiple,
             'name':      opt.name|default(opt['name+id']|default('')),
-            'options':   opt.options|default([]),
+            'options':   options,
             'required':  opt.required|default(false),
         } %}
 

--- a/app/view/twig/_macro/_buic.twig
+++ b/app/view/twig/_macro/_buic.twig
@@ -155,7 +155,7 @@
                             {% set optattr = {
                                 'value!':   option.value,
                                 'selected': option.selected|default(false),
-                                'label':    option.value == '' and opttext == '' ? '-' : false,
+                                'label':    option.value == '' and opttext == '' ? '–' : false,
                             } %}
                             <option{{ hattr(optattr) }}>{{ opttext }}</option>
                         {% endfor %}


### PR DESCRIPTION
In buic-select an empty option was added to non multiple selects regardless of if there already ways an empty option included. That produced an output like this:

```html
<select><option value="" label="–"></option><option selected></option>…
```

Now we check for empty values for correct output.