### PR TITLE
Multiple fixes to related contenttype listings

### DIFF
--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -27,25 +27,22 @@
     <p>{{ __('This record is related to:') }}</p>
     <div class="buic-listing" data-bolt-widget="buicListing">
         <table class="table dashboardlisting listing">
-        {% for incoming in incomingrelations if not incoming.isInverted %}
-            {% setcontent record = incoming.from_contenttype ~ '/' ~ incoming.from_id %}
-            {% if record %}
-                {% set editable = isallowed('edit', record) %}
-                {% set listing_vars = {
-                    'compact':       true,
-                    'content':       record,
-                    'excerptlength': 280,
-                    'permissions':   {
-                        'edit':      isallowed('edit', record),
-                        'create':    isallowed('create', record),
-                        'publish':   isallowed('publish', record),
-                        'delete':    isallowed('delete', record),
-                        'depublish': isallowed('depublish', record)
-                    },
-                    'thumbsize':     54,
-                } %}
-                {% include ['@bolt/_sub/_listing.twig'] with listing_vars %}
-            {% endif %}
+        {% for record in incoming_not_inverted %}
+            {% set editable = isallowed('edit', record) %}
+            {% set listing_vars = {
+                'compact':       true,
+                'content':       record,
+                'excerptlength': 280,
+                'permissions':   {
+                    'edit':      isallowed('edit', record),
+                    'create':    isallowed('create', record),
+                    'publish':   isallowed('publish', record),
+                    'delete':    isallowed('delete', record),
+                    'depublish': isallowed('depublish', record)
+                },
+                'thumbsize':     54,
+            } %}
+            {% include ['@bolt/_sub/_listing.twig'] with listing_vars %}
         {% endfor %}
         </table>
     </div>

