### PR TITLE
Fix Handling of Bi-directional relations

### DIFF
--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -14,7 +14,7 @@
 
 {# Output 'incoming' relations #}
 {% set incomingrelations = context.content.relation.incoming(context.content) %}
-{% if incomingrelations is iterable %}
+{% if context.has.incoming_relations %}
     <p>{{ __('This record is related to:') }}</p>
     <div class="buic-listing" data-bolt-widget="buicListing">
         <table class="table dashboardlisting listing">

--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -20,7 +20,7 @@
         <table class="table dashboardlisting listing">
         {% for incoming in incomingrelations %}
             {% setcontent record = incoming.from_contenttype ~ '/' ~ incoming.from_id %}
-            {% if record %}
+            {% if record and not record.isInverted %}
                 {% set editable = isallowed('edit', record) %}
                 {% set listing_vars = {
                     'compact':       true,

--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -18,9 +18,9 @@
     <p>{{ __('This record is related to:') }}</p>
     <div class="buic-listing" data-bolt-widget="buicListing">
         <table class="table dashboardlisting listing">
-        {% for incoming in incomingrelations %}
+        {% for incoming in incomingrelations if not incoming.isInverted %}
             {% setcontent record = incoming.from_contenttype ~ '/' ~ incoming.from_id %}
-            {% if record and not record.isInverted %}
+            {% if record %}
                 {% set editable = isallowed('edit', record) %}
                 {% set listing_vars = {
                     'compact':       true,

--- a/app/view/twig/editcontent/fields/_relationship.twig
+++ b/app/view/twig/editcontent/fields/_relationship.twig
@@ -8,7 +8,7 @@
 
 {# Currently selected relationship values #}
 {% set relselect = [] %}
-{% for item in context.content.relation.getField(relcontenttype)|default([]) %}
+{% for item in context.content.relation.getField(relcontenttype, true)|default([]) %}
     {% set relselect =  relselect|merge([item.to_id]) %}
 {% endfor %}
 

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -136,10 +136,10 @@ class Relations extends ArrayCollection
     {
         foreach ($this as $k => $existing) {
             if (
-                $existing->getFrom_id() == $entity->getFrom_id() &&
-                $existing->getFrom_contenttype() == $entity->getFrom_contenttype() &&
-                $existing->getTo_contenttype() == $entity->getTo_contenttype() &&
-                $existing->getTo_id() == $entity->getTo_id()
+                $existing->getFromId() == $entity->getFromId() &&
+                $existing->getFromContenttype() == $entity->getFromContenttype() &&
+                $existing->getToContenttype() == $entity->getToContenttype() &&
+                $existing->getTo_id() == $entity->getToId()
             ) {
                 return $existing;
             }

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -131,10 +131,17 @@ class Relations extends ArrayCollection
      *
      * @param $fieldname
      *
+     * @param bool $biDirectional
      * @return Relations
      */
-    public function getField($fieldname)
+    public function getField($fieldname, $biDirectional = false)
     {
+        if ($biDirectional) {
+            return $this->filter(function ($el) use ($entity) {
+                return $el->getTo_contenttype() == $fieldname || $el->getFrom_contenttype() == $fieldname;
+            });
+        }
+
         return $this->filter(function ($el) use ($fieldname) {
             return $el->getTo_contenttype() == $fieldname;
         });

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -116,7 +116,7 @@ class Relations extends ArrayCollection
                     $collectionItem->to_contenttype == $inverseItem['from_contenttype'] &&
                     $collectionItem->to_id == $inverseItem['from_id']
                 ) {
-                    $this->remove($collectionItem);
+                    $this->removeElement($collectionItem);
                 }
             }
         }

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -138,7 +138,13 @@ class Relations extends ArrayCollection
     {
         if ($biDirectional) {
             return $this->filter(function ($el) use ($fieldname) {
-                return $el->getTo_contenttype() == $fieldname || $el->getFrom_contenttype() == $fieldname;
+                if ($el->getTo_contenttype() == $fieldname) {
+                    return true;
+                }
+                if ($el->getFrom_contenttype() == $fieldname) {
+                    $el->actAsInverse();
+                    return true;
+                }
             });
         }
 

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -137,7 +137,7 @@ class Relations extends ArrayCollection
     public function getField($fieldname, $biDirectional = false)
     {
         if ($biDirectional) {
-            return $this->filter(function ($el) use ($entity) {
+            return $this->filter(function ($el) use ($fieldname) {
                 return $el->getTo_contenttype() == $fieldname || $el->getFrom_contenttype() == $fieldname;
             });
         }

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -101,6 +101,28 @@ class Relations extends ArrayCollection
     }
 
     /**
+     * This takes an array resultset of existing inverse relations, that is incoming relations that already exist in
+     * the database but pointing towards this entity. For historic reasons Bolt has treated these as interchangeable
+     * so for backwards compatibility we allow an incoming relation to behave as an outgoing one, but we don't want
+     * to overwrite it in the database. This method takes any affected entity out of the collection before the write
+     * to the database.
+     * @param $inverse
+     */
+    public function filterInverseValues($inverse)
+    {
+        foreach ($inverse as $inverseItem) {
+            foreach ($this as $collectionItem) {
+                if (
+                    $collectionItem->to_contenttype == $inverseItem['from_contenttype'] &&
+                    $collectionItem->to_id == $inverseItem['from_id']
+                ) {
+                    $this->remove($collectionItem);
+                }
+            }
+        }
+    }
+
+    /**
      * This loops over the existing collection to see if the properties in the incoming
      * are already available on a saved record. To do this it checks the four key properties
      * if there's a match it returns the original, otherwise

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -143,8 +143,7 @@ class Edit
             'can'                => $contextCan,
             'has'                => $contextHas,
             'values'             => $contextValues,
-            'relations_list'     => $this->getRelationsList($contentType),
-            'relations'          => $this->getBidirectionalRelations($content, $contentType['relations'])
+            'relations_list'     => $this->getRelationsList($contentType)
         ];
 
         return $context;
@@ -173,12 +172,6 @@ class Edit
         }
 
         return $list;
-    }
-
-    private function getBidirectionalRelations($content, $relations)
-    {
-        $original = $content->getRelation();
-
     }
 
     /**

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -144,7 +144,7 @@ class Edit
             'has'                => $contextHas,
             'values'             => $contextValues,
             'relations_list'     => $this->getRelationsList($contentType),
-            'relations'          => $this->getBidirectionalRelations($content, $this->getRelationsList($contentType))
+            'relations'          => $this->getBidirectionalRelations($content, $contentType['relations'])
         ];
 
         return $context;
@@ -177,6 +177,7 @@ class Edit
 
     private function getBidirectionalRelations($content, $relations)
     {
+        $original = $content->getRelation();
 
     }
 

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -144,6 +144,7 @@ class Edit
             'has'                => $contextHas,
             'values'             => $contextValues,
             'relations_list'     => $this->getRelationsList($contentType),
+            'relations'          => $this->getBidirectionalRelations($content, $this->getRelationsList($contentType))
         ];
 
         return $context;
@@ -172,6 +173,11 @@ class Edit
         }
 
         return $list;
+    }
+
+    private function getBidirectionalRelations($content, $relations)
+    {
+
     }
 
     /**

--- a/src/Storage/Entity/MagicAttributeTrait.php
+++ b/src/Storage/Entity/MagicAttributeTrait.php
@@ -105,4 +105,29 @@ trait MagicAttributeTrait
     {
         return in_array($field, $this->getFields());
     }
+
+    /**
+     * Converts a string from underscored to Camel Case.
+     *
+     * @param string $id A string to camelize
+     *
+     * @return string The camelized string
+     */
+    public function camelize($id)
+    {
+        return strtr(ucwords(strtr($id, array('_' => ' ', '.' => '_ ', '\\' => '_ '))), array(' ' => ''));
+    }
+
+    /**
+     * Converts a string from camel case to underscored.
+     *
+     * @param string $id The string to underscore
+     *
+     * @return string The underscored string
+     */
+    public function underscore($id)
+    {
+        return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), str_replace('_', '.', $id)));
+    }
+
 }

--- a/src/Storage/Entity/MagicAttributeTrait.php
+++ b/src/Storage/Entity/MagicAttributeTrait.php
@@ -53,7 +53,7 @@ trait MagicAttributeTrait
         if (strncasecmp($method, 'get', 3) == 0) {
             if ($this->has($var) && property_exists($this, $var)) {
                 return $this->$var;
-            } elseif ($this->has($underscored) && property_exists($this, $underscored) ){
+            } elseif ($this->has($underscored) && property_exists($this, $underscored)) {
                 return $this->$underscored;
             } elseif ($this->has($var)) {
                 return $this->_fields[$var];

--- a/src/Storage/Entity/MagicAttributeTrait.php
+++ b/src/Storage/Entity/MagicAttributeTrait.php
@@ -48,10 +48,13 @@ trait MagicAttributeTrait
     public function __call($method, $arguments)
     {
         $var = lcfirst(substr($method, 3));
+        $underscored = $this->underscore($var);
 
         if (strncasecmp($method, 'get', 3) == 0) {
             if ($this->has($var) && property_exists($this, $var)) {
                 return $this->$var;
+            } elseif ($this->has($underscored) && property_exists($this, $underscored) ){
+                return $this->$underscored;
             } elseif ($this->has($var)) {
                 return $this->_fields[$var];
             }
@@ -66,6 +69,8 @@ trait MagicAttributeTrait
         if (strncasecmp($method, 'set', 3) == 0) {
             if ($this->has($var) && property_exists($this, $var)) {
                 $this->$var = $arguments[0];
+            } elseif ($this->has($underscored) && property_exists($this, $underscored)) {
+                $this->$underscored = $arguments[0];
             } else {
                 $this->_fields[$var] = $arguments[0];
             }

--- a/src/Storage/Entity/Relations.php
+++ b/src/Storage/Entity/Relations.php
@@ -27,4 +27,9 @@ class Relations extends Entity
 
         return $this->to_id;
     }
+
+    public function isInverted()
+    {
+        return $this->invert;
+    }
 }

--- a/src/Storage/Entity/Relations.php
+++ b/src/Storage/Entity/Relations.php
@@ -11,4 +11,20 @@ class Relations extends Entity
     protected $from_id;
     protected $to_contenttype;
     protected $to_id;
+
+    private $invert = false;
+
+    public function actAsInverse()
+    {
+        $this->invert = true;
+    }
+
+    public function getToId()
+    {
+        if ($this->invert === true) {
+            return $this->from_id;
+        }
+
+        return $this->to_id;
+    }
 }

--- a/src/Storage/Entity/Relations.php
+++ b/src/Storage/Entity/Relations.php
@@ -19,7 +19,7 @@ class Relations extends Entity
         $this->invert = true;
     }
 
-    public function getToId()
+    public function getTo_id()
     {
         if ($this->invert === true) {
             return $this->from_id;

--- a/src/Storage/Entity/Relations.php
+++ b/src/Storage/Entity/Relations.php
@@ -19,7 +19,7 @@ class Relations extends Entity
         $this->invert = true;
     }
 
-    public function getTo_id()
+    public function getToId()
     {
         if ($this->invert === true) {
             return $this->from_id;

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -123,8 +123,10 @@ class RelationType extends FieldTypeBase
 
         // Fetch existing relations and create two sets of records, updates and deletes.
         $existingDB = $this->getExistingRelations($entity) ?: [];
+        $existingInverse = $this->getInverseRelations($entity) ?: [];
         $collection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
         $collection->setFromDatabaseValues($existingDB);
+        $collection->filterInverseValues($existingInverse);
         $toDelete = $collection->update($relations);
         $repo = $this->em->getRepository('Bolt\Storage\Entity\Relations');
 
@@ -170,6 +172,29 @@ class RelationType extends FieldTypeBase
                 'from_id'          => $entity->id,
                 'from_contenttype' => $entity->getContenttype(),
                 'to_contenttype'   => $this->mapping['fieldname'],
+            ]);
+        $result = $query->execute()->fetchAll();
+
+        return $result ?: [];
+    }
+
+    /**
+     * Get inverse relationship records. That is ones where the definition happened on the opposite record
+     *
+     * @param mixed $entity
+     *
+     * @return array
+     */
+    protected function getInverseRelations($entity)
+    {
+        $query = $this->em->createQueryBuilder()
+            ->select('*')
+            ->from($this->mapping['target'])
+            ->where('to_id = :to_id')
+            ->andWhere('to_contenttype = :to_contenttype')
+            ->setParameters([
+                'to_id'          => $entity->id,
+                'to_contenttype' => $entity->getContenttype()
             ]);
         $result = $query->execute()->fetchAll();
 

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -126,8 +126,8 @@ class RelationType extends FieldTypeBase
         $existingInverse = $this->getInverseRelations($entity) ?: [];
         $collection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
         $collection->setFromDatabaseValues($existingDB);
-        $collection->filterInverseValues($existingInverse);
         $toDelete = $collection->update($relations);
+        $collection->filterInverseValues($existingInverse);
         $repo = $this->em->getRepository('Bolt\Storage\Entity\Relations');
 
         // Add a listener to the main query save that sets the from ID on save and then saves the relations


### PR DESCRIPTION
This takes care of maintaining backwards compatibility with Bi-directional related records. For example where pages is related to entries and entries related to pages. 

The current behaviour operates on a first-come first-saved system for determining the direction of the relation and once saved there's no distinction between a page that's related to an entry, or an entry related to a page.

This PR attempts to replicate this, whilst leaving open the ability to deprecate in future when we are ready to move to uni-directional relations.