### PR TITLE
[Extension] Add a trait to simplify extensions to add tables

### DIFF
--- a/src/Extension/DatabaseSchemaTrait.php
+++ b/src/Extension/DatabaseSchemaTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Bolt\Extension;
+
+use Bolt\Storage\Database\Schema\Table\BaseTable;
+use Pimple as Container;
+
+/**
+ * Database schema modification.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+trait DatabaseSchemaTrait
+{
+    /**
+     * Return a set of tables to register.
+     *
+     * @return BaseTable[]
+     */
+    protected function registerExtensionTables()
+    {
+        return [];
+    }
+
+    /**
+     * Call this in register method.
+     *
+     * @internal
+     */
+    final protected function extendDatabaseSchemaServices()
+    {
+        $app = $this->getContainer();
+
+        $app['schema.extension_tables'] = $app->share(
+            $app->extend(
+                'schema.extension_tables',
+                function (\Pimple $tables) use ($app) {
+                    //foreach ($app['members.schema.table']->keys() as $baseName) {
+                    //    $tables[$baseName] = $app['members.schema.table'][$baseName];
+                    //}
+
+                    foreach ((array) $this->registerExtensionTables() as $baseName => $table) {
+                        $tables[$baseName] = $table;
+                    }
+
+                    return $tables;
+                }
+            )
+        );
+    }
+
+    /** @return Container */
+    abstract protected function getContainer();
+}

--- a/src/Storage/Database/Schema/Builder/ExtensionTables.php
+++ b/src/Storage/Database/Schema/Builder/ExtensionTables.php
@@ -27,6 +27,11 @@ class ExtensionTables extends BaseBuilder
     public function getSchemaTables(Schema $schema)
     {
         $tables = [];
+
+        foreach ($this->tables->keys() as $name) {
+            $tables[$name] = $this->tables[$name]->buildTable($schema, $this->prefix . $name, $name, $this->charset, $this->collate);
+        }
+
         foreach ($this->tableGenerators as $generator) {
             $table = call_user_func($generator, $schema);
 
@@ -52,6 +57,8 @@ class ExtensionTables extends BaseBuilder
 
     /**
      * This method allows extensions to register their own tables.
+     *
+     * @deprecated Deprecated since 3.0, to be removed in 4.0.
      *
      * @param callable $generator A generator function that takes the Schema
      *                            instance and returns a table or an array of


### PR DESCRIPTION
Allows:

```php
    /**
     * {@inheritdoc}
     */
    protected function registerExtensionTables()
    {
        return [
            'my_table' => new MyTable(),
        ];
    }
```

**DISCLAIMER:** This is the shorthand version (that will still work), however tables should ideally be DI objects.