### PR TITLE
[master] Prevent duplicate content for paging requests

### DIFF
--- a/src/Pager/PagerManager.php
+++ b/src/Pager/PagerManager.php
@@ -58,7 +58,7 @@ class PagerManager implements \ArrayAccess
     public static function isPagingRequest(Request $request)
     {
         $matches = [];
-        $found = preg_match('/page_[A-Za-z0-9_]+=\d+/', $request->getRequestUri(), $matches);
+        $found = preg_match('/page_[A-Za-z0-9_]+=(?!1\b)\d+/', $request->getRequestUri(), $matches);
 
         return (bool) $found;
     }


### PR DESCRIPTION
Forward-port of #4981: /blog?page_blog=1 isn't really paging, it's the same as /blog, so only match numbers higher than 1 when checking if the request is paging.