### PR TITLE
Enable access control events for login, logout & password reset

### DIFF
--- a/src/Events/AccessControlEvent.php
+++ b/src/Events/AccessControlEvent.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Bolt\Events;
+
+use Exception;
+use Silex\Application;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+class AccessControlEvent extends Event
+{
+    /** @var string */
+    private $clientIp;
+    /** @var integer */
+    private $dateTime;
+    /** @var string */
+    private $uri;
+    /** @var string */
+    private $userName;
+    /** @var \Exception */
+    private $exception;
+
+    /**
+     * Constructor.
+     *
+     * @param Request   $request
+     * @param Exception $exception
+     */
+    public function __construct(Request $request, \Exception $exception = null)
+    {
+        $this->exception = $exception;
+
+        $this->clientIp = $request->getClientIp();
+        $this->dateTime = $request->server->get('REQUEST_TIME');
+        $this->uri = $request->getUri();
+        $this->userName = $request->request->get('username');
+    }
+
+    /**
+     * Return any trapped exceptions.
+     *
+     * @return Exception
+     */
+    public function getException()
+    {
+        return $this->exception;
+    }
+
+    /**
+     * Return the IP address requesting the access.
+     *
+     * @return string
+     */
+    public function getClientIp()
+    {
+        return $this->clientIp;
+    }
+
+    /**
+     * Return a DateTime object representing the time the request occurred.
+     *
+     * @return \DateTime
+     */
+    public function getDateTime()
+    {
+        $dt = new \DateTime();
+
+        return $dt->setTimestamp($this->dateTime);
+    }
+
+    /**
+     * Return the requested URI of the access event.
+     *
+     * @return string
+     */
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     * Return the given user name of the access event.
+     *
+     * @return mixed|string
+     */
+    public function getUserName()
+    {
+        return $this->userName;
+    }
+}

--- a/src/Events/AccessControlEvents.php
+++ b/src/Events/AccessControlEvents.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bolt\Events;
+
+class AccessControlEvents
+{
+    const LOGIN_SUCCESS = 'login.success';
+    const LOGIN_FAILURE = 'login.failure';
+
+    const RESET_REQUEST = 'reset.request';
+    const RESET_SUCCESS = 'reset.success';
+    const RESET_FAILURE = 'reset.failure';
+
+    /**
+     * Singleton constructor.
+     */
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
This is an alternative approach to #4878 that adds forward compatible events for login, logout & password reset