--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -14,6 +14,15 @@
 
 {# Output 'incoming' relations #}
 {% set incomingrelations = context.content.relation.incoming(context.content) %}
+
+{% set incoming_not_inverted = [] %}
+{% for incoming in incomingrelations if not incoming.isInverted %}
+    {% setcontent record = incoming.from_contenttype ~ '/' ~ incoming.from_id %}
+    {% if record %}
+        {% set incoming_not_inverted = incoming_not_inverted|merge([record]) %}
+    {% endif %}
+{% endfor %}
+
 {% if context.has.incoming_relations %}
     <p>{{ __('This record is related to:') }}</p>
     <div class="buic-listing" data-bolt-widget="buicListing">

--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -13,16 +13,6 @@
 {% endif %}
 
 {# Output 'incoming' relations #}
-{% set incomingrelations = context.content.relation.incoming(context.content) %}
-
-{% set incoming_not_inverted = [] %}
-{% for incoming in incomingrelations if not incoming.isInverted %}
-    {% setcontent record = incoming.from_contenttype ~ '/' ~ incoming.from_id %}
-    {% if record %}
-        {% set incoming_not_inverted = incoming_not_inverted|merge([record]) %}
-    {% endif %}
-{% endfor %}
-
 {% if context.has.incoming_relations %}
     {% for incoming_contenttype, incoming_records in context.incoming_not_inv %}
         <p>{{ __('This record is related to:') }}</p>

--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -24,28 +24,30 @@
 {% endfor %}
 
 {% if context.has.incoming_relations %}
-    <p>{{ __('This record is related to:') }}</p>
-    <div class="buic-listing" data-bolt-widget="buicListing">
-        <table class="table dashboardlisting listing">
-        {% for record in incoming_not_inverted %}
-            {% set editable = isallowed('edit', record) %}
-            {% set listing_vars = {
-                'compact':       true,
-                'content':       record,
-                'excerptlength': 280,
-                'permissions':   {
-                    'edit':      isallowed('edit', record),
-                    'create':    isallowed('create', record),
-                    'publish':   isallowed('publish', record),
-                    'delete':    isallowed('delete', record),
-                    'depublish': isallowed('depublish', record)
-                },
-                'thumbsize':     54,
-            } %}
-            {% include ['@bolt/_sub/_listing.twig'] with listing_vars %}
-        {% endfor %}
-        </table>
-    </div>
+    {% for incoming_contenttype, incoming_records in context.incoming_not_inv %}
+        <p>{{ __('This record is related to:') }}</p>
+        <div class="buic-listing" data-bolt-widget="buicListing">
+            <table class="table dashboardlisting listing">
+            {% for record in incoming_records %}
+                {% set editable = isallowed('edit', record) %}
+                {% set listing_vars = {
+                    'compact':       true,
+                    'content':       record,
+                    'excerptlength': 280,
+                    'permissions':   {
+                        'edit':      isallowed('edit', record),
+                        'create':    isallowed('create', record),
+                        'publish':   isallowed('publish', record),
+                        'delete':    isallowed('delete', record),
+                        'depublish': isallowed('depublish', record)
+                    },
+                    'thumbsize':     54,
+                } %}
+                {% include ['@bolt/_sub/_listing.twig'] with listing_vars %}
+            {% endfor %}
+            </table>
+        </div>
+    {% endfor %}
 {% endif %}
 
 {% if context.has.tabs and 'relations' in context.contenttype.groups %}

--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -15,7 +15,9 @@
 {# Output 'incoming' relations #}
 {% if context.has.incoming_relations %}
     {% for incoming_contenttype, incoming_records in context.incoming_not_inv %}
-        <p>{{ __('This record is related to:') }}</p>
+        {% set name = __(['contenttypes', incoming_contenttype, 'name', 'plural'], {DEFAULT: incoming_contenttype}) %}
+
+        <p>{{ __('This record is related to the following %CTNAME%:', {'%CTNAME%': name}) }}</p>
         <div class="buic-listing" data-bolt-widget="buicListing">
             <table class="table dashboardlisting listing">
             {% for record in incoming_records %}

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -135,7 +135,7 @@ class Edit
             'change_ownership'   => $this->users->isAllowed('contenttype:' . $contentTypeSlug . ':change-ownership:' . $content->getId()),
         ];
         $contextHas = [
-            'incoming_relations' => count($content->getRelation()->incoming($content)),
+            'incoming_relations' => count($incomingNotInverted) > 0,
             'relations'          => isset($contentType['relations']),
             'tabs'               => $contentType['groups'] !== false,
             'taxonomy'           => isset($contentType['taxonomy']),
@@ -146,7 +146,6 @@ class Edit
             'datedepublish'      => $this->getPublishingDate($content->getDatedepublish()),
         ];
         $context = [
-            'inc'                => $content->getRelation()->incoming($content),
             'incoming_not_inv'   => $incomingNotInverted,
             'contenttype'        => $contentType,
             'content'            => $content,

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -108,6 +108,18 @@ class Edit
             $contentowner = $this->users->getUser($content->getOwnerid());
         }
 
+        // Build list of incoming non inverted related records.
+        $incomingNotInverted = [];
+        foreach ($content->getRelation()->incoming($content) as $relation) {
+            if (!$relation->isInverted()) {
+                $record = $this->em->getContent($relation['from_contenttype'] . '/' . $relation['from_id']);
+
+                if ($record) {
+                    $incomingNotInverted[$relation['from_contenttype']][] = $record;
+                }
+            }
+        }
+
         // Test write access for uploadable fields.
         $contentType['fields'] = $this->setCanUpload($contentType['fields']);
         $templateFields = $content->getTemplatefields();
@@ -134,6 +146,8 @@ class Edit
             'datedepublish'      => $this->getPublishingDate($content->getDatedepublish()),
         ];
         $context = [
+            'inc'                => $content->getRelation()->incoming($content),
+            'incoming_not_inv'   => $incomingNotInverted,
             'contenttype'        => $contentType,
             'content'            => $content,
             'allowed_status'     => $allowedStatuses,

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -115,7 +115,7 @@ class Edit
                 continue;
             }
             $fromContentType = $relation->getFromContenttype();
-            $record = $this->em->getContent($fromContentType . '/' . $relation['from_id']);
+            $record = $this->em->getContent($fromContentType . '/' . $relation->getFromId());
 
             if ($record) {
                 $incomingNotInverted[$fromContentType][] = $record;

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -112,10 +112,11 @@ class Edit
         $incomingNotInverted = [];
         foreach ($content->getRelation()->incoming($content) as $relation) {
             if (!$relation->isInverted()) {
-                $record = $this->em->getContent($relation['from_contenttype'] . '/' . $relation['from_id']);
+                $fromContentType = $relation->getFromContenttype();
+                $record = $this->em->getContent($fromContentType . '/' . $relation['from_id']);
 
                 if ($record) {
-                    $incomingNotInverted[$relation['from_contenttype']][] = $record;
+                    $incomingNotInverted[$fromContentType][] = $record;
                 }
             }
         }

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -111,13 +111,14 @@ class Edit
         // Build list of incoming non inverted related records.
         $incomingNotInverted = [];
         foreach ($content->getRelation()->incoming($content) as $relation) {
-            if (!$relation->isInverted()) {
-                $fromContentType = $relation->getFromContenttype();
-                $record = $this->em->getContent($fromContentType . '/' . $relation['from_id']);
+            if ($relation->isInverted()) {
+                continue;
+            }
+            $fromContentType = $relation->getFromContenttype();
+            $record = $this->em->getContent($fromContentType . '/' . $relation['from_id']);
 
-                if ($record) {
-                    $incomingNotInverted[$fromContentType][] = $record;
-                }
+            if ($record) {
+                $incomingNotInverted[$fromContentType][] = $record;
             }
         }
 


### PR DESCRIPTION
First removes the if clause (introduced [here](https://github.com/bolt/bolt/commit/2063fcdc5cb3251386387286e82ef817003388ef)) from the for loop as twig has unpredictable behavior on the loop variable then. That finally is a correct fix for #4901 as that one introduced an almost random generation of ``<tbody>``s which then caused #5000 and #5008 .

Next fix is to decide on the filtered list if the listing should be output and not on the full unfiltered list.

Additional some business logic was moved from twig to php and another bug was fixed that wasn't noticed sofar: Custom listings can have a different column count so it doesn't work to list them in them on in table. Also UIX wise it makes sense to have them in distinct tables.

fixes #4901 
fixes #5000 
fixes #5008 

