### PR TITLE
Less entity magic

### DIFF
--- a/src/Storage/Entity/Authtoken.php
+++ b/src/Storage/Entity/Authtoken.php
@@ -3,34 +3,129 @@ namespace Bolt\Storage\Entity;
 
 /**
  * Entity for Auth Tokens.
- *
- * @method integer   getId()
- * @method string    getUsername()
- * @method string    getToken()
- * @method string    getSalt()
- * @method \DateTime getLastseen()
- * @method string    getIp()
- * @method string    getUseragent()
- * @method string    getValidity()
- * @method setId($id)
- * @method setUsername($username)
- * @method setToken($token)
- * @method setSalt($salt)
- * @method setLastseen($lastseen)
- * @method setIp($ip)
- * @method setUseragent($useragent)
- * @method setValidity($validity)
  */
 class Authtoken extends Entity
 {
+    /** @var int */
     protected $id;
+    /** @var string */
     protected $username;
+    /** @var string */
     protected $token;
+    /** @var string */
     protected $salt;
+    /** @var \DateTime */
     protected $lastseen;
+    /** @var string */
     protected $ip;
+    /** @var string */
     protected $useragent;
+    /** @var \DateTime */
     protected $validity;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param string $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    /**
+     * @param string $token
+     */
+    public function setToken($token)
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSalt()
+    {
+        return $this->salt;
+    }
+
+    /**
+     * @param string $salt
+     */
+    public function setSalt($salt)
+    {
+        $this->salt = $salt;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getLastseen()
+    {
+        return $this->lastseen;
+    }
+
+    /**
+     * @param \DateTime $lastseen
+     */
+    public function setLastseen($lastseen)
+    {
+        $this->lastseen = $lastseen;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIp()
+    {
+        return $this->ip;
+    }
+
+    /**
+     * @param string $ip
+     */
+    public function setIp($ip)
+    {
+        $this->ip = $ip;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUseragent()
+    {
+        return $this->useragent;
+    }
 
     /**
      * Setter for the user agent string.
@@ -40,5 +135,21 @@ class Authtoken extends Entity
     public function setUseragent($useragent)
     {
         $this->useragent = substr($useragent, 0, 128);
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getValidity()
+    {
+        return $this->validity;
+    }
+
+    /**
+     * @param \DateTime $validity
+     */
+    public function setValidity($validity)
+    {
+        $this->validity = $validity;
     }
 }

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -8,18 +8,6 @@ use Carbon\Carbon;
 
 /**
  * Entity for Content.
- *
- * @method integer   getId()
- * @method string    getSlug()
- * @method \DateTime getDatepublish()
- * @method \DateTime getDatedepublish()
- * @method integer   getOwnerid()
- * @method string    getStatus()
- * @method setId(integer $id)
- * @method setSlug(string $slug)
- * @method setOwnerid(integer $ownerid)
- * @method setUsername(string $userName)
- * @method setStatus(string $status)
  */
 class Content extends Entity
 {
@@ -27,16 +15,27 @@ class Content extends Entity
     use ContentTypeTitleTrait;
 
     protected $contenttype;
+    /** @var ContentLegacyService */
     protected $_legacy;
+    /** @var int */
     protected $id;
+    /** @var string */
     protected $slug;
+    /** @var \DateTime */
     protected $datecreated;
+    /** @var \DateTime */
     protected $datechanged;
-    protected $datepublish = null;
-    protected $datedepublish = null;
+    /** @var \DateTime */
+    protected $datepublish;
+    /** @var \DateTime */
+    protected $datedepublish;
+    /** @var int */
     protected $ownerid;
+    /** @var string */
     protected $status;
+    /** @var Collection\Relations */
     protected $relation;
+    /** @var Collection\Taxonomy */
     protected $taxonomy;
 
     /** @var array @deprecated Deprecated since 3.0, to be removed in 4.0. */
@@ -183,6 +182,9 @@ class Content extends Entity
         $this->contenttype = $value;
     }
 
+    /**
+     * @return Collection\Relations
+     */
     public function getRelation()
     {
         if (!$this->relation instanceof Collection\Relations) {
@@ -192,6 +194,9 @@ class Content extends Entity
         return $this->relation;
     }
 
+    /**
+     * @param Collection\Relations $rel
+     */
     public function setRelation(Collection\Relations $rel)
     {
         $this->relation = $rel;
@@ -207,6 +212,9 @@ class Content extends Entity
         $this->templatefields = $value;
     }
 
+    /**
+     * @return Collection\Taxonomy
+     */
     public function getTaxonomy()
     {
         if (!$this->taxonomy instanceof Collection\Taxonomy) {
@@ -216,11 +224,17 @@ class Content extends Entity
         return $this->taxonomy;
     }
 
+    /**
+     * @param Collection\Taxonomy $taxonomy
+     */
     public function setTaxonomy(Collection\Taxonomy $taxonomy)
     {
         $this->taxonomy = $taxonomy;
     }
 
+    /**
+     * @param ContentLegacyService $service
+     */
     public function setLegacyService(ContentLegacyService $service)
     {
         $this->_legacy = $service;

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -40,6 +40,7 @@ class Content extends Entity
 
     /** @var array @deprecated Deprecated since 3.0, to be removed in 4.0. */
     protected $group;
+    /** @var int */
     protected $sortorder;
 
     /**
@@ -74,34 +75,51 @@ class Content extends Entity
     }
 
     /**
-     * Helper to set an array of values
-     *
-     * @param array $values
+     * @return int
      */
-    public function setValues(array $values)
+    public function getSortorder()
     {
-        foreach ($values as $key => $value) {
-            $this->set($key, $value);
-        }
+        return $this->sortorder;
     }
 
     /**
-     * Getter for a record's 'title' field.
-     *
-     * If there is no field called 'title' then we just return the first text
-     * type field.
-     *
+     * @param int $sortorder
+     */
+    public function setSortorder($sortorder)
+    {
+        $this->sortorder = $sortorder;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
      * @return string
      */
-    public function getTitle()
+    public function getSlug()
     {
-        if (isset($this->_fields['title'])) {
-            return $this->_fields['title'];
-        }
+        return $this->slug;
+    }
 
-        $fieldName = $this->getTitleColumnName($this->contenttype);
-
-        return $this->$fieldName;
+    /**
+     * @param string $slug
+     */
+    public function setSlug($slug)
+    {
+        $this->slug = $slug;
     }
 
     /**
@@ -153,6 +171,14 @@ class Content extends Entity
     }
 
     /**
+     * @return \DateTime
+     */
+    public function getDatepublish()
+    {
+        return $this->datepublish;
+    }
+
+    /**
      * Set published date.
      *
      * @param \DateTime|string|null $date
@@ -160,6 +186,14 @@ class Content extends Entity
     public function setDatepublish($date)
     {
         $this->datepublish = $this->getValidDateObject($date);
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDatedepublish()
+    {
+        return $this->datedepublish;
     }
 
     /**
@@ -172,14 +206,36 @@ class Content extends Entity
         $this->datedepublish = $this->getValidDateObject($date);
     }
 
-    public function getContenttype()
+    /**
+     * @return int
+     */
+    public function getOwnerid()
     {
-        return $this->contenttype;
+        return $this->ownerid;
     }
 
-    public function setContenttype($value)
+    /**
+     * @param int $ownerid
+     */
+    public function setOwnerid($ownerid)
     {
-        $this->contenttype = $value;
+        $this->ownerid = $ownerid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param string $status
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
     }
 
     /**
@@ -202,16 +258,6 @@ class Content extends Entity
         $this->relation = $rel;
     }
 
-    public function getTemplatefields()
-    {
-        return $this->templatefields;
-    }
-
-    public function setTemplatefields($value)
-    {
-        $this->templatefields = $value;
-    }
-
     /**
      * @return Collection\Taxonomy
      */
@@ -230,6 +276,81 @@ class Content extends Entity
     public function setTaxonomy(Collection\Taxonomy $taxonomy)
     {
         $this->taxonomy = $taxonomy;
+    }
+
+    /**
+     * @return array
+     */
+    public function getGroup()
+    {
+        return $this->group;
+    }
+
+    /**
+     * @param array $group
+     */
+    public function setGroup($group)
+    {
+        $this->group = $group;
+    }
+
+    /**
+     * Helper to set an array of values
+     *
+     * @param array $values
+     */
+    public function setValues(array $values)
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value);
+        }
+    }
+
+    /**
+     * Getter for a record's 'title' field.
+     *
+     * If there is no field called 'title' then we just return the first text
+     * type field.
+     *
+     * @return string
+     */
+    public function getTitle()
+    {
+        if (isset($this->_fields['title'])) {
+            return $this->_fields['title'];
+        }
+
+        $fieldName = $this->getTitleColumnName($this->contenttype);
+
+        return $this->$fieldName;
+    }
+
+    public function getContenttype()
+    {
+        return $this->contenttype;
+    }
+
+    public function setContenttype($value)
+    {
+        $this->contenttype = $value;
+    }
+
+    public function getTemplatefields()
+    {
+        return $this->templatefields;
+    }
+
+    public function setTemplatefields($value)
+    {
+        $this->templatefields = $value;
+    }
+
+    /**
+     * @return ContentLegacyService
+     */
+    public function getLegacy()
+    {
+        return $this->_legacy;
     }
 
     /**

--- a/src/Storage/Entity/Cron.php
+++ b/src/Storage/Entity/Cron.php
@@ -3,17 +3,61 @@ namespace Bolt\Storage\Entity;
 
 /**
  * Entity for cron jobs.
- *
- * @method integer   getId()
- * @method string    getInterim()
- * @method \DateTime getLastrun()
- * @method setId($id)
- * @method setInterim($interim)
- * @method setLastrun($lastrun)
  */
 class Cron extends Entity
 {
+    /** @var integer */
     protected $id;
+    /** @var string */
     protected $interim;
+    /** @var \DateTime */
     protected $lastrun;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInterim()
+    {
+        return $this->interim;
+    }
+
+    /**
+     * @param string $interim
+     */
+    public function setInterim($interim)
+    {
+        $this->interim = $interim;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getLastrun()
+    {
+        return $this->lastrun;
+    }
+
+    /**
+     * @param \DateTime $lastrun
+     */
+    public function setLastrun($lastrun)
+    {
+        $this->lastrun = $lastrun;
+    }
 }

--- a/src/Storage/Entity/Entity.php
+++ b/src/Storage/Entity/Entity.php
@@ -14,6 +14,14 @@ abstract class Entity implements ArrayAccess, JsonSerializable
     use EntitySerializeTrait;
     use EntityArrayAccessTrait;
 
+    /** @var int */
+    protected $id;
+
+    /**
+     * Constructor.
+     *
+     * @param array $data
+     */
     public function __construct($data = [])
     {
         foreach ($data as $key => $value) {
@@ -22,8 +30,24 @@ abstract class Entity implements ArrayAccess, JsonSerializable
         }
     }
 
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
     public function __toString()
     {
-        return strval($this->getId());
+        return (string) $this->getId();
     }
 }

--- a/src/Storage/Entity/FieldValue.php
+++ b/src/Storage/Entity/FieldValue.php
@@ -6,13 +6,19 @@ namespace Bolt\Storage\Entity;
  */
 class FieldValue extends Entity
 {
+    /** @var int */
     protected $id;
+    /** @var mixed */
     protected $value;
+    /** @var string */
     protected $name;
     protected $grouping;
+    /** @var string */
     protected $fieldname;
+    /** @var string */
     protected $fieldtype;
     protected $contenttype;
+    /** @var int */
     protected $content_id;
 
     /**
@@ -23,6 +29,9 @@ class FieldValue extends Entity
         return $this->value;
     }
 
+    /**
+     * @param mixed $value
+     */
     public function setValue($value)
     {
         $this->value = $value;
@@ -34,7 +43,7 @@ class FieldValue extends Entity
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getName()
     {
@@ -42,7 +51,7 @@ class FieldValue extends Entity
     }
 
     /**
-     * @param mixed $name
+     * @param string $name
      */
     public function setName($name)
     {
@@ -50,10 +59,11 @@ class FieldValue extends Entity
     }
 
     /**
-     *  When the entity needs to be persisted the value has to be copied to  a field specific to the storage type
-     *  To do this we need a field type so we lookup the correct column to write to.
+     * When the entity needs to be persisted the value has to be copied to a field specific to the storage type
      *
-     * @param $fieldObject
+     * To do this we need a field type so we lookup the correct column to write to.
+     *
+     * @param \Bolt\Storage\Field\Base $fieldObject
      */
     public function handleStorage($fieldObject)
     {

--- a/src/Storage/Entity/LogChange.php
+++ b/src/Storage/Entity/LogChange.php
@@ -3,37 +3,171 @@ namespace Bolt\Storage\Entity;
 
 /**
  * Entity for change logs.
- *
- * @method integer   getId()
- * @method \DateTime getDate()
- * @method integer   getOwnerid()
- * @method string    getTitle()
- * @method string    getContenttype()
- * @method integer   getContentid()
- * @method string    getMutationType()
- * @method array     getDiff()
- * @method string    getComment()
- * @method setId($id)
- * @method setDate(\DateTime $date)
- * @method setOwnerid($ownerid)
- * @method setTitle($title)
- * @method setContenttype($contenttype)
- * @method setContentid($contentid)
- * @method setMutationType($mutationType)
- * @method setDiff($diff)
- * @method setComment($comment)
  */
 class LogChange extends Entity
 {
+    /** @var int */
     protected $id;
+    /** @var \DateTime */
     protected $date;
+    /** @var int */
     protected $ownerid;
+    /** @var string */
     protected $title;
+    /** @var string */
     protected $contenttype;
+    /** @var int */
     protected $contentid;
+    /** @var string */
     protected $mutationType;
+    /** @var array */
     protected $diff;
+    /** @var string */
     protected $comment;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param \DateTime $date
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOwnerid()
+    {
+        return $this->ownerid;
+    }
+
+    /**
+     * @param int $ownerid
+     */
+    public function setOwnerid($ownerid)
+    {
+        $this->ownerid = $ownerid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContenttype()
+    {
+        return $this->contenttype;
+    }
+
+    /**
+     * @param string $contenttype
+     */
+    public function setContenttype($contenttype)
+    {
+        $this->contenttype = $contenttype;
+    }
+
+    /**
+     * @return int
+     */
+    public function getContentid()
+    {
+        return $this->contentid;
+    }
+
+    /**
+     * @param int $contentid
+     */
+    public function setContentid($contentid)
+    {
+        $this->contentid = $contentid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMutationType()
+    {
+        return $this->mutationType;
+    }
+
+    /**
+     * @param string $mutationType
+     */
+    public function setMutationType($mutationType)
+    {
+        $this->mutationType = $mutationType;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDiff()
+    {
+        return $this->diff;
+    }
+
+    /**
+     * @param array $diff
+     */
+    public function setDiff($diff)
+    {
+        $this->diff = $diff;
+    }
+
+    /**
+     * @return string
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @param string $comment
+     */
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+    }
 
     /**
      * Get changed fields.

--- a/src/Storage/Entity/LogSystem.php
+++ b/src/Storage/Entity/LogSystem.php
@@ -3,35 +3,169 @@ namespace Bolt\Storage\Entity;
 
 /**
  * Entity for system logs.
- *
- * @method integer   getId()
- * @method integer   getLevel()
- * @method \DateTime getDate()
- * @method string    getMessage()
- * @method integer   getOwnerid()
- * @method string    getRoute()
- * @method string    getIp()
- * @method string    getContext()
- * @method array     getSource()
- * @method setId($id)
- * @method setLevel($level)
- * @method setDate(\DateTime $date)
- * @method setMessage($message)
- * @method setOwnerid($ownerid)
- * @method setRoute($route)
- * @method setIp($ip)
- * @method setContext($context)
- * @method setSource($source)
  */
 class LogSystem extends Entity
 {
+    /** @var integer */
     protected $id;
+    /** @var integer */
     protected $level;
+    /** @var \DateTime */
     protected $date;
+    /** @var string */
     protected $message;
+    /** @var int */
     protected $ownerid;
+    /** @var string */
     protected $route;
+    /** @var string */
     protected $ip;
+    /** @var string */
     protected $context;
+    /** @var array */
     protected $source;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    /**
+     * @param int $level
+     */
+    public function setLevel($level)
+    {
+        $this->level = $level;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param \DateTime $date
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOwnerid()
+    {
+        return $this->ownerid;
+    }
+
+    /**
+     * @param int $ownerid
+     */
+    public function setOwnerid($ownerid)
+    {
+        $this->ownerid = $ownerid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
+     * @param string $route
+     */
+    public function setRoute($route)
+    {
+        $this->route = $route;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIp()
+    {
+        return $this->ip;
+    }
+
+    /**
+     * @param string $ip
+     */
+    public function setIp($ip)
+    {
+        $this->ip = $ip;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * @param string $context
+     */
+    public function setContext($context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    /**
+     * @param array $source
+     */
+    public function setSource($source)
+    {
+        $this->source = $source;
+    }
 }

--- a/src/Storage/Entity/Relations.php
+++ b/src/Storage/Entity/Relations.php
@@ -2,23 +2,82 @@
 namespace Bolt\Storage\Entity;
 
 /**
- * Entity for Auth Tokens.
+ * Entity for relations.
  */
 class Relations extends Entity
 {
+    /** @var int */
     protected $id;
+    /** @var string */
     protected $from_contenttype;
+    /** @var int */
     protected $from_id;
+    /** @var string */
     protected $to_contenttype;
+    /** @var int */
     protected $to_id;
 
     private $invert = false;
 
-    public function actAsInverse()
+    /**
+     * @return int
+     */
+    public function getId()
     {
-        $this->invert = true;
+        return $this->id;
     }
 
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFromContenttype()
+    {
+        return $this->from_contenttype;
+    }
+
+    /**
+     * @param string $from_contenttype
+     */
+    public function setFromContenttype($from_contenttype)
+    {
+        $this->from_contenttype = $from_contenttype;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFromId()
+    {
+        return $this->from_id;
+    }
+
+    /**
+     * @param int $from_id
+     */
+    public function setFromId($from_id)
+    {
+        $this->from_id = $from_id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getToContenttype()
+    {
+        return $this->to_contenttype;
+    }
+
+    /**
+     * @return int
+     */
     public function getToId()
     {
         if ($this->invert === true) {
@@ -26,6 +85,43 @@ class Relations extends Entity
         }
 
         return $this->to_id;
+    }
+
+    /**
+     * @param int $to_id
+     */
+    public function setToId($to_id)
+    {
+        $this->to_id = $to_id;
+    }
+
+    /**
+     * @param string $to_contenttype
+     */
+    public function setToContenttype($to_contenttype)
+    {
+        $this->to_contenttype = $to_contenttype;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isInvert()
+    {
+        return $this->invert;
+    }
+
+    /**
+     * @param boolean $invert
+     */
+    public function setInvert($invert)
+    {
+        $this->invert = $invert;
+    }
+
+    public function actAsInverse()
+    {
+        $this->invert = true;
     }
 
     public function isInverted()

--- a/src/Storage/Entity/Taxonomy.php
+++ b/src/Storage/Entity/Taxonomy.php
@@ -2,21 +2,144 @@
 namespace Bolt\Storage\Entity;
 
 /**
- * Entity for Auth Tokens.
+ * Entity for taxonomy.
  */
 class Taxonomy extends Entity
 {
+    /** @var array */
     protected $_config = [];
+    /** @var int */
     protected $id;
+    /** @var int */
     protected $content_id;
+    /** @var string */
     protected $contenttype;
+    /** @var string */
     protected $taxonomytype;
+    /** @var string */
     protected $slug;
+    /** @var string */
     protected $name;
+    /** @var int */
     protected $sortorder = 0;
 
+    /**
+     * @param array $config
+     */
     public function setConfig(array $config)
     {
         $this->_config = $config;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getContentId()
+    {
+        return $this->content_id;
+    }
+
+    /**
+     * @param int $content_id
+     */
+    public function setContentId($content_id)
+    {
+        $this->content_id = $content_id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContenttype()
+    {
+        return $this->contenttype;
+    }
+
+    /**
+     * @param string $contenttype
+     */
+    public function setContenttype($contenttype)
+    {
+        $this->contenttype = $contenttype;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTaxonomytype()
+    {
+        return $this->taxonomytype;
+    }
+
+    /**
+     * @param string $taxonomytype
+     */
+    public function setTaxonomytype($taxonomytype)
+    {
+        $this->taxonomytype = $taxonomytype;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSlug()
+    {
+        return $this->slug;
+    }
+
+    /**
+     * @param string $slug
+     */
+    public function setSlug($slug)
+    {
+        $this->slug = $slug;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSortorder()
+    {
+        return $this->sortorder;
+    }
+
+    /**
+     * @param int $sortorder
+     */
+    public function setSortorder($sortorder)
+    {
+        $this->sortorder = $sortorder;
     }
 }

--- a/src/Storage/Entity/Users.php
+++ b/src/Storage/Entity/Users.php
@@ -3,51 +3,175 @@ namespace Bolt\Storage\Entity;
 
 /**
  * Entity for User.
- *
- * @method integer   getId()
- * @method string    getUsername()
- * @method string    getPassword()
- * @method string    getEmail()
- * @method \DateTime getLastseen()
- * @method string    getLastip()
- * @method string    getDisplayname()
- * @method array     getStack()
- * @method string    getShadowpassword()
- * @method string    getShadowtoken()
- * @method string    getShadowvalidity()
- * @method integer   getFailedlogins()
- * @method \DateTime getThrottleduntil()
- * @method setId($id)
- * @method setUsername($username)
- * @method setPassword($password)
- * @method setEmail($email)
- * @method setLastseen(\DateTime $lastseen)
- * @method setLastip($lastip)
- * @method setDisplayname($displayname)
- * @method setStack(array $stack)
- * @method setShadowpassword($shadowpassword)
- * @method setShadowtoken($shadowtoken)
- * @method setShadowvalidity($shadowvalidity)
- * @method setFailedlogins($failedlogins)
- * @method setThrottleduntil(\DateTime $throttleduntil)
  */
 class Users extends Entity
 {
+    /** @var int */
     protected $id;
+    /** @var string */
     protected $username;
+    /** @var string */
     protected $password;
+    /** @var string */
     protected $email;
+    /** @var \DateTime */
     protected $lastseen;
+    /** @var string */
     protected $lastip;
+    /** @var string */
     protected $displayname;
+    /** @var array */
     protected $stack = [];
+    /** @var bool */
     protected $enabled;
+    /** @var string */
     protected $shadowpassword;
+    /** @var string */
     protected $shadowtoken;
+    /** @var string */
     protected $shadowvalidity;
+    /** @var int */
     protected $failedlogins = 0;
+    /** @var \DateTime */
     protected $throttleduntil;
+    /** @var array */
     protected $roles = [];
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param string $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * @param string $password
+     */
+    public function setPassword($password)
+    {
+        $this->password = $password;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param string $email
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getLastseen()
+    {
+        return $this->lastseen;
+    }
+
+    /**
+     * @param \DateTime $lastseen
+     */
+    public function setLastseen($lastseen)
+    {
+        $this->lastseen = $lastseen;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastip()
+    {
+        return $this->lastip;
+    }
+
+    /**
+     * @param string $lastip
+     */
+    public function setLastip($lastip)
+    {
+        $this->lastip = $lastip;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayname()
+    {
+        return $this->displayname;
+    }
+
+    /**
+     * @param string $displayname
+     */
+    public function setDisplayname($displayname)
+    {
+        $this->displayname = $displayname;
+    }
+
+    /**
+     * @return array
+     */
+    public function getStack()
+    {
+        return $this->stack;
+    }
+
+    /**
+     * @param array $stack
+     */
+    public function setStack($stack)
+    {
+        $this->stack = $stack;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isEnabled()
+    {
+        return (bool) $this->enabled;
+    }
 
     /**
      * Getter for enabled flag
@@ -60,9 +184,7 @@ class Users extends Entity
     }
 
     /**
-     * Setter for enabled flag
-     *
-     * @param string|integer|boolean $enabled
+     * @param boolean $enabled
      */
     public function setEnabled($enabled)
     {
@@ -70,8 +192,94 @@ class Users extends Entity
     }
 
     /**
-     * Setter for roles to ensure the array is always unique.
-     *
+     * @return string
+     */
+    public function getShadowpassword()
+    {
+        return $this->shadowpassword;
+    }
+
+    /**
+     * @param string $shadowpassword
+     */
+    public function setShadowpassword($shadowpassword)
+    {
+        $this->shadowpassword = $shadowpassword;
+    }
+
+    /**
+     * @return string
+     */
+    public function getShadowtoken()
+    {
+        return $this->shadowtoken;
+    }
+
+    /**
+     * @param string $shadowtoken
+     */
+    public function setShadowtoken($shadowtoken)
+    {
+        $this->shadowtoken = $shadowtoken;
+    }
+
+    /**
+     * @return string
+     */
+    public function getShadowvalidity()
+    {
+        return $this->shadowvalidity;
+    }
+
+    /**
+     * @param string $shadowvalidity
+     */
+    public function setShadowvalidity($shadowvalidity)
+    {
+        $this->shadowvalidity = $shadowvalidity;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFailedlogins()
+    {
+        return $this->failedlogins;
+    }
+
+    /**
+     * @param int $failedlogins
+     */
+    public function setFailedlogins($failedlogins)
+    {
+        $this->failedlogins = $failedlogins;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getThrottleduntil()
+    {
+        return $this->throttleduntil;
+    }
+
+    /**
+     * @param \DateTime $throttleduntil
+     */
+    public function setThrottleduntil($throttleduntil)
+    {
+        $this->throttleduntil = $throttleduntil;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+
+    /**
      * @param array $roles
      */
     public function setRoles(array $roles)

--- a/src/Storage/Field/Base.php
+++ b/src/Storage/Field/Base.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Storage\Field;
 
+use Doctrine\DBAL\Types\Type;
+
 class Base implements FieldInterface
 {
     /** @var string */
@@ -42,7 +44,7 @@ class Base implements FieldInterface
      */
     public function getStorageType()
     {
-        return 'text';
+        return Type::getType('text');
     }
 
     /**

--- a/src/Storage/Field/Base.php
+++ b/src/Storage/Field/Base.php
@@ -1,33 +1,53 @@
 <?php
-namespace Bolt\Storage\Field;
 
+namespace Bolt\Storage\Field;
 
 class Base implements FieldInterface
 {
+    /** @var string */
     public $name;
+    /** @var string */
     public $template;
 
+    /**
+     * Constructor.
+     *
+     * @param string $name
+     * @param string $template
+     */
     public function __construct($name, $template)
     {
         $this->name = $name;
         $this->template = $template;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getTemplate()
     {
         return $this->template;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getStorageType()
     {
         return 'text';
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getStorageOptions()
     {
         return [];

--- a/src/Storage/Field/FieldInterface.php
+++ b/src/Storage/Field/FieldInterface.php
@@ -1,6 +1,9 @@
 <?php
 namespace Bolt\Storage\Field;
 
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Types\Type;
+
 /**
  * Interface implemented by content fields.
  *
@@ -25,7 +28,9 @@ interface FieldInterface
     /**
      * Returns the storage type.
      *
-     * @return string A Valid Storage Type
+     * @throws DBALException
+     *
+     * @return Type A Valid Storage Type
      */
     public function getStorageType();
 

--- a/tests/phpunit/unit/Field/BaseFieldTest.php
+++ b/tests/phpunit/unit/Field/BaseFieldTest.php
@@ -13,12 +13,13 @@ class BaseFieldTest extends BoltUnitTest
 {
     public function testFieldSetup()
     {
+        /** @var Base $field */
         $field = $this->getMock('Bolt\Storage\Field\Base', null, ['test', 'test.twig']);
         $this->assertEquals('test', $field->getName());
         $this->assertEquals('test.twig', $field->getTemplate());
 
         // This tests the default returns for base
-        $this->assertEquals('text', $field->getStorageType());
+        $this->assertEquals('Text', (string) $field->getStorageType());
         $this->assertEquals([], $field->getStorageOptions());
     }
 }


### PR DESCRIPTION
This updates the **base table** entities away from `@method` annotations to using getter/setters, and updates a bunch of PHPDoc in the process… hopefully making debugging easier, and understanding the classes easier for those that aren't @rossriley and @gawainlynch :wink: 

@rossriley when you're done with :beers: for the day, can you give a "yay" or "nay" on 3c652b992d439da77958b6de7895255e7b2cc6a1 please… my preference would be to have it as is, but if there is a valid design decision behind mixing them, I am all ears.