### PR TITLE
Version class

### DIFF
--- a/app/view/toolbar/bolt.html.twig
+++ b/app/view/toolbar/bolt.html.twig
@@ -28,10 +28,6 @@
             <strong>Bolt {{ collector.version }}</strong>
         </span>
 
-        {% if collector.versionname is not empty %}
-            <span class="sf-toolbar-value sf-toolbar-status-yellow">{{ collector.versionname }}</span>
-        {% endif %}
-
     {% endset %}
 
     {% set text %}
@@ -44,7 +40,7 @@
 
         <div class="sf-toolbar-info-piece">
             <span>
-                {{ collector.fullversion }} - {{ collector.aboutlink|raw }} - Visit <a href="http://bolt.cm" target="_blank">Bolt.cm</a>
+                Version: {{ collector.version }} - {{ collector.aboutlink|raw }} - Visit <a href="http://bolt.cm" target="_blank">Bolt.cm</a>
             </span>
         </div>
 

--- a/app/view/twig/about/about.twig
+++ b/app/view/twig/about/about.twig
@@ -11,7 +11,7 @@
 
     <div class="row">
         <div class="col-md-9">
-            <h2>Bolt {{ bolt_version }}<small>{% if bolt_name is defined %} - {{ bolt_name }}{% endif %}</small></h2>
+            <h2>Bolt {{ bolt_version }}</h2>
 
             {{ app.translator.trans('about.bolt', {}, 'infos')|raw }}
 

--- a/app/view/twig/checks/checks.twig
+++ b/app/view/twig/checks/checks.twig
@@ -5,7 +5,7 @@
 {% block page_title __('System Configuration Checks') %}
 
 {% block page_subtitle %}
-    Bolt {{ bolt_version }}<small>{% if bolt_name is defined %} - {{ bolt_name }}{% endif %}</small>
+    Bolt {{ bolt_version }}
 {% endblock page_subtitle %}
 
 {% block page_main %}

