### PR TITLE
Repeater move buttons

### DIFF
--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -103,6 +103,20 @@
                 self._renumber();
             });
 
+            self.element.on('click', '.move-up', function () {
+                var setToMove = $(this).closest('.repeater-group');
+
+                setToMove.insertBefore(setToMove.prev('.repeater-group'));
+                self._renumber();
+            });
+
+            self.element.on('click', '.move-down', function () {
+                var setToMove = $(this).closest('.repeater-group');
+
+                setToMove.insertAfter(setToMove.next('.repeater-group'));
+                self._renumber();
+            });
+
             // Add initial groups until minimum number is reached.
             while (self._count < self.options.minimum) {
                 self._append();
@@ -176,6 +190,18 @@
                     this.name = this.name.replace(re, name + '[' + index + ']');
                     //console.log('  - ' + this.name + ' => ' +this.name.replace(re, name + '[' + index + ']'));
                 });
+
+                if ($(group).is(':first-of-type')) {
+                    $(group).find('.move-up').addClass('disabled');
+                } else {
+                    $(group).find('.move-up').removeClass('disabled');
+                }
+
+                if ($(group).is(':last-of-type')) {
+                    $(group).find('.move-down').addClass('disabled');
+                } else {
+                    $(group).find('.move-down').removeClass('disabled');
+                }
             });
         },
 

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -1,6 +1,12 @@
 <div class="repeater-group row panel panel-default">
     <div class="panel-heading text-right">
         <div class="btn-group">
+            <button type="button" class="btn btn-sm btn-default move-up">
+                <i class="fa fa-arrow-up"></i> {{ __('Move Up') }}
+            </button>
+            <button type="button" class="btn btn-sm btn-default  move-down">
+                <i class="fa fa-arrow-down"></i> {{ __('Move Down') }}
+            </button>
             <button type="button" class="btn btn-sm btn-default duplicate-button">
                 <i class="fa fa-copy"></i> {{ __('Duplicate Set') }}
             </button>


### PR DESCRIPTION
Adds Move Up and Move Down buttons for repeaters, also takes into account if it's the first/last item and disables the relevant buttons.

Fixes: #4975 