### PR TITLE
Fix incorrect timestamp results for Ajax saves

### DIFF
--- a/src/Storage/ContentRequest/Save.php
+++ b/src/Storage/ContentRequest/Save.php
@@ -348,7 +348,9 @@ class Save
 
         $val = $content->toArray();
 
-        if (isset($val['datechanged'])) {
+        if ($val['datechanged'] instanceof Carbon) {
+            $val['datechanged'] = $val['datechanged']->toIso8601String();
+        } elseif (isset($val['datechanged'])) {
             $val['datechanged'] = (new Carbon($val['datechanged']))->toIso8601String();
         }
 


### PR DESCRIPTION
This is mainly the fault of statics in general :wink: 

On ajax saves the timestamp was incorrect, showing as midnight of the day, not precise to the time.
It was caused by us re-instantiating the Carbon date object from the format, which has been overriden elsewhere in the app using a static call on the class.

Because we already have datachanged instantiated as a Carbon object with the correct time then this patch just calls the format method on the instance directly.

The old behaviour is left in since presumably it is possible for a non-carbon instance to arrive here too.