--- a/app/view/twig/dashboard/_aside.twig
+++ b/app/view/twig/dashboard/_aside.twig
@@ -4,7 +4,7 @@
 {% include '@bolt/_sub/_configuration_notices.twig' %}
 
 {# If we're running a development version, show annoying message. #}
-{% if app.bolt_released == false %}
+{% if not bolt_stable %}
 <div class="panel panel-default panel-news">
     <div class="progress-bar progress-bar-warning progress-bar-striped active" style="width: 100%; text-align: left; color: #333; padding: 10px 14px; margin-bottom: 15px;">
         <b><i class="fa fa-fw fa-bullhorn"></i> Warning: Development version </b>

--- a/src/Application.php
+++ b/src/Application.php
@@ -23,12 +23,14 @@ class Application extends Silex\Application
      */
     public function __construct(array $values = [])
     {
-        $values['bolt_version'] = '3.0.0';
-        $values['bolt_name'] = 'alpha 6';
-        $values['bolt_released'] = false; // `true` for stable releases, `false` for alpha, beta and RC.
-        $values['bolt_long_version'] = function ($app) {
-            return $app['bolt_version'] . ' ' . $app['bolt_name'];
-        };
+        /** @deprecated since 3.0, to be removed in 4.0. */
+        $values['bolt_version'] = Version::VERSION;
+        /** @deprecated since 3.0, to be removed in 4.0. */
+        $values['bolt_name'] = Version::name();
+        /** @deprecated since 3.0, to be removed in 4.0. */
+        $values['bolt_released'] = Version::isStable();
+        /** @deprecated since 3.0, to be removed in 4.0. */
+        $values['bolt_long_version'] = Version::VERSION;
 
         /** @internal Parameter to track a deprecated PHP version */
         $values['deprecated.php'] = version_compare(PHP_VERSION, '5.5.9', '<');
@@ -321,16 +323,14 @@ class Application extends Silex\Application
     /**
      * Get the Bolt version string
      *
-     * @param boolean $long TRUE returns 'version name', FALSE 'version'
-     *
      * @return string
      *
      * @deprecated Deprecated since 3.0, to be removed in 4.0.
      *             Use parameters in application instead
      */
-    public function getVersion($long = true)
+    public function getVersion()
     {
-        return $this[$long ? 'bolt_long_version' : 'bolt_version'];
+        return Version::VERSION;
     }
 
     /**

--- a/src/Composer/JsonManager.php
+++ b/src/Composer/JsonManager.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Composer;
 
+use Bolt;
 use Bolt\Filesystem\Exception\IOException;
 use Bolt\Filesystem\Handler\JsonFile;
 use Bolt\Helpers\Arr;
@@ -127,7 +128,7 @@ class JsonManager
                 'preferred-install' => 'dist',
             ],
             'provide' => [
-                'bolt/bolt' => $this->app['bolt_version'],
+                'bolt/bolt' => Bolt\Version::forComposer(),
             ],
             'extra' => [
                 'bolt-web-path' => $pathToWeb,

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Composer;
 
+use Bolt;
 use Bolt\Extension\ResolvedExtension;
 use Bolt\Filesystem\Exception\ParseException;
 use Bolt\Filesystem\Handler\JsonFile;
@@ -248,14 +249,14 @@ class PackageManager
             // Handle non-Bolt packages
             if ($extension) {
                 $title = $extension->getDisplayName();
-                $constraint = $extension->getDescriptor()->getConstraint() ?: $this->app['bolt_version'];
+                $constraint = $extension->getDescriptor()->getConstraint() ?: Bolt\Version::VERSION;
                 $readme = $this->linkReadMe($extension);
                 $config = $this->linkConfig($extension);
                 $valid = $extension->isValid();
                 $enabled = $extension->isEnabled();
             } else {
                 $title = $name;
-                $constraint = $this->app['bolt_version'];
+                $constraint = Bolt\Version::VERSION;
                 $readme = null;
                 $config = null;
                 $valid = true;
@@ -380,8 +381,7 @@ class PackageManager
         }
         if ($addQuery) {
             $query = [
-                'bolt_ver'  => $this->app['bolt_version'],
-                'bolt_name' => $this->app['bolt_name'],
+                'bolt_ver'  => Bolt\Version::VERSION,
                 'php'       => phpversion(),
                 'www'       => $www,
             ];

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,6 +2,7 @@
 
 namespace Bolt;
 
+use Bolt;
 use Bolt\Controller\Zone;
 use Bolt\Exception\LowlevelException;
 use Bolt\Helpers\Arr;
@@ -1151,7 +1152,7 @@ class Config
 
             // Check to make sure the version is still the same. If not, effectively invalidate the
             // cached config to force a reload.
-            if (!isset($this->data['version']) || ($this->data['version'] != $this->app['bolt_long_version'])) {
+            if (!isset($this->data['version']) || Bolt\Version::compare($this->data['version'], '!=')) {
                 // The logger and the flashbags aren't available yet, so we set a flag to notify the user later.
                 $this->notify_update = true;
 
@@ -1174,7 +1175,7 @@ class Config
     protected function saveCache()
     {
         // Store the version number along with the config.
-        $this->data['version'] = $this->app['bolt_long_version'];
+        $this->data['version'] = Bolt\Version::VERSION;
         $configCache = $this->app['resources']->getPath('cache/config-cache.json');
         $fs = new Filesystem();
 

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Controller\Async;
 
+use Bolt;
 use Bolt\Pager;
 use GuzzleHttp\Exception\RequestException;
 use Silex\ControllerCollection;
@@ -335,11 +336,10 @@ class General extends AsyncBase
 
                     // Iterate over the items, pick the first news-item that
                     // applies and the first alert we need to show
-                    $version = $this->app['bolt_version'];
                     foreach ($fetchedNewsItems as $item) {
                         $type = ($item->type === 'alert') ? 'alert' : 'information';
                         if (!isset($news[$type])
-                            && (empty($item->target_version) || version_compare($item->target_version, $version, '>'))
+                            && (empty($item->target_version) || Bolt\Version::compare($item->target_version, '>'))
                         ) {
                             $news[$type] = $item;
                         }
@@ -377,7 +377,7 @@ class General extends AsyncBase
         $url = sprintf(
             '%s?v=%s&p=%s&db=%s&name=%s',
             $source,
-            rawurlencode($this->app['bolt_version']),
+            rawurlencode(Bolt\Version::VERSION),
             phpversion(),
             $driver,
             base64_encode($hostname)

--- a/src/Controller/Backend/Extend.php
+++ b/src/Controller/Backend/Extend.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Controller\Backend;
 
+use Bolt;
 use Bolt\Exception\PackageManagerException;
 use Bolt\Translation\Translator as Trans;
 use Silex;
@@ -221,7 +222,7 @@ class Extend extends BackendBase
     {
         $package = $request->get('package');
         $versions = ['dev' => [], 'stable' => []];
-        $info = $this->app['extend.info']->info($package, $this->app['bolt_version']);
+        $info = $this->app['extend.info']->info($package, Bolt\Version::VERSION);
 
         if (isset($info->version) && is_array($info->version)) {
             foreach ($info->version as $version) {

--- a/src/Profiler/BoltDataCollector.php
+++ b/src/Profiler/BoltDataCollector.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Profiler;
 
+use Bolt;
 use Bolt\Translation\Translator as Trans;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,9 +36,7 @@ class BoltDataCollector extends DataCollector
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         $this->data = [
-            'version'     => $this->app['bolt_version'],
-            'name'        => $this->app['bolt_name'],
-            'fullversion' => 'Version: ' . $this->app['bolt_long_version'],
+            'version'     => Bolt\Version::VERSION,
             'payoff'      => 'Sophisticated, lightweight & simple CMS',
             'aboutlink'   => sprintf('<a href="%s">%s</a>', $this->app['url_generator']->generate('about'), 'About'),
             'branding'    => null,
@@ -68,26 +67,6 @@ class BoltDataCollector extends DataCollector
     public function getVersion()
     {
         return $this->data['version'];
-    }
-
-    /**
-     * Getter for fullversion.
-     *
-     * @return string
-     */
-    public function getFullVersion()
-    {
-        return $this->data['fullversion'];
-    }
-
-    /**
-     * Getter for name.
-     *
-     * @return string
-     */
-    public function getVersionName()
-    {
-        return $this->data['name'];
     }
 
     /**

--- a/src/Provider/ConfigServiceProvider.php
+++ b/src/Provider/ConfigServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Provider;
 
+use Bolt;
 use Bolt\Config;
 use Bolt\Configuration\Environment;
 use Silex\Application;
@@ -29,7 +30,7 @@ class ConfigServiceProvider implements ServiceProviderInterface
                     $viewPath,
                     $app['cache'],
                     $app['extend.action'],
-                    $app['bolt_long_version']
+                    Bolt\Version::VERSION
                 );
 
                 return $environment;

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Provider;
 
+use Bolt;
 use Bolt\Nut;
 use Bolt\Nut\NutApplication;
 use LogicException;
@@ -17,9 +18,7 @@ class NutServiceProvider implements ServiceProviderInterface
                 $console = new NutApplication();
 
                 $console->setName('Bolt console tool - Nut');
-                if (isset($app['bolt_long_version'])) {
-                    $console->setVersion($app['bolt_long_version']);
-                }
+                $console->setVersion(Bolt\Version::VERSION);
 
                 $console->addCommands($app['nut.commands']);
 

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Twig;
 
+use Bolt;
 use Bolt\Controller\Zone;
 use Silex;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -170,8 +171,9 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
 
         // Structured to allow PHPStorm's SymfonyPlugin to provide code completion
         return [
-            'bolt_name'    => $this->app['bolt_name'],
-            'bolt_version' => $this->app['bolt_version'],
+            'bolt_name'    => Bolt\Version::name(),
+            'bolt_version' => Bolt\Version::VERSION,
+            'bolt_stable'  => Bolt\Version::isStable(),
             'frontend'     => $zone === Zone::FRONTEND,
             'backend'      => $zone === Zone::BACKEND,
             'async'        => $zone === Zone::ASYNC,

--- a/src/Version.php
+++ b/src/Version.php
@@ -49,7 +49,7 @@ final class Version
         }
 
         $parts = explode(' ', static::VERSION, 2);
-        $version = $parts[0] . '@' . $parts[1];
+        $version = $parts[0] . '-' . $parts[1];
         $version = str_replace(' ', '', strtolower($version));
 
         return $version;

--- a/src/Version.php
+++ b/src/Version.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Bolt;
+
+/**
+ * Bolt's current version.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+final class Version
+{
+    const VERSION = '3.0.0 alpha 6';
+
+    /**
+     * Whether this release is a stable one.
+     *
+     * @return bool
+     */
+    public static function isStable()
+    {
+        return (bool) preg_match('/^[0-9\.]+$/', static::VERSION);
+    }
+
+    /**
+     * Compares a version to Bolt's version.
+     *
+     * @param string $version  The version to compare.
+     * @param string $operator The comparison operator: <, <=, >, >=, ==, !=
+     *
+     * @return bool Whether the comparison succeeded.
+     */
+    public static function compare($version, $operator)
+    {
+        $currentVersion = str_replace(' ', '', strtolower(static::VERSION));
+        $version = str_replace(' ', '', strtolower($version));
+
+        return version_compare($version, $currentVersion, $operator);
+    }
+
+    /**
+     * Returns a version formatted for composer.
+     *
+     * @return string
+     */
+    public static function forComposer()
+    {
+        if (strpos(static::VERSION, ' ') === false) {
+            return static::VERSION;
+        }
+
+        $parts = explode(' ', static::VERSION, 2);
+        $version = $parts[0] . '@' . $parts[1];
+        $version = str_replace(' ', '', strtolower($version));
+
+        return $version;
+    }
+
+    /**
+     * @deprecated since 3.0, to be removed in 4.0.
+     *
+     * @return string|null
+     */
+    public static function name()
+    {
+        if (strpos(static::VERSION, ' ') === false) {
+            return null;
+        }
+
+        return explode(' ', static::VERSION)[1];
+    }
+
+    /**
+     * Must not be instantiated.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/tests/phpunit/unit/Profiler/BoltDataCollectorTest.php
+++ b/tests/phpunit/unit/Profiler/BoltDataCollectorTest.php
@@ -31,8 +31,6 @@ class BoltDataCollectorTest extends BoltUnitTest
         $data->collect($request, $response);
         $this->assertNotEmpty($data->getName());
         $this->assertNotEmpty($data->getVersion());
-        $this->assertNotEmpty($data->getFullVersion());
-        $this->assertNotNull($data->getVersionName());
         $this->assertNotEmpty($data->getPayoff());
         $this->assertNotEmpty($data->getAboutLink());
         $this->assertEmpty($data->getEditLink());

--- a/tests/phpunit/unit/Twig/TwigExtensionTest.php
+++ b/tests/phpunit/unit/Twig/TwigExtensionTest.php
@@ -37,6 +37,7 @@ class TwigExtensionTest extends BoltUnitTest
         $response = $twig->getGlobals();
         $this->assertArrayHasKey('bolt_name', $response);
         $this->assertArrayHasKey('bolt_version', $response);
+        $this->assertArrayHasKey('bolt_stable', $response);
         $this->assertArrayHasKey('frontend', $response);
         $this->assertArrayHasKey('backend', $response);
         $this->assertArrayHasKey('async', $response);


### PR DESCRIPTION
There's no reason to have the current version in DI container since it doesn't change. This just makes us require an app container in places we may not necessarily have it.

The approach everyone else is doing, if they are, is a `Version` class with a constant in it for the current version.