### PR TITLE
Don't show "Update DB" notice, when we're already updating the DB.

### DIFF
--- a/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
+++ b/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
@@ -318,9 +318,13 @@ class BackendAdminCest
         // Set up the browser
         $I->setCookie($this->tokenNames['authtoken'], $this->cookies[$this->tokenNames['authtoken']]);
         $I->setCookie($this->tokenNames['session'], $this->cookies[$this->tokenNames['session']]);
-        $I->amOnPage('/bolt/dbcheck');
-
+        $I->amOnPage('/bolt');
         $I->see('The database needs to be updated/repaired');
+
+        $I->see('Check Database', 'a');
+        $I->click('Check Database', 'a');
+
+        // We are now on '/bolt/dbcheck'.
         $I->see('is not present');
         $I->see('Update the database', Locator::find('button', ['type' => 'submit']));
 


### PR DESCRIPTION
As pointed out by @EJanuszewski in #4899 

> The database message also stays popped up after updating it(on the database update page), I might open a separate issue for this.

This PR fixes that, as soon as #4912 is also fixed. 