### PR TITLE
Don't attempt to initialise the `thumbs` folder, if we're not using it.

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -68,10 +68,10 @@ class Cache extends FilesystemCache
 
         if ($this->filesystem instanceof AggregateFilesystemInterface) {
             // Clear our own cache folder.
-            $this->flushFilesystemCache($this->filesystem->getFilesystem('cache'), $result);
+            $this->flushFilesystemCache($this->filesystem->getFilesystem('cache'), '/', $result);
 
             // Clear the thumbs folder.
-            $this->flushFilesystemCache($this->filesystem->getFilesystem('thumbs'), $result);
+            $this->flushFilesystemCache($this->filesystem->getFilesystem('web'), '/thumbs', $result);
         }
 
         return $result;
@@ -81,11 +81,17 @@ class Cache extends FilesystemCache
      * Helper function for doFlush().
      *
      * @param FilesystemInterface $filesystem
+     * @param string              $path
      * @param array               $result
      */
-    private function flushFilesystemCache(FilesystemInterface $filesystem, &$result)
+    private function flushFilesystemCache(FilesystemInterface $filesystem, $path, &$result)
     {
+        if (!$filesystem->has($path)) {
+            return;
+        }
+
         $files = $filesystem->find()
+            ->in($path)
             ->files()
             ->notName('index.html')
             ->ignoreDotFiles()

--- a/src/Provider/FilesystemServiceProvider.php
+++ b/src/Provider/FilesystemServiceProvider.php
@@ -31,7 +31,6 @@ class FilesystemServiceProvider implements ServiceProviderInterface
                         'theme'      => new Filesystem(new Local($app['resources']->getPath('themebase') . '/' . $app['config']->get('general/theme'))),
                         'extensions' => new Filesystem(new Local($app['resources']->getPath('extensions'))),
                         'cache'      => new Filesystem(new Local($app['resources']->getPath('cache'))),
-                        'thumbs'     => new Filesystem(new Local($app['resources']->getPath('web/thumbs'))),
                     ],
                     [
                         new Plugin\PublicUrl($app),


### PR DESCRIPTION
Fixes two things related to #4960:

 - Don't attempt to initialise the `thumbs` folder, if we're not using it.
 - ~~Show a nice 'configuration notice' instead of breaking~~

![screenshot 2016-03-06 14 42 56](https://cloud.githubusercontent.com/assets/1833361/13554520/4ea20918-e3aa-11e5-8d99-613248d417bf.png)


Fixes: #4960