### PR TITLE
Shorter version notation in the 'tiny footer'.

### DIFF
--- a/app/view/twig/_nav/_footer.twig
+++ b/app/view/twig/_nav/_footer.twig
@@ -13,7 +13,7 @@
 {% else %}
 
     <footer id="bolt-footer" class="hidden-xs bolt-footer-mini {% if app.request.cookies.get('sidebar') %}bolt-footer-hidden{% endif %}">
-        <i class="fa fa-cog"></i> <a href="http://bolt.cm" target="_blank">Bolt {{ bolt_version }}</a> &ndash;
+        <i class="fa fa-cog"></i> <a href="http://bolt.cm" target="_blank">Bolt {{ bolt_version|replace({'alpha': 'α', ' beta ': 'β'}) }}</a> &ndash;
         <i class="fa fa-heart"></i > <a href="{{ path('about') }}">{{ __('general.about') }}</a>
     </footer>
 


### PR DESCRIPTION
Fixes #4951

Result: 

![screenshot 2016-03-03 20 23 08](https://cloud.githubusercontent.com/assets/1833361/13506336/f841d4dc-e17d-11e5-8e72-c781f5fb04b5.png)
