### PR TITLE
Fix fatal error when missing "fields" in contenttype.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -452,6 +452,12 @@ class Config
             throw new LowlevelException($error);
         }
 
+        // Contenttypes without fields make no sense.
+        if (!isset($contentType['fields'])) {
+            $error = sprintf("In contenttype <code>%s</code>, no 'fields' are set. Please edit <code>contenttypes.yml</code>, and correct this.", $key);
+            throw new LowlevelException($error);
+        }
+
         if (!isset($contentType['slug'])) {
             $contentType['slug'] = Slugify::create()->slugify($contentType['name']);
         }


### PR DESCRIPTION
Fixes #4687

(or rather: It will, after #4686 has been resolved)