### PR TITLE
Using `1.x-dev` for monolog/monolog.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-pdo" : "*",
         "filp/whoops" : "~2.0",
         "ircmaxell/random-lib" : "~1.1",
-        "monolog/monolog" : "~1.12",
+        "monolog/monolog" : "^1.17|^2.0@dev",
         "nesbot/carbon" : "^1.20",
         "PasswordLib/PasswordLib": "^1.0@beta",
         "php" : ">=5.5.9",


### PR DESCRIPTION
Partial / preliminary fix for #4796