### PR TITLE
Fixes for Twig strict-mode with repeater groups

### DIFF
--- a/app/view/twig/editcontent/fields/_date.twig
+++ b/app/view/twig/editcontent/fields/_date.twig
@@ -6,7 +6,7 @@
     label:     field.label,
     info:      field.info|default(''),
     options:   field.options.datepicker|default(''),
-    default:   (context.content.id == null and field.default) ? field.default|date('Y-m-d') : null,
+    default:   (context.content.get('id') == null and field.default) ? field.default|date('Y-m-d') : null,
     required:  field.required|default(false),
     errortext: field.error|default(''),
 } %}

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -15,7 +15,8 @@
             class:      '',
             label:      '',
             variant:    '',
-            canUpload:  field.canUpload
+            canUpload:  field.canUpload,
+            default:    null
         } %}
         {% for rkey, rfield in field.fields %}
             {% set rfield = defaults|merge(rfield) %}

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -101,6 +101,22 @@ class RepeaterType extends FieldTypeBase
     }
 
     /**
+     * The set method gets called directly by a new entity builder. For this field we never want to allow
+     * null values, rather we want an empty collection so this overrides the default and handles that.
+     *
+     * @param object $entity
+     * @param mixed $val
+     */
+    public function set($entity, $val)
+    {
+        if ($val === null) {
+            $val = new RepeatingFieldCollection($this->em, $this->mapping);
+        }
+
+        return parent::set($entity, $val);
+    }
+
+    /**
      * Normalize step ensures that we have correctly hydrated objects at the collection
      * and entity level.
      *


### PR DESCRIPTION
Pinging @bobdenotter @EJanuszewski for test please.

Hopefully Fixes: #4907 

Adds some auto defaults to the base default array that should prevent Twig choking in strict mode.
Also fixes an access issue for the date field which was also causing a failure in strict mode.
