### PR TITLE
VarDumper, Casters, and Image Info! Oh my!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     ],
     "license" : "MIT",
     "require" : {
-        "bolt/dumper" : "~2.0",
         "bolt/filesystem" : "^2.0@dev",
         "bolt/package-wrapper": "^3.0",
         "bolt/pathogen" : "~0.6",

--- a/src/Application.php
+++ b/src/Application.php
@@ -181,6 +181,8 @@ class Application extends Silex\Application
             $this->register(new WhoopsServiceProvider());
         }
 
+        $this->register(new Provider\DumperServiceProvider());
+
         // Initialize Web Profiler providers
         $this->initProfiler();
     }

--- a/src/Debug/Caster/AbstractCasterProvider.php
+++ b/src/Debug/Caster/AbstractCasterProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bolt\Debug\Caster;
+
+/**
+ * Abstract class providing casters.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+abstract class AbstractCasterProvider
+{
+    /**
+     * @return callable[]
+     */
+    protected static function defineCasters()
+    {
+        return [];
+    }
+
+    public static function getCasters()
+    {
+        $cls = get_called_class();
+
+        return array_map(
+            function ($func) use ($cls) {
+                if (method_exists($cls, $func)) {
+                    return [$cls, $func];
+                }
+
+                return $func;
+            },
+            static::defineCasters()
+        );
+    }
+}

--- a/src/Debug/Caster/FilesystemCasters.php
+++ b/src/Debug/Caster/FilesystemCasters.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Bolt\Debug\Caster;
+
+use Bolt\Filesystem\Handler\DirectoryInterface;
+use Bolt\Filesystem\Handler\FileInterface;
+use Bolt\Filesystem\Handler\HandlerInterface;
+use Bolt\Filesystem\Handler\Image;
+use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Casters for Filesystem objects.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class FilesystemCasters extends AbstractCasterProvider
+{
+    protected static function defineCasters()
+    {
+        return [
+            HandlerInterface::class   => 'castHandler',
+            FileInterface::class      => 'castFile',
+            DirectoryInterface::class => 'castDirectory',
+            Image::class              => 'castImage',
+            Image\Info::class         => 'castImageInfo',
+            Image\Type::class         => 'castImageType',
+            Image\Dimensions::class   => 'castDimensions',
+            Image\Exif::class         => 'castImageExif',
+        ];
+    }
+
+    public static function castHandler(HandlerInterface $handler, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        // Populate lazy loaded properties
+        $a[Caster::PREFIX_PROTECTED . 'fullPath'] = $handler->getFullPath();
+        $a[Caster::PREFIX_PROTECTED . 'dirname'] = $handler->getDirname();
+        $a[Caster::PREFIX_PROTECTED . 'filename'] = $handler->getFilename();
+        $a[Caster::PREFIX_PROTECTED . 'exists'] = $handler->exists();
+        $a[Caster::PREFIX_PROTECTED . 'type'] = $handler->getType();
+        $a[Caster::PREFIX_PROTECTED . 'timestamp'] = $handler->getTimestamp();
+        $a[Caster::PREFIX_PROTECTED . 'visibility'] = $handler->getVisibility();
+
+        // Some methods return results instead of setting properties, show these as virtual.
+        if ($ext = $handler->getExtension()) {
+            $a[Caster::PREFIX_VIRTUAL . 'extension'] = $ext;
+        }
+        $a[Caster::PREFIX_VIRTUAL . 'dir'] = $handler->isDir();
+        $a[Caster::PREFIX_VIRTUAL . 'file'] = $handler->isFile();
+        $a[Caster::PREFIX_VIRTUAL . 'image'] = $handler->isImage();
+        $a[Caster::PREFIX_VIRTUAL . 'document'] = $handler->isDocument();
+        $a[Caster::PREFIX_VIRTUAL . 'carbon'] = $handler->getCarbon();
+        $a[Caster::PREFIX_VIRTUAL . 'public'] = $handler->isPublic();
+        $a[Caster::PREFIX_VIRTUAL . 'private'] = $handler->isPrivate();
+
+        return $a;
+    }
+
+    public static function castFile(FileInterface $file, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        $a[Caster::PREFIX_PROTECTED . 'mimetype'] = $file->getMimeType();
+        $a[Caster::PREFIX_PROTECTED . 'size'] = $file->getSize();
+        $a[Caster::PREFIX_VIRTUAL . 'sizeFormatted'] = $file->getSizeFormatted();
+
+        return $a;
+    }
+
+    public static function castDirectory(DirectoryInterface $directory, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        $a[Caster::PREFIX_VIRTUAL . 'root'] = $directory->isRoot();
+
+        return $a;
+    }
+
+    public static function castImage(Image $image, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        $a[Caster::PREFIX_PROTECTED . 'info'] = $image->getInfo();
+
+        return $a;
+    }
+
+    public static function castImageInfo(Image\Info $info, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        $a[Caster::PREFIX_VIRTUAL . 'width'] = $info->getWidth();
+        $a[Caster::PREFIX_VIRTUAL . 'height'] = $info->getHeight();
+
+        return $a;
+    }
+
+    public static function castImageType(Image\Type $type, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        unset($a["\0Bolt\\Filesystem\\Handler\\Image\\Type\0name"]);
+
+        $a[Caster::PREFIX_VIRTUAL . 'string'] = $type->toString();
+        $a[Caster::PREFIX_VIRTUAL . 'mimeType'] = $type->getMimeType();
+        $a[Caster::PREFIX_VIRTUAL . 'extension'] = $type->getExtension();
+        $stub->class .= sprintf(' "%s"', $type->toString());
+
+        return $a;
+    }
+
+    public static function castDimensions(Image\Dimensions $dimensions, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        $stub->class .= sprintf(' "%s"', (string) $dimensions);
+
+        return $a;
+    }
+
+    public static function castImageExif(Image\Exif $exif, array $a, Stub $stub, $isNested, $filter = 0)
+    {
+        $a = $a[Caster::PREFIX_PROTECTED . 'data'];
+
+        $a[Caster::PREFIX_VIRTUAL . 'aspectRatio'] = $exif->getAspectRatio();
+        $a[Caster::PREFIX_VIRTUAL . 'latitude'] = $exif->getLatitude();
+        $a[Caster::PREFIX_VIRTUAL . 'longitude'] = $exif->getLongitude();
+
+        return $a;
+    }
+}

