### PR TITLE
Fixes "non-interactive configuration" of composer-install by providing extra vars in composer.json

### DIFF
--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -83,7 +83,8 @@ class ScriptHandler
         $webroot = $event->getIO()->askConfirmation('<info>Do you want your web directory to be a separate folder to root? [y/n] </info>', $defaultOptions['bolt-separate-web-dir']);
 
         if ($webroot) {
-            $webname  = $event->getIO()->ask('<info>What do you want your public directory to be named? [default: public] </info>', $defaultOptions['bolt-web-dir']);
+            $defaultDir = $defaultOptions['bolt-web-dir'];
+            $webname  = $event->getIO()->ask('<info>What do you want your public directory to be named? [default: '.$defaultDir.'] </info>', $defaultDir);
             $webname  = trim($webname, '/');
             $assetDir = './' . $webname;
         } else {

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -78,10 +78,12 @@ class ScriptHandler
 
     public static function bootstrap(CommandEvent $event)
     {
-        $webroot = $event->getIO()->askConfirmation('<info>Do you want your web directory to be a separate folder to root? [y/n] </info>', false);
+        $defaultOptions = self::getOptions($event);
+
+        $webroot = $event->getIO()->askConfirmation('<info>Do you want your web directory to be a separate folder to root? [y/n] </info>', $defaultOptions['bolt-separate-web-dir']);
 
         if ($webroot) {
-            $webname  = $event->getIO()->ask('<info>What do you want your public directory to be named? [default: public] </info>', 'public');
+            $webname  = $event->getIO()->ask('<info>What do you want your public directory to be named? [default: public] </info>', $defaultOptions['bolt-web-dir']);
             $webname  = trim($webname, '/');
             $assetDir = './' . $webname;
         } else {
@@ -91,7 +93,7 @@ class ScriptHandler
 
         $generator = new BootstrapGenerator($webroot, $webname);
         $generator->create();
-        $options = array_merge(self::getOptions($event), array('bolt-web-dir' => $assetDir));
+        $options = array_merge($defaultOptions, array('bolt-web-dir' => $assetDir));
         self::installAssets($event, $options);
         $event->getIO()->write('<info>Your project has been setup</info>');
     }
@@ -107,7 +109,8 @@ class ScriptHandler
     {
         $options = array_merge(
             array(
-                'bolt-web-dir'  => 'web',
+                'bolt-separate-web-dir' => true,
+                'bolt-web-dir'  => 'public',
                 'bolt-app-dir'  => 'app',
                 'bolt-dir-mode' => 0777
             ),


### PR DESCRIPTION
So here goes my first pull request, please help me out if I'm doing something wrong.

I posted the issue this weekend in the bolt/composer-install repository, see https://github.com/bolt/composer-install/issues/7. I also described the solution to this problem put forward by this PR.

**Quick summary**
*Problem*: "I want to install Bolt in separate directory, but I can't do this when doing a composer install non-interactively."
*Solution*: "Do a composer install instead with a slightly modified version of the composer.json file, where an extra option named 'bolt-separate-web-dir' can be set."

This PR also modifies the default values so that by default the web root is installed as a separate directory. This way the code reflects the recommendations from [the documentation](https://docs.bolt.cm/installation-advanced), which states:

> As of version 2.0 the location of app resources is completely configurable so you only need to store public assets inside the web root directory. We would strongly recommend that you use this strategy if you have control over your hosting environment.