### PR TITLE
Fix Deleting last relations and taxonomies

### DIFF
--- a/app/view/twig/editcontent/fields/_tags.twig
+++ b/app/view/twig/editcontent/fields/_tags.twig
@@ -2,7 +2,7 @@
 
 {# Build the select options array #}
 {% set options = [] %}
-{% for tag in context.content.taxonomy.getField(taxonomy.slug)|default([]) %}
+{% for tag in context.content.get(taxonomy.slug)|default([]) %}
     {% set options = options|merge([{
         value:     tag.slug,
         text:      tag.name,

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -42,6 +42,9 @@ class Relations extends ArrayCollection
             $flatVals = $formValues;
         }
         foreach ($flatVals as $field => $values) {
+            if (!is_array($values)) {
+                continue;
+            }
             foreach ($values as $val) {
                 if (!$val) {
                     continue;

--- a/src/Storage/Collection/Taxonomy.php
+++ b/src/Storage/Collection/Taxonomy.php
@@ -38,6 +38,9 @@ class Taxonomy extends ArrayCollection
             $flatVals = $formValues;
         }
         foreach ($flatVals as $field => $values) {
+            if (!is_array($values)) {
+                continue;
+            }
             foreach ($values as $val) {
                 $order = isset($formValues['taxonomy-order'][$field]) ? $formValues['taxonomy-order'][$field] : 0;
                 if (isset($this->config[$field]['options'][$val])) {

--- a/src/Storage/ContentRequest/Save.php
+++ b/src/Storage/ContentRequest/Save.php
@@ -177,14 +177,14 @@ class Save
 
         // Set the object values appropriately
         foreach ($formValues as $name => $value) {
-            if ($name === 'relation') {
-                $this->setPostedRelations($content, $formValues);
-            } elseif ($name === 'taxonomy') {
-                $this->setPostedTaxonomies($content, $formValues);
+            if ($name === 'relation' || $name === 'taxonomy') {
+                continue;
             } else {
                 $content->set($name, empty($value) ? null : $value);
             }
         }
+        $this->setPostedRelations($content, $formValues);
+        $this->setPostedTaxonomies($content, $formValues);
     }
 
     /**
@@ -196,10 +196,6 @@ class Save
      */
     private function setPostedRelations(Entity\Content $content, $formValues)
     {
-        if (!isset($formValues['relation'])) {
-            return;
-        }
-
         $related = $this->em->createCollection('Bolt\Storage\Entity\Relations');
         $related->setFromPost($formValues, $content);
         $content->setRelation($related);
@@ -213,10 +209,6 @@ class Save
      */
     private function setPostedTaxonomies(Entity\Content $content, $formValues)
     {
-        if (!isset($formValues['taxonomy'])) {
-            return;
-        }
-
         $taxonomies = $this->em->createCollection('Bolt\Storage\Entity\Taxonomy');
         $taxonomies->setFromPost($formValues, $content);
         $content->setTaxonomy($taxonomies);

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -215,11 +215,11 @@ class RelationType extends FieldTypeBase
         $platform = $query->getConnection()->getDatabasePlatform()->getName();
         switch ($platform) {
             case 'mysql':
-                return "GROUP_CONCAT($column) as $alias";
+                return "GROUP_CONCAT(DISTINCT $column) as $alias";
             case 'sqlite':
-                return "GROUP_CONCAT($column) as $alias";
+                return "GROUP_CONCAT(DISTINCT $column) as $alias";
             case 'postgresql':
-                return "string_agg($column, ',') as $alias";
+                return "string_agg(DISTINCT $column, ',') as $alias";
         }
     }
 }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -181,11 +181,11 @@ class TaxonomyType extends FieldTypeBase
 
         switch ($platform) {
             case 'mysql':
-                return "GROUP_CONCAT($column ORDER BY $order ASC) as $alias";
+                return "GROUP_CONCAT(DISTINCT $column ORDER BY $order ASC) as $alias";
             case 'sqlite':
-                return "GROUP_CONCAT($column) as $alias";
+                return "GROUP_CONCAT(DISTINCT $column) as $alias";
             case 'postgresql':
-                return "string_agg($column, ',' ORDER BY $order) as $alias";
+                return "string_agg(DISTINCT $column, ',' ORDER BY $order) as $alias";
         }
     }
 


### PR DESCRIPTION
This fixes the issue where the save wasn't being called on the field if an empty post was sent for that field.

There's also a fix for another edge case where large contenttypes (with lots of relations, taxonomies and repeaters) was leading to an overflow of the maximum select column size which on MySQL seems to be 1024 characters. 

Adding distinct to the query, rather than just doing it in the code afterwards will stop this length from getting as big.

Fixes: #5036 #5037 
