### PR TITLE
[RFC] Set default error reporting to ignore 'warnings'

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -249,7 +249,7 @@ debug: true
 developer_notices: false
 debug_show_loggedoff: false
 debug_permission_audit_mode: false
-debug_error_level: 6135 # equivalent to E_ALL &~ E_NOTICE &~ E_DEPRECATED &~ E_USER_DEPRECATED
+debug_error_level: 8181 # equivalent to E_ALL &~ E_NOTICE &~ E_DEPRECATED &~ E_USER_DEPRECATED &~ E_WARNING
 # debug_error_level: 30719 # equivalent to E_ALL
 debug_enable_whoops: true # change this to false to use PHP's built-in error handling instead of Whoops
 


### PR DESCRIPTION
Peter bumped into an issue on bolt 2.2.18, where the composer code was inserting warnings in ajaxy requests.

See screenshot: 

![screenshot 2016-02-27 20 16 27](https://cloud.githubusercontent.com/assets/1833361/13374798/2f1cdae4-dd8f-11e5-843a-740113df122b.png)

This proposed fix 'resolves' it, but i'm not certain it's the right way to go. The offending code is not ours, so we can't easily fix it. 

