### PR TITLE
Add 'single record' as an array to 'records'.

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -100,14 +100,12 @@ class Frontend extends ConfigurableBase
 
         $template = $this->templateChooser()->homepage($content);
 
-        $globals = [
-            'records' => $content,
-        ];
-
         if (is_array($content)) {
             $first = current($content);
             $globals[$first->contenttype['slug']] = $content;
+            $globals['records'] = $content;
         } elseif (!empty($content)) {
+            $globals['records'] = [$content->id => $content];
             $globals['record'] = $content;
             $globals[$content->contenttype['singular_slug']] = $content;
         }

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -105,9 +105,9 @@ class Frontend extends ConfigurableBase
             $globals[$first->contenttype['slug']] = $content;
             $globals['records'] = $content;
         } elseif (!empty($content)) {
-            $globals['records'] = [$content->id => $content];
             $globals['record'] = $content;
             $globals[$content->contenttype['singular_slug']] = $content;
+            $globals['records'] = [$content->id => $content];
         }
 
         return $this->render($template, [], $globals);

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -99,6 +99,7 @@ class Frontend extends ConfigurableBase
         $content = $this->getContent($this->getOption('general/homepage'), $listingparameters);
 
         $template = $this->templateChooser()->homepage($content);
+        $globals = [];
 
         if (is_array($content)) {
             $first = current($content);

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -66,6 +66,7 @@ class FrontendTest extends ControllerUnitTest
 
         $storage = $this->getMock('Bolt\Storage', ['getContent'], [$app]);
         $content1 = new Content($app);
+        $content1->setValue('id', 42);
         $storage->expects($this->once())
             ->method('getContent')
             ->will($this->returnValue($content1));
@@ -75,7 +76,7 @@ class FrontendTest extends ControllerUnitTest
         $globals = $response->getGlobalContext();
 
         $this->assertTrue($response instanceof BoltResponse);
-        $this->assertSame($content1, $globals['records']);
+        $this->assertSame([42 => $content1], $globals['records']);
     }
 
     public function testMultipleHomepages()


### PR DESCRIPTION
This should fix the reported issue, without causing side-effects. This way `records` always contains an actual "array of records", instead of just 'one record'. See screenshot for what `homepage: pages/21` gets you now: 

![screen shot 2016-03-09 at 12 55 14](https://cloud.githubusercontent.com/assets/1833361/13634610/d75c74a2-e5f6-11e5-89b9-f6ecbed399cd.png)


Fixes: #4980
