### PR TITLE
Lock cocur/slugify to 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "bolt/pathogen" : "~0.6",
         "bolt/thumbs" : "~2.0",
         "brandonwamboldt/utilphp" : "~1.0",
-        "cocur/slugify" : "~1.0",
+        "cocur/slugify" : "1.4",
         "composer/composer" : "dev-master@dev",
         "doctrine/dbal" : "2.5.1",
         "erusev/parsedown-extra" : "~0.2",


### PR DESCRIPTION
Slugify changed the function signature of Slugify::create() in 1.4.1 and we can't (yet) know if they intend to revert in 1.4.2 so we'll lock on a known-good version