### PR TITLE
Move NutSP::addCommand to $app['nut.commands.add'] so it's not "static"

### DIFF
--- a/tests/phpunit/unit/Provider/NutServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/NutServiceProviderTest.php
@@ -29,7 +29,7 @@ class NutServiceProviderTest extends BoltUnitTest
         $app->register($provider);
         $app->boot();
         $command = $this->getMock('Symfony\Component\Console\Command\Command', null, array('mockCommand'));
-        NutServiceProvider::addCommand($app, $command);
+        $app['nut.commands.add']($command);
         $this->assertTrue(in_array($command, $app['nut.commands']));
     }
 }


### PR DESCRIPTION
Back port of #3585