### PR TITLE
[Tests] Rebuild extension autoloader after clean up

### DIFF
--- a/tests/codeception/extensions/CodeceptionEventsExtension.php
+++ b/tests/codeception/extensions/CodeceptionEventsExtension.php
@@ -219,6 +219,7 @@ class CodeceptionEventsExtension extends \Codeception\Platform\Extension
         if ($fs->exists(INSTALL_ROOT . '/app/config/extensions/testerevents.bolt.yml')) {
             $fs->remove(INSTALL_ROOT . '/app/config/extensions/testerevents.bolt.yml');
         }
+        system('php ' . NUT_PATH . ' extensions:dumpautoload');
     }
 
     /**


### PR DESCRIPTION
This will just prevent some noise after an acceptance test is run when you have display errors turned up to 11