### PR TITLE
Move noscript message to a danger flash message

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -557,7 +557,7 @@ field:
 generic:
     noscript:
         headline: "JavaScript disabled"
-        message: "JavaScript is currently disabled in your browser. Most functionality in Bolt will work without it, but for greater ease of use we recommend you enable JavaScript in your browser."
+        message: "JavaScript is currently disabled in your browser. Bolt requires JavaScript to function properly and continuing without it might corrupt or erase data."
 
 menu:
     configuration:

--- a/app/resources/translations/sv_SE/messages.sv_SE.yml
+++ b/app/resources/translations/sv_SE/messages.sv_SE.yml
@@ -480,7 +480,7 @@ field:
 generic:
     noscript:
         headline: "JavaScript är avstängt"
-        message: "JavaScript är avstängt i din webbläsare. Bolt kan fungera utan det, men många funktioner kräver eller underlättas ifall du aktiverar det. Vänligen aktivera JavaScript."
+        message: "JavaScript är avstängt i din webbläsare. Bolt kräver JavaScript för att fungera korrekt och ifall du fortsätter utan JavaScript så kan du förlora data."
 
 page:
     extend:

--- a/app/view/twig/_sub/_messages.twig
+++ b/app/view/twig/_sub/_messages.twig
@@ -29,3 +29,10 @@
 {% else %}
     {{ self.flashbag }}
 {% endif %}
+
+{# No Javascript #}
+<noscript>
+    <div class="alert alert-danger">
+        <p>{{ __('generic.noscript.message') }}</p>
+    </div>
+</noscript>

--- a/app/view/twig/dashboard/_aside.twig
+++ b/app/view/twig/dashboard/_aside.twig
@@ -1,13 +1,5 @@
 {% import '@bolt/_macro/_panels.twig' as panels %}
 
-{# No Javascript #}
-<noscript>
-    <section>
-        <h2>{{ __('generic.noscript.headline') }}</h2>
-        <p>{{ __('generic.noscript.message') }}</p>
-    </section>
-</noscript>
-
 {# If we're running a development version, show annoying message. #}
 {% if app.bolt_released == false %}
 <div class="panel panel-default panel-news">

--- a/app/view/twig/omnisearch/_aside.twig
+++ b/app/view/twig/omnisearch/_aside.twig
@@ -1,12 +1,5 @@
 {% import '@bolt/_macro/_panels.twig' as panels %}
 
-<noscript>
-    <section>
-        <h2>{{ __('generic.noscript.headline') }}</h2>
-        <p>{{ __('generic.noscript.message') }}</p>
-    </section>
-</noscript>
-
 {{ render(path('dashboardnews')) }}
 
 {{ panels.stack(7) }}


### PR DESCRIPTION
Move noscript message to a danger flash message, which makes it appear on every page and also make it more clear that JS isn't really optional. Fixes #4615, but will require updates of all translations.