### PR TITLE
DB Query Optimisations

### DIFF
--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -62,7 +62,7 @@ class DatabaseServiceProvider implements ServiceProviderInterface
 
         $app['db.query_cache'] = $app->share(
             function ($app) {
-                $cache = ($app['config']->get('general/caching/database') == true) ? $app['cache'] :  new ArrayCache();
+                $cache = ($app['config']->get('general/caching/database') == true) ? $app['cache'] : new ArrayCache();
 
                 return $cache;
             }
@@ -71,13 +71,14 @@ class DatabaseServiceProvider implements ServiceProviderInterface
         $app['db.query_cache_profile'] = $app->share(
             function ($app) {
                 $lifetime = $app['config']->get('general/caching/duration') ?: 0;
+
                 return new QueryCacheProfile($lifetime, 'bolt.db', $app['db.query_cache']);
             }
         );
 
         $app['db'] = $app->share(
             $app->extend('db',
-                function($db) use($app) {
+                function ($db) use ($app) {
                     $db->setQueryCacheProfile($app['db.query_cache_profile']);
 
                     return $db;

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -70,7 +70,7 @@ class DatabaseServiceProvider implements ServiceProviderInterface
 
         $app['db.query_cache_profile'] = $app->share(
             function ($app) {
-                return new QueryCacheProfile(0, 'bolt.db');
+                return new QueryCacheProfile(0, 'bolt.db', $app['db.query_cache']);
             }
         );
 
@@ -78,7 +78,6 @@ class DatabaseServiceProvider implements ServiceProviderInterface
             $app->extend('db',
                 function($db) use($app) {
                     $db->setQueryCacheProfile($app['db.query_cache_profile']);
-                    $db->getConfiguration()->setResultCacheImpl($app['db.query_cache']);
 
                     return $db;
                 }

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -28,7 +28,8 @@ class DatabaseServiceProvider implements ServiceProviderInterface
         }
 
         $app['db.config'] = $app->share(
-            $app->extend('db.config',
+            $app->extend(
+                'db.config',
                 function ($config) use ($app) {
                     $config->setFilterSchemaAssetsExpression($app['schema.tables_filter']);
 
@@ -77,7 +78,8 @@ class DatabaseServiceProvider implements ServiceProviderInterface
         );
 
         $app['db'] = $app->share(
-            $app->extend('db',
+            $app->extend(
+                'db',
                 function ($db) use ($app) {
                     $db->setQueryCacheProfile($app['db.query_cache_profile']);
 

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Bolt\Provider;
 
 use Bolt\EventListener\DoctrineListener;
+use Doctrine\Common\Cache\ArrayCache;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -29,6 +29,8 @@ class DatabaseServiceProvider implements ServiceProviderInterface
             $app->extend('db',
                 function($db) use($app) {
                     $db->setQueryCacheProfile($app['db.query_cache']);
+
+                    return $db;
                 }
             )
         );

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -62,7 +62,7 @@ class DatabaseServiceProvider implements ServiceProviderInterface
 
         $app['db.query_cache'] = $app->share(
             function ($app) {
-                $cache = ($app['config']->get('general/caching/query')) ? $app['cache'] :  new ArrayCache();
+                $cache = ($app['config']->get('general/caching/database') == true) ? $app['cache'] :  new ArrayCache();
 
                 return $cache;
             }
@@ -70,7 +70,8 @@ class DatabaseServiceProvider implements ServiceProviderInterface
 
         $app['db.query_cache_profile'] = $app->share(
             function ($app) {
-                return new QueryCacheProfile(0, 'bolt.db', $app['db.query_cache']);
+                $lifetime = $app['config']->get('general/caching/duration') ?: 0;
+                return new QueryCacheProfile($lifetime, 'bolt.db', $app['db.query_cache']);
             }
         );
 

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -4,6 +4,7 @@ namespace Bolt\Provider;
 
 use Bolt\EventListener\DoctrineListener;
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -26,16 +26,6 @@ class DatabaseServiceProvider implements ServiceProviderInterface
             );
         }
 
-        $app['db'] = $app->share(
-            $app->extend('db',
-                function($db) use($app) {
-                    $db->setQueryCacheProfile($app['db.query_cache']);
-
-                    return $db;
-                }
-            )
-        );
-
         $app['db.config'] = $app->share(
             $app->extend('db.config',
                 function ($config) use ($app) {
@@ -77,6 +67,16 @@ class DatabaseServiceProvider implements ServiceProviderInterface
 
                 return new QueryCacheProfile(0, 'bolt.db');
             }
+        );
+
+        $app['db'] = $app->share(
+            $app->extend('db',
+                function($db) use($app) {
+                    $db->setQueryCacheProfile($app['db.query_cache']);
+
+                    return $db;
+                }
+            )
         );
     }
 

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -25,6 +25,14 @@ class DatabaseServiceProvider implements ServiceProviderInterface
             );
         }
 
+        $app['db'] = $app->share(
+            $app->extend('db',
+                function($db) use($app) {
+                    $db->setQueryCacheProfile($app['db.query_cache']);
+                }
+            )
+        );
+
         $app['db.config'] = $app->share(
             $app->extend('db.config',
                 function ($config) use ($app) {
@@ -56,6 +64,16 @@ class DatabaseServiceProvider implements ServiceProviderInterface
                     return $managers;
                 }
             )
+        );
+
+        $app['db.query_cache'] = $app->share(
+            function ($app) {
+                $cache = ($app['config']->get('general/caching/query')) ? $app['cache'] :  new ArrayCache();
+                $config = $app['db']->getConfiguration();
+                $config->setResultCacheImpl($cache);
+
+                return new QueryCacheProfile(0, 'bolt.db');
+            }
         );
     }
 

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -63,9 +63,13 @@ class DatabaseServiceProvider implements ServiceProviderInterface
         $app['db.query_cache'] = $app->share(
             function ($app) {
                 $cache = ($app['config']->get('general/caching/query')) ? $app['cache'] :  new ArrayCache();
-                $config = $app['db']->getConfiguration();
-                $config->setResultCacheImpl($cache);
 
+                return $cache;
+            }
+        );
+
+        $app['db.query_cache_profile'] = $app->share(
+            function ($app) {
                 return new QueryCacheProfile(0, 'bolt.db');
             }
         );
@@ -73,7 +77,8 @@ class DatabaseServiceProvider implements ServiceProviderInterface
         $app['db'] = $app->share(
             $app->extend('db',
                 function($db) use($app) {
-                    $db->setQueryCacheProfile($app['db.query_cache']);
+                    $db->setQueryCacheProfile($app['db.query_cache_profile']);
+                    $db->getConfiguration()->setResultCacheImpl($app['db.query_cache']);
 
                     return $db;
                 }

--- a/src/Storage/Database/Connection.php
+++ b/src/Storage/Database/Connection.php
@@ -3,6 +3,7 @@
 namespace Bolt\Storage\Database;
 
 use Bolt\Events\FailedConnectionEvent;
+use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\DBALException;
 
 /**
@@ -14,6 +15,9 @@ use Doctrine\DBAL\DBALException;
  */
 class Connection extends \Doctrine\DBAL\Connection
 {
+
+    protected $_queryCacheProfile;
+
     /**
      * {@inheritdoc}
      */
@@ -27,5 +31,24 @@ class Connection extends \Doctrine\DBAL\Connection
                 $this->_eventManager->dispatchEvent('failConnect', $eventArgs);
             }
         }
+    }
+
+    /**
+     * Prepares and executes an SQL query and returns the result as an associative array.
+     *
+     * @param string $sql    The SQL query.
+     * @param array  $params The query parameters.
+     * @param array  $types  The query parameter types.
+     *
+     * @return array
+     */
+    public function fetchAll($sql, array $params = array(), $types = array())
+    {
+        return $this->executeQuery($sql, $params, $types, $this->_queryCacheProfile)->fetchAll();
+    }
+
+    public function setQueryCacheProfile(QueryCacheProfile $profile)
+    {
+        $this->_queryCacheProfile = $profile;
     }
 }

--- a/src/Storage/Database/Connection.php
+++ b/src/Storage/Database/Connection.php
@@ -34,7 +34,10 @@ class Connection extends \Doctrine\DBAL\Connection
     }
 
     /**
-     * Prepares and executes an SQL query and returns the result as an associative array.
+     * This method wraps the native fetchAll method to pass in the configured QueryCacheProfile.
+     * If the profile is set to null then operation will continue identically to the standard, otherwise
+     * the existence of a cache profile will result in the executeQueryCache() method being called.
+     *
      *
      * @param string $sql    The SQL query.
      * @param array  $params The query parameters.
@@ -51,6 +54,11 @@ class Connection extends \Doctrine\DBAL\Connection
         return $result;
     }
 
+
+    /**
+     * Sets an optional Query Cache handler on the connection class
+     * @param QueryCacheProfile $profile
+     */
     public function setQueryCacheProfile(QueryCacheProfile $profile)
     {
         $this->_queryCacheProfile = $profile;

--- a/src/Storage/Database/Connection.php
+++ b/src/Storage/Database/Connection.php
@@ -68,10 +68,11 @@ class Connection extends \Doctrine\DBAL\Connection
      *
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function executeUpdate($query, array $params = array(), array $types = array()) {
+    public function executeUpdate($query, array $params = array(), array $types = array())
+    {
         $result = parent::executeUpdate($query, $params, $types);
         $this->_queryCacheProfile->getResultCacheDriver()->flushAll();
-        
+
         return $result;
     }
 

--- a/src/Storage/Database/Connection.php
+++ b/src/Storage/Database/Connection.php
@@ -44,7 +44,11 @@ class Connection extends \Doctrine\DBAL\Connection
      */
     public function fetchAll($sql, array $params = array(), $types = array())
     {
-        return $this->executeQuery($sql, $params, $types, $this->_queryCacheProfile)->fetchAll();
+        $stmt = $this->executeQuery($sql, $params, $types, $this->_queryCacheProfile);
+        $result = $stmt->fetchAll();
+        $stmt->closeCursor();
+
+        return $result;
     }
 
     public function setQueryCacheProfile(QueryCacheProfile $profile)

--- a/src/Storage/Database/Connection.php
+++ b/src/Storage/Database/Connection.php
@@ -54,6 +54,27 @@ class Connection extends \Doctrine\DBAL\Connection
         return $result;
     }
 
+    /**
+     * Executes an SQL INSERT/UPDATE/DELETE query with the given parameters
+     * and returns the number of affected rows.
+     *
+     * This method supports PDO binding types as well as DBAL mapping types.
+     *
+     * @param string $query  The SQL query.
+     * @param array  $params The query parameters.
+     * @param array  $types  The parameter types.
+     *
+     * @return integer The number of affected rows.
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function executeUpdate($query, array $params = array(), array $types = array()) {
+        $result = parent::executeUpdate($query, $params, $types);
+        $this->_queryCacheProfile->getResultCacheDriver()->flushAll();
+        
+        return $result;
+    }
+
 
     /**
      * Sets an optional Query Cache handler on the connection class

--- a/src/Storage/Database/MasterSlaveConnection.php
+++ b/src/Storage/Database/MasterSlaveConnection.php
@@ -14,6 +14,9 @@ use Doctrine\DBAL\DBALException;
  */
 class MasterSlaveConnection extends \Doctrine\DBAL\Connections\MasterSlaveConnection
 {
+
+    protected $_queryCacheProfile;
+
     /**
      * {@inheritdoc}
      */
@@ -28,4 +31,14 @@ class MasterSlaveConnection extends \Doctrine\DBAL\Connections\MasterSlaveConnec
             }
         }
     }
+
+    /**
+     * Sets an optional Query Cache handler on the connection class
+     * @param QueryCacheProfile $profile
+     */
+    public function setQueryCacheProfile(QueryCacheProfile $profile)
+    {
+        $this->_queryCacheProfile = $profile;
+    }
+
 }

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -66,7 +66,8 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
                 'driver' => 'pdo_sqlite',
                 'prefix' => 'bolt_',
                 'user'   => 'test',
-                'path'   => PHPUNIT_WEBROOT . '/app/database/bolt.db'
+                'path'   => PHPUNIT_WEBROOT . '/app/database/bolt.db',
+                'wrapperClass' => '\Bolt\Storage\Database\Connection',
             ]
         );
 


### PR DESCRIPTION
This PR adds some per-request database query caching which should reduce unnecessary multiple queries for the same item.

To do this it uses the built-in functionality of Doctrine DBAL, which is triggered by passing in a `QueryCacheProfile` instance to the standard `executeQuery` method.

I've also built in the future potential to allow user-level opt-in to the cache (via Bolt's standard `$app['cache']`) although this is for now a secret feature because it warrants some more testing at production scale.