### PR TITLE
Move create factory to the start of setup in src/Composer/PackageManager

### DIFF
--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -125,6 +125,9 @@ class PackageManager
      */
     private function setup()
     {
+        // Create our Factory
+        $this->factory = new Factory($this->app, $this->options);
+
         if ($this->app['extend.writeable']) {
             // Copy/update installer helper
             $this->copyInstaller();
@@ -143,9 +146,6 @@ class PackageManager
                 $this->messages[] = $this->app['extend.site'] . ' is unreachable.';
             }
         }
-
-        // Create our Factory
-        $this->factory = new Factory($this->app, $this->options);
     }
 
     /**


### PR DESCRIPTION
While running nut:extensions I got an error:

> Warning: Creating default object from empty value in xxx\src\Composer\PackageManager.php on line 613

followed by a callstack. 

Line 613 is:
`$this->getFactory()->downgradeSsl = true;`

Some quick debugging showed the factory is not yet initialized when this is called, so `$this->getFactory()` returns NULL. 

The factory is initialized at the end of the setup method. However if `$this->app['extend.writeable']` is true  `$this->ping(true);` is called before the factory is initialized, which as far as I can see triggers the error on line 613.

This pull request moves the factory initialization to the start of the setup method, before the `$this->app['extend.writeable']` block to ensure the factory is initialized before it is used.
