### PR TITLE
Removed BC for $app['console'] forwarding to $app['nut']

### DIFF
--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -106,13 +106,6 @@ class NutServiceProvider implements ServiceProviderInterface
                 );
             }
         );
-
-        // Maintain backwards compatibility
-        $app['console'] = $app->share(
-            function ($app) {
-                return $app['nut'];
-            }
-        );
     }
 
     public function boot(Application $app)

--- a/tests/phpunit/unit/Provider/NutServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/NutServiceProviderTest.php
@@ -3,6 +3,7 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\NutServiceProvider;
 use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\Console;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -19,8 +20,7 @@ class NutServiceProviderTest extends BoltUnitTest
         $app->register(new NutServiceProvider());
         $app->boot();
 
-        $this->assertInstanceOf('Symfony\Component\Console\Application', $app['nut']);
-        $this->assertInstanceOf('Symfony\Component\Console\Application', $app['console']);
+        $this->assertInstanceOf(Console\Application::class, $app['nut']);
         $this->assertTrue(is_array($app['nut.commands']));
     }
 


### PR DESCRIPTION
This is a major version so this is valid. 

Argument: It is way easier for a user to re-add this if needed vs having bolt override another console service.