### PR TITLE
missing loop.last gives fatal error in strict mode

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -31,7 +31,7 @@
     nextgroup:      new_group|default(false),
     unordered:      request('order') == '',
     first:          loop.first,
-    last:           loop.last
+    last:           loop.last|default(loop.first)
 }%}
 
 {% set local = {


### PR DESCRIPTION
when strict variables is on and there is only a single relation  the loop.last is empty.

this sets the loop last to the same as loop first in that case - which prevents the error