### PR TITLE
Allow for overriding `notfound` in theme.yml

### DIFF
--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -33,7 +33,7 @@ class EventListenerServiceProvider implements ServiceProviderInterface
         $app['listener.not_found'] = $app->share(
             function ($app) {
                 return new Listener\NotFoundListener(
-                    $app['config']->get('theme/notfound') ?: $app['config']->get('theme/notfound'),
+                    $app['config']->get('theme/notfound') ?: $app['config']->get('general/notfound'),
                     $app['storage.legacy'],
                     $app['templatechooser'],
                     $app['render']

--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -33,7 +33,7 @@ class EventListenerServiceProvider implements ServiceProviderInterface
         $app['listener.not_found'] = $app->share(
             function ($app) {
                 return new Listener\NotFoundListener(
-                    $app['config']->get('general/notfound'),
+                    $app['config']->get('theme/notfound') ?: $app['config']->get('theme/notfound'),
                     $app['storage.legacy'],
                     $app['templatechooser'],
                     $app['render']


### PR DESCRIPTION
In theme.yml, we can currently override most of the templates, optionally: 

```
maintenance_template: maintenance_default.twig

homepage_template: index.twig
record_template: record.twig
listing_template: listing.twig
search_results_template: listing.twig
```

The only one we can't override, is `notfound:`:

```
notfound: notfound.twig
```

This PR makes the behaviour consistent. 