### PR TITLE
Added the search dialog to the standalone file editor interface

### DIFF
--- a/app/view/twig/editfile/editfile.twig
+++ b/app/view/twig/editfile/editfile.twig
@@ -93,6 +93,7 @@
         <link rel="stylesheet" property="stylesheet" href="{{ paths.app }}view/js/ckeditor/plugins/codemirror/css/codemirror.min.css">
         <script src="{{ paths.app }}view/js/ckeditor/ckeditor.js"></script>
         <script src="{{ paths.app }}view/js/ckeditor/plugins/codemirror/js/codemirror.min.js"></script>
+        <script src="{{ paths.app }}view/js/ckeditor/plugins/codemirror/js/codemirror.addons.search.min.js"></script>
         {% for file in codemirror %}
             <script src="{{ paths.app }}view/js/ckeditor/plugins/codemirror/plugins/{{ file }}.min.js"></script>
         {% endfor %}


### PR DESCRIPTION
After Logging in and selecting 

**File Management** > **View/Edit templates**

Doing a Ctrl+F for search does not load the search dialog like it does when editing a page from a content type. As you may know using the native browser search does not work with codemirror for any longer than a couple of pages.

Added the search dialog plugin script resource to the template