### PR TITLE
Fix checkbox not showing on filelist modal

### DIFF
--- a/app/view/twig/files_async/files_async.twig
+++ b/app/view/twig/files_async/files_async.twig
@@ -83,6 +83,11 @@
                     {% else %}
 
                         <tr>
+                            {% if context.multiselect == 1 %}
+                                <td>
+                                    <input type="checkbox" class="file-checkbox" onclick="Bolt.stack.checkFileToAdd('{{ file.relativepath }}')" />
+                                </td>
+                            {% endif %}
                             <td>
 
                                 <i class="fa fa-fw fa-file-image-o"></i>


### PR DESCRIPTION
Fix the checkbox not showing in the modal when using filelist type, this got missed and was only showing for imagelist type.