### PR TITLE
Prevent duplicate content for paging requests

### DIFF
--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -552,7 +552,7 @@ class ResourceManager
     private function isPagingRequest(Request $request)
     {
         $matches = array();
-        $found = preg_match('/page_[A-Za-z0-9_]+=\d+/', $request->getRequestUri(), $matches);
+        $found = preg_match('/page_[A-Za-z0-9_]+=(?!1\b)\d+/', $request->getRequestUri(), $matches);
 
         return (bool) $found;
     }


### PR DESCRIPTION
/blog?page_blog=1 isn't really paging, it's the same as /blog, so only match numbers higher than 1 when checking if the request is paging.