### PR TITLE
Configurable bootstrap

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -65,7 +65,6 @@ return function (array $paths = []) {
 
     /** @var \Bolt\Configuration\ResourceManager $config */
     $config->verify();
-    $config->compat();
 
     // Create the 'Bolt application'
     $app = new Application(['resources' => $config]);

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,66 +1,77 @@
 <?php
+
 namespace Bolt;
 
 use Bolt\Exception\LowlevelException;
 
 /**
- * Second stage loader. Here we bootstrap the app:
+ * Second stage loader. Do bootstrapping within a new local scope to avoid
+ * polluting the global space.
  *
+ * Here we bootstrap the app:
  * - Initialize mb functions for UTF-8
  * - Figure out path structure
  * - Bring in the autoloader
  * - Load and verify configuration
  * - Initialize the application
+ *
+ * @param array $paths Paths in the format ['name' => 'relative/path']
+ *
+ * @throws LowlevelException
+ *
+ * @return \Closure
  */
+return function (array $paths = []) {
+    // Use UTF-8 for all multi-byte functions
+    mb_internal_encoding('UTF-8');
+    mb_http_output('UTF-8');
 
-// Do bootstrapping within a new local scope to avoid polluting the global
-return call_user_func(
-    function () {
-        // Use UTF-8 for all multi-byte functions
-        mb_internal_encoding('UTF-8');
-        mb_http_output('UTF-8');
+    // Resolve Bolt-root
+    $boltRootPath = realpath(__DIR__ . '/..');
 
-        // Resolve Bolt-root
-        $boltRootPath = realpath(__DIR__ . '/..');
+    // Look for the autoloader in known positions relative to the Bolt-root,
+    // and autodetect an appropriate configuration class based on this
+    // information. (autoload.php path maps to a configuration class)
+    $autodetectionMappings = [
+        $boltRootPath . '/vendor/autoload.php' => 'Standard',
+        $boltRootPath . '/../../autoload.php'  => 'Composer',
+    ];
 
-        // Look for the autoloader in known positions relative to the Bolt-root,
-        // and autodetect an appropriate configuration class based on this
-        // information. (autoload.php path maps to a configuration class)
-        $autodetectionMappings = [
-            $boltRootPath . '/vendor/autoload.php' => 'Standard',
-            $boltRootPath . '/../../autoload.php' => 'Composer'
-        ];
-
-        foreach ($autodetectionMappings as $autoloadPath => $configType) {
-            if (file_exists($autoloadPath)) {
-                $loader = require $autoloadPath;
-                // Instantiate the configuration class
-                $configClass = '\\Bolt\\Configuration\\' . $configType;
-                $config = new $configClass($loader);
-                break;
-            }
+    foreach ($autodetectionMappings as $autoloadPath => $configType) {
+        if (file_exists($autoloadPath)) {
+            $loader = require $autoloadPath;
+            // Instantiate the configuration class
+            $configClass = '\\Bolt\\Configuration\\' . $configType;
+            /** @var \Bolt\Configuration\ResourceManager $config */
+            $config = new $configClass($loader);
+            break;
         }
-
-        // None of the mappings matched, error
-        if (!isset($config)) {
-            include $boltRootPath . '/src/Exception/LowlevelException.php';
-            throw new LowlevelException(
-                "Configuration autodetection failed because The file " .
-                "<code>vendor/autoload.php</code> doesn't exist. Make sure " .
-                "you've installed the required components with Composer."
-            );
-        }
-
-        /** @var \Bolt\Configuration\ResourceManager $config */
-        $config->verify();
-        $config->compat();
-
-        // Create the 'Bolt application'
-        $app = new Application(['resources' => $config]);
-
-        // Initialize the 'Bolt application': Set up all routes, providers, database, templating, etc..
-        $app->initialize();
-
-        return $app;
     }
-);
+
+    // None of the mappings matched, error
+    if (!isset($config)) {
+        include $boltRootPath . '/src/Exception/LowlevelException.php';
+        throw new LowlevelException(
+            'Configuration autodetection failed because The file ' .
+            "<code>vendor/autoload.php</code> doesn't exist. Make sure " .
+            "you've installed the required components with Composer."
+        );
+    }
+
+    // Set any non-standard paths
+    foreach ($paths as $name => $path) {
+        $config->setPath($name, $path);
+    }
+
+    /** @var \Bolt\Configuration\ResourceManager $config */
+    $config->verify();
+    $config->compat();
+
+    // Create the 'Bolt application'
+    $app = new Application(['resources' => $config]);
+
+    // Initialize the 'Bolt application': Set up all routes, providers, database, templating, etc..
+    $app->initialize();
+
+    return $app;
+};

--- a/app/nut
+++ b/app/nut
@@ -1,11 +1,11 @@
 #!/usr/bin/env php
 <?php
 
-use Symfony\Component\Console\Application;
+/** @var \Closure $bootstrap */
+$bootstrap = require_once __DIR__ . '/bootstrap.php';
+/** @var \Silex\Application $app */
+$app = $bootstrap();
 
-$app = require_once __DIR__ . '/bootstrap.php';
-
-/** @var Application $application retrieve the Nut Console Application from the Bolt application in the bootstrap */
-$application = $app['nut'];
-
-$application->run();
+/** @var \Symfony\Component\Console\Application $nut Nut Console Application */
+$nut = $app['nut'];
+$nut->run();

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Bolt entry script
+ * Bolt entry script.
  *
  * Here we'll require in the first stage load script, which handles all the
  * tasks needed to return the app.  Once we get the app, we simply tell it
@@ -11,7 +11,6 @@
  *
  * Next, we'll check if the script is being run with PHP's built in web
  * server, and make sure static assets are handled gracefully.
- *
  */
 
 /**
@@ -26,11 +25,13 @@
  */
 if (version_compare(PHP_VERSION, '5.5.9', '<')) {
     require dirname(__FILE__) . '/app/legacy.php';
+
     return false;
 }
 
 /**
  * Return false if the requested file is available on the filesystem.
+ *
  * @see: http://silex.sensiolabs.org/doc/web_servers.html#php-5-4
  */
 if (php_sapi_name() === 'cli-server') {
@@ -41,8 +42,8 @@ if (php_sapi_name() === 'cli-server') {
     }
 }
 
-/**
- * @var \Silex\Application $app
- */
-$app = require_once __DIR__ . '/app/bootstrap.php';
+/** @var \Closure $bootstrap */
+$bootstrap = require_once __DIR__ . '/app/bootstrap.php';
+/** @var \Silex\Application $app */
+$app = $bootstrap();
 $app->run();

--- a/src/Application.php
+++ b/src/Application.php
@@ -46,7 +46,6 @@ class Application extends Silex\Application
         // must be defined for working properly
         if (!isset($this['resources'])) {
             $this['resources'] = new Configuration\ResourceManager($this);
-            $this['resources']->compat();
         } else {
             $this['classloader'] = $this['resources']->getClassLoader();
         }

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -409,25 +409,6 @@ class ResourceManager
         $this->verifyDb();
     }
 
-    public function compat()
-    {
-        if (! defined('BOLT_COMPOSER_INSTALLED')) {
-            define('BOLT_COMPOSER_INSTALLED', false);
-        }
-        if (! defined('BOLT_PROJECT_ROOT_DIR')) {
-            define('BOLT_PROJECT_ROOT_DIR', $this->getPath('root'));
-        }
-        if (! defined('BOLT_WEB_DIR')) {
-            define('BOLT_WEB_DIR', $this->getPath('web'));
-        }
-        if (! defined('BOLT_CACHE_DIR')) {
-            define('BOLT_CACHE_DIR', $this->getPath('cache'));
-        }
-        if (! defined('BOLT_CONFIG_DIR')) {
-            define('BOLT_CONFIG_DIR', $this->getPath('config'));
-        }
-    }
-
     /**
      * This currently gets special treatment because of the processing order.
      * The theme path is needed before the app has constructed, so this is a shortcut to

--- a/tests/phpunit/unit/Configuration/ResourceManagerTest.php
+++ b/tests/phpunit/unit/Configuration/ResourceManagerTest.php
@@ -156,7 +156,6 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
                 ]
             )
         );
-        $config->compat();
 
         $app = new Application(['resources' => $config]);
         $this->assertEquals($config->getPaths(), $app['resources']->getPaths());
@@ -231,7 +230,6 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
                 ]
             )
         );
-        $config->compat();
         $app = new Application(['resources' => $config]);
         $this->assertEquals('https', $config->getRequest('protocol'));
         $this->assertEquals('test.dev', $config->getRequest('hostname'));

--- a/tests/phpunit/unit/Filesystem/FilesystemProviderTest.php
+++ b/tests/phpunit/unit/Filesystem/FilesystemProviderTest.php
@@ -21,7 +21,6 @@ class FilesystemProviderTest extends BoltUnitTest
                 ]
             )
         );
-        $config->compat();
         $bolt = $this->getApp();
 
         $this->assertNotNull($bolt['filesystem']);
@@ -38,7 +37,6 @@ class FilesystemProviderTest extends BoltUnitTest
                 ]
             )
         );
-        $config->compat();
         $bolt = $this->getApp();
         $this->assertInstanceOf('Bolt\Filesystem\Filesystem', $bolt['filesystem']->getFilesystem('root'));
         $this->assertInstanceOf('Bolt\Filesystem\Filesystem', $bolt['filesystem']->getFilesystem('config'));


### PR DESCRIPTION
Another major release… another re-do of `index.php` and `app/bootstrap.php`… where would we be without them ;-)

This might be a little contentious for some, but we're moving to a Composer based archive install for v3, and want to keep bootstrapping for the average user to catch problems.

This PR changes  `app/bootstrap.php` to return a closure instead of an `Application` object. The closure when called accepts an array of paths and then returns the `Application` object, e.g.:

```php
$bootstrap = require_once '../vendor/bolt/bolt/app/bootstrap.php';
$app = $bootstrap([
    'themebase' => 'public/theme',
    'web'       => 'public',
    'files'     => 'public/files',
    'view'      => 'public/bolt-public/view',
]);

$app->run();
```