--- a/src/Filesystem/Handler/NullableImage.php
+++ b/src/Filesystem/Handler/NullableImage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bolt\Filesystem\Handler;
+
+use Bolt\Filesystem\Exception\IOException;
+use Bolt\Filesystem\Handler\Image;
+
+/**
+ * Image used for twig where exceptions cannot be caught.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class NullableImage extends Image
+{
+    /**
+     * @inheritDoc
+     */
+    public function getInfo($cache = true)
+    {
+        if (!$cache) {
+            $this->info = null;
+        }
+        if (!$this->info) {
+            try {
+                $this->info = $this->filesystem->getImageInfo($this->path);
+            } catch (IOException $e) {
+                $this->info = Image\Info::createEmpty();
+            }
+        }
+
+        return $this->info;
+    }
+}

--- a/src/Provider/DumperServiceProvider.php
+++ b/src/Provider/DumperServiceProvider.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Bolt\Provider;
+
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\VarDumper;
+
+/**
+ * DI for Symfony's VarDumper.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class DumperServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function register(Application $app)
+    {
+        $app['dump'] = $app->protect(
+            function ($var) use ($app) {
+                $app['dumper']->dump($app['dumper.cloner']->cloneVar($var));
+            }
+        );
+
+        VarDumper::setHandler($app['dump']);
+
+        $app['dumper'] = $app->share(
+            function ($app) {
+                return PHP_SAPI === 'cli' ? $app['dumper.cli'] : $app['dumper.html'];
+            }
+        );
+
+        $app['dumper.cli'] = $app->share(
+            function () {
+                return new CliDumper();
+            }
+        );
+
+        $app['dumper.html'] = $app->share(
+            function () {
+                return new HtmlDumper();
+            }
+        );
+
+        $app['dumper.cloner'] = $app->share(
+            function () {
+                $cloner = new VarCloner();
+
+                return $cloner;
+            }
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot(Application $app)
+    {
+    }
+}

--- a/src/Provider/DumperServiceProvider.php
+++ b/src/Provider/DumperServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Provider;
 
+use Bolt\Debug\Caster;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
@@ -50,6 +51,7 @@ class DumperServiceProvider implements ServiceProviderInterface
         $app['dumper.cloner'] = $app->share(
             function () {
                 $cloner = new VarCloner();
+                $cloner->addCasters(Caster\FilesystemCasters::getCasters());
 
                 return $cloner;
             }

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Provider;
 
+use Bolt\Twig\DumpExtension;
 use Bolt\Twig\FilesystemLoader;
 use Bolt\Twig\Handler;
 use Bolt\Twig\TwigExtension;
@@ -72,6 +73,9 @@ class TwigServiceProvider implements ServiceProviderInterface
                 'twig',
                 function (\Twig_Environment $twig, $app) {
                     $twig->addExtension(new TwigExtension($app, $app['twig.handlers'], false));
+                    if ($app['debug'] && isset($app['dump'])) {
+                        $twig->addExtension(new DumpExtension($app['dumper.cloner'], $app['dumper.html']));
+                    }
 
                     return $twig;
                 }

--- a/src/Twig/DumpExtension.php
+++ b/src/Twig/DumpExtension.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Bolt\Twig;
+
+use Symfony\Bridge\Twig\Extension\DumpExtension as BaseDumpExtension;
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
+use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+
+/**
+ * Extended to allow dumper to be passed in.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class DumpExtension extends BaseDumpExtension
+{
+    /** @var ClonerInterface */
+    private $cloner;
+    /** @var DataDumperInterface */
+    private $dumper;
+
+    /**
+     * Constructor.
+     *
+     * @param ClonerInterface          $cloner
+     * @param DataDumperInterface|null $dumper
+     */
+    public function __construct(ClonerInterface $cloner, DataDumperInterface $dumper = null)
+    {
+        parent::__construct($cloner);
+        $this->dumper = $dumper ?: new HtmlDumper();
+        $this->cloner = $cloner;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dump(\Twig_Environment $env, $context)
+    {
+        if (!$env->isDebug()) {
+            return null;
+        }
+
+        if (func_num_args() === 2) {
+            $vars = [];
+            foreach ($context as $key => $value) {
+                if (!$value instanceof \Twig_Template) {
+                    $vars[$key] = $value;
+                }
+            }
+
+            $vars = [$vars];
+        } else {
+            $vars = func_get_args();
+            unset($vars[0], $vars[1]);
+        }
+
+        $output = fopen('php://memory', 'r+b');
+        $prevOutput = $this->dumper->setOutput($output);
+
+        foreach ($vars as $value) {
+            $this->dumper->dump($this->cloner->cloneVar($value));
+        }
+
+        $this->dumper->setOutput($prevOutput);
+
+        rewind($output);
+
+        return stream_get_contents($output);
+    }
+}

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -62,13 +62,16 @@ class ImageHandler
      * Get an image.
      *
      * @param string $filename
