### PR TITLE
Add a missing comma to _checkbox.twig

### DIFF
--- a/app/view/twig/editcontent/fields/_checkbox.twig
+++ b/app/view/twig/editcontent/fields/_checkbox.twig
@@ -13,7 +13,7 @@
     class:    option.class,
     name:     name,
     id:       key,
-    type:     'checkbox'
+    type:     'checkbox',
     value:    1
 } %}
 


### PR DESCRIPTION
Line 17 was added in #4869. Without the comma on line 16 I get an error:

```
Twig_Error_Syntax

A hash value must be followed by a comma. Unexpected token "name" of value "value" ("punctuation" expected with value ",") in "editcontent/fields/_checkbox.twig" at line 17.
```

...I do not like brown M&M's. :smile_cat: 