### PR TITLE
Replacing all (deprecated) `{% include %}` tags with `{{ include() }}` function.

### DIFF
--- a/app/view/twig/_base/_page-nav.twig
+++ b/app/view/twig/_base/_page-nav.twig
@@ -21,14 +21,14 @@
     <div id="navpage-wrapper"{% if app.request.cookies.get('sidebar') %} class="nav-secondary-collapsed nav-secondary-collapsed-hoverable"{% endif %}>
         <nav id="navpage-primary" class="navbar navbar-static-top navbar-inverse navbar-bolt">
             <div class="container-fluid">
-                {% include '@bolt/_nav/_primary.twig' %}
+                {{ include('@bolt/_nav/_primary.twig') }}
             </div>
         </nav>
 
         <nav id="navpage-secondary" class="navbar-default navbar-static-side">
-            {% include '@bolt/_nav/_secondary.twig' %}
+            {{ include('@bolt/_nav/_secondary.twig') }}
             {# Note: We include the footer here, because of z-index issues otherwise. #}
-            {% include '@bolt/_nav/_footer.twig' %}
+            {{ include('@bolt/_nav/_footer.twig') }}
         </nav>
 
         <div id="navpage-content" class="container-fluid">
@@ -60,7 +60,7 @@
             {{ widgets('below_header', 'backend') }}
 
             {% block messages %}
-                {% include '@bolt/_sub/_messages.twig' with {'wrapper': true} %}
+                {{ include('@bolt/_sub/_messages.twig', {'wrapper': true}) }}
             {% endblock messages %}
 
             {% block page_main %}[PAGE_MAIN]{% endblock page_main %}

--- a/app/view/twig/_base/_page-no_nav.twig
+++ b/app/view/twig/_base/_page-no_nav.twig
@@ -30,7 +30,7 @@
 
                 <div class="panel panel-default">
                     <div class="panel-body">
-                        {% include '@bolt/_sub/_messages.twig' %}
+                        {{ include('@bolt/_sub/_messages.twig') }}
                         {% block page_main %}[PAGE_MAIN]{% endblock page_main %}
                     </div>
                 </div>

--- a/app/view/twig/_nav/_secondary.twig
+++ b/app/view/twig/_nav/_secondary.twig
@@ -4,7 +4,7 @@
     {% if app.session.get('authentication') is not null %}
 
         {# Omnisearch: one here for "extra small", the other in the header-navbar #}
-        {% include '@bolt/_nav/_secondary-search.twig' %}
+        {{ include('@bolt/_nav/_secondary-search.twig') }}
 
         {# Dashboard #}
         {{ nav.link('fa:dashboard', __('Dashboard'), 'dashboard', (page_nav == 'Dashboard')) }}
@@ -16,16 +16,16 @@
 
         {# Contenttypes #}
         {{ nav.heading(__('Content'), 'fa:file-text') }}
-        {% include '@bolt/_nav/_secondary-content.twig' %}
+        {{ include('@bolt/_nav/_secondary-content.twig') }}
 
         {# Settings #}
         {% if isallowed('settings') %}
-            {% set nav_config %}{% include '@bolt/_nav/_secondary-configuration.twig' %}{% endset %}
-            {% set nav_files %}{% include '@bolt/_nav/_secondary-filemanagement.twig' %}{% endset %}
-            {% set nav_trans %}{% include '@bolt/_nav/_secondary-translations.twig' %}{% endset %}
+            {% set nav_config %}{{ include('@bolt/_nav/_secondary-configuration.twig') }}{% endset %}
+            {% set nav_files %}{{ include('@bolt/_nav/_secondary-filemanagement.twig') }}{% endset %}
+            {% set nav_trans %}{{ include('@bolt/_nav/_secondary-translations.twig') }}{% endset %}
             {# Link to Extend Bolt #}
             {% if app['menu.admin'].get('extend').children or isallowed('extensions||extensions:config') %}
-                {% set nav_extend %}{% include '@bolt/_nav/_secondary-extensions.twig' %}{% endset %}
+                {% set nav_extend %}{{ include('@bolt/_nav/_secondary-extensions.twig') }}{% endset %}
             {% else %}
                 {% set nav_extend = '' %}
             {% endif %}

--- a/app/view/twig/_sub/_record_list.twig
+++ b/app/view/twig/_sub/_record_list.twig
@@ -53,7 +53,7 @@
                     },
                     'filter':        filter
                 } %}
-                {% include includes with listing_vars %}
+                {{ include(includes, listing_vars) }}
 
                 {% if content.group.name is defined and (loop.first or content.group.name != lastgroup) %}
                     {% set lastgroup = content.group.name %}

--- a/app/view/twig/checks/checks.twig
+++ b/app/view/twig/checks/checks.twig
@@ -34,7 +34,7 @@
         </div>
 
         <aside class="col-md-4">
-            {% include '@bolt/checks/_aside.twig' %}
+            {{ include('@bolt/checks/_aside.twig') }}
         </aside>
     </div>
 

--- a/app/view/twig/components/panel-activity.twig
+++ b/app/view/twig/components/panel-activity.twig
@@ -2,5 +2,5 @@
  # Sidebar-Panel: Displays the latest activity
  # (Usage Example: Dashboards sidebar)
  #}
-{% include '@bolt/components/panel-activity-change.twig' with context %}
-{% include '@bolt/components/panel-activity-system.twig' with context %}
+{{ include('@bolt/components/panel-activity-change.twig', context) }}
+{{ include('@bolt/components/panel-activity-system.twig', context) }}

--- a/app/view/twig/components/panel-news.twig
+++ b/app/view/twig/components/panel-news.twig
@@ -3,5 +3,5 @@
  # (Usage Example: Dashboards sidebar)
  #}
 {% for news in context %}
-    {% include '@bolt/components/panel-news-item.twig' %}
+    {{ include('@bolt/components/panel-news-item.twig') }}
 {% endfor %}

--- a/app/view/twig/dashboard/_aside.twig
+++ b/app/view/twig/dashboard/_aside.twig
@@ -1,7 +1,7 @@
 {% import '@bolt/_macro/_panels.twig' as panels %}
 
 {# Configuration notices #}
-{% include '@bolt/_sub/_configuration_notices.twig' %}
+{{ include('@bolt/_sub/_configuration_notices.twig') }}
 
 {# If we're running a development version, show annoying message. #}
 {% if not bolt_stable %}

--- a/app/view/twig/dashboard/_recently_edited.twig
+++ b/app/view/twig/dashboard/_recently_edited.twig
@@ -17,7 +17,7 @@
                 'permissions':   context.permissions[contenttype],
                 'thumbsize':     54,
             } %}
-            {% include ['@bolt/custom/listing/' ~ content.contenttype.slug ~ '.twig', '@bolt/_sub/_listing.twig'] with listing_vars %}
+            {{ include(['@bolt/custom/listing/' ~ content.contenttype.slug ~ '.twig', '@bolt/_sub/_listing.twig'],  listing_vars) }}
         {% endfor %}
     </table>
 </div>

--- a/app/view/twig/dashboard/dashboard.twig
+++ b/app/view/twig/dashboard/dashboard.twig
@@ -14,25 +14,25 @@
     <div class="row">
         <div class="col-md-8">
 
-            {% include '@bolt/_sub/_messages.twig' %}
+            {{ include('@bolt/_sub/_messages.twig') }}
 
             {% if context.suggestloripsum %}
-                {% include '@bolt/dashboard/_suggestloripsum.twig' %}
+                {{ include('@bolt/dashboard/_suggestloripsum.twig') }}
             {% endif %}
 
             {{ widgets('dashboard_below_header', 'backend') }}
 
             <div class="quicklinks">
                 {% if app.config.get('contenttypes')|length() > 3 %}
-                    {% include '@bolt/dashboard/_quicklinks-dropdown.twig' %}
+                    {{ include('@bolt/dashboard/_quicklinks-dropdown.twig') }}
                 {% else %}
-                    {% include '@bolt/dashboard/_quicklinks-buttons.twig' %}
+                    {{ include('@bolt/dashboard/_quicklinks-buttons.twig') }}
                 {% endif %}
             </div>
 
             {% for contenttype, multiplecontent in context.latest %}
                 {% if multiplecontent %}
-                    {% include '@bolt/dashboard/_recently_edited.twig' %}
+                    {{ include('@bolt/dashboard/_recently_edited.twig') }}
                 {% endif %}
             {% endfor %}
 
@@ -41,7 +41,7 @@
         </div>
 
         <aside class="col-md-4">
-            {% include '@bolt/dashboard/_aside.twig' %}
+            {{ include('@bolt/dashboard/_aside.twig') }}
         </aside>
 
     </div>

--- a/app/view/twig/editcontent/_aside.twig
+++ b/app/view/twig/editcontent/_aside.twig
@@ -8,12 +8,12 @@
     </div>
 
     <div class="panel-body">
-        {% include '@bolt/editcontent/_aside-save.twig' %}
-        {% include '@bolt/editcontent/_aside-live-editor.twig' %}
-        {% include '@bolt/editcontent/_aside-preview.twig' %}
-        {% include '@bolt/editcontent/_aside-status.twig' %}
+        {{ include('@bolt/editcontent/_aside-save.twig') }}
+        {{ include('@bolt/editcontent/_aside-live-editor.twig') }}
+        {{ include('@bolt/editcontent/_aside-preview.twig') }}
+        {{ include('@bolt/editcontent/_aside-status.twig') }}
         {% if isallowed('delete', context.content) and context.content.id is not empty %}
-            {% include '@bolt/editcontent/_aside-delete.twig' %}
+            {{ include('@bolt/editcontent/_aside-delete.twig') }}
         {% endif %}
     </div>
 </div>

--- a/app/view/twig/editcontent/_includes-data.twig
+++ b/app/view/twig/editcontent/_includes-data.twig
@@ -17,11 +17,11 @@
 {# Process field specific includes and data #}
 
 {% for type in context.fieldtypes %}
-    {% include '@bolt/editcontent/fielddata/_' ~ type ~ '.twig' ignore missing %}
+    {{ include('@bolt/editcontent/fielddata/_' ~ type ~ '.twig', ignore_missing = true) }}
 {% endfor %}
 
 {# Has uploads? #}
 
 {% if 'file' in context.fieldtypes or 'filelist' in context.fieldtypes or 'image' in context.fieldtypes or 'imagelist' in context.fieldtypes %}
-    {% include '@bolt/editcontent/data/_uploads.twig' %}
+    {{ include('@bolt/editcontent/data/_uploads.twig') }}
 {% endif %}

--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -9,7 +9,7 @@
 {% endif %}
 
 {% if context.has.relations %}
-    {% include '@bolt/editcontent/_relationships.twig' %}
+    {{ include('@bolt/editcontent/_relationships.twig') }}
 {% endif %}
 
 {# Output 'incoming' relations #}
@@ -35,7 +35,7 @@
                     },
                     'thumbsize':     54,
                 } %}
-                {% include ['@bolt/_sub/_listing.twig'] with listing_vars %}
+                {{ include(['@bolt/_sub/_listing.twig'], listing_vars) }}
             {% endfor %}
             </table>
         </div>
@@ -43,7 +43,7 @@
 {% endif %}
 
 {% if context.has.tabs and 'relations' in context.contenttype.groups %}
-    {% include '@bolt/editcontent/_fields.twig' %}{# TODO doesn't exist #}
+    {{ include('@bolt/editcontent/_fields.twig') }}{
 {% endif %}
 
 {% if not context.has.tabs %}

--- a/app/view/twig/editcontent/_relationships.twig
+++ b/app/view/twig/editcontent/_relationships.twig
@@ -11,7 +11,7 @@
         {% endif %}
 
         {# Relationship #}
-        {% include '@bolt/editcontent/fields/_relationship.twig' %}
+        {{ include('@bolt/editcontent/fields/_relationship.twig') }}
 
         {# Postfix #}
         {% if relation.postfix is defined and relation.postfix is not empty %}

--- a/app/view/twig/editcontent/_taxonomies.twig
+++ b/app/view/twig/editcontent/_taxonomies.twig
@@ -22,11 +22,11 @@
 
             {# Fieldset #}
             {% if taxonomy.behaves_like == 'tags' %}
-                {% include '@bolt/editcontent/fields/_tags.twig' %}
+                {{ include('@bolt/editcontent/fields/_tags.twig') }}
             {% elseif taxonomy.behaves_like == 'categories' %}
-                {% include '@bolt/editcontent/fields/_categories.twig' %}
+                {{ include('@bolt/editcontent/fields/_categories.twig') }}
             {% elseif taxonomy.behaves_like == 'grouping' %}
-                {% include '@bolt/editcontent/fields/_grouping.twig' %}
+                {{ include('@bolt/editcontent/fields/_grouping.twig') }}
             {% endif %}
 
             {# Postfix #}
@@ -40,5 +40,5 @@
 {% endfor %}
 
 {% if context.has.tabs and 'taxonomy' in context.contenttype.groups %}
-    {% include '@bolt/editcontent/_fields.twig' %}{# TODO doesn't exist #}
+    {{ include('@bolt/editcontent/_fields.twig') }}
 {% endif %}

--- a/app/view/twig/editcontent/editcontent.twig
+++ b/app/view/twig/editcontent/editcontent.twig
@@ -64,7 +64,7 @@
     <div class="row">
         <div class="col-md-8">
 
-            {% include '@bolt/_sub/_messages.twig' %}
+            {{ include('@bolt/_sub/_messages.twig') }}
 
             {{ widgets('editcontent_below_header', 'backend') }}
 
@@ -80,7 +80,7 @@
             {% endif %}
 
             <form{{ macro.attr(attr_form) }}>
-                {% include '@bolt/_sub/_csrf_token.twig' %}
+                {{ include('@bolt/_sub/_csrf_token.twig') }}
 
                 <input{{ macro.attr(attributes.hid_editreferrer) }}>
                 <input{{ macro.attr(attributes.hid_contenttype) }}>
@@ -94,21 +94,21 @@
                     {% for key in group.fields %}
 
                         {% if key == '*relations' %}
-                            {% include '@bolt/editcontent/_relations.twig' %}
+                            {{ include('@bolt/editcontent/_relations.twig') }}
 
                         {% elseif key == '*taxonomy' %}
-                            {% include '@bolt/editcontent/_taxonomies.twig' %}
+                            {{ include('@bolt/editcontent/_taxonomies.twig') }}
 
                         {% elseif key == '*meta' %}
                             <div data-bolt-fieldset="meta">
-                                {% include '@bolt/editcontent/fields/_meta.twig' %}
+                                {{ include('@bolt/editcontent/fields/_meta.twig') }}
                             </div>
 
                         {% elseif key == '*template' %}
-                            {% include '@bolt/editcontent/_templatefields.twig' %}
+                            {{ include('@bolt/editcontent/_templatefields.twig') }}
 
                         {% else %}
-                            {% include '@bolt/editcontent/_field.twig' %}
+                            {{ include('@bolt/editcontent/_field.twig') }}
                         {% endif %}
 
                     {% endfor %}
@@ -121,22 +121,22 @@
 
                 <input type="hidden" name="_live-editor-preview" value=""/>
 
-                {% include '@bolt/editcontent/_buttons.twig' %}
+                {{ include('@bolt/editcontent/_buttons.twig') }}
             </form>
 
-            {% include '@bolt/editcontent/_includes-data.twig' %}
+            {{ include('@bolt/editcontent/_includes-data.twig') }}
 
             {{ widgets('editcontent_bottom', 'backend') }}
 
         </div>
 
         <aside class="col-md-4 hidden-sm">
-            {% include '@bolt/editcontent/_aside.twig' %}
+            {{ include('@bolt/editcontent/_aside.twig') }}
         </aside>
     </div>
 
 {% endblock page_main %}
 
 {% block page_main_extra_content %}
-    {% include '@bolt/editcontent/_live-editor.twig' %}
+    {{ include('@bolt/editcontent/_live-editor.twig') }}
 {% endblock %}

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -45,7 +45,7 @@
                     </div>
                 {% endif %}
 
-                {% include context.fields[rfield.type].template with rcontext %}
+                {{ include(context.fields[rfield.type].template, rcontext) }}
 
                 {# Postfix #}
                 {% if rcontext.field.postfix is defined and rcontext.field.postfix is not empty %}

--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -23,11 +23,11 @@
     <div class="repeater-slot">
         <script type="text/template">
             {% set index = '#' %}
-            {% include '@bolt/editcontent/fields/_repeater-group.twig' with { 'content': repeatfieldvals.getEmptySet , 'index': index} %}
+            {{ include('@bolt/editcontent/fields/_repeater-group.twig', { 'content': repeatfieldvals.getEmptySet , 'index': index}) }}
         </script>
 
         {% for index, repeatfieldset in repeatfieldvals %}
-            {% include '@bolt/editcontent/fields/_repeater-group.twig' with { 'content': repeatfieldset, 'index': index} %}
+            {{ include('@bolt/editcontent/fields/_repeater-group.twig', { 'content': repeatfieldset, 'index': index}) }}
         {% endfor %}
     </div>
 

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -10,7 +10,7 @@
 {% block messages "" %}
 
 {% block page_main %}
-    {% include '@bolt/extend/_package.twig' %}
+    {{ include('@bolt/extend/_package.twig') }}
 
     {% if context.messages %}
         <div class="row">
@@ -44,7 +44,7 @@
             </div>
             {% endif %}
 
-            {% include '@bolt/_sub/_messages.twig' %}
+            {{ include('@bolt/_sub/_messages.twig') }}
 
             <section>
                 <h2>{{ __('page.extend.headline.install-new-extension') }}</h2>
@@ -66,7 +66,7 @@
                         <div class="modal fade" id="installModal" tabindex="-1" role="dialog">
                             <div class="modal-dialog">
                                 <div class="modal-content">
-                                    {% include '@bolt/extend/install-package.twig' %}
+                                    {{ include('@bolt/extend/install-package.twig') }}
                                 </div>
                             </div>
                         </div>

--- a/app/view/twig/files/files.twig
+++ b/app/view/twig/files/files.twig
@@ -31,7 +31,7 @@
             {{ widgets('files_below_header', 'backend') }}
 
             {% if context.directories|length > 0 %}
-                {% include '@bolt/files/_folders.twig' %}
+                {{ include('@bolt/files/_folders.twig') }}
             {% endif %}
 
             <p>
@@ -52,12 +52,12 @@
             </p>
 
             {% if context.files|length > 0 %}
-                {% include '@bolt/files/_files.twig' %}
+                {{ include('@bolt/files/_files.twig') }}
             {% endif %}
 
             {# Only show the "Upload here" form, if the folder is writable. #}
             {% if context.form != false %}
-                {% include '@bolt/files/_upload.twig' %}
+                {{ include('@bolt/files/_upload.twig') }}
             {% else %}
                 <p><i class="fa fa-fw fa-exclamation-sign"></i> {{ __('Uploading to this folder is not allowed.') }}</p>
             {% endif %}

--- a/app/view/twig/files_ck/files_ck.twig
+++ b/app/view/twig/files_ck/files_ck.twig
@@ -28,11 +28,11 @@
     {{ files_path(context.pathsegments, context.namespace, pathoptions) }}
 
     {% if context.folders|length > 0 %}
-        {% include '@bolt/files_ck/_folders.twig' %}
+        {{ include('@bolt/files_ck/_folders.twig') }}
     {% endif %}
 
     {% if context.files|length > 0 %}
-            {% include '@bolt/files_ck/_files.twig' %}
+            {{ include('@bolt/files_ck/_files.twig') }}
     {% endif %}
 
 {% endblock page_main %}

--- a/app/view/twig/omnisearch/omnisearch.twig
+++ b/app/view/twig/omnisearch/omnisearch.twig
@@ -39,7 +39,7 @@
                                     'heading': loop.first ? heading : '',
                                 }
                             } %}
-                            {% include includes with listing_vars %}
+                            {{ include(includes with listing_vars) }}
                         {% endfor %}
                     </table>
                 </div>
@@ -74,7 +74,7 @@
         </div>
 
         <aside class="col-md-4">
-            {% include '@bolt/omnisearch/_aside.twig' %}
+            {{ include('@bolt/omnisearch/_aside.twig') }}
         </aside>
 
     </div>

--- a/app/view/twig/overview/overview.twig
+++ b/app/view/twig/overview/overview.twig
@@ -24,7 +24,7 @@
     <div class="row">
         <div class="col-md-8">
 
-            {% include '@bolt/_sub/_messages.twig' %}
+            {{ include('@bolt/_sub/_messages.twig') }}
 
             {{ widgets('overview_below_header', 'backend') }}
 
@@ -38,7 +38,7 @@
 
             {{ widgets('overview_aside_top', 'backend') }}
 
-            {% include '@bolt/overview/_panel-actions_overview.twig' %}
+            {{ include('@bolt/overview/_panel-actions_overview.twig') }}
 
             {{ widgets('overview_aside_middle', 'backend') }}
 

--- a/app/view/twig/recordbrowser/recordbrowser.twig
+++ b/app/view/twig/recordbrowser/recordbrowser.twig
@@ -16,9 +16,9 @@
 
     <div class="row">
         <div class="col-xs-12"{{ macro.attr({_bind: ['recordbrowser']}) }}>
-            {% include '@bolt/recordbrowser/_navigation.twig' %}
+            {{ include('@bolt/recordbrowser/_navigation.twig') }}
 
-            {% include '@bolt/recordbrowser/_content.twig' %}
+            {{ include('@bolt/recordbrowser/_content.twig') }}
 
             <hr>
 

--- a/app/view/twig/relatedto/relatedto.twig
+++ b/app/view/twig/relatedto/relatedto.twig
@@ -31,13 +31,13 @@
         <div class="col-xs-12">
         {% if context.show_contenttype %}
             <div class="col-md-9">
-                {% include '@bolt/relatedto/_toolbar.twig' %}
+                {{ include('@bolt/relatedto/_toolbar.twig') }}
                 {# TODO: add order #}
                 {{ list(context.show_contenttype, context.related_content, context.permissions, '') }}
             </div>
 
             <aside class="col-md-3">
-                {% include '@bolt/relatedto/_panel-actions_relatedto.twig' %}
+                {{ include('@bolt/relatedto/_panel-actions_relatedto.twig') }}
                 {{ panels.lastmodified(context.show_contenttype.slug) }}
                 {{ panels.stack(5) }}
             </aside>

--- a/app/view/twig/users/_aside.twig
+++ b/app/view/twig/users/_aside.twig
@@ -1,4 +1,4 @@
-{% include '@bolt/users/_panel-actions_users.twig' %}
+{{ include('@bolt/users/_panel-actions_users.twig') }}
 
 <div data-bolt-widget="panelActivity">
     {{ render(path('latestactivity')) }}

--- a/app/view/twig/users/_userlist-actions.twig
+++ b/app/view/twig/users/_userlist-actions.twig
@@ -14,7 +14,7 @@
             {% if user.enabled %}
                 <li>
                     <form action="{{ path('useraction', {'action': 'disable', 'id': user.id}) }}" method="post">
-                        {% include '@bolt/_sub/_csrf_token.twig' %}
+                        {{ include('@bolt/_sub/_csrf_token.twig') }}
                         <button type="submit" class="btn btn-block btn-link">
                             <span class="pull-left">{{ __('Disable %username%',{'%username%':user.displayname}) }}</span>
                         </button>
@@ -23,7 +23,7 @@
             {% else %}
                 <li>
                     <form action="{{ path('useraction', {'action': 'enable', 'id': user.id}) }}" method="post">
-                        {% include '@bolt/_sub/_csrf_token.twig' %}
+                        {{ include('@bolt/_sub/_csrf_token.twig') }}
                         <button type="submit" class="btn btn-block btn-link">
                             <span class="pull-left">{{ __('Enable %username%',{'%username%':user.displayname}) }}</span>
                         </button>
@@ -32,7 +32,7 @@
             {% endif %}
             <li>
                 <form action="{{ path('useraction', {'action': 'delete', 'id': user.id}) }}" method="post">
-                    {% include '@bolt/_sub/_csrf_token.twig' %}
+                    {{ include('@bolt/_sub/_csrf_token.twig') }}
                     <button type="submit" class="btn btn-block btn-link confirm"
                     data-confirm="{{ __('Are you sure you want to delete %username%?',{'%username%':user.displayname}) }}" >
                         <span class="pull-left">{{ __('Delete %username%',{'%username%':user.displayname}) }}</span>

--- a/app/view/twig/users/_userlist.twig
+++ b/app/view/twig/users/_userlist.twig
@@ -39,7 +39,7 @@
                 </td>
 
                 <td class="actions">
-                    {% include '@bolt/users/_userlist-actions.twig' %}
+                    {{ include('@bolt/users/_userlist-actions.twig') }}
                 </td>
             </tr>
         {% endfor %}

--- a/app/view/twig/users/users.twig
+++ b/app/view/twig/users/users.twig
@@ -16,22 +16,22 @@
     <div class="row">
         <div class="col-md-9">
 
-            {% include '@bolt/_sub/_messages.twig' %}
+            {{ include('@bolt/_sub/_messages.twig') }}
 
-            {% include '@bolt/users/_userlist.twig' %}
+            {{ include('@bolt/users/_userlist.twig') }}
 
             <h2><strong>{{ __('Roles and Permissions') }}</strong></h2>
 
-            {% include '@bolt/users/_roles-permissons.twig' %}
+            {{ include('@bolt/users/_roles-permissons.twig') }}
 
             <h2><strong>{{ __('Current sessions') }}</strong></h2>
 
-            {% include '@bolt/users/_sessions.twig' %}
+            {{ include('@bolt/users/_sessions.twig') }}
 
         </div>
 
         <aside class="col-md-3">
-            {% include '@bolt/users/_aside.twig' %}
+            {{ include('@bolt/users/_aside.twig') }}
         </aside>
     </div>
 

--- a/theme/base-2014/_header.twig
+++ b/theme/base-2014/_header.twig
@@ -48,7 +48,7 @@
                     {{ menu('main', '_sub_menu.twig') }}
 
                     {# Include the '_sub_searchbox.twig' template, for the searchbox. If this file wasn't included in the theme, the default searchbox template in app/theme_defaults/_sub_searchbox.twig would be used. #}
-                    {% include '_sub_searchbox.twig' %}
+                    {{ include('_sub_searchbox.twig') }}
                 </ul>
             </section>
         </nav>

--- a/theme/base-2014/_recordfooter.twig
+++ b/theme/base-2014/_recordfooter.twig
@@ -8,5 +8,5 @@
     <a href="{{ record.link }}">{{ __('Permalink') }}</a> -
     {# include the 'default' links to taxonomies. Check the documentation for ways to modify and customize
        what is output to the browser: http://docs.bolt.cm/taxonomies#taxonomies #}
-    {% include '_sub_taxonomylinks.twig' with {record: record} %}
+    {{ include('_sub_taxonomylinks.twig', {record: record}) }}
 </h6>

--- a/theme/base-2014/entry.twig
+++ b/theme/base-2014/entry.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 <!-- Main Page Content and Sidebar -->
 
@@ -31,7 +31,7 @@
 
             {{ record.body }}
 
-            {% include '_recordfooter.twig' with {'record': record} %}
+            {{ include('_recordfooter.twig', {'record': record}) }}
 
             {% if Disqus is defined %}
                 {# Show the Disqus comment box, if the Disqus extension is installed .. #}
@@ -66,10 +66,10 @@
 
     <!-- End Main Content -->
 
-    {% include '_aside.twig' %}
+    {{ include('_aside.twig') }}
 
 <!-- End Main Content and Sidebar -->
 
 
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}

--- a/theme/base-2014/extrafields.twig
+++ b/theme/base-2014/extrafields.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 <!-- Main Page Content and Sidebar -->
 
@@ -15,10 +15,10 @@
 
     <!-- End Main Content -->
 
-    {% include '_aside.twig' %}
+    {{ include('_aside.twig') }}
 
     <!-- End Main Content and Sidebar -->
 
 
 
-    {% include '_footer.twig' %}
+    {{ include('_footer.twig') }}

--- a/theme/base-2014/index.twig
+++ b/theme/base-2014/index.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 <!-- Main Page Content and Sidebar -->
 
@@ -90,10 +90,10 @@
     <!-- End Main Content -->
     {# include the sidebar. The include tag can be used to break up your templates in logical parts,
        and re-use them across different templates/pages. #}
-    {% include '_aside.twig' %}
+    {{ include('_aside.twig') }}
 
 <!-- End Main Content and Sidebar -->
 
 
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}

--- a/theme/base-2014/listing.twig
+++ b/theme/base-2014/listing.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 <!-- Main Page Content and Sidebar -->
 
@@ -53,7 +53,7 @@
                     <p>{{ record.excerpt(300, false, search|default('')) }}</p>
                 {% endif %}
 
-                {% include '_recordfooter.twig' with {'record': record} %}
+                {{ include('_recordfooter.twig', {'record': record}) }}
 
             </article>
 
@@ -85,8 +85,8 @@
 
     <!-- End Main Content -->
 
-    {% include '_aside.twig' %}
+    {{ include('_aside.twig') }}
 
 <!-- End Main Content and Sidebar -->
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}

--- a/theme/base-2014/record.twig
+++ b/theme/base-2014/record.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 <!-- Main Page Content and Sidebar -->
 
@@ -19,7 +19,7 @@
             {{ dump(record) }}
             #}
 
-            {% include '_recordfooter.twig' with {'record': record} %}
+            {{ include('_recordfooter.twig', {'record': record}) }}
 
             <p class="meta">
                 {% set previous = record.previous('id') %}
@@ -51,10 +51,10 @@
 
     <!-- End Main Content -->
 
-    {% include '_aside.twig' %}
+    {{ include('_aside.twig') }}
 
     <!-- End Main Content and Sidebar -->
 
 
 
-    {% include '_footer.twig' %}
+    {{ include('_footer.twig') }}

--- a/theme/base-2014/search.twig
+++ b/theme/base-2014/search.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 <!-- Main Page Content and Sidebar -->
 
@@ -54,7 +54,7 @@
                     <p>{{ record.excerpt(300, false, search|default('')) }}</p>
                 {% endif %}
 
-                {% include '_recordfooter.twig' with {'record': record} %}
+                {{ include('_recordfooter.twig', {'record': record}) }}
 
             </article>
 
@@ -79,8 +79,8 @@
 
     <!-- End Main Content -->
 
-    {% include '_aside.twig' %}
+    {{ include('_aside.twig') }}
 
 <!-- End Main Content and Sidebar -->
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}

--- a/theme/base-2016/_recordfooter.twig
+++ b/theme/base-2016/_recordfooter.twig
@@ -7,5 +7,5 @@
     {{ __('Written by <em>%name%</em> on %date%',{ '%name%': record.user.displayname, '%date%': recdate }) }} - <a href="{{ record.link }}">{{ __('Permalink') }}</a><br>
     {# include the 'default' links to taxonomies. Check the documentation for ways to modify and customize
        what is output to the browser: http://docs.bolt.cm/taxonomies#taxonomies #}
-    {% include '_sub_taxonomylinks.twig' with {record: record} %}
+    {{ include('_sub_taxonomylinks.twig', {record: record}) }}
 </p>

--- a/theme/base-2016/anotherextrafields.twig
+++ b/theme/base-2016/anotherextrafields.twig
@@ -45,7 +45,7 @@
             {{ dump(record) }}
             #}
 
-            {% include '_recordfooter.twig' with {'record': record} %}
+            {{ include('_recordfooter.twig', {'record': record}) }}
             <p class="meta">
                 {% set previous = record.previous('id') %}
                 {% if previous %}

--- a/theme/base-2016/extrafields.twig
+++ b/theme/base-2016/extrafields.twig
@@ -45,7 +45,7 @@
             {{ dump(record) }}
             #}
 
-            {% include '_recordfooter.twig' with {'record': record} %}
+            {{ include('_recordfooter.twig', {'record': record}) }}
             <p class="meta">
                 {% set previous = record.previous('id') %}
                 {% if previous %}

--- a/theme/base-2016/listing.twig
+++ b/theme/base-2016/listing.twig
@@ -43,7 +43,7 @@
             {% else %}
                 <p>{{ record.excerpt(300, false, search|default('')) }}</p>
             {% endif %}
-            {% include '_recordfooter.twig' with {'record': record} %}
+            {{ include('_recordfooter.twig', {'record': record}) }}
             {% if not loop.last %}<hr>{% endif %}
         {% else %}
             <article>
@@ -66,6 +66,6 @@
         {{ pager() }}
         {{ widgets('main_bottom') }}
     </section>
-    {% include '_aside.twig' %}
+    {{ include('_aside.twig') }}
     </div>
 {% endblock %}

--- a/theme/base-2016/record.twig
+++ b/theme/base-2016/record.twig
@@ -13,7 +13,7 @@
             {{ dump(record) }}
             #}
 
-            {% include '_recordfooter.twig' with {'record': record} %}
+            {{ include('_recordfooter.twig', {'record': record}) }}
             <p class="meta">
                 {% set previous = record.previous('id') %}
                 {% if previous %}
@@ -37,6 +37,6 @@
             {% endif %}
             {{ widgets('main_bottom') }}
         </article>
-    {% include '_aside.twig' %}
+    {{ include('_aside.twig') }}
     </div>
 {% endblock %}

--- a/theme/default/_footer.twig
+++ b/theme/default/_footer.twig
@@ -1,15 +1,15 @@
 </div>
-	
-    {% include '_aside.twig' %}
-    
+
+    {{ include('_aside.twig') }}
+
     <footer class="clearfix">
         <p>This site is powered by <a href="http://bolt.cm">Bolt</a>: Sophisticated, lightweight & simple CMS.</p>
     </footer>
-    
-    
-    </div>		
+
+
+    </div>
 
 </body>
-	
+
 </html>
 

--- a/theme/default/_header.twig
+++ b/theme/default/_header.twig
@@ -25,7 +25,7 @@
 
             {{ menu() }}
 
-            {% include '_sub_searchbox.twig' %}
+            {{ include('_sub_searchbox.twig') }}
 
         </header>
 

--- a/theme/default/_recordfooter.twig
+++ b/theme/default/_recordfooter.twig
@@ -2,6 +2,6 @@
 <p class="meta">
     <a href="{{ record.link }}">Link</a> -
     Posted by {{ record.user.displayname }} on {{ record.datepublish|localdate("%A %e %B %Y")}} <br>
-    {% include '_sub_taxonomylinks.twig' with {record: record} %}
+    {{ include('_sub_taxonomylinks.twig', {record: record}) }}
 </p>
 

--- a/theme/default/entry.twig
+++ b/theme/default/entry.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 <article>
 
@@ -14,7 +14,7 @@
 
     {{ record.body }}
 
-    {% include '_recordfooter.twig' with {record: record} %}
+    {{ include('_recordfooter.twig', {record: record}) }}
 
     <p class="meta">
         {% set previous = record.previous() %}
@@ -30,4 +30,4 @@
 
 </article>
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}

--- a/theme/default/index.twig
+++ b/theme/default/index.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 
 {% setcontent entries = "entries/latest/4" allowpaging %}
@@ -14,7 +14,7 @@
 
     {{ entry.teaser }}
 
-    {% include '_recordfooter.twig' with {record: record} %}
+    {{ include('_recordfooter.twig', {record: record}) }}
 
 </article>
 {% endfor %}
@@ -22,5 +22,5 @@
 {{ pager() }}
 
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}
 

--- a/theme/default/listing.twig
+++ b/theme/default/listing.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 
 {% for record in records %}
@@ -12,7 +12,7 @@
 
     {{ record.excerpt(300) }}
 
-    {% include '_recordfooter.twig' with {record: record} %}
+    {{ include('_recordfooter.twig', {record: record}) }}
 
 </article>
 {% endfor %}
@@ -20,5 +20,5 @@
 {{ pager() }}
 
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}
 

--- a/theme/default/record.twig
+++ b/theme/default/record.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 {# -----
 This is the 'default record' template. Try to do some generic stuff, so we
@@ -71,7 +71,7 @@ templates. 'entry.twig' is much more straightforward.
     {% endif %}
 
 
-    {% include '_recordfooter.twig' with {record: record} %}
+    {{ include('_recordfooter.twig', {record: record}) }}
 
     <p class="meta">
         {% set previous = record.previous() %}
@@ -91,4 +91,4 @@ templates. 'entry.twig' is much more straightforward.
 
 </article>
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}

--- a/theme/default/searchresults.twig
+++ b/theme/default/searchresults.twig
@@ -1,4 +1,4 @@
-{% include '_header.twig' %}
+{{ include('_header.twig') }}
 
 <h1>Search results</h1>
 
@@ -15,7 +15,7 @@
 
             {{ record.excerpt(300) }}
 
-            {% include '_recordfooter.twig' with {record: record} %}
+            {{ include('_recordfooter.twig', {record: record}) }}
 
         </article>
     {% endfor %}
@@ -26,5 +26,5 @@
 {{ pager() }}
 
 
-{% include '_footer.twig' %}
+{{ include('_footer.twig') }}
 


### PR DESCRIPTION
As pointed out to us by Javier Eguilez: 

> 2) The {% include %} tag is deprecated in favor of the {{ include() }} function. It's not officially deprecated by Twig, but it's pseudo-officially deprecated. A while ago we decided to only recommend the function, so that's the "future-proof" way of including templates.