### PR TITLE
[Travis] Don't cache vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,8 +123,8 @@ script:
 after_script:
 
 # cache vendor dirs
-cache:
-  directories:
-    - vendor
-    - $COMPOSER_CACHE_DIR
+#cache:
+#  directories:
+#    - vendor
+#    - $COMPOSER_CACHE_DIR
 


### PR DESCRIPTION
Temporary fix as `cocur/slugify` seems to still be cached at the old 1.4.1