### PR TITLE
Guzzle 5 & 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require" : {
         "bolt/dumper" : "~2.0",
         "bolt/filesystem" : "^2.0@dev",
-        "bolt/package-wrapper": "~1.0|~2.0",
+        "bolt/package-wrapper": "^3.0",
         "bolt/pathogen" : "~0.6",
         "bolt/thumbs" : "~3.0@dev",
         "brandonwamboldt/utilphp" : "~1.0",

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -110,7 +110,11 @@ class PackageManager
         }
 
         try {
-            ClientUtils::getDefaultCaBundle();
+            if ($this->app['guzzle.api_version'] === 5) {
+                ClientUtils::getDefaultCaBundle();
+            } else {
+                \GuzzleHttp\default_ca_bundle();
+            }
 
             return $this->useSsl = true;
         } catch (\RuntimeException $e) {

--- a/src/Provider/GuzzleServiceProvider.php
+++ b/src/Provider/GuzzleServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Bolt\Provider;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -12,6 +13,21 @@ class GuzzleServiceProvider implements ServiceProviderInterface
     {
         $app['guzzle.base_url'] = '/';
 
+        $app['guzzle.api_version'] = $app->share(
+            function () use ($app) {
+                return version_compare(Client::VERSION, '6.0.0', '>=') ? 6 : 5;
+            }
+        );
+
+        if (!isset($app['guzzle.handler_stack'])) {
+            $app['guzzle.handler_stack'] = $app->share(
+                function () {
+                    return HandlerStack::create();
+                }
+            );
+        }
+
+        /** @deprecated Remove when Guzzle 5 support is dropped */
         if (!isset($app['guzzle.plugins'])) {
             $app['guzzle.plugins'] = [];
         }
@@ -19,10 +35,18 @@ class GuzzleServiceProvider implements ServiceProviderInterface
         // Register a simple Guzzle Client object (requires absolute URLs when guzzle.base_url is unset)
         $app['guzzle.client'] = $app->share(
             function () use ($app) {
-                $options = ['base_url' => $app['guzzle.base_url']];
-                $client = new Client($options);
-                foreach ($app['guzzle.plugins'] as $plugin) {
-                    $client->addSubscriber($plugin);
+                if ($app['guzzle.api_version'] === 5) {
+                    $options = ['base_url' => $app['guzzle.base_url']];
+                    $client = new Client($options);
+                    foreach ($app['guzzle.plugins'] as $plugin) {
+                        $client->addSubscriber($plugin);
+                    }
+                } else {
+                    $options = [
+                        'base_uri' => $app['guzzle.base_url'],
+                        'handler'  => $app['guzzle.handler_stack'],
+                    ];
+                    $client = new Client($options);
                 }
 
                 return $client;

--- a/tests/phpunit/unit/Controller/Async/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Async/GeneralTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\Tests\Controller\Async;
 
 use Bolt\Controller\Zone;
@@ -67,8 +68,14 @@ class GeneralTest extends ControllerUnitTest
         $app = $this->getApp();
         $testGuzzle = $this->getMock('GuzzleHttp\Client', ['get'], []);
 
-        $guzzleInterface = $this->getMock('GuzzleHttp\Message\RequestInterface');
-        $testGuzzle->expects($this->at(0))->method('get')->will($this->throwException(new RequestException('Mock Fail', $guzzleInterface)));
+        if ($app['guzzle.api_version'] === 5) {
+            $guzzleInterface = $this->getMock('GuzzleHttp\Message\RequestInterface');
+            $testGuzzle->expects($this->at(0))->method('get')->will($this->throwException(new RequestException('Mock Fail', $guzzleInterface)));
+        } else {
+            $guzzleInterface = $this->getMock('Psr\Http\Message\RequestInterface');
+            $testGuzzle->expects($this->at(0))->method('get')->will($this->throwException(new RequestException('Mock Fail', $guzzleInterface)));
+        }
+
         $app['guzzle.client'] = $testGuzzle;
 
         $changeRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogChange');

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Controller\Zone;
@@ -121,7 +122,12 @@ class GeneralTest extends ControllerUnitTest
         // Test for the Exception if connection fails to the prefill service
         $store = $this->getMock('Bolt\Storage', ['preFill'], [$this->getApp()]);
 
-        $guzzleRequest = new \GuzzleHttp\Message\Request('GET', '');
+        $app = $this->getApp();
+        if ($app['guzzle.api_version'] === 5) {
+            $guzzleRequest = new \GuzzleHttp\Message\Request('GET', '');
+        } else {
+            $guzzleRequest = new \GuzzleHttp\Psr7\Request('GET', '');
+        }
         $store->expects($this->any())
             ->method('preFill')
             ->will($this->returnCallback(function () use ($guzzleRequest) {

--- a/tests/phpunit/unit/Storage/PrefillTest.php
+++ b/tests/phpunit/unit/Storage/PrefillTest.php
@@ -1,8 +1,10 @@
 <?php
+
 namespace Bolt\Tests\Storage;
 
 use Bolt\Tests\BoltUnitTest;
 use GuzzleHttp\Message\MessageFactory;
+use GuzzleHttp\Psr7\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -16,9 +18,15 @@ class PrefillTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $factory = new MessageFactory();
-        $request = $factory->createRequest('GET', '/');
         $response = new Response(Response::HTTP_OK);
+
+        if ($app['guzzle.api_version'] === 5) {
+            $factory = new MessageFactory();
+            $request = $factory->createRequest('GET', '/');
+        } else {
+            $request = new Request('GET', '/');
+        }
+
         $guzzle = $this->getMock('GuzzleHttp\Client', ['get']);
 
         $guzzle->expects($this->once())


### PR DESCRIPTION
With the agreement in the development meeting 2016-01-12 to have Bolt 3 require PHP 5.5.9, we are now able to use Guzzle 6 as our default.

This PR creates a compatibility layer for projects that still require Guzzle 5 in their root project, but for everyone else… PSR-7 is here. :grin: 