### PR TITLE
Use the computed slug as key for the contenttypes array

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -366,6 +366,7 @@ class Config
         $tempContentTypes = $this->parseConfigYaml('contenttypes.yml');
         foreach ($tempContentTypes as $key => $contentType) {
             $contentType = $this->parseContentType($key, $contentType, $generalConfig);
+            $key = $contentType['slug'];
             $contentTypes[$key] = $contentType;
         }
 


### PR DESCRIPTION
Fixes #4754 