### PR TITLE
Get more fields for the "select dropdowns", if specified in the 'format: '.

### DIFF
--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -190,7 +190,7 @@ class Edit
 
         // Regex the 'format' for things that look like 'item.foo', and intersect with the actual fields in the contenttype.
         if (!empty($relationValues['format'])) {
-            preg_match_all('/item.([a-z0-9_]+)/i', $relationValues['format'], $matches);
+            preg_match_all('/\bitem\.([a-z0-9_]+)\b/i', $relationValues['format'], $matches);
             $fields = array_intersect($matches[1], array_keys($relationConfig['fields']));
         }
 

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -168,11 +168,33 @@ class Edit
         foreach ($contentType['relations'] as $relationName => $relationValues) {
             $repo = $this->em->getRepository($relationName);
             $relationConfig = $this->config->get('contenttypes/' . $relationName, []);
+            $neededFields = $this->neededFields($relationValues, $relationConfig);
 
-            $list[$relationName] = $repo->getSelectList($relationConfig, $relationValues['order']);
+            $list[$relationName] = $repo->getSelectList($relationConfig, $relationValues['order'], $neededFields);
         }
 
         return $list;
+    }
+
+    /**
+     * Get an array of fields mentioned in the 'format:' for a relationship in contenttypes.
+     *
+     * @param array $relationValues
+     * @param array $relationConfig
+     *
+     * @return array
+     */
+    private function neededFields($relationValues, $relationConfig)
+    {
+        $fields = [];
+
+        // Regex the 'format' for things that look like 'item.foo', and intersect with the actual fields in the contenttype.
+        if (!empty($relationValues['format'])) {
+            preg_match_all('/item.([a-z0-9_]+)/i', $relationValues['format'], $matches);
+            $fields = array_intersect($matches[1], array_keys($relationConfig['fields']));
+        }
+
+        return $fields;
     }
 
     /**

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -8,6 +8,7 @@ use Bolt\Filesystem\Manager;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Storage\Entity\Content;
 use Bolt\Storage\EntityManager;
+use Bolt\Storage\Repository;
 use Bolt\Translation\Translator as Trans;
 use Bolt\Users;
 use Cocur\Slugify\Slugify;
@@ -166,6 +167,7 @@ class Edit
         }
 
         foreach ($contentType['relations'] as $relationName => $relationValues) {
+            /** @var Repository\ContentRepository $repo */
             $repo = $this->em->getRepository($relationName);
             $relationConfig = $this->config->get('contenttypes/' . $relationName, []);
             $neededFields = $this->neededFields($relationValues, $relationConfig);

--- a/src/Storage/Repository/ContentRepository.php
+++ b/src/Storage/Repository/ContentRepository.php
@@ -26,9 +26,9 @@ class ContentRepository extends Repository
      *
      * @return array|false
      */
-    public function getSelectList(array $contentType, $order)
+    public function getSelectList(array $contentType, $order, $neededFields = [])
     {
-        $query = $this->querySelectList($contentType, $order);
+        $query = $this->querySelectList($contentType, $order, $neededFields);
 
         return $query->execute()->fetchAll();
     }
@@ -41,7 +41,7 @@ class ContentRepository extends Repository
      *
      * @return QueryBuilder
      */
-    public function querySelectList(array $contentType, $order = null)
+    public function querySelectList(array $contentType, $order = null, $neededFields = [])
     {
         if (strpos($order, '-') === 0) {
             $direction = 'ASC';
@@ -50,8 +50,10 @@ class ContentRepository extends Repository
             $direction = 'DESC';
         }
 
+        $neededFields = array_unshift($neededFields, 'id', $this->getTitleColumnName($contentType) . ' as title');
+
         $qb = $this->createQueryBuilder($contentType['tablename']);
-        $qb->select('id, ' . $this->getTitleColumnName($contentType) . ' as title');
+        $qb->select(implode(', ', $neededFields));
 
         if ($order !== null) {
             $qb->orderBy($order, $direction);

--- a/src/Storage/Repository/ContentRepository.php
+++ b/src/Storage/Repository/ContentRepository.php
@@ -50,7 +50,7 @@ class ContentRepository extends Repository
             $direction = 'DESC';
         }
 
-        $neededFields = array_unshift($neededFields, 'id', $this->getTitleColumnName($contentType) . ' as title');
+        array_unshift($neededFields, 'id', $this->getTitleColumnName($contentType) . ' as title');
 
         $qb = $this->createQueryBuilder($contentType['tablename']);
         $qb->select(implode(', ', $neededFields));


### PR DESCRIPTION
Fixes #4830. 

(only one `!empty()`, and I think it’s legitimate. ;-) )