### PR TITLE
Better check for templatefields in 'editcontent'

### DIFF
--- a/app/view/twig/editcontent/_templatefields.twig
+++ b/app/view/twig/editcontent/_templatefields.twig
@@ -4,9 +4,9 @@
     </h3>
 {% endif %}
 
-{% set templatefields = context.content.get('templatefields').contenttype %}
-{% if templatefields.fields is not empty %}
-    {% for templatekey, templatefield in templatefields.fields %}
+{% set templatefields = context.content.get('templatefields') %}
+{% if templatefields.contenttype.fields is defined and templatefields.contenttype.fields is not empty %}
+    {% for templatekey, templatefield in templatefields.contenttype.fields %}
 
             <div data-bolt-fieldset="{{ templatefield.type }}">
                 {# Prefix #}
@@ -23,7 +23,7 @@
                     field: templatefield,
                     key: 'templatefields-' ~ templatekey,
                     contentkey: templatekey,
-                    context: context|merge({ content: context.content.get('templatefields') }),
+                    context: context|merge({ content: templatefields }),
                     name: 'templatefields[' ~ templatekey ~ ']',
                     labelkey:  templatelabelkey
                 } %}


### PR DESCRIPTION
This is a bit of an edgecase: Let's say you have a field with `group: template`, but the currently selected template doesn't have any actual 'templatefields'. You'll get this nice error:

![screen shot 2016-02-29 at 16 28 43](https://cloud.githubusercontent.com/assets/1833361/13399033/875caa2c-df01-11e5-9b58-43fdb1c56689.png)

This PR fixes that.
