### PR TITLE
In `.related()` only get published items, unless explicitly stated otherwise.

### DIFF
--- a/src/Storage/Entity/ContentRelationTrait.php
+++ b/src/Storage/Entity/ContentRelationTrait.php
@@ -67,6 +67,11 @@ trait ContentRelationTrait
                 }
             }
 
+            // Only get published items, unless specifically stated otherwise.
+            if (!isset($where['status'])) {
+                $where['status'] = 'published';
+            }
+
             $tempResult = $this->app['storage']->getContent($contenttype, $params, $dummy, $where);
 
             if (empty($tempResult)) {


### PR DESCRIPTION

Fixes: #4896 

