### PR TITLE
Use `asset()` instead of `bolt()`.

### DIFF
--- a/app/view/twig/editcontent/fielddata/_markdown.twig
+++ b/app/view/twig/editcontent/fielddata/_markdown.twig
@@ -1,7 +1,7 @@
 {### Scripts ###}
 
 {% for file in ['uikit.min', 'marked', 'codemirror-compressed', 'htmleditor'] %}
-    <script src="{{ bolt('js/uikit/' ~ file ~'.js', 'bolt') }}"></script>
+    <script src="{{ asset('js/uikit/' ~ file ~'.js', 'bolt') }}"></script>
 {% endfor %}
 
 {### Stylesheet ###}


### PR DESCRIPTION
Fixes:

```
Twig_Error_Syntax
Unknown "bolt" function in "@bolt/editcontent/fielddata/_markdown.twig" at line 4.
```