### PR TITLE
Fix our Cache implementation to follow Doctrine's interface.

### DIFF
--- a/src/Configuration/Environment.php
+++ b/src/Configuration/Environment.php
@@ -59,7 +59,7 @@ class Environment
             return;
         }
         $this->syncView();
-        $this->cache->doFlush();
+        $this->cache->flushAll();
         $this->updateAutoloader();
         $this->updateCacheVersion();
     }

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -81,15 +81,12 @@ class General extends BackendBase
      */
     public function clearCache()
     {
-        $result = $this->app['cache']->doFlush();
+        $result = $this->app['cache']->flushAll();
 
-        $output = Trans::__('Deleted %s files from cache.', ['%s' => $result['successfiles']]);
-
-        if (!empty($result['failedfiles'])) {
-            $output .= ' ' . Trans::__('%s files could not be deleted. You should delete them manually.', ['%s' => $result['failedfiles']]);
-            $this->flashes()->error($output);
+        if ($result) {
+            $this->flashes()->success(Trans::__('Cleared cache.'));
         } else {
-            $this->flashes()->success($output);
+            $this->flashes()->error(Trans::__('Failed to clear cache. You should delete it manually.'));
         }
 
         return $this->render('@bolt/clearcache/clearcache.twig');

--- a/src/Events/CronEvent.php
+++ b/src/Events/CronEvent.php
@@ -84,7 +84,7 @@ class CronEvent extends Event
     private function cronWeekly()
     {
         // Clear the cache
-        $this->app['cache']->doFlush();
+        $this->app['cache']->flushAll();
         $this->notify('Clearing cache');
 
         // Trim system log files

--- a/src/Nut/CacheClear.php
+++ b/src/Nut/CacheClear.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CacheClear extends BaseCommand
 {
     /**
-     * @see \Symfony\Component\Console\Command\Command::configure()
+     * {@inheritdoc}
      */
     protected function configure()
     {
@@ -22,23 +22,18 @@ class CacheClear extends BaseCommand
     }
 
     /**
-     * @see \Symfony\Component\Console\Command\Command::execute()
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $result = $this->app['cache']->doFlush();
-
-        $output->writeln(sprintf("Deleted %s files from cache.\n", $result['successfiles']));
-
-        if (!empty($result['failedfiles'])) {
-            $output->writeln(sprintf('<error>These %s files could not be deleted. You should delete them manually.</error>', $result['failedfiles']));
-            foreach ($result['failed'] as $failed) {
-                $output->writeln(" - $failed");
-            }
-            $output->writeln('');
-        }
+        $result = $this->app['cache']->flushAll();
 
         $this->auditLog(__CLASS__, 'Cache cleared');
-        $output->writeln('<info>Cache cleared!</info>');
+
+        if ($result) {
+            $output->writeln('<info>Cache cleared!</info>');
+        } else {
+            $output->writeln('<warning>Failed to clear cache. You should delete it manually.</warning>');
+        }
     }
 }

--- a/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
+++ b/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
@@ -564,8 +564,7 @@ class BackendAdminCest
         $I->setCookie($this->tokenNames['session'], $this->cookies[$this->tokenNames['session']]);
         $I->amOnPage('/bolt/clearcache');
 
-        $I->see('Deleted');
-        $I->see('files from cache.');
+        $I->see('Cleared cache');
         $I->see('Clear cache again', 'a');
     }
 

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -242,7 +242,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
             $app['filesystem'],
         ];
 
-        $cache = $this->getMock('Bolt\Cache', ['doFlush'], $params);
+        $cache = $this->getMock('Bolt\Cache', ['flushAll'], $params);
 
         return $cache;
     }

--- a/tests/phpunit/unit/Cache/CacheTest.php
+++ b/tests/phpunit/unit/Cache/CacheTest.php
@@ -36,7 +36,7 @@ class CacheTest extends BoltUnitTest
 
     public function tearDown()
     {
-        $this->cache->doFlush();
+        $this->cache->flushAll();
         $this->clean($this->workspace);
     }
 

--- a/tests/phpunit/unit/Controller/Async/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Async/GeneralTest.php
@@ -117,7 +117,7 @@ class GeneralTest extends ControllerUnitTest
     public function testDashboardNewsWithVariable()
     {
         $app = $this->getApp();
-        $app['cache']->doFlush();
+        $app['cache']->flushAll();
         $this->setRequest(Request::create('/async/dashboardnews'));
         $app['config']->set('general/branding/news_variable', 'testing');
 

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -51,12 +51,12 @@ class GeneralTest extends ControllerUnitTest
         $this->allowLogin($this->getApp());
         $cache = $this->getCacheMock();
         $cache->expects($this->at(0))
-            ->method('doFlush')
-            ->will($this->returnValue(['successfiles' => '1.txt', 'failedfiles' => '2.txt']));
+            ->method('flushAll')
+            ->will($this->returnValue(false));
 
         $cache->expects($this->at(1))
-            ->method('doFlush')
-            ->will($this->returnValue(['successfiles' => '1.txt']));
+            ->method('flushAll')
+            ->will($this->returnValue(true));
 
         $this->setService('cache', $cache);
         $this->setRequest(Request::create('/bolt/clearcache'));

--- a/tests/phpunit/unit/Events/CronEventTest.php
+++ b/tests/phpunit/unit/Events/CronEventTest.php
@@ -22,7 +22,7 @@ class CronEventTest extends BoltUnitTest
         $app['cache'] = $this->getCacheMock();
         $app['cache']
             ->expects($this->exactly(1))
-            ->method('doFlush');
+            ->method('flushAll');
 
         $changeRepository = $app['storage']->getRepository('Bolt\Storage\Entity\LogChange');
         $systemRepository = $app['storage']->getRepository('Bolt\Storage\Entity\LogSystem');

--- a/tests/phpunit/unit/Nut/CacheClearTest.php
+++ b/tests/phpunit/unit/Nut/CacheClearTest.php
@@ -21,31 +21,28 @@ class CacheClearTest extends BoltUnitTest
         $tester = new CommandTester($command);
         $tester->execute([]);
         $result = $tester->getDisplay();
-        $this->assertRegExp('/Deleted 1 file/', $result);
+        $this->assertRegExp('/Cache cleared/', $result);
     }
 
     public function testWithFailures()
     {
         $app = $this->getApp();
-        $app['cache'] = $this->getCacheMock('bad');
+        $app['cache'] = $this->getCacheMock(null, false);
         $command = new CacheClear($app);
         $tester = new CommandTester($command);
 
         $tester->execute([]);
         $result = $tester->getDisplay();
-        $this->assertRegExp('/files could not be deleted/', $result);
-        $this->assertRegExp('/test.txt/', $result);
+        $this->assertRegExp('/Failed to clear cache/', $result);
     }
 
-    protected function getCacheMock($type = 'good')
+    protected function getCacheMock($path = null, $flushResult = true)
     {
-        $good = ['successfiles' => 1, 'failedfiles' => 0];
-        $bad = ['successfiles' => 0, 'failedfiles' => 1, 'failed' => ['test.txt']];
-
-        $cache = parent::getCacheMock();
+        $cache = parent::getCacheMock($path);
         $cache->expects($this->once())
-            ->method('doFlush')
-            ->will($this->returnValue($$type));
+            ->method('flushAll')
+            ->will($this->returnValue($flushResult))
+        ;
 
         return $cache;
     }


### PR DESCRIPTION
There was a miscommunication between @GawainLynch and I with his last changes to `Bolt\Cache`.
This corrects it by using `flushAll()` from Doctrine's Cache interface, instead of making `doFlush()` public and using it which isn't any better than the deprecated `clearCache()` method. Now the cache implementation can replaced with any Doctrine Cache implementation.