### PR TITLE
Rework the FilesystemManager controller and add tests

### DIFF
--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -123,7 +123,7 @@ class FilesystemManager extends AsyncBase
         try {
             $this->filesystem()->createDir("$namespace://$parentPath$folderName");
 
-            return $this->json(null, Response::HTTP_OK);
+            return $this->json("$parentPath$folderName", Response::HTTP_OK);
         } catch (IOException $e) {
             $msg = Trans::__('Unable to create directory: %DIR%', ['%DIR%' => $folderName]);
 
@@ -149,7 +149,7 @@ class FilesystemManager extends AsyncBase
         try {
             $this->filesystem()->put("$namespace://$parentPath/$filename", ' ');
 
-            return $this->json(null, Response::HTTP_OK);
+            return $this->json("$parentPath/$filename", Response::HTTP_OK);
         } catch (IOException $e) {
             $msg = Trans::__('Unable to create file: %FILE%', ['%FILE%' => $filename]);
 
@@ -174,7 +174,7 @@ class FilesystemManager extends AsyncBase
         try {
             $this->filesystem()->delete("$namespace://$filename");
 
-            return $this->json(null, Response::HTTP_OK);
+            return $this->json($filename, Response::HTTP_OK);
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to delete file: %FILE%', ['%FILE%' => $filename]);
 
@@ -220,7 +220,7 @@ class FilesystemManager extends AsyncBase
         try {
             $filesystem->copy($filename, $destination);
 
-            return $this->json(null, Response::HTTP_OK);
+            return $this->json($destination, Response::HTTP_OK);
         } catch (IOException $e) {
             $msg = Trans::__('Unable to duplicate file: %FILE%', ['%FILE%' => $filename]);
 
@@ -301,7 +301,7 @@ class FilesystemManager extends AsyncBase
         try {
             $this->filesystem()->deleteDir("$namespace://$parentPath$folderName");
 
-            return $this->json(null, Response::HTTP_OK);
+            return $this->json("$parentPath$folderName", Response::HTTP_OK);
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to delete directory: %DIR%', ['%DIR%' => $folderName]);
 
@@ -332,7 +332,7 @@ class FilesystemManager extends AsyncBase
         try {
             $this->filesystem()->rename("$namespace://$parentPath/$oldName", "$parentPath/$newName");
 
-            return $this->json(null, Response::HTTP_OK);
+            return $this->json("$parentPath/$newName", Response::HTTP_OK);
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to rename file: %FILE%', ['%FILE%' => $oldName]);
 
@@ -367,7 +367,7 @@ class FilesystemManager extends AsyncBase
         try {
             $this->filesystem()->rename("$namespace://$parentPath$oldName", "$parentPath$newName");
 
-            return $this->json(null, Response::HTTP_OK);
+            return $this->json("$parentPath$newName", Response::HTTP_OK);
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to rename directory: %DIR%', ['%DIR%' => $oldName]);
 

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -408,11 +408,8 @@ class FilesystemManager extends AsyncBase
 
         $oldFile = new \SplFileInfo($oldName);
         $newFile = new \SplFileInfo($newName);
-        if ($oldFile->getExtension() === $newFile->getExtension()) {
-            return true;
-        }
 
-        return false;
+        return $oldFile->getExtension() === $newFile->getExtension();
     }
 
     /**

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -410,7 +410,7 @@ class FilesystemManager extends AsyncBase
      * Log an exception to the system log
      *
      * @param string $message A formatted error message
-     * @param string $exception The exception that has been thrown
+     * @param \Exception $exception The exception that has been thrown
      *
      * @return Boolean Whether the record has been processed
      */

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -116,9 +116,9 @@ class FilesystemManager extends AsyncBase
      */
     public function createFolder(Request $request)
     {
-        $namespace = $request->request->get('namespace');
-        $parentPath = $request->request->get('parent');
-        $folderName = $request->request->get('foldername');
+        $namespace = $request->get('namespace');
+        $parentPath = $request->get('parent');
+        $folderName = $request->get('foldername');
 
         try {
             $this->filesystem()->createDir("$namespace://$parentPath$folderName");
@@ -142,9 +142,9 @@ class FilesystemManager extends AsyncBase
      */
     public function createFile(Request $request)
     {
-        $namespace = $request->request->get('namespace');
-        $parentPath = $request->request->get('parentPath');
-        $filename = $request->request->get('filename');
+        $namespace = $request->get('namespace');
+        $parentPath = $request->get('parentPath');
+        $filename = $request->get('filename');
 
         try {
             $this->filesystem()->put("$namespace://$parentPath/$filename", ' ');
@@ -168,8 +168,8 @@ class FilesystemManager extends AsyncBase
      */
     public function deleteFile(Request $request)
     {
-        $namespace = $request->request->get('namespace');
-        $filename = $request->request->get('filename');
+        $namespace = $request->get('namespace');
+        $filename = $request->get('filename');
 
         try {
             $this->filesystem()->delete("$namespace://$filename");
@@ -196,8 +196,8 @@ class FilesystemManager extends AsyncBase
      */
     public function duplicateFile(Request $request)
     {
-        $namespace = $request->request->get('namespace');
-        $filename = $request->request->get('filename');
+        $namespace = $request->get('namespace');
+        $filename = $request->get('filename');
 
         $filesystem = $this->filesystem()->getFilesystem($namespace);
 
@@ -294,9 +294,9 @@ class FilesystemManager extends AsyncBase
      */
     public function removeFolder(Request $request)
     {
-        $namespace = $request->request->get('namespace');
-        $parentPath = $request->request->get('parent');
-        $folderName = $request->request->get('foldername');
+        $namespace = $request->get('namespace');
+        $parentPath = $request->get('parent');
+        $folderName = $request->get('foldername');
 
         try {
             $this->filesystem()->deleteDir("$namespace://$parentPath$folderName");
@@ -320,10 +320,10 @@ class FilesystemManager extends AsyncBase
      */
     public function renameFile(Request $request)
     {
-        $namespace  = $request->request->get('namespace');
-        $parentPath = $request->request->get('parent');
-        $oldName    = $request->request->get('oldname');
-        $newName    = $request->request->get('newname');
+        $namespace = $request->get('namespace');
+        $parentPath = $request->get('parent');
+        $oldName = $request->get('oldname');
+        $newName = $request->get('newname');
 
         if (!$this->isMatchingExtension($oldName, $newName)) {
             return $this->json(Trans::__('Only root can change file extensions.'), Response::HTTP_FORBIDDEN);
@@ -359,10 +359,10 @@ class FilesystemManager extends AsyncBase
      */
     public function renameFolder(Request $request)
     {
-        $namespace  = $request->request->get('namespace');
-        $parentPath = $request->request->get('parent');
-        $oldName    = $request->request->get('oldname');
-        $newName    = $request->request->get('newname');
+        $namespace = $request->get('namespace');
+        $parentPath = $request->get('parent');
+        $oldName = $request->get('oldname');
+        $newName = $request->get('newname');
 
         try {
             $this->filesystem()->rename("$namespace://$parentPath$oldName", "$parentPath$newName");

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -336,10 +336,7 @@ class FilesystemManager extends AsyncBase
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to rename file: %FILE%', ['%FILE%' => $oldName]);
 
-            $this->app['logger.system']->error(
-                $msg . ': ' . $e->getMessage(),
-                ['event' => 'status', 'status' => $e]
-            );
+            $this->logException($msg, $e);
 
             if ($e instanceof FileExistsException) {
                 $status = Response::HTTP_CONFLICT;
@@ -374,10 +371,7 @@ class FilesystemManager extends AsyncBase
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to rename directory: %DIR%', ['%DIR%' => $oldName]);
 
-            $this->app['logger.system']->error(
-                $msg . ': ' . $e->getMessage(),
-                ['event' => 'status', 'status' => $e]
-            );
+            $this->logException($msg, $e);
 
             if ($e instanceof FileExistsException) {
                 $status = Response::HTTP_CONFLICT;

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -85,7 +85,7 @@ class FilesystemManager extends AsyncBase
         } catch (IOException $e) {
             $msg = Trans::__("Folder '%s' could not be found, or is not readable.", ['%s' => $path]);
 
-            $this->app['logger.system']->critical(
+            $this->app['logger.system']->error(
                 $msg . ': ' . $e->getMessage(),
                 ['event' => 'exception', 'exception' => $e]
             );
@@ -154,7 +154,7 @@ class FilesystemManager extends AsyncBase
         } catch (IOException $e) {
             $msg = Trans::__('Unable to create file: %FILE%', ['%FILE%' => $filename]);
 
-            $this->app['logger.system']->critical(
+            $this->app['logger.system']->error(
                 $msg . ': ' . $e->getMessage(),
                 ['event' => 'exception', 'exception' => $e]
             );
@@ -182,7 +182,7 @@ class FilesystemManager extends AsyncBase
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to delete file: %FILE%', ['%FILE%' => $filename]);
 
-            $this->app['logger.system']->critical(
+            $this->app['logger.system']->error(
                 $msg . ': ' . $e->getMessage(),
                 ['event' => 'exception', 'exception' => $e]
             );
@@ -332,7 +332,7 @@ class FilesystemManager extends AsyncBase
         } catch (\Exception $e) {
             $msg = Trans::__('Unable to rename file: %FILE%', ['%FILE%' => $oldName]);
 
-            $this->app['logger.system']->critical(
+            $this->app['logger.system']->error(
                 $msg . ': ' . $e->getMessage(),
                 ['event' => 'status', 'status' => $e]
             );
@@ -370,7 +370,7 @@ class FilesystemManager extends AsyncBase
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to rename directory: %DIR%', ['%DIR%' => $oldName]);
 
-            $this->app['logger.system']->critical(
+            $this->app['logger.system']->error(
                 $msg . ': ' . $e->getMessage(),
                 ['event' => 'status', 'status' => $e]
             );

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -298,7 +298,7 @@ class FilesystemManager extends AsyncBase
 
             $this->logException($msg, $e);
 
-            return $this->json($msg, Response::HTTP_FORBIDDEN);
+            return $this->json($msg, Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -306,9 +306,14 @@ class FilesystemManager extends AsyncBase
 
             return $this->json(null, Response::HTTP_OK);
         } catch (IOException $e) {
-            return $this->json(Trans::__('Unable to delete directory: %DIR%', ['%DIR%' => $folderName]), Response::HTTP_FORBIDDEN);
-        } catch (\Exception $e) {
-            return $this->json($e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+            $msg = Trans::__('Unable to delete directory: %DIR%', ['%DIR%' => $folderName]);
+
+            $this->app['logger.system']->error(
+                $msg . ': ' . $e->getMessage(),
+                ['event' => 'exception', 'exception' => $e]
+            );
+
+            return $this->json($msg, Response::HTTP_FORBIDDEN);
         }
     }
 

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -192,7 +192,7 @@ class FilesystemManager extends AsyncBase
      *
      * @param Request $request
      *
-     * @return boolean
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     public function duplicateFile(Request $request)
     {

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -240,7 +240,7 @@ class FilesystemManager extends AsyncBase
     public function filesAutoComplete(Request $request)
     {
         $term = $request->get('term', '.*');
-        $extensions = implode('|', explode(',', $request->query->get('ext', '.*')));
+        $extensions = implode('|', explode(',', $request->get('ext', '.*')));
         $regex = sprintf('/.*(%s).*\.(%s)$/', $term, $extensions);
 
         $files = $this->filesystem()->find()->in('files://')->name($regex);

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -305,7 +305,7 @@ class FilesystemManager extends AsyncBase
             $this->filesystem()->deleteDir("$namespace://$parentPath$folderName");
 
             return $this->json(null, Response::HTTP_OK);
-        } catch (IOException $e) {
+        } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to delete directory: %DIR%', ['%DIR%' => $folderName]);
 
             $this->app['logger.system']->error(

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -263,15 +263,16 @@ class FilesystemManager extends AsyncBase
     {
         $results = [];
 
-        foreach ($this->storage()->getContentTypes() as $contenttype) {
-            if ($this->app['config']->get("contenttypes/{$contenttype}/viewless")) {
+        foreach ($this->app['config']->get('contenttypes') as $contenttype) {
+            if ($contenttype['viewless']) {
                 // Skip viewless ContentTypes
                 continue;
             }
-            $records = $this->getContent($contenttype, ['published' => true, 'hydrate' => false]);
 
+            $slug = $contenttype['slug'];
+            $records = $this->getContent($slug, ['published' => true, 'hydrate' => false]);
             foreach ($records as $record) {
-                $results[$contenttype][] = [
+                $results[$slug][] = [
                     'title' => $record->getTitle(),
                     'id'    => $record->id,
                     'link'  => $record->link(),
@@ -279,9 +280,7 @@ class FilesystemManager extends AsyncBase
             }
         }
 
-        $context = [
-            'results' => $results,
-        ];
+        $context = ['results' => $results];
 
         return $this->render('@bolt/recordbrowser/recordbrowser.twig', ['context' => $context]);
     }

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -82,8 +82,14 @@ class FilesystemManager extends AsyncBase
 
         try {
             $filesystem->listContents($path);
-        } catch (\Exception $e) {
+        } catch (IOException $e) {
             $msg = Trans::__("Folder '%s' could not be found, or is not readable.", ['%s' => $path]);
+
+            $this->app['logger.system']->critical(
+                $msg . ': ' . $e->getMessage(),
+                ['event' => 'exception', 'exception' => $e]
+            );
+
             $this->flashes()->error($msg);
         }
 

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -85,10 +85,7 @@ class FilesystemManager extends AsyncBase
         } catch (IOException $e) {
             $msg = Trans::__("Folder '%s' could not be found, or is not readable.", ['%s' => $path]);
 
-            $this->app['logger.system']->error(
-                $msg . ': ' . $e->getMessage(),
-                ['event' => 'exception', 'exception' => $e]
-            );
+            $this->logException($msg, $e);
 
             $this->flashes()->error($msg);
         }
@@ -130,10 +127,7 @@ class FilesystemManager extends AsyncBase
         } catch (IOException $e) {
             $msg = Trans::__('Unable to create directory: %DIR%', ['%DIR%' => $folderName]);
 
-            $this->app['logger.system']->error(
-                $msg . ': ' . $e->getMessage(),
-                ['event' => 'exception', 'exception' => $e]
-            );
+            $this->logException($msg, $e);
 
             return $this->json($msg, Response::HTTP_INTERNAL_SERVER_ERROR);
         }
@@ -159,10 +153,7 @@ class FilesystemManager extends AsyncBase
         } catch (IOException $e) {
             $msg = Trans::__('Unable to create file: %FILE%', ['%FILE%' => $filename]);
 
-            $this->app['logger.system']->error(
-                $msg . ': ' . $e->getMessage(),
-                ['event' => 'exception', 'exception' => $e]
-            );
+            $this->logException($msg, $e);
 
             return $this->json($msg, Response::HTTP_INTERNAL_SERVER_ERROR);
         }
@@ -187,10 +178,7 @@ class FilesystemManager extends AsyncBase
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to delete file: %FILE%', ['%FILE%' => $filename]);
 
-            $this->app['logger.system']->error(
-                $msg . ': ' . $e->getMessage(),
-                ['event' => 'exception', 'exception' => $e]
-            );
+            $this->logException($msg, $e);
 
             return $this->json(
                 $msg,
@@ -308,10 +296,7 @@ class FilesystemManager extends AsyncBase
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to delete directory: %DIR%', ['%DIR%' => $folderName]);
 
-            $this->app['logger.system']->error(
-                $msg . ': ' . $e->getMessage(),
-                ['event' => 'exception', 'exception' => $e]
-            );
+            $this->logException($msg, $e);
 
             return $this->json($msg, Response::HTTP_FORBIDDEN);
         }
@@ -419,5 +404,21 @@ class FilesystemManager extends AsyncBase
         }
 
         return false;
+    }
+
+    /**
+     * Log an exception to the system log
+     *
+     * @param string $message A formatted error message
+     * @param string $exception The exception that has been thrown
+     *
+     * @return Boolean Whether the record has been processed
+     */
+    private function logException($message, $exception)
+    {
+        return $this->app['logger.system']->error(
+            $message . ': ' . $exception->getMessage(),
+            ['event' => 'exception', 'exception' => $exception]
+        );
     }
 }

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -243,12 +243,9 @@ class FilesystemManager extends AsyncBase
         $extensions = implode('|', explode(',', $request->query->get('ext', '.*')));
         $regex = sprintf('/.*(%s).*\.(%s)$/', $term, $extensions);
 
-        $files = $this->filesystem()
-            ->find()
-            ->in('files://')
-            ->name($regex)
-        ;
+        $files = $this->filesystem()->find()->in('files://')->name($regex);
 
+        $result = [];
         /** @var \Bolt\Filesystem\Handler\File $file */
         foreach ($files as $file) {
             $result[] = $file->getPath();

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -201,15 +201,21 @@ class FilesystemManager extends AsyncBase
 
         $filesystem = $this->filesystem()->getFilesystem($namespace);
 
-        $extensionPos = strrpos($filename, '.');
-        $destination = substr($filename, 0, $extensionPos) . '_copy' . substr($filename, $extensionPos);
+        // If the filename doesn't have an extension $extensionPos will be equal to its length, so that$fileBase will
+        // contain the entire filename. This also accounts for dotfiles.
+        $extensionPos = strrpos($filename, '.') ?: strlen($filename);
+
+        $fileBase = substr($filename, 0, $extensionPos) . '_copy';
+        $fileExtension = substr($filename, $extensionPos + 1);
+
         $n = 1;
 
-        while ($filesystem->has($destination)) {
-            $extensionPos = strrpos($destination, '.');
-            $destination = substr($destination, 0, $extensionPos) . "$n" . substr($destination, $extensionPos);
-            $n = rand(0, 1000);
+        // Increase $n until filename_copy$n.ext doesn't exist
+        while ($filesystem->has($fileBase . $n . $fileExtension)) {
+            $n++;
         }
+
+        $destination = $fileBase . $n . $fileExtension;
 
         try {
             $filesystem->copy($filename, $destination);

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -329,7 +329,7 @@ class FilesystemManager extends AsyncBase
             $this->filesystem()->rename("$namespace://$parentPath/$oldName", "$parentPath/$newName");
 
             return $this->json(null, Response::HTTP_OK);
-        } catch (\Exception $e) {
+        } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to rename file: %FILE%', ['%FILE%' => $oldName]);
 
             $this->app['logger.system']->error(

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -141,13 +141,18 @@ class FilesystemManager extends AsyncBase
         $filename = $request->request->get('filename');
 
         try {
-            if ($this->filesystem()->put("$namespace://$parentPath/$filename", ' ')) {
-                return $this->json(null, Response::HTTP_OK);
-            }
+            $this->filesystem()->put("$namespace://$parentPath/$filename", ' ');
 
-            return $this->json(Trans::__('Unable to create file: %FILE%', ['%FILE%' => $filename]), Response::HTTP_FORBIDDEN);
-        } catch (\Exception $e) {
-            return $this->json($e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+            return $this->json(null, Response::HTTP_OK);
+        } catch (IOException $e) {
+            $msg = Trans::__('Unable to create file: %FILE%', ['%FILE%' => $filename]);
+
+            $this->app['logger.system']->critical(
+                $msg . ': ' . $e->getMessage(),
+                ['event' => 'exception', 'exception' => $e]
+            );
+
+            return $this->json($msg, Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -210,11 +210,18 @@ class FilesystemManager extends AsyncBase
             $destination = substr($destination, 0, $extensionPos) . "$n" . substr($destination, $extensionPos);
             $n = rand(0, 1000);
         }
-        if ($filesystem->copy($filename, $destination)) {
-            return true;
-        }
 
-        return false;
+        try {
+            $filesystem->copy($filename, $destination);
+
+            return $this->json(null, Response::HTTP_OK);
+        } catch (IOException $e) {
+            $msg = Trans::__('Unable to duplicate file: %FILE%', ['%FILE%' => $filename]);
+
+            $this->logException($msg, $e);
+
+            return $this->json($msg, Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
     }
 
     /**

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -128,9 +128,14 @@ class FilesystemManager extends AsyncBase
 
             return $this->json(null, Response::HTTP_OK);
         } catch (IOException $e) {
-            return $this->json(Trans::__('Unable to create directory: %DIR%', ['%DIR%' => $folderName]), Response::HTTP_FORBIDDEN);
-        } catch (\Exception $e) {
-            return $this->json($e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);
+            $msg = Trans::__('Unable to create directory: %DIR%', ['%DIR%' => $folderName]);
+
+            $this->app['logger.system']->error(
+                $msg . ': ' . $e->getMessage(),
+                ['event' => 'exception', 'exception' => $e]
+            );
+
+            return $this->json($msg, Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -206,7 +206,7 @@ class FilesystemManager extends AsyncBase
         $extensionPos = strrpos($filename, '.') ?: strlen($filename);
 
         $fileBase = substr($filename, 0, $extensionPos) . '_copy';
-        $fileExtension = substr($filename, $extensionPos + 1);
+        $fileExtension = substr($filename, $extensionPos);
 
         $n = 1;
 

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -16,12 +16,14 @@ use Symfony\Component\HttpFoundation\Response;
  **/
 class FilesystemManagerTest extends ControllerUnitTest
 {
+    const FILESYSTEM = 'files';
+
     const FOLDER_NAME = '__phpunit_test_folder_delete_me';
 
     public function testBrowse()
     {
         $this->setRequest(Request::create('/async/browse'));
-        $response = $this->controller()->browse($this->getRequest(), 'files', '/');
+        $response = $this->controller()->browse($this->getRequest(), self::FILESYSTEM, '/');
 
         $this->assertInstanceOf(BoltResponse::class, $response);
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
@@ -31,7 +33,7 @@ class FilesystemManagerTest extends ControllerUnitTest
     public function testCreateFolder()
     {
         $this->setRequest(Request::create('/async/folder/create', 'POST', [
-            'namespace'  => 'files',
+            'namespace'  => self::FILESYSTEM,
             'parent'     => '',
             'foldername' => self::FOLDER_NAME,
         ]));
@@ -39,6 +41,9 @@ class FilesystemManagerTest extends ControllerUnitTest
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\JsonResponse', $response);
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        // Test whether the new folder actually exists
+        $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FOLDER_NAME));
     }
 
     public function testDeleteFile()
@@ -96,7 +101,7 @@ class FilesystemManagerTest extends ControllerUnitTest
     public function testRemoveFolder()
     {
         $this->setRequest(Request::create('/async/folder/delete', 'POST', [
-            'namespace'  => 'files',
+            'namespace'  => self::FILESYSTEM,
             'parent'     => '',
             'foldername' => self::FOLDER_NAME,
         ]));

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -30,7 +30,7 @@ class FilesystemManagerTest extends ControllerUnitTest
 
     public function testCreateFolder()
     {
-        $this->setRequest(Request::create('/async/createfolder', 'POST', [
+        $this->setRequest(Request::create('/async/folder/create', 'POST', [
             'namespace'  => 'files',
             'parent'     => '',
             'foldername' => '' . self::FOLDER_NAME,
@@ -66,7 +66,7 @@ class FilesystemManagerTest extends ControllerUnitTest
     public function testFileBrowser()
     {
         //$this->setSessionUser(new Entity\Users($this->getService('users')->getUser('admin')));
-        $this->setRequest(Request::create('/async/filebrowser'));
+        $this->setRequest(Request::create('/async/recordbrowser'));
 
         $response = $this->controller()->recordBrowser();
 
@@ -95,7 +95,7 @@ class FilesystemManagerTest extends ControllerUnitTest
 
     public function testRemoveFolder()
     {
-        $this->setRequest(Request::create('/async/removefolder', 'POST', [
+        $this->setRequest(Request::create('/async/folder/delete', 'POST', [
             'namespace'  => 'files',
             'parent'     => '',
             'foldername' => self::FOLDER_NAME,
@@ -122,7 +122,7 @@ class FilesystemManagerTest extends ControllerUnitTest
 
     public function testRenameFolder()
     {
-        //         $this->setRequest(Request::create('/async/renamefolder', 'POST', [
+        //         $this->setRequest(Request::create('/async/folder/rename', 'POST', [
 //             'namespace' => 'files',
 //             'parent'    => '',
 //             'oldname'   => 'foo',

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -36,7 +36,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->setRequest(Request::create('/async/folder/create', 'POST', [
             'namespace'  => self::FILESYSTEM,
             'parent'     => '',
-            'foldername' => self::FOLDER_NAME,
+            'foldername' => self::FOLDER_NAME
         ]));
         $response = $this->controller()->createFolder($this->getRequest());
 
@@ -52,7 +52,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->setRequest(Request::create('/async/file/create', 'POST', [
             'namespace'  => self::FILESYSTEM,
             'parentPath' => '',
-            'filename'   => self::FILE_NAME,
+            'filename'   => self::FILE_NAME
         ]));
         $response = $this->controller()->createFile($this->getRequest());
 
@@ -65,13 +65,23 @@ class FilesystemManagerTest extends ControllerUnitTest
 
     public function testDeleteFile()
     {
-        //         $this->setRequest(Request::create('/async/file/delete', 'POST', [
-//             'namespace' => 'files',
-//             'filename'  => 'foo.txt',
-//         ]));
-//         $response = $this->controller()->deleteFile($this->getRequest());
+        $this->setRequest(Request::create('/async/file/delete', 'POST', [
+            'namespace' => 'files',
+            'filename'  => self::FILE_NAME
+        ]));
 
-//         $this->assertTrue($response);
+        $response = $this->controller()->deleteFile($this->getRequest());
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\JsonResponse', $response);
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        // The file shouldn't exist anymore
+        $this->assertFalse($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FILE_NAME));
+
+        // Attempting to delete the same file twice (or simply attempting to remove a file that doesn't exist) should
+        // return a 404 Not Found status code
+        $response = $this->controller()->deleteFile($this->getRequest());
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\JsonResponse', $response);
+        $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
     }
 
     public function testDuplicateFile()

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -155,22 +155,7 @@ class FilesystemManagerTest extends ControllerUnitTest
             'folder' => ['old' => self::FOLDER_NAME, 'new' => self::FOLDER_NAME_2]
         ];
         foreach ($definitions as $object => $data) {
-            // Create the object
-            $this->setRequest(Request::create("/async/$object/create", 'POST', [
-                'namespace'  => 'files',
-                'parent'     => '',
-                'filename'   => $data['old'],
-                'foldername' => $data['old']
-            ]));
-            switch ($object) {
-                case 'file':
-                    $this->controller()->createFile($this->getRequest());
-                    break;
-                case 'folder':
-                    $this->controller()->createFolder($this->getRequest());
-                    break;
-            }
-            $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . $data['old']));
+            $this->createObject($object, $data['old']);
 
             // Rename the object
             $this->setRequest(Request::create("/async/$object/rename", 'POST', [
@@ -210,22 +195,7 @@ class FilesystemManagerTest extends ControllerUnitTest
             /*
              * Object doesn't exist
              */
-            // Create the Object
-            $this->setRequest(Request::create("/async/$object/create", 'POST', [
-                'namespace'  => 'files',
-                'parent'     => '',
-                'filename'   => $data['old'],
-                'foldername' => $data['old']
-            ]));
-            switch ($object) {
-                case 'file':
-                    $this->controller()->createFile($this->getRequest());
-                    break;
-                case 'folder':
-                    $this->controller()->createFolder($this->getRequest());
-                    break;
-            }
-            $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . $data['old']));
+            $this->createObject($object, $data['old']);
 
             $this->setRequest(Request::create("/async/$object/rename", 'POST', [
                 'namespace' => 'files',
@@ -249,21 +219,8 @@ class FilesystemManagerTest extends ControllerUnitTest
              * Destination already exists
              */
             // Create the objects
-            foreach ([$data['old'], $data['old']] as $filename) {
-                $this->setRequest(Request::create("/async/$object/create", 'POST', [
-                    'namespace'  => 'files',
-                    'parent'     => '',
-                    'filename'   => $filename,
-                    'foldername' => $data['old']
-                ]));
-                switch ($object) {
-                    case 'file':
-                        $this->controller()->renameFile($this->getRequest());
-                        break;
-                    case 'folder':
-                        $this->controller()->createFolder($this->getRequest());
-                        break;
-                }
+            foreach ([$data['old'], $data['new']] as $filename) {
+                $this->createObject($object, $filename);
             }
 
             $this->setRequest(Request::create("/async/$object/rename", 'POST', [
@@ -343,6 +300,29 @@ class FilesystemManagerTest extends ControllerUnitTest
 //         $response = $this->controller()->renameFolder($this->getRequest());
 
 //         $this->assertTrue($response);
+    }
+
+    /**
+     * @param string $object The type of the object, either 'file' or 'folder'
+     * @param string $name The name of the new object
+     */
+    private function createObject($object, $name)
+    {
+        $this->setRequest(Request::create("/async/$object/create", 'POST', [
+            'namespace'  => 'files',
+            'parent'     => '',
+            'filename'   => $name,
+            'foldername' => $name
+        ]));
+        switch ($object) {
+            case 'file':
+                $this->controller()->createFile($this->getRequest());
+                break;
+            case 'folder':
+                $this->controller()->createFolder($this->getRequest());
+                break;
+        }
+        $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . $name));
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -18,6 +18,7 @@ class FilesystemManagerTest extends ControllerUnitTest
 {
     const FILESYSTEM = 'files';
 
+    const FILE_NAME = '__phpunit_test_file_delete_me';
     const FOLDER_NAME = '__phpunit_test_folder_delete_me';
 
     public function testBrowse()
@@ -44,6 +45,22 @@ class FilesystemManagerTest extends ControllerUnitTest
 
         // Test whether the new folder actually exists
         $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FOLDER_NAME));
+    }
+
+    public function testCreateFile()
+    {
+        $this->setRequest(Request::create('/async/file/create', 'POST', [
+            'namespace'  => self::FILESYSTEM,
+            'parentPath' => '',
+            'filename'   => self::FILE_NAME,
+        ]));
+        $response = $this->controller()->createFile($this->getRequest());
+
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\JsonResponse', $response);
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        // Test whether the new folder actually exists
+        $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FILE_NAME));
     }
 
     public function testDeleteFile()

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -3,6 +3,7 @@ namespace Bolt\Tests\Controller\Async;
 
 use Bolt\Filesystem\Handler\HandlerInterface;
 use Bolt\Response\BoltResponse;
+use Bolt\Session\Handler\FileHandler;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -40,7 +41,13 @@ class FilesystemManagerTest extends ControllerUnitTest
      */
     public function restoreFileList()
     {
-        $newFiles = array_diff($this->getService('filesystem')->listContents(self::FILESYSTEM . '://'), $this->oldFiles);
+        $newFiles = array_udiff(
+            $this->getService('filesystem')->listContents(self::FILESYSTEM . '://'),
+            $this->oldFiles,
+            function (HandlerInterface $file1, HandlerInterface $file2) {
+                return strcmp($file2->getPath(), $file2->getPath());
+            }
+        );
         /** @var HandlerInterface $file */
         foreach ($newFiles as $file) {
             $file->delete();

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -91,7 +91,7 @@ class FilesystemManagerTest extends ControllerUnitTest
     {
         $filenames = ['__phpunit_test_file_delete_me.extension', '.__phpunit_test_dotfile_delete_me'];
 
-        foreach($filenames as $filename) {
+        foreach ($filenames as $filename) {
             // Create the file
             $this->getService('filesystem')->put(self::FILESYSTEM . '://' . $filename, '');
 
@@ -224,7 +224,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $response = $this->controller()->filesAutoComplete($this->getRequest());
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertCount($count*count($extensions), json_decode($response->getContent()));
+        $this->assertCount($count * count($extensions), json_decode($response->getContent()));
 
         // Filtering by one extension should return only $count files
         $this->setRequest(Request::create('/async/file/autocomplete', 'GET', [

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Tests\Controller\Async;
 
+use Bolt\Filesystem\Handler\HandlerInterface;
 use Bolt\Response\BoltResponse;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
@@ -21,6 +22,30 @@ class FilesystemManagerTest extends ControllerUnitTest
     const FILE_NAME_2 = '__phpunit_test_file_2_delete_me';
     const FOLDER_NAME = '__phpunit_test_folder_delete_me';
     const FOLDER_NAME_2 = '__phpunit_test_folder_2_delete_me';
+
+    private $oldFiles = [];
+
+    /**
+     * Store the list of files in the files folder so we can delete any added files after we're done testing
+     * @before
+     */
+    public function storeFileList()
+    {
+        $this->oldFiles = $this->getService('filesystem')->listContents(self::FILESYSTEM . '://');
+    }
+
+    /**
+     * Remove any files added during the test
+     * @after
+     */
+    public function restoreFileList()
+    {
+        $newFiles = array_diff($this->getService('filesystem')->listContents(self::FILESYSTEM . '://'), $this->oldFiles);
+        /** @var HandlerInterface $file */
+        foreach ($newFiles as $file) {
+            $file->delete();
+        }
+    }
 
     public function testBrowse()
     {

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -47,6 +47,25 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FOLDER_NAME));
     }
 
+    public function testRemoveFolder()
+    {
+        $this->setRequest(Request::create('/async/folder/delete', 'POST', [
+            'namespace'  => self::FILESYSTEM,
+            'parent'     => '',
+            'foldername' => self::FOLDER_NAME,
+        ]));
+
+        // The folder should exist before deleting
+        $this->controller()->createFolder($this->getRequest());
+        $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FOLDER_NAME));
+
+        $response = $this->controller()->removeFolder($this->getRequest());
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        $this->assertFalse($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FOLDER_NAME));
+    }
+
     public function testCreateFile()
     {
         $this->setRequest(Request::create('/async/file/create', 'POST', [
@@ -169,20 +188,6 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->assertTrue($response instanceof BoltResponse);
         $this->assertSame('@bolt/recordbrowser/recordbrowser.twig', $response->getTemplateName());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-    }
-
-    public function testRemoveFolder()
-    {
-        $this->setRequest(Request::create('/async/folder/delete', 'POST', [
-            'namespace'  => self::FILESYSTEM,
-            'parent'     => '',
-            'foldername' => self::FOLDER_NAME,
-        ]));
-        $this->controller()->createFolder($this->getRequest());
-        $response = $this->controller()->removeFolder($this->getRequest());
-
-        $this->assertInstanceOf(JsonResponse::class, $response);
-        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testRenameFile()

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -23,9 +23,9 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->setRequest(Request::create('/async/browse'));
         $response = $this->controller()->browse($this->getRequest(), 'files', '/');
 
-        $this->assertTrue($response instanceof BoltResponse);
+        $this->assertInstanceOf(BoltResponse::class, $response);
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertSame('@bolt/async/browse.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/async/browse.twig', $response->getTemplateName());
     }
 
     public function testCreateFolder()
@@ -33,7 +33,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->setRequest(Request::create('/async/folder/create', 'POST', [
             'namespace'  => 'files',
             'parent'     => '',
-            'foldername' => '' . self::FOLDER_NAME,
+            'foldername' => self::FOLDER_NAME,
         ]));
         $response = $this->controller()->createFolder($this->getRequest());
 

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -107,6 +107,9 @@ class FilesystemManagerTest extends ControllerUnitTest
             'filename'  => self::FILE_NAME
         ]));
 
+        // The file should still exist before deleting
+        $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FILE_NAME));
+
         $response = $this->controller()->deleteFile($this->getRequest());
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -108,6 +108,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         ]));
 
         // The file should still exist before deleting
+        $this->controller()->createFile($this->getRequest());
         $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . self::FILE_NAME));
 
         $response = $this->controller()->deleteFile($this->getRequest());

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Response;
  **/
 class FilesystemManagerTest extends ControllerUnitTest
 {
+    const FOLDER_NAME = '__phpunit_test_folder_delete_me';
+
     public function testBrowse()
     {
         $this->setRequest(Request::create('/async/browse'));
@@ -31,7 +33,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->setRequest(Request::create('/async/createfolder', 'POST', [
             'namespace'  => 'files',
             'parent'     => '',
-            'foldername' => '__phpunit_test_delete_me',
+            'foldername' => '' . self::FOLDER_NAME,
         ]));
         $response = $this->controller()->createFolder($this->getRequest());
 
@@ -96,7 +98,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->setRequest(Request::create('/async/removefolder', 'POST', [
             'namespace'  => 'files',
             'parent'     => '',
-            'foldername' => '__phpunit_test_delete_me',
+            'foldername' => self::FOLDER_NAME,
         ]));
         $this->controller()->createFolder($this->getRequest());
         $response = $this->controller()->removeFolder($this->getRequest());

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -158,21 +158,8 @@ class FilesystemManagerTest extends ControllerUnitTest
             $this->createObject($object, $data['old']);
 
             // Rename the object
-            $this->setRequest(Request::create("/async/$object/rename", 'POST', [
-                'namespace' => 'files',
-                'parent'    => '',
-                'oldname'   => $data['old'],
-                'newname'   => $data['new']
-            ]));
+            $response = $this->renameObject($object, $data['old'], $data['new']);
 
-            switch ($object) {
-                case 'file':
-                    $response = $this->controller()->renameFile($this->getRequest());
-                    break;
-                case 'folder':
-                    $response = $this->controller()->renameFolder($this->getRequest());
-                    break;
-            }
             $this->assertInstanceOf(JsonResponse::class, $response);
             $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
 
@@ -196,22 +183,8 @@ class FilesystemManagerTest extends ControllerUnitTest
              * Object doesn't exist
              */
             $this->createObject($object, $data['old']);
+            $response = $this->renameObject($object, $data['old'] . '_nonexistent', $data['new']);
 
-            $this->setRequest(Request::create("/async/$object/rename", 'POST', [
-                'namespace' => 'files',
-                'parent'    => '',
-                'oldname'   => $data['old'] . '_nonexistent',
-                'newname'   => $data['new']
-            ]));
-
-            switch ($object) {
-                case 'file':
-                    $response = $this->controller()->renameFile($this->getRequest());
-                    break;
-                case 'folder':
-                    $response = $this->controller()->renameFolder($this->getRequest());
-                    break;
-            }
             $this->assertInstanceOf(JsonResponse::class, $response);
             $this->assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
 
@@ -223,21 +196,7 @@ class FilesystemManagerTest extends ControllerUnitTest
                 $this->createObject($object, $filename);
             }
 
-            $this->setRequest(Request::create("/async/$object/rename", 'POST', [
-                'namespace' => 'files',
-                'parent'    => '',
-                'oldname'   => $data['old'],
-                'newname'   => $data['new']
-            ]));
-
-            switch ($object) {
-                case 'file':
-                    $response = $this->controller()->renameFile($this->getRequest());
-                    break;
-                case 'folder':
-                    $response = $this->controller()->renameFolder($this->getRequest());
-                    break;
-            }
+            $response = $this->renameObject($object, $data['old'], $data['new']);
             $this->assertInstanceOf(JsonResponse::class, $response);
             $this->assertEquals(Response::HTTP_CONFLICT, $response->getStatusCode());
         }
@@ -289,19 +248,6 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
-    public function testRenameFolder()
-    {
-        //         $this->setRequest(Request::create('/async/folder/rename', 'POST', [
-//             'namespace' => 'files',
-//             'parent'    => '',
-//             'oldname'   => 'foo',
-//             'newname'   => 'bar',
-//         ]));
-//         $response = $this->controller()->renameFolder($this->getRequest());
-
-//         $this->assertTrue($response);
-    }
-
     /**
      * @param string $object The type of the object, either 'file' or 'folder'
      * @param string $name The name of the new object
@@ -323,6 +269,33 @@ class FilesystemManagerTest extends ControllerUnitTest
                 break;
         }
         $this->assertTrue($this->getService('filesystem')->has(self::FILESYSTEM . '://' . $name));
+    }
+
+    /**
+     * @param string $object The type of the object, either 'file' or 'folder'
+     * @param string $old
+     * @param string $new
+     *
+     * @return JsonResponse
+     */
+    private function renameObject($object, $old, $new)
+    {
+        $this->setRequest(Request::create("/async/$object/rename", 'POST', [
+            'namespace' => 'files',
+            'parent'    => '',
+            'oldname'   => $old,
+            'newname'   => $new
+        ]));
+        switch ($object) {
+            case 'file':
+                $response = $this->controller()->renameFile($this->getRequest());
+                break;
+            case 'folder':
+                $response = $this->controller()->renameFolder($this->getRequest());
+                break;
+        }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
I've updated `\Bolt\Controller\Async\FilesystemManager` to work properly with Bolt 3.0's filesystem API and I've improved its responses by returning more proper status codes where possible, logging any errors to the system log (as suggested by @GawainLynch in #4882) and returning a file path instead of an empty JSON object (`{}`) on success. I've also added missing tests so that every controller action is covered.

There are a lot of commits (I was feeling generous) so I could probably squash some of them.

Fixes: #4886