### PR TITLE
Add repeater fields to legacy content objects

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2674,7 +2674,7 @@ class Storage
         foreach ($ids as $id) {
             foreach ($contenttype['fields'] as $fieldkey => $field) {
                 if ($field['type'] == 'repeater') {
-                    $collection = new RepeatingFieldCollection($app['storage'], $this->mapping);
+                    $collection = new RepeatingFieldCollection($this->app['storage'], $field);
                     $existingFields = $repo->getExistingFields($id, $contenttypeslug, $fieldkey) ?: [];
                     foreach ($existingFields as $group => $ids) {
                         $collection->addFromReferences($ids, $group);

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -985,6 +985,7 @@ class Storage
         // Make sure all content has their taxonomies and relations
         $this->getTaxonomy($content);
         $this->getRelation($content);
+        $this->getRepeaters($content);
 
         // Set up the $pager array with relevant values.
         $rowcount = $this->app['db']->executeQuery($pagerquery)->fetch();
@@ -1689,6 +1690,8 @@ class Storage
         foreach ($rows as $row) {
             $objects[$row['id']] = $this->getContentObject($contenttype, $row);
         }
+
+        $this->getRepeaters($objects);
 
         if ($getTaxoAndRel) {
             // Make sure all content has their taxonomies and relations

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2653,6 +2653,38 @@ class Storage
         }
     }
 
+    public function getRepeaters($content)
+    {
+
+        $ids = util::array_pluck($content, 'id');
+
+        if (empty($ids)) {
+            return;
+        }
+
+        // Get the contenttype from first $content
+        $contenttypeslug = $content[util::array_first_key($content)]->contenttype['slug'];
+        $contenttype = $this->getContentType($contenttypeslug);
+        $repo = $this->app['storage']->getRepository('Bolt\Storage\Entity\FieldValue');
+
+        foreach ($ids as $id) {
+            foreach ($contenttype['fields'] as $fieldkey => $field) {
+                if ($field['type'] == 'repeater') {
+                    $collection = new RepeatingFieldCollection($app['storage'], $this->mapping);
+                    $existingFields = $repo->getExistingFields($id, $contenttypeslug, $fieldkey) ?: [];
+                    foreach ($existingFields as $group => $ids) {
+                        $collection->addFromReferences($ids, $group);
+                    }
+                    $content[$id]->setValue($field, $collection);
+                }
+            }
+
+        }
+
+
+
+    }
+
     /**
      * Update / insert relation for a given content-unit.
      *

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2679,7 +2679,7 @@ class Storage
                     foreach ($existingFields as $group => $ids) {
                         $collection->addFromReferences($ids, $group);
                     }
-                    $content[$id]->setValue($field, $collection);
+                    $content[$id]->setValue($fieldkey, $collection);
                 }
             }
 

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -10,6 +10,7 @@ use Bolt\Helpers\Arr;
 use Bolt\Helpers\Html;
 use Bolt\Helpers\Str;
 use Bolt\Pager;
+use Bolt\Storage\Field\Collection\RepeatingFieldCollection;
 use Bolt\Translation\Translator as Trans;
 use Doctrine\DBAL\Connection as DoctrineConn;
 use Doctrine\DBAL\DBALException;

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -171,31 +171,9 @@ class RepeaterType extends FieldTypeBase
      */
     protected function getExistingFields($entity)
     {
-        $query = $this->em->createQueryBuilder()
-            ->select('grouping, id', 'name')
-            ->from($this->mapping['tables']['field_value'])
-            ->where('content_id = :id')
-            ->andWhere('contenttype = :contenttype')
-            ->andWhere('name = :name')
-            ->setParameters([
-                'id'          => $entity->id,
-                'contenttype' => $entity->getContenttype(),
-                'name'        => $this->mapping['fieldname'],
-            ]);
+        $repo = $this->em->getRepository('Bolt\Storage\Entity\FieldValue');
 
-        $results = $query->execute()->fetchAll();
-
-        $fields = [];
-
-        if (!$results) {
-            return $fields;
-        }
-
-        foreach ($results as $result) {
-            $fields[$result['grouping']][] = $result['id'];
-        }
-
-        return $fields;
+        return $repo->getExistingFields($entity->getId(), $entity->getContenttype(), $this->mapping['fieldname']);
     }
 
     /**

--- a/src/Storage/Repository/FieldValueRepository.php
+++ b/src/Storage/Repository/FieldValueRepository.php
@@ -12,4 +12,37 @@ use Bolt\Storage\Repository;
 
 class FieldValueRepository extends Repository
 {
+    public function queryExistingFields($id, $contenttype, $field)
+    {
+        $query = $this->createQueryBuilder()
+            ->select('grouping, id', 'name')
+            ->where('content_id = :id')
+            ->andWhere('contenttype = :contenttype')
+            ->andWhere('name = :name')
+            ->setParameters([
+                'id'          => $id,
+                'contenttype' => $contenttype,
+                'name'        => $field,
+            ]);
+
+        return $query;
+    }
+
+    public function getExistingFields($id, $contenttype, $field)
+    {
+        $query = $this->queryExistingFields($id, $contenttype, $field);
+        $results = $query->execute()->fetchAll();
+
+        $fields = [];
+
+        if (!$results) {
+            return $fields;
+        }
+
+        foreach ($results as $result) {
+            $fields[$result['grouping']][] = $result['id'];
+        }
+
+        return $fields;
+    }
 }


### PR DESCRIPTION
This makes repeating fields available in templates. Note that this PR doesn't actually implement the output of these fields, just makes them available in the resulting `record` object.

The field values are different to standard value based fields in that the field contains an iterable collection, so you will need to do two for loops one to loop the sets and then a further inner loop to list each of the fields within a set.