### PR TITLE
[Feature] Added capability to set a record amount for specific kind of taxonomy

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -287,6 +287,12 @@ class Frontend extends ConfigurableBase
         $page = $query->get($pagerid, $query->get('page', 1));
         // Theme value takes precedence over default config @see https://github.com/bolt/bolt/issues/3951
         $amount = $this->getOption('theme/listing_records', false) ?: $this->getOption('general/listing_records');
+
+        // Handle case where listing records has been override for specific taxonomy
+        if (array_key_exists('listing_records', $taxonomy) && is_int($taxonomy['listing_records'])) {
+            $amount = $taxonomy['listing_records'];
+        }
+
         $order = $this->getOption('theme/listing_sort', false) ?: $this->getOption('general/listing_sort');
         $content = $this->storage()->getContentByTaxonomy($taxonomytype, $slug, ['limit' => $amount, 'order' => $order, 'page' => $page]);
 


### PR DESCRIPTION
Hey guys, thanks for this great CMS.

I'm facing a case where I want to define differents amounts of records for multiple kind of taxonomies.

For my articles I have a taxonomy called **Thematic**, for which I want 2 records fetched in the full view of the taxonomy **Thematic**, but I also have a taxonomy **levelofDifficulty** and for that one I want 6 records per pages.

Therefore I made a little fix that override the theme's specific or theme's global config. Do you agree about that ? Or do you have a better way to handle that ?

PS : I wanted also include the listing option, but I contents doesn't have the same fields, it can make some issues. So nevermind about listing order. ^

PS2 : Carry on buddy !