### PR TITLE
Don't filter on empty strings

### DIFF
--- a/src/Storage/ContentRequest/ListingOptions.php
+++ b/src/Storage/ContentRequest/ListingOptions.php
@@ -111,7 +111,7 @@ class ListingOptions
      */
     public function setFilter($filter)
     {
-        $this->filter = $filter ?: null;
+        $this->filter = $filter === '' ? null : $filter;
 
         return $this;
     }

--- a/src/Storage/ContentRequest/ListingOptions.php
+++ b/src/Storage/ContentRequest/ListingOptions.php
@@ -22,6 +22,8 @@ class ListingOptions
      * Set the order.
      *
      * @param string|null $order
+     *
+     * @return ListingOptions
      */
     public function setOrder($order)
     {
@@ -44,6 +46,8 @@ class ListingOptions
      * Set the page.
      *
      * @param integer|null $page
+     *
+     * @return ListingOptions
      */
     public function setPage($page)
     {
@@ -78,6 +82,8 @@ class ListingOptions
      * Set the taxonomies.
      *
      * @param array|null $taxonomies
+     *
+     * @return ListingOptions
      */
     public function setTaxonomies($taxonomies)
     {
@@ -100,10 +106,12 @@ class ListingOptions
      * Set the filter.
      *
      * @param string|null $filter
+     *
+     * @return ListingOptions
      */
     public function setFilter($filter)
     {
-        $this->filter = $filter;
+        $this->filter = $filter ?: null;
 
         return $this;
     }


### PR DESCRIPTION
By default when filtering on a taxonomy you get a query string like this: "?taxonomy-chapters=main&filter=" which then makes bolt "filter" the content with a empty string, which means that you get this:
![skarmklipp 2016-03-13 10 32 38](https://cloud.githubusercontent.com/assets/5096632/13728045/abe3f6a8-e90a-11e5-8678-0d56871ea109.png)
