### PR TITLE
Replace "sort" icon.

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -198,7 +198,10 @@
                     <i class="fa fa-circle status-{{ content.status }} fa-fw"></i> {{ content.datepublish|localdate('%x') }}<br>
                 {% endif %}
                 {% if content.sortorder|default() is not empty %}
-                    <i class="fa fa-align-left fa-fw"></i> {{ __('Order: %sort%',{'%sort%': content.sortorder}) }}<br>
+                    <i class="fa fa-align-left fa-fw"></i>
+                        <a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id}) }}#taxonomy" >
+                            {{ __('Order: %sort%',{'%sort%': content.sortorder}) }}
+                        </a>
                 {% endif %}
             </td>
         {% endblock %}

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -198,7 +198,7 @@
                     <i class="fa fa-circle status-{{ content.status }} fa-fw"></i> {{ content.datepublish|localdate('%x') }}<br>
                 {% endif %}
                 {% if content.sortorder|default() is not empty %}
-                    <i class="fa fa-sort fa-fw"></i> {{ __('Order: %sort%',{'%sort%': content.sortorder}) }}<br>
+                    <i class="fa fa-align-left fa-fw"></i> {{ __('Order: %sort%',{'%sort%': content.sortorder}) }}<br>
                 {% endif %}
             </td>
         {% endblock %}


### PR DESCRIPTION
It's happened a bunch of times now, where people have been confused about the icon used for `Order:`. It looks too much like something you can interact with, but that's not the purpose of it. This icon still indicates it's to do with ordering, but looks less like something you'd except to be able to drag. 

![screen shot 2016-03-02 at 17 34 00](https://cloud.githubusercontent.com/assets/1833361/13467096/fa9850da-e09c-11e5-9669-20fd168c73ed.png)

