### PR TITLE
Fix translation resources not being applied

### DIFF
--- a/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
@@ -36,8 +36,8 @@ class TranslationServiceProviderTest extends BoltUnitTest
     public function testDefaultTranslationLoading()
     {
         $app = $this->makeApp();
-        $app->initialize();
         $this->registerTranslationServiceWithCachingDisabled($app);
+        $app->initialize();
         $app->boot();
         $this->assertEquals('About', $app['translator']->trans('general.about'));
     }
@@ -46,9 +46,9 @@ class TranslationServiceProviderTest extends BoltUnitTest
     {
         $app = $this->makeApp();
         $this->initializeFakeTranslationFiles('xx', 'general.about: "So very about"', $app['resources']);
+        $this->registerTranslationServiceWithCachingDisabled($app);
         $app->initialize();
         $app['locale'] = 'xx_XX';
-        $this->registerTranslationServiceWithCachingDisabled($app);
         $app->boot();
         $this->assertEquals('So very about', $app['translator']->trans('general.about'));
     }
@@ -57,8 +57,8 @@ class TranslationServiceProviderTest extends BoltUnitTest
     {
         $app = $this->makeApp();
         $this->initializeFakeTranslationFiles('en_GB', 'general.about: "Not so about"', $app['resources']);
-        $app->initialize();
         $this->registerTranslationServiceWithCachingDisabled($app);
+        $app->initialize();
         $app->boot();
         $this->assertEquals('Not so about', $app['translator']->trans('general.about'));
     }


### PR DESCRIPTION
Although translator should not be invoked before boot, there is a chance that it is. In this case not all of the translations resources have been applied to it. 
This moves them to be added when the translator is invoked, so they are added regardless of when that is.