### PR TITLE
Fixes #4953 – Repeater field won't show unless there's also an 'html' field

### DIFF
--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -393,6 +393,11 @@ class Edit
             foreach ($fields as $field) {
                 $fieldtypes[$field['type']] = true;
             }
+            if ($field['type'] === 'repeater') {
+                foreach ($field['fields'] as $rfield) {
+                    $fieldtypes[$rfield['type']] = true;
+                }
+            }
         }
 
         if ($has['relations'] || $has['incoming_relations']) {


### PR DESCRIPTION
Some repeater fields were not correctly initialiased

Fixes: #4953 
