### PR TITLE
Fix false test fatal errors on PHP 7 

### DIFF
--- a/tests/phpunit/unit/Library/BoltLibraryTest.php
+++ b/tests/phpunit/unit/Library/BoltLibraryTest.php
@@ -13,6 +13,14 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class BoltLibraryTest extends BoltUnitTest
 {
+    protected function tearDown()
+    {
+        parent::tearDown();
+        // Clear the queue of LowlevelExceptions or they get needlessly reported at the end of the test run.
+        // @deprcated remove with new error handling.
+        LowlevelException::$screen = null;
+    }
+
     public function testFormatFilesize()
     {
         $b = 300;


### PR DESCRIPTION
Recent :koala: based changes caused a whole lot of these to be generated on Travis PHP 7 tests:

```
Bolt - Fatal Error
File is not readable!The following file could not be read: [snip]/non/existent/path/data.php
Try logging in with your ftp-client and make the file readable. 
Else try to go back to the last page.
This is a fatal error. Please fix the error, and refresh the page.
Bolt can not run, until this error has been corrected. 
Make sure you've read the instructions in the documentation for help. If you
can't get it to work, post a message on our forum, and we'll try to help you
out. Be sure to include the exact error message you're getting!
* https://docs.bolt.cm/installation - Bolt documentation - Setup
* https://discuss.bolt.cm/ - The Bolt discussion forum
* https://bolt.cm/community - IRC, Slack or Twitter - Bolt Community
```

This just resets the static property in the offending test class to prevent this.