+     * @param string $safe
      *
      * @return \Bolt\Filesystem\Handler\ImageInterface
      */
-    public function imageInfo($filename)
+    public function imageInfo($filename, $safe)
     {
         if ($filename instanceof ImageInterface) {
             return $filename;
+        } elseif ($safe) {
+            return null;
         }
 
         $image = $this->app['filesystem']->getFile('files://' . $filename, new NullableImage());

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Twig\Handler;
 
+use Bolt\Filesystem\Handler\ImageInterface;
 use Bolt\Filesystem\Handler\NullableImage;
 use Bolt\Helpers\Image\Thumbnail;
 use Bolt\Library as Lib;
@@ -66,6 +67,10 @@ class ImageHandler
      */
     public function imageInfo($filename)
     {
+        if ($filename instanceof ImageInterface) {
+            return $filename;
+        }
+
         $image = $this->app['filesystem']->getFile('files://' . $filename, new NullableImage());
 
         return $image;

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -2,10 +2,7 @@
 
 namespace Bolt\Twig\Handler;
 
-use Bolt\Filesystem\Handler\Image\Dimensions;
-use Bolt\Filesystem\Handler\Image\Exif;
-use Bolt\Filesystem\Handler\Image\Info;
-use Bolt\Filesystem\Handler\Image\Type;
+use Bolt\Filesystem\Handler\NullableImage;
 use Bolt\Helpers\Image\Thumbnail;
 use Bolt\Library as Lib;
 use Bolt\Translation\Translator as Trans;
@@ -65,17 +62,13 @@ class ImageHandler
      *
      * @param string $filename
      *
-     * @return \Bolt\Filesystem\Handler\Image
+     * @return \Bolt\Filesystem\Handler\ImageInterface
      */
     public function imageInfo($filename)
     {
-        $image = $this->app['filesystem']->getImage('files://' . $filename);
+        $image = $this->app['filesystem']->getFile('files://' . $filename, new NullableImage());
 
-        if (!$image->exists()) {
-            return new Info(new Dimensions(0, 0), Type::getById(IMAGETYPE_UNKNOWN), 0, 0, null, new Exif([]));
-        }
-
-        return $image->getInfo();
+        return $image;
     }
 
     /**
@@ -155,7 +148,7 @@ class ImageHandler
         $thumb = $this->getThumbnail($fileName, $width, $height, $crop);
 
         if ($width === null || $height === null) {
-            $info = $this->imageInfo($thumb->getFileName(), false);
+            $info = $this->imageInfo($thumb->getFileName(), false)->getInfo();
 
             if ($width !== null) {
                 $thumb->setHeight(round($width / $info->getAspectRatio()));

--- a/src/Twig/Handler/UtilsHandler.php
+++ b/src/Twig/Handler/UtilsHandler.php
@@ -60,23 +60,6 @@ class UtilsHandler
     }
 
     /**
-     * Output pretty-printed arrays / objects.
-     *
-     * @param mixed   $var
-     * @param boolean $safe
-     *
-     * @return string
-     */
-    public function printDump($var, $safe)
-    {
-        if ($safe || !$this->app['debug']) {
-            return null;
-        }
-
-        return VarDumper::dump($var);
-    }
-
-    /**
      * Send debug data to the developers FirePHP instance in-browser.
      *
      * @param mixed   $var  The data to be dumped into FirePHP

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -333,7 +333,7 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
      */
     public function imageInfo($filename)
     {
-        return $this->handlers['image']->imageInfo($filename);
+        return $this->handlers['image']->imageInfo($filename, $this->safe);
     }
 
     /**

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -458,11 +458,11 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
     }
 
     /**
-     * @see \Bolt\Twig\Handler\UtilsHandler::printDump()
+     * Just for safe_twig. Main twig overrides this function.
      */
-    public function printDump($var)
+    public function printDump()
     {
-        return $this->handlers['utils']->printDump($var, $this->safe);
+        return null;
     }
 
     /**

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Tests\Twig;
 
+use Bolt\Filesystem\Handler\Image;
+use Bolt\Filesystem\Handler\ImageInterface;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Handler\ImageHandler;
 use Symfony\Component\Filesystem\Filesystem;
@@ -97,17 +99,9 @@ class ImageHandlerTest extends BoltUnitTest
         $app = $this->getApp();
         $handler = new ImageHandler($app);
 
-        $result = $handler->imageInfo('koala.jpg', false);
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Info', $result);
-        $this->assertSame(0, $result->getWidth());
-        $this->assertSame(0, $result->getHeight());
-        $this->assertSame('UNKNOWN', (string) $result->getType());
-        $this->assertNull($result->getMime());
-        $this->assertSame(0.0, $result->getAspectRatio());
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Exif', $result->getExif());
-        $this->assertFalse($result->isLandscape());
-        $this->assertTrue($result->isPortrait());
-        $this->assertFalse($result->isSquare());
+        $image = $handler->imageInfo('koala.jpg', false);
+        $this->assertInstanceOf(ImageInterface::class, $image);
+        $this->assertInstanceOf(Image\Info::class, $image->getInfo());
     }
 
     public function testImageInfo()
@@ -115,21 +109,9 @@ class ImageHandlerTest extends BoltUnitTest
         $app = $this->getApp();
         $handler = new ImageHandler($app);
 
-        $result = $handler->imageInfo('generic-logo.png', false);
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Info', $result);
-        $this->assertSame(624, $result->getWidth());
-        $this->assertSame(351, $result->getHeight());
-        $this->assertSame('JPEG', (string) $result->getType());
-        $this->assertSame('image/jpeg', $result->getMime());
-        $this->assertRegExp('#1.7777#', (string) $result->getAspectRatio());
-        $this->assertFalse($result->getExif()->getLatitude());
-        $this->assertFalse($result->getExif()->getLongitude());
-        $this->assertFalse($result->getExif()->getDatetime());
-        $this->assertFalse($result->getExif()->getOrientation());
-        $this->assertRegExp('#1.7777#', (string) $result->getExif()->getAspectRatio());
-        $this->asserttrue($result->isLandscape());
-        $this->assertFalse($result->isPortrait());
-        $this->assertFalse($result->isSquare());
+        $image = $handler->imageInfo('generic-logo.png', false);
+        $this->assertInstanceOf(ImageInterface::class, $image);
+        $this->assertInstanceOf(Image\Info::class, $image->getInfo());
     }
 
     public function testPopupEmptyFileName()

--- a/tests/phpunit/unit/Twig/Handler/UtilsHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/UtilsHandlerTest.php
@@ -86,39 +86,6 @@ class UtilsHandlerTest extends BoltUnitTest
         $this->assertArrayHasKey('class', $result[0]);
     }
 
-    public function testPrintDumpSafeDebugOn()
-    {
-        $app = $this->getApp();
-        $app['debug'] = true;
-        $handler = new UtilsHandler($app);
-
-        $result = $handler->printDump($this, true);
-        $this->assertNull($result);
-    }
-
-    public function testPrintDumpNoSafeDebugOff()
-    {
-        $app = $this->getApp();
-        $app['debug'] = false;
-        $handler = new UtilsHandler($app);
-
-        $result = $handler->printDump($this, false);
-        $this->assertNull($result);
-    }
-
-    public function testPrintDumpNoSafeDebugOn()
-    {
-        $this->stubVarDumper();
-
-        $app = $this->getApp();
-        $app['debug'] = true;
-        $handler = new UtilsHandler($app);
-
-        $result = $handler->printDump($this, false);
-        $this->assertCount(1, $result);
-        $this->assertInstanceOf('Bolt\Tests\Twig\UtilsHandlerTest', $result);
-    }
-
     public function testPrintFirebugSafeDebugOn()
     {
         $app = $this->getApp();

--- a/tests/phpunit/unit/Twig/TwigExtensionTest.php
+++ b/tests/phpunit/unit/Twig/TwigExtensionTest.php
@@ -445,7 +445,6 @@ class TwigExtensionTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $handlers = $this->getTwigHandlers($app);
-        $handlers['utils'] = $this->getMockHandler('UtilsHandler', 'printDump');
         $twig = new TwigExtension($app, $handlers, true);
 
         $twig->printDump(null, null);


### PR DESCRIPTION
Working backwards: This fixes #4679. The `imageinfo` twig function now returns a filesystem image, which has image info as one of its properties. Note that BC is mostly kept with magic calls. [`NullableImage`](https://github.com/CarsonF/bolt/blob/bugfix/twig-dump/src/Filesystem/Handler/NullableImage.php) was needed to return an empty `Image\Info` where there is a problem, since twig cannot catch exceptions.

The other problem @SahAssar was bringing up is that `dump()` doesn't show all the properties he is expecting (lazy getters and getters that don't have properties). Symfony's VarDumper has a nifty way to extend the data pulled from objects called _Casters_. I created [`FilesystemCasters`](https://github.com/CarsonF/bolt/blob/bugfix/twig-dump/src/Debug/Caster/FilesystemCasters.php) to populate these lazy properties and getter methods without properties.

This caster needs to be injected into `VarCloner`, so DI was needed for the entire object tree (see [`DumperServiceProvider`](https://github.com/CarsonF/bolt/blob/bugfix/twig-dump/src/Provider/DumperServiceProvider.php)).

This also needs to be passed into Twig. Symfony has a `DumpExtension`. I've hooked in, and that fixes #4170. However, the dumper cannot be passed in, only the cloner. So I extended that to allow the dumper to be passed in. Hopefully, I can get that change upstreamed and we won't have to reimplement all of it.

All in all it was lots of stuff, but this is a good foundation for more casters, which will make `dump` more helpful.

Before: 
![before](http://i.imgur.com/RzKzuJs.png)
After: 
![after](https://cloud.githubusercontent.com/assets/932566/12427114/f81c4508-bea2-11e5-84d5-27207c50edd9.png)
