### PR TITLE
Allow to set context for custom Twig functions and filters

### DIFF
--- a/src/BaseExtension.php
+++ b/src/BaseExtension.php
@@ -387,27 +387,33 @@ abstract class BaseExtension implements ExtensionInterface
     /**
      * Add a Twig Function.
      *
-     * @param string $name
-     * @param string $callback
-     * @param array  $options
+     * @param string        $name
+     * @param string|array  $callback
+     * @param array         $options
      */
     public function addTwigFunction($name, $callback, $options = array())
     {
+        if (is_string($callback)) {
+            $callback = array($this, $callback);
+        }
         $this->initializeTwig();
-        $this->twigExtension->addTwigFunction(new \Twig_SimpleFunction($name, array($this, $callback), $options));
+        $this->twigExtension->addTwigFunction(new \Twig_SimpleFunction($name, $callback, $options));
     }
 
     /**
      * Add a Twig Filter.
      *
-     * @param string $name
-     * @param string $callback
-     * @param array  $options
+     * @param string        $name
+     * @param string|array  $callback
+     * @param array         $options
      */
     public function addTwigFilter($name, $callback, $options = array())
     {
+        if (is_string($callback)) {
+            $callback = array($this, $callback);
+        }
         $this->initializeTwig();
-        $this->twigExtension->addTwigFilter(new \Twig_SimpleFilter($name, array($this, $callback), $options));
+        $this->twigExtension->addTwigFilter(new \Twig_SimpleFilter($name, $callback, $options));
     }
 
     protected function initializeTwig()


### PR DESCRIPTION
The methods to add custom filters and functions for Twig have hardcoded context so the developer can only write his handlers in the Extension.php file. This change will allow to set any context so the handlers can be moved to separate classes which will improve the code organization.

With this change functions and filter can be added in two new ways:
```
$twigHandlers = new TwigHandlers();
$this->addTwigFunction('my_twig_func', array($twigHandlers , 'myTwigFunc'));
```

```
$twigHandlers = new TwigHandlers($this);
// inside TwigHandlers class:
$this->extension->addTwigFunction('my_twig_func', array($this, 'myTwigFunc'));
```
Of course this pull request is backward compatible so when a string with method name is passed then the default context is used.