### PR TITLE
Thumb presets

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -196,6 +196,10 @@ thumbnails:
     allow_upscale: false
     exif_orientation: true
 #    browser_cache_time: 2592000
+#    presets:
+#      default : [  160,  120 ]
+#      image   : [ 1000,  750 ]
+#      preview : [  300,    0 ]
 
 # Define the HTML tags and attributes that are allowed in 'cleaned' HTML. This
 # is used for sanitizing HTML, to make sure there are no undesirable elements


### PR DESCRIPTION
Some default thumb sizes presets, 
in anticipation of the thumbs update to restrict allowed sizes as discussed in #3703 

- Presets are commented out by default
- When no presets found by thumbs,  
  it falls back to allow all arbitrary sizes (for Backward Compatibility)
