### PR TITLE
Fix assets

### DIFF
--- a/app/view/twig/_base/_page-no_nav.twig
+++ b/app/view/twig/_base/_page-no_nav.twig
@@ -24,7 +24,7 @@
         <div class="row">
             <div class="{{ form_class|default('col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2') }}">
 
-                <img src="{{ app.paths.app }}view/img/bolt-logo.png" width="150" height="62" alt="Bolt" class="logo">
+                <img src="{{ asset('img/bolt-logo.png', 'bolt') }}" width="150" height="62" alt="Bolt" class="logo">
 
                 {{ widgets('login_top', 'backend') }}
 

--- a/app/view/twig/_base/_page.twig
+++ b/app/view/twig/_base/_page.twig
@@ -136,7 +136,7 @@
 
 {# Add the Grunt livereload script, if Grunt livereload is enabled in config.yml. #}
 {% if app.config.get('general/grunt/livereload') %}
-    <script src="{{ paths.hosturl }}:{{ app.config.get('general/grunt/livereloadport') }}/livereload.js"></script>
+    <script src="//{{ app.request.host }}:{{ app.config.get('general/grunt/livereloadport') }}/livereload.js"></script>
 {% endif %}
 
 </body>

--- a/app/view/twig/_base/_page.twig
+++ b/app/view/twig/_base/_page.twig
@@ -23,37 +23,37 @@
 
 {# TODO: Refactor this out. Too much business logic in the template. #}
 {% set page_scripts_inc = [
-    'view/js/lib.js'
+    'js/lib.js'
 ] %}
 
 {# Add locale include for datepicker #}
-{% set localepath = 'view/js/locale/datepicker/' %}
-{% if file_exists(paths.apppath ~ '/' ~ localepath ~ page_locale_long ~ '.min.js') %}
+{% set localepath = 'js/locale/datepicker/' %}
+{% if file_exists(paths.viewpath ~ '/' ~ localepath ~ page_locale_long ~ '.min.js') %}
     {% set page_scripts_inc = page_scripts_inc|merge([localepath ~ page_locale_long ~ '.min.js']) %}
-{% elseif page_locale_short != 'en' and file_exists(paths.apppath ~ '/' ~ localepath ~ page_locale_short ~ '.min.js') %}
+{% elseif page_locale_short != 'en' and file_exists(paths.viewpath ~ '/' ~ localepath ~ page_locale_short ~ '.min.js') %}
     {% set page_scripts_inc = page_scripts_inc|merge([localepath ~ page_locale_short ~ '.min.js']) %}
 {% endif %}
 
 {# Add locale include for moment #}
-{% set localepath = 'view/js/locale/moment/' %}
-{% if file_exists(paths.apppath ~ '/' ~ localepath ~ page_locale_long ~ '.min.js') %}
+{% set localepath = 'js/locale/moment/' %}
+{% if file_exists(paths.viewpath ~ '/' ~ localepath ~ page_locale_long ~ '.min.js') %}
     {% set page_scripts_inc = page_scripts_inc|merge([localepath ~ page_locale_long ~ '.min.js']) %}
-{% elseif page_locale_short != 'en' and file_exists(paths.apppath ~ '/' ~ localepath ~ page_locale_short ~ '.min.js') %}
+{% elseif page_locale_short != 'en' and file_exists(paths.viewpath ~ '/' ~ localepath ~ page_locale_short ~ '.min.js') %}
     {% set page_scripts_inc = page_scripts_inc|merge([localepath ~ page_locale_short ~ '.min.js']) %}
 {% endif %}
 
 {# Add locale include for select2 #}
-{% set localepath = 'view/js/locale/select2/' %}
-{% if file_exists(paths.apppath ~ '/' ~ localepath ~ page_locale_long ~ '.min.js') %}
+{% set localepath = 'js/locale/select2/' %}
+{% if file_exists(paths.viewpath ~ '/' ~ localepath ~ page_locale_long ~ '.min.js') %}
     {% set page_scripts_inc = page_scripts_inc|merge([localepath ~ page_locale_long ~ '.min.js']) %}
-{% elseif page_locale_short != 'en' and file_exists(paths.apppath ~ '/' ~ localepath ~ page_locale_short ~ '.min.js') %}
+{% elseif page_locale_short != 'en' and file_exists(paths.viewpath ~ '/' ~ localepath ~ page_locale_short ~ '.min.js') %}
     {% set page_scripts_inc = page_scripts_inc|merge([localepath ~ page_locale_short ~ '.min.js']) %}
 {% endif %}
 
 {# Determine locale include for ckeditor #}
-{% set localepath = 'view/js/locale/ckeditor/' %}
+{% set localepath = 'js/locale/ckeditor/' %}
 {% set page_locale_long_bcp47 = page_locale_long|replace('_', '-')|lower %}
-{% if file_exists(paths.apppath ~ '/' ~ localepath ~ page_locale_long_bcp47 ~ '.js') %}
+{% if file_exists(paths.viewpath ~ '/' ~ localepath ~ page_locale_long_bcp47 ~ '.js') %}
     {% set ckeditor_lang = page_locale_long_bcp47 %}
 {% else %}
     {% set ckeditor_lang = page_locale_short %}
@@ -70,18 +70,18 @@
 
     <title>{{ page_title|striptags|trim|raw }} – {{ app.config.get('general/branding/name') }}</title>
 
-    <link rel="stylesheet" href="{{ cachehash(paths.app ~ 'view/css/lib.css') }}">
-    <link rel="stylesheet" href="{{ cachehash(paths.app ~ 'view/css/bolt.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/lib.css', 'bolt') }}">
+    <link rel="stylesheet" href="{{ asset('css/bolt.css', 'bolt') }}">
 
     {% for script in page_scripts_inc -%}
-        <script src="{{ cachehash(paths.app ~ script) }}"></script>
+        <script src="{{ asset(script, 'bolt') }}"></script>
     {% endfor %}
 
-    <link rel="shortcut icon" href="{% if app.config.get('general/branding/favicon') %}{{ app.config.get('general/branding/favicon') }}{% else %}{{ paths.app }}view/img/favicon-bolt.ico{% endif %}">
-    <link rel="apple-touch-icon" sizes="57x57" href="{% if app.config.get('general/branding/apple-touch-icon') %}{{ app.config.get('general/branding/apple-touch-icon') }}{% else %}{{ paths.app }}view/img/apple-touch-icon.png{% endif %}">
-    <link rel="apple-touch-icon" sizes="72x72" href="{% if app.config.get('general/branding/apple-touch-icon-72x72') %}{{ app.config.get('general/branding/apple-touch-icon-72x72') }}{% else %}{{ paths.app }}view/img/apple-touch-icon-72x72.png{% endif %}">
-    <link rel="apple-touch-icon" sizes="114x114" href="{% if app.config.get('general/branding/apple-touch-icon-114x114') %}{{ app.config.get('general/branding/apple-touch-icon-114x114') }}{% else %}{{ paths.app }}view/img/apple-touch-icon-114x114.png{% endif %}">
-    <link rel="apple-touch-icon" sizes="144x144" href="{% if app.config.get('general/branding/apple-touch-icon-144x144') %}{{ app.config.get('general/branding/apple-touch-icon-144x144') }}{% else %}{{ paths.app }}view/img/apple-touch-icon-144x144.png{% endif %}">
+    <link rel="shortcut icon" href="{{ config.get('general/branding/favicon') ?: asset('img/favicon-bolt.ico', 'bolt') }}">
+    <link rel="apple-touch-icon" sizes="57x57" href="{{ config.get('general/branding/apple-touch-icon') ?: asset('img/apple-touch-icon.png', 'bolt') }}">
+    {% for size in ['72x72', '114x114', '144x144'] %}
+        <link rel="apple-touch-icon" sizes="{{ size }}" href="{{ config.get('general/branding/apple-touch-icon-' ~ size) ?: asset('img/apple-touch-icon-' ~ size ~ '.png', 'bolt') }}">
+    {% endfor %}
 </head>
 
 <body{% if page_bodyclass %} class="{{ page_bodyclass }}"{% endif %}>
@@ -129,7 +129,7 @@
                         ? config.get('general/wysiwyg/filebrowser') : false,
     },
 } %}
-<script src="{{ cachehash(paths.app ~ 'view/js/bolt.js') }}" data-config="{{ bconfig|json_encode }}" data-jsdata="{{ app.jsdata|json_encode }}"></script>
+<script src="{{ asset('js/bolt.js', 'bolt') }}" data-config="{{ bconfig|json_encode }}" data-jsdata="{{ app.jsdata|json_encode }}"></script>
 
 {% block page_script %}
 {% endblock page_script %}

--- a/app/view/twig/editcontent/fielddata/_html.twig
+++ b/app/view/twig/editcontent/fielddata/_html.twig
@@ -1,3 +1,3 @@
 {### Scripts ###}
 
-<script src="{{ cachehash(paths.app ~ 'view/js/ckeditor/ckeditor.js') }}"></script>
+<script src="{{ asset('js/ckeditor/ckeditor.js', 'bolt') }}"></script>

--- a/app/view/twig/editcontent/fielddata/_markdown.twig
+++ b/app/view/twig/editcontent/fielddata/_markdown.twig
@@ -1,11 +1,10 @@
 {### Scripts ###}
 
-<script src="{{ cachehash(paths.app ~ 'view/js/uikit/uikit.min.js') }}"></script>
-<script src="{{ cachehash(paths.app ~ 'view/js/uikit/marked.js') }}"></script>
-<script src="{{ cachehash(paths.app ~ 'view/js/uikit/codemirror-compressed.js') }}"></script>
-<script src="{{ cachehash(paths.app ~ 'view/js/uikit/htmleditor.js') }}"></script>
+{% for file in ['uikit.min', 'marked', 'codemirror-compressed', 'htmleditor'] %}
+    <script src="{{ bolt('js/uikit/' ~ file ~'.js', 'bolt') }}"></script>
+{% endfor %}
 
 {### Stylesheet ###}
 
-<link rel="stylesheet" property="stylesheet" href="{{ cachehash(paths.app ~ 'view/js/ckeditor/plugins/codemirror/css/codemirror.min.css') }}">
-<link rel="stylesheet" property="stylesheet" href="{{ cachehash(paths.app ~ 'view/js/uikit/htmleditor.min.css') }}">
+<link rel="stylesheet" property="stylesheet" href="{{ asset('js/ckeditor/plugins/codemirror/css/codemirror.min.css', 'bolt') }}">
+<link rel="stylesheet" property="stylesheet" href="{{ asset('js/uikit/htmleditor.min.css', 'bolt') }}">

--- a/app/view/twig/editcontent/fields/_video.twig
+++ b/app/view/twig/editcontent/fields/_video.twig
@@ -87,7 +87,7 @@
     preview: {
         alt:       __('field.video.label.preview'),
         height:    preview_h,
-        src:       video.thumbnail|default(app.paths.app ~ 'view/img/default_empty_4x3.png'),
+        src:       video.thumbnail|default(asset('img/default_empty_4x3.png', 'bolt')),
         width:     preview_w,
     },
 

--- a/app/view/twig/editfile/editfile.twig
+++ b/app/view/twig/editfile/editfile.twig
@@ -95,12 +95,12 @@
     {% endif %}
 
     {# use the files includes in ckeditor/codemirror plugin, instead of duplicating files. #}
-    <link rel="stylesheet" property="stylesheet" href="{{ cachehash(paths.app ~ 'view/js/ckeditor/plugins/codemirror/css/codemirror.min.css') }}">
-    <script src="{{ cachehash(paths.app ~ 'view/js/ckeditor/ckeditor.js') }}"></script>
-    <script src="{{ cachehash(paths.app ~ 'view/js/ckeditor/plugins/codemirror/js/codemirror.min.js') }}"></script>
-    <script src="{{ cachehash(paths.app ~ 'view/js/ckeditor/plugins/codemirror/js/codemirror.addons.search.min.js') }}"></script>
+    <link rel="stylesheet" property="stylesheet" href="{{ asset('js/ckeditor/plugins/codemirror/css/codemirror.min.css', 'bolt') }}">
+    <script src="{{ asset('js/ckeditor/ckeditor.js', 'bolt') }}"></script>
+    <script src="{{ asset('js/ckeditor/plugins/codemirror/js/codemirror.min.js', 'bolt') }}"></script>
+    <script src="{{ asset('js/ckeditor/plugins/codemirror/js/codemirror.addons.search.min.js', 'bolt') }}"></script>
     {% for file in codemirror %}
-        <script src="{{ cachehash(paths.app ~ 'view/js/ckeditor/plugins/codemirror/plugins/' ~ file ~ '.min.js') }}"></script>
+        <script src="{{ asset('js/ckeditor/plugins/codemirror/plugins/' ~ file ~ '.min.js', 'bolt') }}"></script>
     {% endfor %}
 
 {% endblock page_main %}

--- a/app/view/twig/editlocale/editlocale.twig
+++ b/app/view/twig/editlocale/editlocale.twig
@@ -38,10 +38,10 @@
 
     {% if not ismobileclient() %}
         {# use the files includes in ckeditor/codemirror plugin, instead of duplicating files. #}
-    <link rel="stylesheet" property="stylesheet" href="{{ cachehash(paths.app ~ 'view/js/ckeditor/plugins/codemirror/css/codemirror.min.css') }}">
-    <script src="{{ cachehash(paths.app ~ 'view/js/ckeditor/ckeditor.js') }}"></script>
-    <script src="{{ cachehash(paths.app ~ 'view/js/ckeditor/plugins/codemirror/js/codemirror.min.js') }}"></script>
-    <script src="{{ cachehash(paths.app ~ 'view/js/ckeditor/plugins/codemirror/plugins/yaml.min.js') }}"></script>
+        <link rel="stylesheet" property="stylesheet" href="{{ asset('js/ckeditor/plugins/codemirror/css/codemirror.min.css', 'bolt') }}">
+        <script src="{{ asset('js/ckeditor/ckeditor.js', 'bolt') }}"></script>
+        <script src="{{ asset('js/ckeditor/plugins/codemirror/js/codemirror.min.js', 'bolt') }}"></script>
+        <script src="{{ asset('js/ckeditor/plugins/codemirror/plugins/yaml.min.js', 'bolt') }}"></script>
     {% endif %}
 
 {% endblock page_main %}

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -197,7 +197,7 @@
     {{ data('extend.text.updated',        __('page.extend.message.updated')) }}
 
     {{ data('extend.siteurl',             context.site) }}
-    {{ data('extend.baseurl',             paths.bolt ~ 'extend/') }}
+    {{ data('extend.baseurl',             '/' ~ app['controller.backend.extend.mount_prefix']|trim('/') ~ '/') }}
     {{ data('extend.rootpath',            paths.rootpath) }}
 
 {% endblock page_main %}

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "siriusphp/upload" : "~1.2",
         "stecman/symfony-console-completion" : "~0.4",
         "swiftmailer/swiftmailer" : "~5.3",
+        "symfony/asset" : "^2.8",
         "symfony/config" : "^2.8",
         "symfony/console" : "^2.8",
         "symfony/debug": "^2.8",

--- a/src/Asset/BoltVersionStrategy.php
+++ b/src/Asset/BoltVersionStrategy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Bolt\Asset;
+
+use Bolt\Filesystem\Exception\IOException;
+use Bolt\Filesystem\FilesystemInterface;
+use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
+
+/**
+ * A version strategy that hashes a base salt, path, and timestamp of file.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class BoltVersionStrategy extends StaticVersionStrategy
+{
+    /** @var FilesystemInterface */
+    protected $filesystem;
+    /** @var string */
+    protected $baseSalt;
+
+    /**
+     * Constructor.
+     *
+     * @param FilesystemInterface $filesystem
+     * @param string              $baseSalt
+     * @param string              $format
+     */
+    public function __construct(FilesystemInterface $filesystem, $baseSalt, $format = null)
+    {
+        parent::__construct(null, $format);
+        $this->filesystem = $filesystem;
+        $this->baseSalt = $baseSalt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVersion($path)
+    {
+        $file = $this->filesystem->getFile($path);
+
+        try {
+            return substr(md5($this->baseSalt . $file->getFullPath() . $file->getTimestamp()), 0, 10);
+        } catch (IOException $e) {
+            return '';
+        }
+    }
+}

--- a/src/Asset/File/FileAssetBase.php
+++ b/src/Asset/File/FileAssetBase.php
@@ -13,7 +13,11 @@ abstract class FileAssetBase implements FileAssetInterface
     /** @var string */
     protected $type;
     /** @var string */
-    protected $fileName;
+    protected $path;
+    /** @var string */
+    protected $packageName;
+    /** @var string */
+    protected $url;
     /** @var boolean */
     protected $late;
     /** @var integer */
@@ -21,18 +25,18 @@ abstract class FileAssetBase implements FileAssetInterface
     /** @var array */
     protected $attributes;
     /** @var string */
-    protected $cacheHash;
-    /** @var string */
     protected $zone = Zone::FRONTEND;
 
     /**
      * Constructor.
      *
-     * @param string $fileName
+     * @param string $path
+     * @param string $packageName
      */
-    public function __construct($fileName = null)
+    public function __construct($path = null, $packageName = null)
     {
-        $this->fileName = $fileName;
+        $this->path = $path;
+        $this->packageName = $packageName;
     }
 
     /**
@@ -48,7 +52,7 @@ abstract class FileAssetBase implements FileAssetInterface
      */
     public function getFileName()
     {
-        return $this->fileName;
+        return $this->path;
     }
 
     /**
@@ -56,7 +60,67 @@ abstract class FileAssetBase implements FileAssetInterface
      */
     public function setFileName($fileName)
     {
-        $this->fileName = $fileName;
+        $this->path = $fileName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return FileAssetBase
+     */
+    public function setPath($path)
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPackageName()
+    {
+        return $this->packageName;
+    }
+
+    /**
+     * @param string $packageName
+     *
+     * @return FileAssetBase
+     */
+    public function setPackageName($packageName)
+    {
+        $this->packageName = $packageName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return FileAssetBase
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
 
         return $this;
     }
@@ -125,24 +189,6 @@ abstract class FileAssetBase implements FileAssetInterface
     public function addAttribute($attribute)
     {
         $this->attributes[] = $attribute;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getCacheHash()
-    {
-        return $this->cacheHash;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setCacheHash($cacheHash)
-    {
-        $this->cacheHash = $cacheHash;
 
         return $this;
     }

--- a/src/Asset/File/FileAssetInterface.php
+++ b/src/Asset/File/FileAssetInterface.php
@@ -19,20 +19,52 @@ interface FileAssetInterface extends AssetInterface
     public function getType();
 
     /**
-     * Get the asset's file name.
+     * Get the package name.
      *
      * @return string
      */
-    public function getFileName();
+    public function getPackageName();
 
     /**
-     * Set the file name for the asset.
+     * Set the package name.
      *
-     * @param string $fileName
+     * @param string $package
      *
      * @return FileAssetInterface
      */
-    public function setFileName($fileName);
+    public function setPackageName($package);
+
+    /**
+     * Get the asset's path.
+     *
+     * @return string
+     */
+    public function getPath();
+
+    /**
+     * Set the asset's path.
+     *
+     * @param string $path
+     *
+     * @return FileAssetInterface
+     */
+    public function setPath($path);
+
+    /**
+     * Get the asset's url.
+     *
+     * @return string
+     */
+    public function getUrl();
+
+    /**
+     * Set the asset's url.
+     *
+     * @param string $url
+     *
+     * @return FileAssetInterface
+     */
+    public function setUrl($url);
 
     /**
      * Check if the asset is set to load late.
@@ -76,20 +108,4 @@ interface FileAssetInterface extends AssetInterface
      * @return FileAssetInterface
      */
     public function addAttribute($attribute);
-
-    /**
-     * Get the cache hash string.
-     *
-     * @return string
-     */
-    public function getCacheHash();
-
-    /**
-     * Set the cache hash string.
-     *
-     * @param string $cacheHash
-     *
-     * @return AssetInterface
-     */
-    public function setCacheHash($cacheHash);
 }

--- a/src/Asset/File/JavaScript.php
+++ b/src/Asset/File/JavaScript.php
@@ -16,8 +16,6 @@ class JavaScript extends FileAssetBase
      */
     public function __toString()
     {
-        $hash = $this->cacheHash ? '?v=' . $this->cacheHash : $this->cacheHash;
-
-        return sprintf('<script src="%s%s" %s></script>', $this->fileName, $hash, $this->getAttributes());
+        return sprintf('<script src="%s" %s></script>', $this->url, $this->getAttributes());
     }
 }

--- a/src/Asset/File/Stylesheet.php
+++ b/src/Asset/File/Stylesheet.php
@@ -16,8 +16,6 @@ class Stylesheet extends FileAssetBase
      */
     public function __toString()
     {
-        $hash = $this->cacheHash ? '?v=' . $this->cacheHash : $this->cacheHash;
-
-        return sprintf('<link rel="stylesheet" href="%s%s" media="screen">', $this->fileName, $hash);
+        return sprintf('<link rel="stylesheet" href="%s" media="screen">', $this->url);
     }
 }

--- a/src/Composer/EventListener/PackageDescriptor.php
+++ b/src/Composer/EventListener/PackageDescriptor.php
@@ -112,18 +112,17 @@ final class PackageDescriptor implements JsonSerializable
      * Create class from uncertain JSON data.
      *
      * @param Composer $composer
-     * @param string   $baseWebPath
+     * @param string   $webPath
      * @param string   $path
      * @param array    $jsonData
      *
      * @return PackageDescriptor
      */
-    public static function parse(Composer $composer, $baseWebPath, $path, array $jsonData)
+    public static function parse(Composer $composer, $webPath, $path, array $jsonData)
     {
         $name = $jsonData['name'];
         $type = strpos($path, 'vendor') === 0 ? 'composer' : 'local';
         $class = self::parseClass($jsonData);
-        $webPath = self::parseWebPath($baseWebPath, $path, $jsonData);
         $constraint = self::parseConstraint($jsonData);
         $valid = self::parseValid($composer, $class, $constraint);
 
@@ -180,25 +179,6 @@ final class PackageDescriptor implements JsonSerializable
         }
 
         return null;
-    }
-
-    /**
-     * Parse the package's web path given the base web path, the relative package path and "bolt-assets".
-     *
-     * @param string $baseWebPath
-     * @param string $path
-     * @param array  $jsonData
-     *
-     * @return string
-     */
-    private static function parseWebPath($baseWebPath, $path, array $jsonData)
-    {
-        $assets = 'web';
-        if (isset($jsonData['extra']['bolt-assets'])) {
-            $assets = $jsonData['extra']['bolt-assets'];
-        }
-
-        return rtrim($baseWebPath . '/' . $path . '/' . ltrim($assets, '/'), '/');
     }
 
     /**

--- a/src/Composer/EventListener/PackageEventListener.php
+++ b/src/Composer/EventListener/PackageEventListener.php
@@ -57,18 +57,23 @@ class PackageEventListener
     public static function dump(Event $event)
     {
         $composer = $event->getComposer();
-        $vendorDir = $composer->getConfig()->get('vendor-dir');
-        $finder = self::getInstalledComposerJson();
+
+        $extra = $event->getComposer()->getPackage()->getExtra();
+        $webDir = realpath($extra['bolt-web-path']) . '/';
+        $baseWebPath = str_replace($webDir, '', getcwd());
+
+        /** @var PackageDescriptor[] $extensions */
         $extensions = [];
 
-        /** @var SplFileInfo $jsonFile */
+        $finder = self::getInstalledComposerJson();
         foreach ($finder as $jsonFile) {
             $jsonData = json_decode($jsonFile->getContents(), true);
             if (isset($jsonData['type']) && $jsonData['type'] === 'bolt-extension') {
-                $extensions[$jsonData['name']] = PackageDescriptor::parse($composer, $jsonFile->getPath(), $jsonData);
+                $extensions[$jsonData['name']] = PackageDescriptor::parse($composer, $baseWebPath, $jsonFile->getPath(), $jsonData);
             }
         }
 
+        $vendorDir = $composer->getConfig()->get('vendor-dir');
         $fs = new Filesystem();
         $fs->dumpFile($vendorDir . '/autoload.json', json_encode($extensions, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }
@@ -97,7 +102,7 @@ class PackageEventListener
     /**
      * Return all the installed extension composer.json files.
      *
-     * @return Finder
+     * @return Finder|SplFileInfo[]
      */
     private static function getInstalledComposerJson()
     {

--- a/src/Composer/EventListener/PackageEventListener.php
+++ b/src/Composer/EventListener/PackageEventListener.php
@@ -44,7 +44,7 @@ class PackageEventListener
 
         // Copy package assets to main web path
         $rootExtra = $event->getComposer()->getPackage()->getExtra();
-        $dest = $rootExtra['bolt-web-path'] . '/extensions/' . $packageAssets;
+        $dest = $rootExtra['bolt-web-path'] . '/extensions/vendor/' . $package->getName();
 
         self::mirror($packageAssets, $dest, $event);
     }

--- a/src/Composer/EventListener/PackageEventListener.php
+++ b/src/Composer/EventListener/PackageEventListener.php
@@ -40,13 +40,17 @@ class PackageEventListener
         if ($package->getType() !== 'bolt-extension' || !isset($extra['bolt-assets'])) {
             return;
         }
-        $packageAssets = 'vendor/' . $package->getName() . '/' . $extra['bolt-assets'];
+
+        $rootExtra = $event->getComposer()->getPackage()->getExtra();
+        if (realpath($rootExtra['bolt-web-path']) === realpath($rootExtra['bolt-root-path'])) {
+            return;
+        }
 
         // Copy package assets to main web path
-        $rootExtra = $event->getComposer()->getPackage()->getExtra();
+        $src = 'vendor/' . $package->getName() . '/' . $extra['bolt-assets'];
         $dest = $rootExtra['bolt-web-path'] . '/extensions/vendor/' . $package->getName();
 
-        self::mirror($packageAssets, $dest, $event);
+        self::mirror($src, $dest, $event);
     }
 
     /**
@@ -60,6 +64,7 @@ class PackageEventListener
 
         $extra = $event->getComposer()->getPackage()->getExtra();
         $webDir = realpath($extra['bolt-web-path']) . '/';
+        $includeAssetsDir = realpath($extra['bolt-web-path']) === realpath($extra['bolt-root-path']);
         $baseWebPath = str_replace($webDir, '', getcwd());
 
         /** @var PackageDescriptor[] $extensions */
@@ -69,7 +74,13 @@ class PackageEventListener
         foreach ($finder as $jsonFile) {
             $jsonData = json_decode($jsonFile->getContents(), true);
             if (isset($jsonData['type']) && $jsonData['type'] === 'bolt-extension') {
-                $extensions[$jsonData['name']] = PackageDescriptor::parse($composer, $baseWebPath, $jsonFile->getPath(), $jsonData);
+                $webPath = $baseWebPath . '/' . $jsonFile->getPath();
+                if ($includeAssetsDir) {
+                    $webPath .= '/' . ltrim(isset($jsonData['extra']['bolt-assets']) ? $jsonData['extra']['bolt-assets'] : '', '/');
+                }
+                $webPath = rtrim($webPath, '/');
+
+                $extensions[$jsonData['name']] = PackageDescriptor::parse($composer, $webPath, $jsonFile->getPath(), $jsonData);
             }
         }
 

--- a/src/Composer/JsonManager.php
+++ b/src/Composer/JsonManager.php
@@ -100,9 +100,11 @@ class JsonManager
      */
     private function setJsonDefaults(array $json)
     {
+        $rootPath = $this->app['resources']->getPath('root');
         $extensionsPath = $this->app['resources']->getPath('extensions');
         $srcPath = $this->app['resources']->getPath('src');
         $webPath = $this->app['resources']->getPath('web');
+        $pathToRoot = $this->app['resources']->findRelativePath($extensionsPath, $rootPath);
         $pathToWeb = $this->app['resources']->findRelativePath($extensionsPath, $webPath);
         $eventPath = sprintf(
             '%sComposer/EventListener',
@@ -132,6 +134,7 @@ class JsonManager
             ],
             'extra' => [
                 'bolt-web-path' => $pathToWeb,
+                'bolt-root-path' => $pathToRoot,
             ],
             'autoload' => [
                 'psr-4' => [

--- a/src/Configuration/Composer.php
+++ b/src/Configuration/Composer.php
@@ -24,6 +24,7 @@ class Composer extends Standard
         $this->setPath('app', realpath(dirname(__DIR__) . '/../app/'));
         $this->setPath('view', realpath(dirname(__DIR__) . '/../app/view'));
         $this->setUrl('app', '/bolt-public/');
+        $this->setUrl('view', '/bolt-public/view/');
     }
 
     public function getVerifier()

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -98,6 +98,7 @@ class ResourceManager
         $this->setPath('database', 'app/database');
         $this->setPath('themebase', 'theme');
         $this->setPath('view', 'app/view');
+        $this->setUrl('view', '/app/view/');
     }
 
     /**

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -204,10 +204,10 @@ class Frontend extends ConfigurableBase
 
         $liveEditor = $request->get('_live-editor-preview');
         if (!empty($liveEditor)) {
-            $jsFile = (new JavaScript($this->app['resources']->getUrl('app') . 'view/js/ckeditor/ckeditor.js'))
+            $jsFile = (new JavaScript('js/ckeditor/ckeditor.js', 'bolt'))
                 ->setPriority(1)
                 ->setLate(false);
-            $cssFile = (new Stylesheet($this->app['resources']->getUrl('app') . 'view/css/liveeditor.css'))
+            $cssFile = (new Stylesheet('css/liveeditor.css', 'bolt'))
                 ->setPriority(5)
                 ->setLate(false);
             $snippet = (new Snippet())

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -15,10 +15,10 @@ abstract class AbstractExtension implements ExtensionInterface
 {
     /** @var Container */
     protected $container;
-    /** @var DirectoryInterface */
-    protected $baseDirectory;
-    /** @var string */
-    protected $relativeUrl;
+    /** @var DirectoryInterface|null */
+    private $baseDirectory;
+    /** @var DirectoryInterface|null */
+    private $webDirectory;
     /** @var string */
     private $name;
     /** @var string */
@@ -49,15 +49,19 @@ abstract class AbstractExtension implements ExtensionInterface
      */
     public function getBaseDirectory()
     {
+        if ($this->webDirectory === null) {
+            throw new \LogicException('Extension was not added with a base directory');
+        }
+
         return $this->baseDirectory;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setRelativeUrl($relativeUrl)
+    public function setWebDirectory(DirectoryInterface $directory)
     {
-        $this->relativeUrl = $relativeUrl;
+        $this->webDirectory = $directory;
 
         return $this;
     }
@@ -65,9 +69,13 @@ abstract class AbstractExtension implements ExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getRelativeUrl()
+    public function getWebDirectory()
     {
-        return $this->relativeUrl;
+        if ($this->webDirectory === null) {
+            throw new \LogicException('Extension was not added with a web directory');
+        }
+
+        return $this->webDirectory;
     }
 
     /**

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -40,25 +40,31 @@ interface ExtensionInterface
     /**
      * Returns the root directory for the extension.
      *
+     * @throws \LogicException If the extension has not been registered with a base directory.
+     *
      * @return DirectoryInterface
      */
     public function getBaseDirectory();
 
     /**
-     * Sets the extension's relative URL.
+     * Returns the web directory for the extension.
      *
-     * @param string
+     * The extension's assets should be installed in this folder.
+     *
+     * @throws \LogicException If the extension has not been registered with a web directory.
+     *
+     * @return DirectoryInterface
+     */
+    public function getWebDirectory();
+
+    /**
+     * Sets the web directory for the extension.
+     *
+     * @param DirectoryInterface $directory
      *
      * @return ExtensionInterface
      */
-    public function setRelativeUrl($relativeUrl);
-
-    /**
-     * Returns the extension's relative URL.
-     *
-     * @return string
-     */
-    public function getRelativeUrl();
+    public function setWebDirectory(DirectoryInterface $directory);
 
     /**
      * Returns a unique identifier for the extension, such as: Vendor/Name

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -247,7 +247,7 @@ class Manager
         $extension = new $className();
         if ($extension instanceof ExtensionInterface) {
             $baseDir = $this->extFs->getDir($descriptor->getPath());
-            $webDir = $this->webFs->getDir($descriptor->getPath());
+            $webDir = $this->webFs->getDir($descriptor->getWebPath());
             $this->add($extension, $baseDir, $webDir, $descriptor->getName())
                 ->setDescriptor($descriptor)
             ;

--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -2,8 +2,12 @@
 namespace Bolt\Provider;
 
 use Bolt\Asset;
+use Bolt\Filesystem\Exception\FileNotFoundException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Symfony\Component\Asset\Context\RequestStackContext;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Asset\PathPackage;
 
 /**
  * HTML asset service providers.
@@ -14,37 +18,57 @@ class AssetServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        $app['asset.salt.factory'] = $app->protect(
-            function () use ($app) {
-                return $app['randomgenerator']->generateString(10);
+        $app['asset.packages'] = $app->share(
+            function ($app) {
+                $packages = new Packages();
+
+                $packages->addPackage('bolt', $app['asset.package_factory']('view'));
+                $packages->addPackage('extensions', $app['asset.package_factory']('extensions'));
+                $packages->addPackage('files', $app['asset.package_factory']('files'));
+                $packages->addPackage('theme', $app['asset.package_factory']('theme'));
+
+                return $packages;
             }
         );
+
+        $app['asset.package_factory'] = $app->protect(
+            function ($name) use ($app) {
+                return new PathPackage(
+                    $app['resources']->getUrl($name),
+                    $app['asset.version_strategy']($name),
+                    $app['asset.context']
+                );
+            }
+        );
+
+        $app['asset.version_strategy'] = $app->protect(
+            function ($name) use ($app) {
+                return new Asset\BoltVersionStrategy($app['filesystem']->getFilesystem($name), $app['asset.salt']);
+            }
+        );
+
+        $app['asset.context'] = $app->share(
+            function () use ($app) {
+                return new RequestStackContext($app['request_stack']);
+            }
+        );
+
+        $app['asset.salt.factory'] = function () use ($app) {
+            return $app['randomgenerator']->generateString(10);
+        };
 
         $app['asset.salt'] = $app->share(
             function ($app) {
-                $path = $app['resources']->getPath('cache/.assetsalt');
-                if (is_readable($path)) {
-                    $salt = file_get_contents($path);
-                } else {
-                    $salt = $app['asset.salt.factory']();
-                    file_put_contents($path, $salt);
+                $file = $app['filesystem']->getFile('cache://.assetsalt');
+
+                try {
+                    $salt = $file->read();
+                } catch (FileNotFoundException $e) {
+                    $salt = $app['asset.salt.factory'];
+                    $file->put($salt);
                 }
 
                 return $salt;
-            }
-        );
-
-        $app['asset.file.hash.factory'] = $app->protect(
-            function ($fileName) use ($app) {
-                $fullPath = $app['resources']->getPath('root') . '/' . $fileName;
-
-                if (is_readable($fullPath)) {
-                    return substr(md5($app['asset.salt'] . $fullPath . (string) filemtime($fullPath)), 0, 10);
-                } elseif (is_readable($fileName)) {
-                    return substr(md5($app['asset.salt'] . $fileName . (string) filemtime($fileName)), 0, 10);
-                } else {
-                    return substr(md5($app['asset.salt'] . $fileName . mt_rand()), 0, 10);
-                }
             }
         );
 
@@ -60,8 +84,7 @@ class AssetServiceProvider implements ServiceProviderInterface
             function ($app) {
                 $queue = new Asset\File\Queue(
                     $app['asset.injector'],
-                    $app['cache'],
-                    $app['asset.file.hash.factory']
+                    $app['asset.packages']
                 );
 
                 return $queue;

--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -6,6 +6,7 @@ use Bolt\Filesystem\Exception\FileNotFoundException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Asset\Context\RequestStackContext;
+use Symfony\Component\Asset\Package;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\PathPackage;
 
@@ -20,7 +21,8 @@ class AssetServiceProvider implements ServiceProviderInterface
     {
         $app['asset.packages'] = $app->share(
             function ($app) {
-                $packages = new Packages();
+                $defaultPackage = new Package($app['asset.version_strategy']('view'));
+                $packages = new Packages($defaultPackage);
 
                 $packages->addPackage('bolt', $app['asset.package_factory']('view'));
                 $packages->addPackage('extensions', new PathPackage('', $app['asset.version_strategy']('web'), $app['asset.context']));

--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -23,7 +23,7 @@ class AssetServiceProvider implements ServiceProviderInterface
                 $packages = new Packages();
 
                 $packages->addPackage('bolt', $app['asset.package_factory']('view'));
-                $packages->addPackage('extensions', $app['asset.package_factory']('extensions'));
+                $packages->addPackage('extensions', new PathPackage('', $app['asset.version_strategy']('web'), $app['asset.context']));
                 $packages->addPackage('files', $app['asset.package_factory']('files'));
                 $packages->addPackage('theme', $app['asset.package_factory']('theme'));
 

--- a/src/Provider/ExtensionServiceProvider.php
+++ b/src/Provider/ExtensionServiceProvider.php
@@ -21,6 +21,7 @@ class ExtensionServiceProvider implements ServiceProviderInterface
             function ($app) {
                 $loader = new Manager(
                     $app['filesystem']->getFilesystem('extensions'),
+                    $app['filesystem']->getFilesystem('web'),
                     $app['logger.flash'],
                     $app['config']
                 );

--- a/src/Provider/FilesystemServiceProvider.php
+++ b/src/Provider/FilesystemServiceProvider.php
@@ -21,6 +21,7 @@ class FilesystemServiceProvider implements ServiceProviderInterface
                 $manager = new Manager(
                     [
                         'root'       => new Filesystem(new Local($app['resources']->getPath('root'))),
+                        'web'        => new Filesystem(new Local($app['resources']->getPath('web'))),
                         'app'        => new Filesystem(new Local($app['resources']->getPath('app'))),
                         'view'       => new Filesystem(new Local($app['resources']->getPath('view'))),
                         'default'    => new Filesystem(new Local($app['resources']->getPath('files'))),

--- a/src/Provider/FilesystemServiceProvider.php
+++ b/src/Provider/FilesystemServiceProvider.php
@@ -22,6 +22,7 @@ class FilesystemServiceProvider implements ServiceProviderInterface
                     [
                         'root'       => new Filesystem(new Local($app['resources']->getPath('root'))),
                         'app'        => new Filesystem(new Local($app['resources']->getPath('app'))),
+                        'view'       => new Filesystem(new Local($app['resources']->getPath('view'))),
                         'default'    => new Filesystem(new Local($app['resources']->getPath('files'))),
                         'files'      => new Filesystem(new Local($app['resources']->getPath('files'))),
                         'config'     => new Filesystem(new Local($app['resources']->getPath('config'))),

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -7,6 +7,7 @@ use Bolt\Twig\Handler;
 use Bolt\Twig\TwigExtension;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Symfony\Bridge\Twig\Extension\AssetExtension;
 
 class TwigServiceProvider implements ServiceProviderInterface
 {
@@ -73,6 +74,8 @@ class TwigServiceProvider implements ServiceProviderInterface
                 'twig',
                 function (\Twig_Environment $twig, $app) {
                     $twig->addExtension(new TwigExtension($app, $app['twig.handlers'], false));
+                    $twig->addExtension($app['twig.extension.asset']);
+
                     if ($app['debug'] && isset($app['dump'])) {
                         $twig->addExtension(new DumpExtension($app['dumper.cloner'], $app['dumper.html']));
                     }
@@ -80,6 +83,12 @@ class TwigServiceProvider implements ServiceProviderInterface
                     return $twig;
                 }
             )
+        );
+
+        $app['twig.extension.asset'] = $app->share(
+            function ($app) {
+                return new AssetExtension($app['asset.packages']);
+            }
         );
 
         $app['twig.loader.filesystem'] = $app->share(

--- a/src/Twig/Handler/HtmlHandler.php
+++ b/src/Twig/Handler/HtmlHandler.php
@@ -27,26 +27,6 @@ class HtmlHandler
     }
 
     /**
-     * Take a file name and add a HTML query paramter with a unique hash based
-     * on the site's salt value and the file modification time, or file name
-     * if the file can't be found by the function.
-     *
-     * @param string $fileName
-     *
-     * @return string
-     */
-    public function cacheHash($fileName)
-    {
-        $fullPath = $this->app['resources']->getPath('root') . '/' . $fileName;
-
-        if (is_readable($fullPath)) {
-            return "$fileName?v=" . $this->app['asset.file.hash.factory']($fullPath);
-        } elseif (is_readable($fileName)) {
-            return "$fileName?v=" . $this->app['asset.file.hash.factory']($fileName);
-        }
-    }
-
-    /**
      * Transforms plain text to HTML
      *
      * @see Bolt\Helpers\Html::decorateTT()

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -49,7 +49,6 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
             new \Twig_SimpleFunction('__',                 [$this, 'trans'],       $safe),
             new \Twig_SimpleFunction('backtrace',          [$this, 'printBacktrace']),
             new \Twig_SimpleFunction('buid',               [$this, 'buid'],        $safe),
-            new \Twig_SimpleFunction('cachehash',          [$this, 'cacheHash'],   $safe),
             new \Twig_SimpleFunction('countwidgets',       [$this, 'countWidgets'],  $safe),
             new \Twig_SimpleFunction('current',            [$this, 'current']),
             new \Twig_SimpleFunction('data',               [$this, 'addData']),
@@ -104,7 +103,6 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
         return [
             // @codingStandardsIgnoreStart
             new \Twig_SimpleFilter('__',             [$this, 'trans']),
-            new \Twig_SimpleFilter('cachehash',      [$this, 'cacheHash'],         $safe),
             new \Twig_SimpleFilter('current',        [$this, 'current']),
             new \Twig_SimpleFilter('editable',       [$this, 'editable'],          $safe),
             new \Twig_SimpleFilter('excerpt',        [$this, 'excerpt'],           $safe),
@@ -210,14 +208,6 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
     public function buid()
     {
         return $this->handlers['admin']->buid();
-    }
-
-    /**
-     * @see \Bolt\Twig\Handler\HtmlHandler::cacheHash()
-     */
-    public function cacheHash($fileName)
-    {
-        return $this->handlers['html']->cacheHash($fileName);
     }
 
     /**

--- a/tests/phpunit/unit/Extension/AbstractExtensionTest.php
+++ b/tests/phpunit/unit/Extension/AbstractExtensionTest.php
@@ -18,7 +18,7 @@ class AbstractExtensionTest extends BoltUnitTest
     {
         $this->assertClassHasAttribute('container', 'Bolt\Extension\AbstractExtension');
         $this->assertClassHasAttribute('baseDirectory', 'Bolt\Extension\AbstractExtension');
-        $this->assertClassHasAttribute('relativeUrl', 'Bolt\Extension\AbstractExtension');
+        $this->assertClassHasAttribute('webDirectory', 'Bolt\Extension\AbstractExtension');
         $this->assertClassHasAttribute('name', 'Bolt\Extension\AbstractExtension');
         $this->assertClassHasAttribute('vendor', 'Bolt\Extension\AbstractExtension');
         $this->assertClassHasAttribute('namespace', 'Bolt\Extension\AbstractExtension');
@@ -34,9 +34,12 @@ class AbstractExtensionTest extends BoltUnitTest
 
     public function testBaseDirectory()
     {
+        $app = $this->getApp();
+        $webDir = $app['filesystem']->getDir('extensions://');
         $dir = new Directory();
         $dir->setPath(__DIR__);
         $ext = new BasicExtension();
+        $ext->setWebDirectory($webDir);
 
         $this->assertInstanceOf('Bolt\Extension\AbstractExtension', $ext->setBaseDirectory($dir));
         $this->assertInstanceOf('Bolt\Filesystem\Handler\Directory', $ext->getBaseDirectory());
@@ -45,10 +48,12 @@ class AbstractExtensionTest extends BoltUnitTest
 
     public function testRelativeUrl()
     {
+        $app = $this->getApp();
+        $webDir = new Directory($app['filesystem']->getFilesystem('extensions'));
         $ext = new BasicExtension();
+        $ext->setWebDirectory($webDir);
 
-        $this->assertInstanceOf('Bolt\Extension\AbstractExtension', $ext->setRelativeUrl('/koalas'));
-        $this->assertSame('/koalas', $ext->getRelativeUrl());
+        $this->assertInstanceOf('Bolt\Filesystem\Handler\Directory', $ext->getWebDirectory());
     }
 
     public function testGetId()

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -6,6 +6,8 @@ use Bolt\Asset\File\JavaScript;
 use Bolt\Asset\File\Stylesheet;
 use Bolt\Asset\Snippet\Snippet;
 use Bolt\Asset\Widget\Widget;
+use Bolt\Filesystem\Adapter\Local;
+use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\Handler\Directory;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\AssetExtension;
@@ -90,7 +92,20 @@ class AssetTraitTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $mock = $this->getMock('\Bolt\Filesystem\Manager', ['has']);
+        $mockParams = [
+            'root'       => new Filesystem(new Local($app['resources']->getPath('root'))),
+            'web'        => new Filesystem(new Local($app['resources']->getPath('web'))),
+            'app'        => new Filesystem(new Local($app['resources']->getPath('app'))),
+            'view'       => new Filesystem(new Local($app['resources']->getPath('view'))),
+            'default'    => new Filesystem(new Local($app['resources']->getPath('files'))),
+            'files'      => new Filesystem(new Local($app['resources']->getPath('files'))),
+            'config'     => new Filesystem(new Local($app['resources']->getPath('config'))),
+            'themes'     => new Filesystem(new Local($app['resources']->getPath('themebase'))),
+            'theme'      => new Filesystem(new Local($app['resources']->getPath('themebase') . '/' . $app['config']->get('general/theme'))),
+            'extensions' => new Filesystem(new Local($app['resources']->getPath('extensions'))),
+            'cache'      => new Filesystem(new Local($app['resources']->getPath('cache'))),
+        ];
+        $mock = $this->getMock('\Bolt\Filesystem\Manager', ['has'], [$mockParams]);
         $mock->expects($this->at(0))
             ->method('has')
             ->willReturn(true)
@@ -104,6 +119,7 @@ class AssetTraitTest extends BoltUnitTest
         $ext->setAssets([new JavaScript('test.js')]);
         $ext->setContainer($app);
         $ext->setBaseDirectory($dir);
+
         $webDir = $app['filesystem']->getDir('extensions://');
         $ext->setWebDirectory($webDir);
         //$ext->setRelativeUrl('/extensions/local/bolt/koala/');
@@ -122,7 +138,20 @@ class AssetTraitTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $mock = $this->getMock('\Bolt\Filesystem\Manager', ['has']);
+        $mockParams = [
+            'root'       => new Filesystem(new Local($app['resources']->getPath('root'))),
+            'web'        => new Filesystem(new Local($app['resources']->getPath('web'))),
+            'app'        => new Filesystem(new Local($app['resources']->getPath('app'))),
+            'view'       => new Filesystem(new Local($app['resources']->getPath('view'))),
+            'default'    => new Filesystem(new Local($app['resources']->getPath('files'))),
+            'files'      => new Filesystem(new Local($app['resources']->getPath('files'))),
+            'config'     => new Filesystem(new Local($app['resources']->getPath('config'))),
+            'themes'     => new Filesystem(new Local($app['resources']->getPath('themebase'))),
+            'theme'      => new Filesystem(new Local($app['resources']->getPath('themebase') . '/' . $app['config']->get('general/theme'))),
+            'extensions' => new Filesystem(new Local($app['resources']->getPath('extensions'))),
+            'cache'      => new Filesystem(new Local($app['resources']->getPath('cache'))),
+        ];
+        $mock = $this->getMock('\Bolt\Filesystem\Manager', ['has'], [$mockParams]);
         $mock->expects($this->at(1))
             ->method('has')
             ->willReturn(true)
@@ -185,7 +214,7 @@ class AssetTraitTest extends BoltUnitTest
         $ext->setBaseDirectory($dir);
         $ext->register($app);
 
-        $this->setExpectedException('RuntimeException', 'Extension file assets must have a file name set.');
+        $this->setExpectedException('RuntimeException', 'Extension file assets must have a path set.');
         $app['asset.queue.file']->getQueue();
     }
 }

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -144,10 +144,9 @@ class AssetTraitTest extends BoltUnitTest
             'cache'      => new Filesystem(new Local($app['resources']->getPath('cache'))),
         ];
         $mock = $this->getMock('\Bolt\Filesystem\Manager', ['has'], [$mockParams]);
-        $mock->expects($this->at(1))
+        $mock->expects($this->any())
             ->method('has')
             ->willReturn(true)
-            ->with('theme://js/test.js')
         ;
 
         $dir = $app['filesystem']->getDir('extensions://');

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -61,7 +61,9 @@ class AssetTraitTest extends BoltUnitTest
         $this->assertSame([], $app['asset.queue.snippet']->getQueue());
         $this->assertSame([], $app['asset.queue.widget']->getQueue());
 
+        $webDir = new Directory($app['filesystem']->getFilesystem('extensions'));
         $ext = new AssetExtension();
+        $ext->setWebDirectory($webDir);
         $ext->setAssets(
             [
                 new JavaScript('test.js'),
@@ -71,7 +73,7 @@ class AssetTraitTest extends BoltUnitTest
             ]
         );
         $ext->setContainer($app);
-        $ext->setBaseDirectory(new Directory());
+        $ext->setBaseDirectory($app['filesystem']->getDir('extensions://'));
         $ext->register($app);
 
         $fileQueue = $app['asset.queue.file']->getQueue();
@@ -95,14 +97,16 @@ class AssetTraitTest extends BoltUnitTest
             ->with('extensions://local/bolt/koala/web/test.js')
         ;
 
-        $dir = new Directory();
+        $dir = $app['filesystem']->getDir('extensions://');
         $dir->setPath('local/bolt/koala');
 
         $ext = new AssetExtension();
         $ext->setAssets([new JavaScript('test.js')]);
         $ext->setContainer($app);
         $ext->setBaseDirectory($dir);
-        $ext->setRelativeUrl('/extensions/local/bolt/koala/');
+        $webDir = $app['filesystem']->getDir('extensions://');
+        $ext->setWebDirectory($webDir);
+        //$ext->setRelativeUrl('/extensions/local/bolt/koala/');
 
         $app['filesystem'] = $mock;
         $ext->register($app);
@@ -125,14 +129,17 @@ class AssetTraitTest extends BoltUnitTest
             ->with('theme://js/test.js')
         ;
 
-        $dir = new Directory();
+        $dir = $app['filesystem']->getDir('extensions://');
         $dir->setPath('local/bolt/koala');
 
         $ext = new AssetExtension();
         $ext->setAssets([new JavaScript('js/test.js')]);
         $ext->setContainer($app);
         $ext->setBaseDirectory($dir);
-        $ext->setRelativeUrl('/extensions/local/bolt/koala/');
+
+        $webDir = $app['filesystem']->getDir('extensions://');
+        $ext->setWebDirectory($webDir);
+        //$ext->setRelativeUrl('/extensions/local/bolt/koala/');
 
         $app['filesystem'] = $mock;
         $ext->register($app);
@@ -152,7 +159,7 @@ class AssetTraitTest extends BoltUnitTest
         $this->assertSame([], $app['asset.queue.snippet']->getQueue());
         $this->assertSame([], $app['asset.queue.widget']->getQueue());
 
-        $dir = new Directory();
+        $dir = $app['filesystem']->getDir('extensions://');
         $ext = new AssetExtension();
         $ext->setAssets('Turning our nightlights on in the daytime to scare');
         $ext->setContainer($app);
@@ -171,7 +178,7 @@ class AssetTraitTest extends BoltUnitTest
         $this->assertSame([], $app['asset.queue.snippet']->getQueue());
         $this->assertSame([], $app['asset.queue.widget']->getQueue());
 
-        $dir = new Directory();
+        $dir = $app['filesystem']->getDir('extensions://');
         $ext = new AssetExtension();
         $ext->setAssets([new JavaScript()]);
         $ext->setContainer($app);

--- a/tests/phpunit/unit/Extension/ConfigTraitTest.php
+++ b/tests/phpunit/unit/Extension/ConfigTraitTest.php
@@ -77,9 +77,11 @@ class ConfigTraitTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $ext = new ConfigExtension();
-        $dir = new Directory();
-        $dir->setPath('local/bolt/config');
-        $ext->setBaseDirectory($dir);
+        $baseDir = $app['filesystem']->getDir('extensions://');
+        $baseDir->setPath('local/bolt/config');
+        $ext->setBaseDirectory($baseDir);
+        $webDir = $app['filesystem']->getDir('extensions://');
+        $ext->setWebDirectory($webDir);
 
         $refObj = new \ReflectionObject($ext);
         $method = $refObj->getMethod('getConfig');
@@ -99,15 +101,18 @@ class ConfigTraitTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $ext = new ConfigExtension();
-        $dir = new Directory();
-        $dir->setPath('local/bolt/config');
-        $ext->setBaseDirectory($dir);
+        $baseDir = $app['filesystem']->getDir('extensions://');
+        $baseDir->setPath('local/bolt/config');
+        $ext->setBaseDirectory($baseDir);
+        $webDir = $app['filesystem']->getDir('extensions://');
+        $ext->setWebDirectory($webDir);
 
         $refObj = new \ReflectionObject($ext);
         $method = $refObj->getMethod('getConfig');
         $method->setAccessible(true);
 
         $ext->setContainer($app);
+        $ext->register($app);
         $filesystem = $app['filesystem'];
         $filesystem->delete('extensions://local/bolt/config/config/config.yml.dist');
 
@@ -119,9 +124,11 @@ class ConfigTraitTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $ext = new ConfigExtension();
-        $dir = new Directory();
-        $dir->setPath('local/bolt/config');
-        $ext->setBaseDirectory($dir);
+        $baseDir = $app['filesystem']->getDir('extensions://');
+        $baseDir->setPath('local/bolt/config');
+        $ext->setBaseDirectory($baseDir);
+        $webDir = $app['filesystem']->getDir('extensions://');
+        $ext->setWebDirectory($webDir);
 
         $refObj = new \ReflectionObject($ext);
         $method = $refObj->getMethod('getConfig');
@@ -146,7 +153,7 @@ class ConfigTraitTest extends BoltUnitTest
         $file->put("\tever so slightly invalid yaml");
 
         $ext = new ConfigExtension();
-        $dir = new Directory();
+        $dir = $app['filesystem']->getDir('extensions://');
         $dir->setPath('local/bolt/config');
         $ext->setBaseDirectory($dir);
 

--- a/tests/phpunit/unit/Extension/DeprecatedAssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/DeprecatedAssetTraitTest.php
@@ -23,9 +23,12 @@ class DeprecatedAssetTraitTest extends BoltUnitTest
 
         $this->assertSame(['javascript' => [], 'stylesheet' => []], $app['asset.queue.file']->getQueue());
 
+        $baseDir = new Directory();
+        $webDir = $app['filesystem']->getDir('extensions://');
         $ext = new DeprecatedAssetExtension();
         $ext->setRegisterFunction('addCss', ['test.css']);
-        $ext->setBaseDirectory(new Directory());
+        $ext->setBaseDirectory($baseDir);
+        $ext->setWebDirectory($webDir);
         $ext->setContainer($app);
         $ext->register($app);
 
@@ -42,9 +45,12 @@ class DeprecatedAssetTraitTest extends BoltUnitTest
 
         $this->assertSame(['javascript' => [], 'stylesheet' => []], $app['asset.queue.file']->getQueue());
 
+        $baseDir = $app['filesystem']->getDir('extensions://');;
+        $webDir = $app['filesystem']->getDir('extensions://');
         $ext = new DeprecatedAssetExtension();
         $ext->setRegisterFunction('addCss', [new Stylesheet('test.css')]);
-        $ext->setBaseDirectory(new Directory());
+        $ext->setBaseDirectory($baseDir);
+        $ext->setWebDirectory($webDir);
         $ext->setContainer($app);
         $ext->register($app);
 
@@ -61,9 +67,12 @@ class DeprecatedAssetTraitTest extends BoltUnitTest
 
         $this->assertSame(['javascript' => [], 'stylesheet' => []], $app['asset.queue.file']->getQueue());
 
+        $baseDir = $app['filesystem']->getDir('extensions://');;
+        $webDir = $app['filesystem']->getDir('extensions://');
         $ext = new DeprecatedAssetExtension();
         $ext->setRegisterFunction('addJavascript', ['test.js']);
-        $ext->setBaseDirectory(new Directory());
+        $ext->setBaseDirectory($baseDir);
+        $ext->setWebDirectory($webDir);
         $ext->setContainer($app);
         $ext->register($app);
 
@@ -80,9 +89,12 @@ class DeprecatedAssetTraitTest extends BoltUnitTest
 
         $this->assertSame(['javascript' => [], 'stylesheet' => []], $app['asset.queue.file']->getQueue());
 
+        $baseDir = $app['filesystem']->getDir('extensions://');;
+        $webDir = $app['filesystem']->getDir('extensions://');
         $ext = new DeprecatedAssetExtension();
         $ext->setRegisterFunction('addJavascript', [new JavaScript('test.js')]);
-        $ext->setBaseDirectory(new Directory());
+        $ext->setBaseDirectory($baseDir);
+        $ext->setWebDirectory($webDir);
         $ext->setContainer($app);
         $ext->register($app);
 
@@ -105,7 +117,7 @@ class DeprecatedAssetTraitTest extends BoltUnitTest
             'snippetCallback',
             5,
         ]);
-        $ext->setBaseDirectory(new Directory());
+        $ext->setBaseDirectory($app['filesystem']->getDir('extensions://'));
         $ext->setContainer($app);
         $ext->register($app);
 
@@ -128,7 +140,7 @@ class DeprecatedAssetTraitTest extends BoltUnitTest
             [$ext, 'snippetCallback'],
             42,
         ]);
-        $ext->setBaseDirectory(new Directory());
+        $ext->setBaseDirectory($app['filesystem']->getDir('extensions://'));
         $ext->setContainer($app);
         $ext->register($app);
 
@@ -147,7 +159,7 @@ class DeprecatedAssetTraitTest extends BoltUnitTest
 
         $ext = new DeprecatedAssetExtension();
         $ext->setRegisterFunction('addWidget', [new Widget()]);
-        $ext->setBaseDirectory(new Directory());
+        $ext->setBaseDirectory($app['filesystem']->getDir('extensions://'));
         $ext->setContainer($app);
         $ext->register($app);
 

--- a/tests/phpunit/unit/Extensions/AssetsProviderTest.php
+++ b/tests/phpunit/unit/Extensions/AssetsProviderTest.php
@@ -33,7 +33,7 @@ HTML;
 <html>
 <head>
 <meta charset="utf-8" />
-<link rel="stylesheet" href="testfile.css?v=5e544598b8d78644071a6f25fd8bba82" media="screen">
+<link rel="stylesheet" href="testfile.css?5e544598b8d78644071a6f25fd8bba82" media="screen">
 <link rel="stylesheet" href="existing.css" media="screen">
 </head>
 <body>
@@ -50,7 +50,7 @@ HTML;
 </head>
 <body>
 <script src="existing.js"></script>
-<link rel="stylesheet" href="testfile.css?v=5e544598b8d78644071a6f25fd8bba82" media="screen">
+<link rel="stylesheet" href="testfile.css?5e544598b8d78644071a6f25fd8bba82" media="screen">
 </body>
 </html>
 HTML;
@@ -63,7 +63,7 @@ HTML;
 </head>
 <body>
 <script src="existing.js"></script>
-<script src="testfile.js?v=289fc946f38fee1a3e947eca1d6208b6"></script>
+<script src="testfile.js?289fc946f38fee1a3e947eca1d6208b6"></script>
 </body>
 </html>
 HTML;
@@ -76,7 +76,7 @@ HTML;
 </head>
 <body>
 <script src="existing.js"></script>
-<script src="testfile.js?v=289fc946f38fee1a3e947eca1d6208b6"></script>
+<script src="testfile.js?289fc946f38fee1a3e947eca1d6208b6"></script>
 </body>
 </html>
 HTML;
@@ -188,8 +188,17 @@ HTML;
     protected function getApp($boot = true)
     {
         $app = parent::getApp();
-        $app['asset.file.hash.factory'] = $app->protect(function ($fileName) {
-            return md5($fileName);
+        $mock = $this->getMock('\Bolt\Asset\BoltVersionStrategy', ['getVersion'], [$app['filesystem']->getFilesystem('extensions'), $app['asset.salt']]);
+        $mock->expects($this->any())
+            ->method('getVersion')
+            ->will($this->returnCallback(
+                function($fileName) {
+                    return md5($fileName);
+                }
+            ))
+        ;
+        $app['asset.version_strategy'] = $app->protect(function () use ($mock) {
+            return $mock;
         });
 
         return $app;

--- a/tests/phpunit/unit/Twig/Handler/HtmlHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/HtmlHandlerTest.php
@@ -14,46 +14,6 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class HtmlHandlerTest extends BoltUnitTest
 {
-    public function testCacheHashRelativePath()
-    {
-        $app = $this->getApp();
-        $app['asset.file.hash.factory'] = $app->protect(function ($fileName) {
-            return md5($fileName);
-        });
-
-        $handler = new HtmlHandler($app);
-
-        $file = str_replace(TEST_ROOT . '/', '', __FILE__);
-        $sum = md5(__FILE__);
-
-        $result = $handler->cacheHash($file);
-        $this->assertSame($file . '?v=' . $sum, $result);
-    }
-
-    public function testCacheHashFullPath()
-    {
-        $app = $this->getApp();
-        $app['asset.file.hash.factory'] = $app->protect(function ($fileName) {
-            return md5($fileName);
-        });
-
-        $handler = new HtmlHandler($app);
-
-        $sum = md5(__FILE__);
-        $result = $handler->cacheHash(__FILE__);
-        $this->assertSame(__FILE__ . '?v=' . $sum, $result);
-    }
-
-    public function testCacheHashInvalid()
-    {
-        $app = $this->getApp();
-
-        $handler = new HtmlHandler($app);
-
-        $result = $handler->cacheHash('/where/is/wally/when/you/need/him');
-        $this->assertNull($result);
-    }
-
     public function testDecorateTT()
     {
         $app = $this->getApp();

--- a/tests/phpunit/unit/Twig/TwigExtensionTest.php
+++ b/tests/phpunit/unit/Twig/TwigExtensionTest.php
@@ -132,16 +132,6 @@ class TwigExtensionTest extends BoltUnitTest
         $twig->buid();
     }
 
-    public function testCacheHash()
-    {
-        $app = $this->getApp();
-        $handlers = $this->getTwigHandlers($app);
-        $handlers['html'] = $this->getMockHandler('HtmlHandler', 'cacheHash');
-        $twig = new TwigExtension($app, $handlers, true);
-
-        $twig->cacheHash(null);
-    }
-
     public function testCountWidgets()
     {
         $app = $this->getApp();


### PR DESCRIPTION
I asked @jkazimir for an intro:
>Ok, so listen up, y’all. Assets can be like the force, or they can be like Gungans. Currently, assets are handled somewhere along the lines of Ewoks. They work well for the goals, but there’s still something obviously off about them.  This PR increased the assets mediclorians, putting things more in balance with the force.  Something something Darth Maul.

----

While @GawainLynch was refactoring the asset code, we talked about implementing Symfony's new [Asset Component](http://symfony.com/doc/current/components/asset/introduction.html). We had decided to wait until 3.1. But seeing how the code settled and with these bugs that have come up we decided it was time.

## Problems (and Solutions)

### Paths
Paths given to the `cachehash` function had to be the web paths. But they needed to be mapped back to the actual filesystem path to do checks with.
Paths were assumed to be under `root`. To handle different locations `file_exists` checks were done. This is what I call "magic" and is bad news. For example, what happens if both locations had the same file? which one wins?
As @GDmac mentions in #4949 trying to access paths in twig is nightmare right now. I am utterly confused about how it works / doesn't work. (Not pointing the finger or anything, I know there was BC to maintain). The sooner we can get away from using the `paths` object in twig, at least in its current state, the better.

Symfony solves both of these problems with `Packages`. Each `Package` has a base path so the path given can be relative. `Packages` are referenced by name, allowing you to declare which one to use. 

From this: 
```twig
{{ app.paths.app }}view/img/bolt-logo.png
or
{{ cachehash(paths.app ~ 'view/img/bolt-logo.png') }}
``` 
To this: 
```twig
{{ asset('img/bolt-logo.png', 'bolt') }}
```
The difference is subtle, but it's important.

### Versioning
With Symfony's Assets, each `Package` has version strategy. This allows individual packages to do versioning their own way. Currently we create a hash from the file's last modified time, a random string, and the file path. But another one could be swapped out like an empty version or a static version (`?3.1.2`).
"cachehash" or "hash" is a poor name because it's really an implementation of a version strategy. `asset` function name is better because it's further abstracted. You can reference an asset but that doesn't mean it has a version attached to it.

I removed  `cacheHash` and `fileName` from `FileAsset`'s interface and replaced it with `path`, `packageName`, and `url`. `path + packageName` are given to asset packages service which returns the `url`. This also removes the business logic from the `FileAsset` objects.

*Note: This does break code that is currently based on master.*

### Extensions
Gawain and I knew there needed to be some distinction between the directory an extension is installed to and how it is referenced from the web. We came up with `DirectoryInterface $baseDirectory` and `string $relativeUrl`. The problem we have run into is we need to do file operations on assets in the web directory. Trying to map the base directory to the relative url or whatever we were doing was a nightmare and only half working I think.

I replaced `string $relativeUrl` with `DirectoryInterface $webDirectory`. This really makes more sense as it is two directories we are working with. This allows us to remove the magic where we are adding assets from the extension, since those directories have been given to the extension from core.

The other problem @rossriley was talking to me about is these are required even though they may not be needed. I changed the directories so setting them is optional, but if they are requested (with getter) and they have not been set an exception is thrown. I want it this way because I don't want to do null checks every time the getter is called. For all "managed" extensions, ones installed with composer or local, the directories are always given. 
So this only affects extensions manually added:
```php
public function add(ExtensionInterface $extension, DirectoryInterface $baseDir = null, DirectoryInterface $webDir = null, $composerName = null)
```

*Note: This does break extensions that reference `relativeUrl`*

---

All in all this is the best solution as we have better separation of concerns, less magic, are closer to Symfony, and don't have to manage BC.

## What's left
- Fixing tests
- ~~Fix copying extension assets on install (may be a different PR)~~