### PR TITLE
Improve process for adding custom fields to new storage layer

### DIFF
--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -66,7 +66,7 @@ class StorageServiceProvider implements ServiceProviderInterface
 
         $app['storage.field_manager'] = $app->share(
             function ($app) {
-                $manager = new FieldManager($app['storage.typemap']);
+                $manager = new FieldManager($app['storage.typemap'], $app['config']);
 
                 foreach ($app['storage.typemap'] as $field) {
                     if (isset($app[$field])) {

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -267,6 +267,22 @@ trait ContentValuesTrait
             return;
         }
 
+        /**
+         * This Block starts introducing new-style hydration into the legacy content object.
+         * To do this we fetch the new field from the manager and hydrate a temporary entity.
+         *
+         * We don't return at this point so continue to let other transforms happen below so hopefully
+         * old behaviour should still happen where adjusted.
+         */
+
+        $newFieldType = $this->app['storage.field_manager']->getFieldFor($this->contenttype['fields'][$key]['type']);
+        if ($newFieldType) {
+            $newFieldType->mapping['fieldname'] = $key;
+            $entity = new Content();
+            $newFieldType->hydrate([$key => $value], $entity);
+            $value = $entity->$key;
+        }
+
         if (in_array($key, ['datecreated', 'datechanged', 'datepublish', 'datedepublish'])) {
             if (!preg_match("/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/", $value)) {
                 // @todo Try better date-parsing, instead of just setting it to

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -271,12 +271,12 @@ trait ContentValuesTrait
          * This Block starts introducing new-style hydration into the legacy content object.
          * To do this we fetch the new field from the manager and hydrate a temporary entity.
          *
-         * We don't return at this point so continue to let other transforms happen below so hopefully
-         * old behaviour should still happen where adjusted.
+         * We don't return at this point so continue to let other transforms happen below so the
+         * old behaviour will still happen where adjusted.
          */
 
-        $newFieldType = $this->app['storage.field_manager']->getFieldFor($this->contenttype['fields'][$key]['type']);
-        if ($newFieldType) {
+        if ($this->app['storage.field_manager']->hasCustomHandler($this->contenttype['fields'][$key]['type'])) {
+            $newFieldType = $this->app['storage.field_manager']->getFieldFor($this->contenttype['fields'][$key]['type']);
             $newFieldType->mapping['fieldname'] = $key;
             $entity = new Content();
             $newFieldType->hydrate([$key => $value], $entity);

--- a/src/Storage/Field/Base.php
+++ b/src/Storage/Field/Base.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Storage\Field;
 
+
 class Base implements FieldInterface
 {
     public $name;

--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -2,6 +2,7 @@
 namespace Bolt\Storage\Field\Type;
 
 use Bolt\Storage\EntityManager;
+use Bolt\Storage\Field\FieldInterface;
 use Bolt\Storage\Mapping\ClassMetadata;
 use Bolt\Storage\Query\QueryInterface;
 use Bolt\Storage\QuerySet;
@@ -15,7 +16,7 @@ use Doctrine\DBAL\Types\Type;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-abstract class FieldTypeBase implements FieldTypeInterface
+abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
 {
     public $mapping;
 
@@ -144,6 +145,25 @@ abstract class FieldTypeBase implements FieldTypeInterface
     public function getStorageType()
     {
         return Type::getType($this->mapping['type']);
+    }
+
+    /**
+     * @deprecated
+     * Here to maintain compatibility with the old interface
+     */
+    public function getStorageOptions()
+    {
+        return [];
+    }
+
+    /**
+     * Provides a template that is able to render the field
+     * @deprecated
+     *
+     */
+    public function getTemplate()
+    {
+        return '@bolt/editcontent/fields/_' . $this->getName() . '.twig';
     }
 
     /**

--- a/src/Storage/Field/Type/SlugType.php
+++ b/src/Storage/Field/Type/SlugType.php
@@ -30,4 +30,12 @@ class SlugType extends FieldTypeBase
         }
         parent::persist($queries, $entity);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStorageType()
+    {
+        return Type::getType('string');
+    }
 }

--- a/src/Storage/Field/Type/SlugType.php
+++ b/src/Storage/Field/Type/SlugType.php
@@ -2,6 +2,7 @@
 namespace Bolt\Storage\Field\Type;
 
 use Bolt\Storage\QuerySet;
+use Doctrine\DBAL\Types\Type;
 
 /**
  * This is one of a suite of basic Bolt field transformers that handles

--- a/src/Storage/FieldManager.php
+++ b/src/Storage/FieldManager.php
@@ -13,6 +13,7 @@ class FieldManager
     protected $handlers = [];
     protected $typemap;
     protected $boltConfig;
+    protected $customHandlers = [];
 
     /**
      * Constructor.
@@ -96,7 +97,17 @@ class FieldManager
     public function addFieldType($name, $handler)
     {
         $this->setHandler($name, $handler);
+        $this->customHandlers[] = $name;
         $this->boltConfig->getFields()->addField($handler);
+    }
+
+    /**
+     * @param $name
+     * @return bool
+     */
+    public function hasCustomHandler($name)
+    {
+        return in_array($name, $this->customHandlers);
     }
 
 }

--- a/src/Storage/FieldManager.php
+++ b/src/Storage/FieldManager.php
@@ -80,9 +80,9 @@ class FieldManager
     /**
      * Links the field name found in the config to a callable handler.
      * @param $class
-     * @param callable $handler
+     * @param callable|object $handler
      */
-    public function setHandler($class, callable $handler)
+    public function setHandler($class, $handler)
     {
         $this->handlers[$class] = $handler;
     }

--- a/src/Storage/FieldManager.php
+++ b/src/Storage/FieldManager.php
@@ -22,7 +22,7 @@ class FieldManager
      * @param array $typemap
      * @param Config $config
      */
-    public function __construct($typemap = [], Config $config)
+    public function __construct(array $typemap, Config $config)
     {
         $this->typemap = $typemap;
         $this->boltConfig = $config;

--- a/src/Storage/FieldManager.php
+++ b/src/Storage/FieldManager.php
@@ -1,6 +1,8 @@
 <?php
 namespace Bolt\Storage;
 
+use Bolt\Config;
+
 /**
  * Uses a typemap to construct an instance of a Field
  */
@@ -10,15 +12,20 @@ class FieldManager
     protected $em;
     protected $handlers = [];
     protected $typemap;
+    protected $boltConfig;
 
     /**
      * Constructor.
+     * Requires access to legacy Config class so that it can add fields to the old-style manager
+     * This can be removed once the templating has migrated to the new system.
      *
      * @param array $typemap
+     * @param Config $config
      */
-    public function __construct($typemap = [])
+    public function __construct($typemap = [], Config $config)
     {
         $this->typemap = $typemap;
+        $this->boltConfig = $config;
     }
 
     /**
@@ -57,7 +64,6 @@ class FieldManager
      * Looks up a type from the typemap and returns a field class.
      *
      * @param $type
-     * @param array $mapping
      *
      * @return bool|mixed
      */
@@ -71,8 +77,26 @@ class FieldManager
         return $this->get($class, ['type' => $type]);
     }
 
+    /**
+     * Links the field name found in the config to a callable handler.
+     * @param $class
+     * @param callable $handler
+     */
     public function setHandler($class, callable $handler)
     {
         $this->handlers[$class] = $handler;
     }
+
+    /**
+     * Shorthand to add a field to both the new and legacy managers.
+     *
+     * @param $name
+     * @param $handler
+     */
+    public function addFieldType($name, $handler)
+    {
+        $this->setHandler($name, $handler);
+        $this->boltConfig->getFields()->addField($handler);
+    }
+
 }

--- a/src/Storage/FieldManager.php
+++ b/src/Storage/FieldManager.php
@@ -102,7 +102,10 @@ class FieldManager
     }
 
     /**
+     * Note, this method is for Bolt use only, as a way to distinguish which fields have been added outside of the
+     * core system. It will be removed in a future version.
      * @param $name
+     * @internal
      * @return bool
      */
     public function hasCustomHandler($name)

--- a/src/Storage/QuerySet.php
+++ b/src/Storage/QuerySet.php
@@ -104,4 +104,13 @@ class QuerySet extends \ArrayIterator
     {
         $this->parentId = $parentId;
     }
+
+    /**
+     * A helper method to get the primary database query from a set. Normally this points to the first in the set
+     * @return QueryBuilder
+     */
+    public function getPrimary()
+    {
+        return $this[0];
+    }
 }


### PR DESCRIPTION
This is mainly some helper syntax to make it  easier to add custom fields.

Bolt 3 needs to keep both the new and the old FieldManager in operation since not everything has been ported over to the new system.

So this PR adds access to the old manager to the new one, so that a call to `$app['storage.field_manager']->addFieldType('mycustomfield', $myCustomFieldObject)` will take care of adding to both the new and the old one.

One thing to note, that shouldn't have any impact on BC, is that this PR also adds a hydrate pass of new custom fields to the legacy content hydration. So if you add a new-style field that does something fancy in the hydration step then it will show up in old-style `Content` objects.