### PR TITLE
option to allow numeric slugs

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1315,7 +1315,10 @@ class Storage
             // like 'entry/12' or '/page/12345'
             $decoded['contenttypes'] = $this->decodeContentTypesFromText($match[1]);
             $decoded['return_single'] = true;
-            $ctypeParameters['id'] = $match[2];
+            // if allow_numeric_slug option is set on contenttype, interpret number as slug instead of id
+            $contenttype = $this->getContentType($decoded['contenttypes'][0]);
+            $field = ( $contenttype['allow_numeric_slugs'] === true ? 'slug' : 'id' );
+            $ctypeParameters[$field] = $match[2];
         } elseif (preg_match('#^/?([a-z0-9_(\),-]+)/search(/([0-9]+))?$#i', $textquery, $match)) {
             // like 'page/search or '(entry,page)/search'
             $decoded['contenttypes'] = $this->decodeContentTypesFromText($match[1]);

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2795,8 +2795,8 @@ class Storage
         $id = intval($id);
         $slug = $this->app['slugify']->slugify($title);
 
-        // Don't allow strictly numeric slugs.
-        if (is_numeric($slug)) {
+        // Don't allow strictly numeric slugs, unless allow_numeric_slugs options is set
+        if (is_numeric($slug) && $contenttype['allow_numeric_slugs'] != 'true') {
             $slug = $contenttype['singular_slug'] . "-" . $slug;
         }
 

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1317,7 +1317,7 @@ class Storage
             $decoded['return_single'] = true;
             // if allow_numeric_slug option is set on contenttype, interpret number as slug instead of id
             $contenttype = $this->getContentType($decoded['contenttypes'][0]);
-            $field = ( $contenttype['allow_numeric_slugs'] === true ? 'slug' : 'id' );
+            $field = ($contenttype['allow_numeric_slugs'] === true ? 'slug' : 'id');
             $ctypeParameters[$field] = $match[2];
         } elseif (preg_match('#^/?([a-z0-9_(\),-]+)/search(/([0-9]+))?$#i', $textquery, $match)) {
             // like 'page/search or '(entry,page)/search'

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2796,7 +2796,7 @@ class Storage
         $slug = $this->app['slugify']->slugify($title);
 
         // Don't allow strictly numeric slugs, unless allow_numeric_slugs options is set
-        if (is_numeric($slug) && $contenttype['allow_numeric_slugs'] != 'true') {
+        if (is_numeric($slug) && $contenttype['allow_numeric_slugs'] !== true) {
             $slug = $contenttype['singular_slug'] . "-" . $slug;
         }
 


### PR DESCRIPTION
Introduces an option `allow_numeric_slugs` in contenttypes.yml. 
See issues #3001 #4770 .

Docs (Contenttypes and records > Defining contenttypes > available options):

* `allow_numeric_slugs`: By default, Bolt prefixes slugs that would be purely numeric with the contenttype slug in order to prevent conflicts with routes of form /{contenttypeslug}/{id}. If this option is set to `true`, numeric slugs remain unprefixed. Care has to be taken not to use routes with IDs in the frontend.

Or something like this.