### PR TITLE
changed visibility of loginFailed function to protected to allow over…

### DIFF
--- a/src/Users.php
+++ b/src/Users.php
@@ -1280,7 +1280,7 @@ class Users
      *
      * @param array $user
      */
-    private function loginFailed($user)
+    protected function loginFailed($user)
     {
         $this->session->getFlashBag()->add('error', Trans::__('Username or password not correct. Please check your input.'));
         $this->app['logger.system']->info("Failed login attempt for '" . $user['displayname'] . "'.", array('event' => 'authentication'));


### PR DESCRIPTION
The function ```Users->loginFailed($user)``` function is currently marked as ```private```making it untouchable for extending classes.

***Use Case***
The use case is this: Our CMS systems are very frequently hit by attackers and need a more thorough monitoring. I can write a Bolt\Extnsion that replaces the normal Bolt\Users class with a new Users class that extends the Bolt\Users class but also fires certain monitoring events on some functions.
(Yes, doing so from within an Extension might be considered cruede, but it is the only option available without modifying core code.) 

The most important function would be the ```loginFailed()``` function obviously. But this function can not be overridden in a extending class because of it's ```private``` visibility.

Other use cases for this are Bolt Extensions adding LDAP login (Something I also need to do in the near future) or replace other internals with extended versions.

***Compatibility***
Changing it to ```protected```does not introduce incompatibilities to the code and does not introduce any kind of security issues. Anyone able to modify PHP is already way beyond secuity here.