### PR TITLE
Default values for fields in contenttypes

### DIFF
--- a/app/view/twig/editcontent/fields/_date.twig
+++ b/app/view/twig/editcontent/fields/_date.twig
@@ -6,7 +6,7 @@
     label:     field.label,
     info:      field.info|default(''),
     options:   field.options.datepicker|default(''),
-    default:   (context.content.id == null and field.default) ? context.content.get(contentkey)|date('Y-m-d') : null,
+    default:   (context.content.id == null and field.default) ? field.default|date('Y-m-d') : null,
     required:  field.required|default(false),
     errortext: field.error|default(''),
 } %}

--- a/app/view/twig/editcontent/fields/_datetime.twig
+++ b/app/view/twig/editcontent/fields/_datetime.twig
@@ -6,7 +6,7 @@
     label:     field.label,
     info:      field.info|default(''),
     options:   field.options.datepicker|default(''),
-    default:   (context.content.id == null and field.default) ? context.content.get(contentkey)|date('Y-m-d H:i:s') : null,
+    default:   (context.content.id == null and field.default) ? field.default|date('Y-m-d H:i:s') : null,
     required:  field.required|default(false),
     errortext: field.error|default(''),
 } %}

--- a/app/view/twig/editcontent/fields/_float.twig
+++ b/app/view/twig/editcontent/fields/_float.twig
@@ -29,7 +29,7 @@
         readonly:        option.readonly,
         title:           option.title,
         type:            'text',
-        value:           0 + context.content.get(contentkey),
+        value:           1 * context.content.get(contentkey)|default(field.default)|default(0),
     }
 } %}
 

--- a/app/view/twig/editcontent/fields/_integer.twig
+++ b/app/view/twig/editcontent/fields/_integer.twig
@@ -30,7 +30,7 @@
         step:            option.step,
         title:           option.title,
         type:            'number',
-        value:           0 + context.content.get(contentkey),
+        value:           1 * context.content.get(contentkey)|default(field.default)|default(0),
     }
 } %}
 

--- a/app/view/twig/editcontent/fields/_relationship.twig
+++ b/app/view/twig/editcontent/fields/_relationship.twig
@@ -1,7 +1,7 @@
 {#=== INIT ===========================================================================================================#}
 
 {# We set the 'format' for the rendering of each <option>. With fallback to a sensible default. #}
-{% set format = context.content.relation.format|default("{{ title|escape }} (№ {{ id }})") %}
+{% set format = relation.format|default("{{ item.title|escape }} (№ {{ item.id }})") %}
 
 {# Use option groups #}
 {% set groupby = relation.groupby|default(false) %}
@@ -21,7 +21,7 @@
 
     {% set options = options|merge([{
         value:    item.id,
-        text:     format|twig({'title': item.title, 'id': item.id}),
+        text:     format|twig({'item' : item, 'title' : item.title, 'id' : item.id}),
         group:    groupby ? item.values[groupby]|default(false) : false,
         selected: (item.id in relselect) or selectedbyrelation,
     }]) %}

--- a/app/view/twig/editcontent/fields/_text.twig
+++ b/app/view/twig/editcontent/fields/_text.twig
@@ -29,7 +29,7 @@
         required:        option.required,
         title:           option.title,
         type:            (option.pattern in ['url', 'email']) ? option.pattern : 'text',
-        value:           context.content.get(contentkey),
+        value:           context.content.get(contentkey)|default(field.default)|default(''),
     }
 } %}
 

--- a/app/view/twig/editcontent/fields/_textarea.twig
+++ b/app/view/twig/editcontent/fields/_textarea.twig
@@ -34,6 +34,6 @@
 
 {% block fieldset_controls %}
     <div class="col-xs-12">
-        <textarea{{ macro.attr(attributes.text) }}>{{ context.content.get(contentkey)|default('') }}</textarea>
+        <textarea{{ macro.attr(attributes.text) }}>{{ context.content.get(contentkey)|default(field.default)|default('') }}</textarea>
     </div>
 {% endblock fieldset_controls %}

--- a/app/view/twig/editcontent/fields/_textarea.twig
+++ b/app/view/twig/editcontent/fields/_textarea.twig
@@ -1,12 +1,13 @@
 {#=== OPTIONS ========================================================================================================#}
 
 {% set option = {
-    class:     ('form-control ' ~ field.class)|trim,
-    height:    field.height|default(''),
-    label:     field.label,
-    info:      field.info|default(''),
-    required:  field.required|default(false),
-    errortext: field.error|default(''),
+    class:       ('form-control ' ~ field.class)|trim,
+    height:      field.height|default(''),
+    label:       field.label,
+    info:        field.info|default(''),
+    required:    field.required|default(false),
+    errortext:   field.error|default(''),
+    placeholder: field.placeholder|default(''),
 } %}
 
 {#=== INIT ===========================================================================================================#}


### PR DESCRIPTION
### Summary:
- partially fixes #4743
- planning to fix #4526 (default value for **geolocation**)

### Comments
I see that default values are generally unused, but i often need that. PR adds an usage of `default` property of field setup in contenttypes (not so verbose). In **date** and **datetime** it was implemented but using incorrect variables.

Also i'm planning to add `placeholder` and `default` value for **markdown** and, probably, **html** fields. Does anyone have objections?

By the way, it would be nice to mention in docs, that for date and datetime you can use "now" as default value (`"now"|date("Y-m-d")` works)