### PR TITLE
don't try writing to vendor on composer installs (2.2)

### DIFF
--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -214,7 +214,7 @@ class Extensions
             return;
         }
 
-        if (!$force && $this->app['filesystem']->has('app://cache/.local.autoload.built')) {
+        if (!$force && $this->app['filesystem']->has('cache://.local.autoload.built')) {
             return;
         }
 
@@ -268,7 +268,7 @@ class Extensions
         $boltJson['autoload']['psr-4'] = $boltPsr4;
         $composerJsonFile->write($boltJson);
         $this->app['extend.manager']->dumpautoload();
-        $this->app['filesystem']->put('app://cache/.local.autoload.built', time());
+        $this->app['filesystem']->put('cache://.local.autoload.built', time());
     }
 
     /**

--- a/src/Filesystem/Manager.php
+++ b/src/Filesystem/Manager.php
@@ -20,6 +20,7 @@ class Manager extends MountManager
             array(
                 'root'       => $app['resources']->getPath('root'),
                 'app'        => $app['resources']->getPath('app'),
+                'cache'      => $app['resources']->getPath('cache'),
                 'default'    => $app['resources']->getPath('files'),
                 'files'      => $app['resources']->getPath('files'),
                 'config'     => $app['resources']->getPath('config'),


### PR DESCRIPTION
These paths are referencing the `app` directory relative to bolt's install, which could mean trying to write to a vendor subdirectory in a composer install.  Using the cache location configured in resources fixes this.