### PR TITLE
Return the correct response after deleting a file

### DIFF
--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -168,8 +168,15 @@ class FilesystemManager extends AsyncBase
 
             return $this->json(null, Response::HTTP_OK);
         } catch (ExceptionInterface $e) {
+            $msg = Trans::__('Unable to delete file: %FILE%', ['%FILE%' => $filename]);
+
+            $this->app['logger.system']->critical(
+                $msg . ': ' . $e->getMessage(),
+                ['event' => 'exception', 'exception' => $e]
+            );
+
             return $this->json(
-                Trans::__('Unable to delete file: %FILE%', ['%FILE%' => $filename]),
+                $msg,
                 $e instanceof FileNotFoundException ? Response::HTTP_NOT_FOUND : Response::HTTP_INTERNAL_SERVER_ERROR
             );
         }


### PR DESCRIPTION
Deleting files through the file manager always resulted in an error as the result of the void method `\Bolt\Filesystem\Manager->delete()` was used to check whether the deletion was successful or not. This fixes #4854.

I decided to not include the exception itself in the error message as that would make the error very verbose.