### PR TITLE
Fix Config Setting for certain options in config.yml

### DIFF
--- a/src/YamlUpdater.php
+++ b/src/YamlUpdater.php
@@ -83,7 +83,7 @@ class YamlUpdater
      */
     public function change($key, $value, $makebackup = true)
     {
-        $pattern = str_replace('/', ":.*", $key);
+        $pattern = str_replace('/', ":[^\\^]*", $key);
         preg_match_all('/^'.$pattern.'(:\s*)/mis', $this->file->read(), $matches,  PREG_OFFSET_CAPTURE);
 
         if (count($matches[0]) > 0 && count($matches[1])) {


### PR DESCRIPTION
Fixes: #4934 
As dangerous as: #1555

Details
-------
Found that the problem with #4934 only happened when another key (as part of a different block) was present in the same file. Hence in the case of the database update this meant that the 'mailoptions: username' caused the regex not to parse properly.

Despite the two character diff this makes the regex less greedy so it only traverses down a single block rather than the whole file.

