### PR TITLE
Translations correction

### DIFF
--- a/app/resources/translations/en_GB/contenttypes.en_GB.yml
+++ b/app/resources/translations/en_GB/contenttypes.en_GB.yml
@@ -1,24 +1,20 @@
-# app/resources/translations/en_GB/contenttypes.en_GB.yml – generated on 2016-03-20 18:26:30 Europe/Berlin
+# app/resources/translations/en_GB/contenttypes.en_GB.yml – generated on 2016-03-20 18:29:49 Europe/Berlin
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
+#          at the moment. This is an ongoing process. Translations currently in the 
+#          repository are automatically mapped to the new scheme. Be aware that there 
+#          can be a race condition between that process and your PR so that it's 
+#          eventually necessary to remap your translations. If you're planning on 
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
 #  no unused messages
 #  no untranslated messages
-#   1 untranslated keyword based messages
+#  no untranslated keyword based messages
 #  no translations
-# 141 keyword based translations
+# 142 keyword based translations
 
-#--- 1 untranslated keyword based messages ------------------------------------
-
-"contenttypes.showcases.group.repeater": #
-
-#--- 141 keyword based translations -------------------------------------------
+#--- 142 keyword based translations -------------------------------------------
 
 contenttypes.blocks.description: "The **Blocks** contenttype is a so-called 'resource contenttype'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: "Block"
@@ -130,6 +126,7 @@ contenttypes.showcases.description: "The **Showcases** contenttype is used to sh
 contenttypes.showcases.group.files: "Files"
 contenttypes.showcases.group.media: "Media"
 contenttypes.showcases.group.other: "Other"
+contenttypes.showcases.group.repeater: "Repeater"
 contenttypes.showcases.group.template: "Template"
 contenttypes.showcases.group.text: "Text"
 contenttypes.showcases.name.plural: "Showcases"

--- a/app/resources/translations/en_GB/contenttypes.en_GB.yml
+++ b/app/resources/translations/en_GB/contenttypes.en_GB.yml
@@ -1,58 +1,59 @@
-# app/resources/translations/en_GB/contenttypes.en_GB.yml – generated on 2016-03-20 17:27:17 Europe/Berlin
+# app/resources/translations/en_GB/contenttypes.en_GB.yml – generated on 2016-03-20 18:26:30 Europe/Berlin
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
 #  no unused messages
 #  no untranslated messages
-#  35 untranslated keyword based messages
+#   1 untranslated keyword based messages
 #  no translations
-# 107 keyword based translations
+# 141 keyword based translations
 
-#--- 35 untranslated keyword based messages -----------------------------------
+#--- 1 untranslated keyword based messages ------------------------------------
 
-"contenttypes.blocks.description": #
-"contenttypes.blocks.group.block": #
-"contenttypes.blocks.name.plural": # "Blocks"
-"contenttypes.blocks.name.singular": # "Block"
-"contenttypes.blocks.text.actions-all": # "Actions for Blocks"
-"contenttypes.blocks.text.actions-one": # "Actions for this Block"
-"contenttypes.blocks.text.created": # "This Block was created"
-"contenttypes.blocks.text.delete": # "Delete Block"
-"contenttypes.blocks.text.duplicate": # "Duplicate Block"
-"contenttypes.blocks.text.duplicated-finalize": # "Content was duplicated. Click 'Save Block' to finalize."
-"contenttypes.blocks.text.edit": # "Edit Block"
-"contenttypes.blocks.text.invalid-field": # "Can't set %field% in Block: Not a valid field."
-"contenttypes.blocks.text.invalid-relation": # "In the contenttype for 'Block', the relation '%relation%' is defined, which is not a valid contenttype. Please edit contenttypes.yml, and correct this."
-"contenttypes.blocks.text.last-modified": # "Last modified Blocks"
-"contenttypes.blocks.text.new": # "New Block"
-"contenttypes.blocks.text.no-latest": # "No latest Block"
-"contenttypes.blocks.text.no-proper-type": # "In the contenttype for 'Block', the field '%field%' has 'type: %type%', which is not a proper field type. Please edit contenttypes.yml, and correct this."
-"contenttypes.blocks.text.no-recent": # "No recent Block."
-"contenttypes.blocks.text.none-available": # "No Blocks available."
-"contenttypes.blocks.text.not-existing": # "The Block you were looking for does not exist. It was probably deleted, or it never existed."
-"contenttypes.blocks.text.not-saved-yet": # "This Block has not been saved yet."
-"contenttypes.blocks.text.overview": # "Blocks overview"
-"contenttypes.blocks.text.publish": # "Publish Block"
-"contenttypes.blocks.text.recent": # "Recent Blocks"
-"contenttypes.blocks.text.recent-changes-one": # "Recent changes to this Block"
-"contenttypes.blocks.text.recently-edited": # "Recently edited Blocks"
-"contenttypes.blocks.text.reserved-name": # "In the contenttype for 'Block', the field '%field%' is defined, which is a reserved name. Please edit contenttypes.yml, and correct this."
-"contenttypes.blocks.text.save": # "Save Block"
-"contenttypes.blocks.text.saved-changes": # "The changes to the Block have been saved."
-"contenttypes.blocks.text.saved-new": # "The new Block has been saved."
-"contenttypes.blocks.text.saving-impossible": # "Could not save Block."
-"contenttypes.blocks.text.show-more": # "More Blocks"
-"contenttypes.blocks.text.view": # "View Blocks"
-"contenttypes.blocks.text.wrong-use-field": # "In the contenttype for 'Block', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
 "contenttypes.showcases.group.repeater": #
 
-#--- 107 keyword based translations -------------------------------------------
+#--- 141 keyword based translations -------------------------------------------
+
+contenttypes.blocks.description: "The **Blocks** contenttype is a so-called 'resource contenttype'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
+contenttypes.blocks.group.block: "Block"
+contenttypes.blocks.name.plural: "Blocks"
+contenttypes.blocks.name.singular: "Block"
+contenttypes.blocks.text.actions-all: "Actions for Blocks"
+contenttypes.blocks.text.actions-one: "Actions for this Block"
+contenttypes.blocks.text.created: "This Block was created"
+contenttypes.blocks.text.delete: "Delete Block"
+contenttypes.blocks.text.duplicate: "Duplicate Block"
+contenttypes.blocks.text.duplicated-finalize: "Content was duplicated. Click 'Save Block' to finalize."
+contenttypes.blocks.text.edit: "Edit Block"
+contenttypes.blocks.text.invalid-field: "Can't set %field% in Block: Not a valid field."
+contenttypes.blocks.text.invalid-relation: "In the contenttype for 'Block', the relation '%relation%' is defined, which is not a valid contenttype. Please edit contenttypes.yml, and correct this."
+contenttypes.blocks.text.last-modified: "Last modified Blocks"
+contenttypes.blocks.text.new: "New Block"
+contenttypes.blocks.text.no-latest: "No latest Block"
+contenttypes.blocks.text.no-proper-type: "In the contenttype for 'Block', the field '%field%' has 'type: %type%', which is not a proper field type. Please edit contenttypes.yml, and correct this."
+contenttypes.blocks.text.no-recent: "No recent Block."
+contenttypes.blocks.text.none-available: "No Blocks available."
+contenttypes.blocks.text.not-existing: "The Block you were looking for does not exist. It was probably deleted, or it never existed."
+contenttypes.blocks.text.not-saved-yet: "This Block has not been saved yet."
+contenttypes.blocks.text.overview: "Blocks overview"
+contenttypes.blocks.text.publish: "Publish Block"
+contenttypes.blocks.text.recent: "Recent Blocks"
+contenttypes.blocks.text.recent-changes-one: "Recent changes to this Block"
+contenttypes.blocks.text.recently-edited: "Recently edited Blocks"
+contenttypes.blocks.text.reserved-name: "In the contenttype for 'Block', the field '%field%' is defined, which is a reserved name. Please edit contenttypes.yml, and correct this."
+contenttypes.blocks.text.save: "Save Block"
+contenttypes.blocks.text.saved-changes: "The changes to the Block have been saved."
+contenttypes.blocks.text.saved-new: "The new Block has been saved."
+contenttypes.blocks.text.saving-impossible: "Could not save Block."
+contenttypes.blocks.text.show-more: "More Blocks"
+contenttypes.blocks.text.view: "View Blocks"
+contenttypes.blocks.text.wrong-use-field: "In the contenttype for 'Block', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
 
 contenttypes.entries.description: "The **Entries** contenttype can be used for things like _'news'_ or _'blogpostings'_. They have a teaser, which can be used for a short blurb on listing-pages, allowing visitors to click-through to the rest of the entry. It also has fields for an image and an optional video. To change the fields that are in this contenttype, edit the file `contenttypes.yml` in the folder `app/config/`, using the editor of your choice, or by going to 'Configuration' » 'Contenttypes' in the menu on the left."
 contenttypes.entries.group.content: "Content"

--- a/app/resources/translations/en_GB/contenttypes.en_GB.yml
+++ b/app/resources/translations/en_GB/contenttypes.en_GB.yml
@@ -1,4 +1,4 @@
-# app/resources/translations/en_GB/contenttypes.en_GB.yml – generated on 2016-03-15 19:27:51 Europe/Berlin
+# app/resources/translations/en_GB/contenttypes.en_GB.yml – generated on 2016-03-20 17:27:17 Europe/Berlin
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
 #          at the moment. This is an ongoing process. Translations currently in the 
@@ -10,11 +10,49 @@
 
 #  no unused messages
 #  no untranslated messages
-#  no untranslated keyword based messages
+#  35 untranslated keyword based messages
 #  no translations
-# 108 keyword based translations
+# 107 keyword based translations
 
-#--- 108 keyword based translations -------------------------------------------
+#--- 35 untranslated keyword based messages -----------------------------------
+
+"contenttypes.blocks.description": #
+"contenttypes.blocks.group.block": #
+"contenttypes.blocks.name.plural": # "Blocks"
+"contenttypes.blocks.name.singular": # "Block"
+"contenttypes.blocks.text.actions-all": # "Actions for Blocks"
+"contenttypes.blocks.text.actions-one": # "Actions for this Block"
+"contenttypes.blocks.text.created": # "This Block was created"
+"contenttypes.blocks.text.delete": # "Delete Block"
+"contenttypes.blocks.text.duplicate": # "Duplicate Block"
+"contenttypes.blocks.text.duplicated-finalize": # "Content was duplicated. Click 'Save Block' to finalize."
+"contenttypes.blocks.text.edit": # "Edit Block"
+"contenttypes.blocks.text.invalid-field": # "Can't set %field% in Block: Not a valid field."
+"contenttypes.blocks.text.invalid-relation": # "In the contenttype for 'Block', the relation '%relation%' is defined, which is not a valid contenttype. Please edit contenttypes.yml, and correct this."
+"contenttypes.blocks.text.last-modified": # "Last modified Blocks"
+"contenttypes.blocks.text.new": # "New Block"
+"contenttypes.blocks.text.no-latest": # "No latest Block"
+"contenttypes.blocks.text.no-proper-type": # "In the contenttype for 'Block', the field '%field%' has 'type: %type%', which is not a proper field type. Please edit contenttypes.yml, and correct this."
+"contenttypes.blocks.text.no-recent": # "No recent Block."
+"contenttypes.blocks.text.none-available": # "No Blocks available."
+"contenttypes.blocks.text.not-existing": # "The Block you were looking for does not exist. It was probably deleted, or it never existed."
+"contenttypes.blocks.text.not-saved-yet": # "This Block has not been saved yet."
+"contenttypes.blocks.text.overview": # "Blocks overview"
+"contenttypes.blocks.text.publish": # "Publish Block"
+"contenttypes.blocks.text.recent": # "Recent Blocks"
+"contenttypes.blocks.text.recent-changes-one": # "Recent changes to this Block"
+"contenttypes.blocks.text.recently-edited": # "Recently edited Blocks"
+"contenttypes.blocks.text.reserved-name": # "In the contenttype for 'Block', the field '%field%' is defined, which is a reserved name. Please edit contenttypes.yml, and correct this."
+"contenttypes.blocks.text.save": # "Save Block"
+"contenttypes.blocks.text.saved-changes": # "The changes to the Block have been saved."
+"contenttypes.blocks.text.saved-new": # "The new Block has been saved."
+"contenttypes.blocks.text.saving-impossible": # "Could not save Block."
+"contenttypes.blocks.text.show-more": # "More Blocks"
+"contenttypes.blocks.text.view": # "View Blocks"
+"contenttypes.blocks.text.wrong-use-field": # "In the contenttype for 'Block', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
+"contenttypes.showcases.group.repeater": #
+
+#--- 107 keyword based translations -------------------------------------------
 
 contenttypes.entries.description: "The **Entries** contenttype can be used for things like _'news'_ or _'blogpostings'_. They have a teaser, which can be used for a short blurb on listing-pages, allowing visitors to click-through to the rest of the entry. It also has fields for an image and an optional video. To change the fields that are in this contenttype, edit the file `contenttypes.yml` in the folder `app/config/`, using the editor of your choice, or by going to 'Configuration' » 'Contenttypes' in the menu on the left."
 contenttypes.entries.group.content: "Content"
@@ -91,7 +129,6 @@ contenttypes.showcases.description: "The **Showcases** contenttype is used to sh
 contenttypes.showcases.group.files: "Files"
 contenttypes.showcases.group.media: "Media"
 contenttypes.showcases.group.other: "Other"
-contenttypes.showcases.group.repeats: "Repeats"
 contenttypes.showcases.group.template: "Template"
 contenttypes.showcases.group.text: "Text"
 contenttypes.showcases.name.plural: "Showcases"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -1,4 +1,4 @@
-# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-03-20 17:43:18 Europe/Berlin
+# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-03-20 17:54:44 Europe/Berlin
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
 #          at the moment. This is an ongoing process. Translations currently in the 
@@ -8,69 +8,11 @@
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#  55 unused messages
+#  no unused messages
 #  no untranslated messages
 #  no untranslated keyword based messages
 # 404 translations
 # 206 keyword based translations
-
-#--- 55 unused messages -------------------------------------------------------
-
-"%contenttypes% overview": "%contenttypes% overview"
-"Bolt Extension could not be found. Please check at %site% to ensure correct name.": "Bolt Extension could not be found. Please check at %site% to ensure correct name."
-"Clear Activitylog": "Clear activity log"
-"Clear the current log": "Clear the current log"
-"Content '%title%' could not be deleted.": "Content '%title%' could not be deleted."
-"Content '%title%' has been changed to '%newStatus%'": "Content '%title%' has been changed to '%newStatus%'"
-"Content '%title%' has been deleted.": "Content '%title%' has been deleted."
-"Delete selected": "Delete selected"
-"Depublish selected": "Depublish selected"
-"Do you really want to delete %foldername%?": "Do you really want to delete %foldername%?"
-"Extension log": "Extension log"
-"File '%file%' could not be uploaded.": "File '%file%' could not be uploaded."
-"Filtering …": "Filtering …"
-"Next": "Next"
-"No recent %contenttype%.": "No recent %contenttype%."
-"No such action for content.": "No such action for content."
-"Originally by %1, ported by %2": "Originally by %1, ported by %2"
-"Other contenttypes": "Other contenttypes"
-"Permission denied": "Permission denied"
-"Previous": "Previous"
-"Proudly powered by %s": "Proudly powered by %s"
-"Publish selected": "Publish selected"
-"Recent %contenttypes%": "Recent %contenttypes%"
-"Search for:": "Search for:"
-"Search…": "Search…"
-"Skip to content": "Skip to content"
-"The extensions directory (<code>%dir%</code>) does not exist, or it is not writable.": "The extensions directory (<code>%dir%</code>) does not exist, or it is not writable."
-"The file '%s' doesn't exist, or is not readable.": "The file '%s' doesn't exist, or is not readable."
-"Trim Activitylog": "Trim Activitylog"
-"You do not have the right privileges to create a new record.": "You do not have the right privileges to create a new record."
-"You must specify both a name and a version to install!": "You must specify both a name and a version to install!"
-"[Extension error] Initialisation failed for %ext%: %error%": "[Extension error] Initialisation failed for %ext%: %error%"
-"[Extension error] Snippet loading failed for %ext%: %error%": "[Extension error] Snippet loading failed for %ext%: %error%"
-"[Extension error] Twig function registration failed for %ext%: %error%": "[Extension error] Twig function registration failed for %ext%: %error%"
-"[Extension error] YAML config failed to load for %ext%: %error%": "[Extension error] YAML config failed to load for %ext%: %error%"
-"in:": "in:"
-"contenttypes.general.choose-an-entry": "Choose an entry"
-"general.thanks": "Thanks"
-"contenttypes.generic.error-saving": "There was an error saving this %contenttype%."
-"field.general.select-from-stack": "Select from stack"
-"field.geolocation.marker": "Pin"
-"field.video.button.preview": "Preview"
-"field.video.preview.button.close": "Close"
-"field.video.preview.no-url": "No video url is set, no video to show."
-"The Bolt extensions file '%composerjson%' isn't readable.": #
-"An error occurred.": "An error occurred."
-"If there was a Page with 'about' for a slug, it would've been shown here. But there isn't one, so that's why you're seeing this placeholder.": "If there was a Page with 'about' for a slug, it would've been shown here. But there isn't one, so that's why you're seeing this placeholder."
-"The Bolt extensions Repo at %repository% is currently unavailable. Check your connection and try again shortly.": "The Bolt extensions Repo at %repository% is currently unavailable. Check your connection and try again shortly."
-"This record is related to:": "This record is related to:"
-"page.ckeditor-browse-server.pixel": "px."
-"Repeat": #
-"Subsubtitle": #
-"Subtitle": #
-"%s files could not be deleted. You should delete them manually.": "%s files could not be deleted. You should delete them manually."
-"Deleted %s files from cache.": "Deleted %s files from cache."
 
 #--- 404 translations ---------------------------------------------------------
 

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -1,4 +1,4 @@
-# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-03-20 17:26:46 Europe/Berlin
+# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-03-20 17:43:18 Europe/Berlin
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
 #          at the moment. This is an ongoing process. Translations currently in the 
@@ -9,9 +9,9 @@
 #          in order to prevent merge conflicts.
 
 #  55 unused messages
-# 109 untranslated messages
+#  no untranslated messages
 #  no untranslated keyword based messages
-# 295 translations
+# 404 translations
 # 206 keyword based translations
 
 #--- 55 unused messages -------------------------------------------------------
@@ -72,119 +72,7 @@
 "%s files could not be deleted. You should delete them manually.": "%s files could not be deleted. You should delete them manually."
 "Deleted %s files from cache.": "Deleted %s files from cache."
 
-#--- 109 untranslated messages ------------------------------------------------
-
-"Add Selected": #
-"An error occured while updating `%TABLE%`. The error is %ERROR%": #
-"Are you sure you want to delete %FILENAME%?": #
-"Are you sure you want to do this for %NUMBER% records?": #
-"Are you sure you want to do this for 1 record?": #
-"Are you sure you want to remove these files?": #
-"Are you sure you want to remove these images?": #
-"Are you sure you want to remove this file?": #
-"Are you sure you want to remove this image?": #
-"Are you sure you wish to delete this record? There is no undo.": #
-"At least %NUM% characters required": #
-"Author": #
-"Bolt has detected one or more configuration issues. You should resolve these, for optimum performance:": #
-"Check/Uncheck all": #
-"Choose an entry": #
-"Clear Change Log": #
-"Clear System Log": #
-"Cleared cache.": #
-"Client error: %errormessage%": #
-"Close editor": #
-"Create File": #
-"Delete": #
-"Delete Set": #
-"Depublish": #
-"Depublish date is in the past. Change the status if you want to depublish now": #
-"Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": #
-"Do you really want to delete %FOLDERNAME%?": #
-"Duplicate Set": #
-"Error reading extensions/composer.json file: %ERROR%": #
-"Extension package %NAME% base class '%CLASS%' does not implement \\\\Bolt\\\\Extension\\\\ExtensionInterface and has been skipped.": #
-"Extension package %NAME% has an invalid class '%CLASS%' and has been skipped.": #
-"Extension server returned an error: %errormessage%": #
-"Failed to clear cache. You should delete it manually.": #
-"Failed to send password request. Please check the email settings.": #
-"Field “%FIELD_NAME%”:": #
-"File '%s' could not be saved, because the form wasn't valid.": #
-"Files could not be uploaded.": #
-"Generic failure while testing connection to extension server: %errormessage%": #
-"Has to be a floating point number!": #
-"Id (№)": #
-"If there was a Block with 'about-us' for a slug, it would've been shown here. But there isn't one, so that's why you're seeing this placeholder. In the Bolt backend, go to 'check database' and 'Add some sample Records', to create these automatically.": #
-"Invalid login parameters.": #
-"Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": #
-"Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
-"Is required or needs to match a pattern!": #
-"Is required!": #
-"Keyword …": #
-"Link": #
-"Live Edit": #
-"Local extension set up incomplete. Please run 'Install all packages' on the Extensions page.": #
-"Menu item property \"add\" is deprecated. Use \"#\" under \"param\" instead.": #
-"Move Down": #
-"Move Up": #
-"New Bolt site has been set up": #
-"No Preview": #
-"No content found.": #
-"No files in the list, yet.": #
-"No images in the list, yet.": #
-"No theme name found. Theme is not generated.": #
-"Not yet installed.": #
-"Only root can change file extensions.": #
-"Order": #
-"Other content": #
-"Others": #
-"Publish": #
-"Records": #
-"Related content:": #
-"Repeater": #
-"Run PHP extension checks": #
-"Run all checks": #
-"Run directory checks": #
-"Run email checks": #
-"Search results for <b>%search%</b>.": #
-"Selection (#):": #
-"Show proposed alterations": #
-"Something went wrong with logging in after first user creation!": #
-"System Configuration Checks": #
-"Testing connection to extension server failed: %errormessage%": #
-"The Bolt extensions composer.json isn't readable.": #
-"The Bolt extensions composer.json isn't writable.": #
-"The email configuration setting 'mailoptions' hasn't been set. Bolt may be unable to send password reset.": #
-"The file '%s' doesn't exist.": #
-"The file '%s' is not readable.": #
-"The value has to be at least “%MINVAL%”!": #
-"The value must not be greater than “%MAXVAL%”!": #
-"There are no saved changes, yet.": #
-"There is no undo!": #
-"This record is related to the following %CTNAME%:": #
-"Thumbnail": #
-"Trim Change Log": #
-"Trim System Log": #
-"Unable to create directory: %DIR%": #
-"Unable to create file: %FILE%": #
-"Unable to delete directory: %DIR%": #
-"Unable to delete file: %FILE%": #
-"Unable to duplicate file: %FILE%": #
-"Unable to get installation information for %PACKAGE% %VERSION%.": #
-"Unable to rename directory: %DIR%": #
-"Unable to rename file: %FILE%": #
-"Unable to retrieve login session data. Please check your system's PHP session settings.": #
-"Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
-"Upload not allowed": #
-"Users & Permissions": #
-"Welcome to your new Bolt site, %USER%.": #
-"You cannot '%s' yourself.": #
-"You do not have the right privileges to edit that user.": #
-"You have unfinished changes on this page. If you continue without saving, you will lose these changes.": #
-"filtered by <em>'%filter%'</em>": #
-"or": #
-
-#--- 295 translations ---------------------------------------------------------
+#--- 404 translations ---------------------------------------------------------
 
 "%name% № %id%": "%name% № %id%"
 "(default template)": "(default template)"
@@ -193,6 +81,7 @@
 "(none)": "(none)"
 "A password reset link has been sent to '%user%'.": "A password reset link has been sent to '%user%'."
 "Actions": "Actions"
+"Add Selected": "Add Selected"
 "Add a brief, optional comment to describe what's changed.": "Add a brief, optional comment to describe what's changed."
 "Add a comment:": "Add a comment:"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>"
@@ -201,12 +90,24 @@
 "All content types": "All content types"
 "All users": "All users"
 "Alt": "Alt"
+"An error occured while updating `%TABLE%`. The error is %ERROR%": "An error occured while updating `%TABLE%`. The error is %ERROR%"
 "Anonymous": "Anonymous"
+"Are you sure you want to delete %FILENAME%?": "Are you sure you want to delete %FILENAME%?"
 "Are you sure you want to delete %username%?": "Are you sure you want to delete %username%?"
+"Are you sure you want to do this for %NUMBER% records?": "Are you sure you want to do this for %NUMBER% records?"
+"Are you sure you want to do this for 1 record?": "Are you sure you want to do this for 1 record?"
+"Are you sure you want to remove these files?": "Are you sure you want to remove these files?"
+"Are you sure you want to remove these images?": "Are you sure you want to remove these images?"
+"Are you sure you want to remove this file?": "Are you sure you want to remove this file?"
+"Are you sure you want to remove this image?": "Are you sure you want to remove this image?"
+"Are you sure you wish to delete this record? There is no undo.": "Are you sure you wish to delete this record? There is no undo."
+"At least %NUM% characters required": "At least %NUM% characters required"
+"Author": "Author"
 "Author:": "Author:"
 "Below are the third party libraries that are used by Bolt.": "Below are the third party libraries that are used by Bolt."
 "Body": "Body"
 "Bolt - Fatal error.": "Bolt - Fatal error."
+"Bolt has detected one or more configuration issues. You should resolve these, for optimum performance:": "Bolt has detected one or more configuration issues. You should resolve these, for optimum performance:"
 "Browser / platform": "Browser / platform"
 "Built-in role, automatically granted at all times, even if no user is logged in": "Built-in role, automatically granted at all times, even if no user is logged in"
 "Built-in role, automatically granted to every registered user": "Built-in role, automatically granted to every registered user"
@@ -222,12 +123,19 @@
 "Chapters": "Chapters"
 "Check again": "Check again"
 "Check database": "Check database"
+"Check/Uncheck all": "Check/Uncheck all"
+"Choose an entry": "Choose an entry"
 "Class:": "Class:"
+"Clear Change Log": "Clear Change Log"
+"Clear System Log": "Clear System Log"
 "Clear cache again": "Clear cache again"
 "Clear filter": "Clear filter"
 "Clear sort/filter": "Clear sort/filter"
 "Clear the cache": "Clear the cache"
+"Cleared cache.": "Cleared cache."
 "Click to change current status.": "Click to change current status."
+"Client error: %errormessage%": "Client error: %errormessage%"
+"Close editor": "Close editor"
 "Code:": "Code:"
 "Collapse sidebar": "Collapse sidebar"
 "Configuration": "Configuration"
@@ -236,6 +144,7 @@
 "Content Type Permissions": "Content Type Permissions"
 "Content for home not found!": "Content for home not found!"
 "Contenttypes": "Contenttypes"
+"Create File": "Create File"
 "Create folder": "Create folder"
 "Create the first user": "Create the first user"
 "Created on:": "Created on:"
@@ -247,29 +156,44 @@
 "Date": "Date"
 "Datetime": "Datetime"
 "Default status": "Default status"
+"Delete": "Delete"
 "Delete %filename%": "Delete %filename%"
 "Delete %foldername%": "Delete %foldername%"
 "Delete %username%": "Delete %username%"
+"Delete Set": "Delete Set"
 "Depublication date:": "Depublication date:"
+"Depublish": "Depublish"
+"Depublish date is in the past. Change the status if you want to depublish now": "Depublish date is in the past. Change the status if you want to depublish now"
 "Deselect all": "Deselect all"
 "Detail template": "Detail template"
 "Details": "Details"
+"Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already."
 "Disable %username%": "Disable %username%"
+"Do you really want to delete %FOLDERNAME%?": "Do you really want to delete %FOLDERNAME%?"
 "Done!": "Done!"
 "Draft": "Draft"
 "Duplicate %filename%": "Duplicate %filename%"
+"Duplicate Set": "Duplicate Set"
 "Edit": "Edit"
 "Edit Roles and Permissions": "Edit Roles and Permissions"
 "Edit file": "Edit file"
 "Enable %username%": "Enable %username%"
+"Error reading extensions/composer.json file: %ERROR%": "Error reading extensions/composer.json file: %ERROR%"
 "Everybody": "Everybody"
 "Excerpt": "Excerpt"
 "Expand sidebar": "Expand sidebar"
+"Extension package %NAME% base class '%CLASS%' does not implement \\\\Bolt\\\\Extension\\\\ExtensionInterface and has been skipped.": "Extension package %NAME% base class '%CLASS%' does not implement \\\\Bolt\\\\Extension\\\\ExtensionInterface and has been skipped."
+"Extension package %NAME% has an invalid class '%CLASS%' and has been skipped.": "Extension package %NAME% has an invalid class '%CLASS%' and has been skipped."
+"Extension server returned an error: %errormessage%": "Extension server returned an error: %errormessage%"
 "Extensions": "Extensions"
 "Extras": "Extras"
+"Failed to clear cache. You should delete it manually.": "Failed to clear cache. You should delete it manually."
+"Failed to send password request. Please check the email settings.": "Failed to send password request. Please check the email settings."
+"Field “%FIELD_NAME%”:": "Field “%FIELD_NAME%”:"
 "File": "File"
 "File '%file%' could not be uploaded (wrong/disallowed file type). Make sure the file extension is one of the following:": "File '%file%' could not be uploaded (wrong/disallowed file type). Make sure the file extension is one of the following:"
 "File '%file%' was uploaded successfully.": "File '%file%' was uploaded successfully."
+"File '%s' could not be saved, because the form wasn't valid.": "File '%s' could not be saved, because the form wasn't valid."
 "File '%s' could not be saved, for some reason.": "File '%s' could not be saved, for some reason."
 "File '%s' could not be saved:": "File '%s' could not be saved:"
 "File '%s' has been saved.": "File '%s' has been saved."
@@ -277,6 +201,7 @@
 "File is not readable!": "File is not readable!"
 "Filelist": "File list"
 "Files": "Files"
+"Files could not be uploaded.": "Files could not be uploaded."
 "Files in %s": "Files in %s"
 "Files on the stack": "Files on the stack"
 "Filesize": "File size"
@@ -289,27 +214,41 @@
 "Folder permissions insufficient": "Folder permissions insufficient"
 "Folders": "Folders"
 "Full list …": "Full list …"
+"Generic failure while testing connection to extension server: %errormessage%": "Generic failure while testing connection to extension server: %errormessage%"
 "Geolocation": "Geolocation"
 "Global Permissions": "Global Permissions"
+"Has to be a floating point number!": "Has to be a floating point number!"
 "Hints:": "Hints:"
 "Html": "Html"
 "IP address": "IP address"
 "Id": "Id"
+"Id (№)": "Id (№)"
+"If there was a Block with 'about-us' for a slug, it would've been shown here. But there isn't one, so that's why you're seeing this placeholder. In the Bolt backend, go to 'check database' and 'Add some sample Records', to create these automatically.": "If there was a Block with 'about-us' for a slug, it would've been shown here. But there isn't one, so that's why you're seeing this placeholder. In the Bolt backend, go to 'check database' and 'Add some sample Records', to create these automatically."
 "Image": "Image"
 "Imagelist": "Image list"
 "Info": "Info"
 "Integerfield": "Integer field"
+"Invalid login parameters.": "Invalid login parameters."
+"Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes."
+"Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!"
+"Is required or needs to match a pattern!": "Is required or needs to match a pattern!"
+"Is required!": "Is required!"
+"Keyword …": "Keyword …"
 "Last edited on:": "Last edited on:"
 "Last known IP": "Last known IP"
 "Last seen": "Last seen"
 "Latest entries": "Latest entries"
+"Link": "Link"
 "Listing template": "Listing template"
+"Live Edit": "Live Edit"
+"Local extension set up incomplete. Please run 'Install all packages' on the Extensions page.": "Local extension set up incomplete. Please run 'Install all packages' on the Extensions page."
 "Login": "Login"
 "Logout": "Logout"
 "Long messages": "Long messages"
 "Main configuration": "Main configuration"
 "Maintenance": "Maintenance"
 "Markdown": "Markdown"
+"Menu item property \"add\" is deprecated. Use \"#\" under \"param\" instead.": "Menu item property \"add\" is deprecated. Use \"#\" under \"param\" instead."
 "Menu setup": "Menu set up"
 "Message:": "Message:"
 "Messages": "Messages"
@@ -318,16 +257,29 @@
 "Modifications made to the database:": "Modifications made to the database:"
 "Modifications needed:": "Modifications needed:"
 "Modified": "Modified"
+"Move Down": "Move Down"
+"Move Up": "Move Up"
 "Multiselect": "Multi-select"
+"New Bolt site has been set up": "New Bolt site has been set up"
+"No Preview": "No Preview"
+"No content found.": "No content found."
+"No files in the list, yet.": "No files in the list, yet."
+"No images in the list, yet.": "No images in the list, yet."
 "No relations found!": "No relations found!"
 "No results found for '%SEARCHTERM%'. Please try another search.": "No results found for '%SEARCHTERM%'. Please try another search."
 "No such action for user '%s'.": "No such action for user '%s'."
+"No theme name found. Theme is not generated.": "No theme name found. Theme is not generated."
 "None": "None"
 "Not published": "Not published"
+"Not yet installed.": "Not yet installed."
 "Note:": "Note:"
 "Omnisearch": "Omnisearch"
+"Only root can change file extensions.": "Only root can change file extensions."
 "Options": "Options"
+"Order": "Order"
 "Order: %sort%": "Order: %sort%"
+"Other content": "Other content"
+"Others": "Others"
 "Overview": "Overview"
 "Overview for": "Overview for"
 "Owner": "Owner"
@@ -350,14 +302,22 @@
 "Profile": "Profile"
 "Provided by:": "Provided by:"
 "Publication date:": "Publication date:"
+"Publish": "Publish"
 "Published": "Published"
 "Published on:": "Published on:"
 "Read more": "Read more"
+"Records": "Records"
 "Related content": "Related content"
+"Related content:": "Related content:"
 "Relationships": "Relationships"
 "Rename %foldername%": "Rename %foldername%"
+"Repeater": "Repeater"
 "Roles": "Roles"
 "Roles and Permissions": "Roles and Permissions"
+"Run PHP extension checks": "Run PHP extension checks"
+"Run all checks": "Run all checks"
+"Run directory checks": "Run directory checks"
+"Run email checks": "Run email checks"
 "Save & create new record": "Save & create new record"
 "Save & return to overview": "Save & return to overview"
 "Saved on:": "Saved on:"
@@ -365,6 +325,7 @@
 "Search": "Search"
 "Search for …": "Search for …"
 "Search results for <b> %search% </b>.": "Search results for <b> %search% </b>."
+"Search results for <b>%search%</b>.": "Search results for <b>%search%</b>."
 "Search …": "Search …"
 "Select": "Select"
 "Select a page": "Select a page"
@@ -374,9 +335,11 @@
 "Select zero or more pages": "Select zero or more pages"
 "Selectentry": "Select entry"
 "Selectfield": "Select field"
+"Selection (#):": "Selection (#):"
 "Session expires": "Session expires"
 "Session resumed.": "Session resumed."
 "Settings": "Settings"
+"Show proposed alterations": "Show proposed alterations"
 "Showing": "Showing"
 "Showing %pager_for% %from% - %to% of %count%": "Showing %pager_for% %from% - %to% of %count%"
 "Size": "Size"
@@ -385,20 +348,28 @@
 "Slug": "Slug"
 "Slug:": "Slug:"
 "Something went wrong": "Something went wrong"
+"Something went wrong with logging in after first user creation!": "Something went wrong with logging in after first user creation!"
 "Sophisticated, lightweight & simple CMS": "Sophisticated, lightweight & simple CMS"
 "Stack": "Stack"
 "Status:": "Status:"
+"System Configuration Checks": "System Configuration Checks"
 "Tag": "Tag"
 "Tags": "Tags"
 "Taxonomy": "Taxonomy"
 "Teaser": "Teaser"
 "Template": "Template"
+"Testing connection to extension server failed: %errormessage%": "Testing connection to extension server failed: %errormessage%"
 "Textarea": "Textarea"
 "That user does not exist.": "That user does not exist."
+"The Bolt extensions composer.json isn't readable.": "The Bolt extensions composer.json isn't readable."
+"The Bolt extensions composer.json isn't writable.": "The Bolt extensions composer.json isn't writable."
 "The change log has been cleared.": "The change log has been cleared."
 "The change log has been trimmed.": "The change log has been trimmed."
 "The database needs to be updated/repaired. Go to 'Configuration' > '<a href=\"%link%\">Check Database</a>' to do this now.": "The database needs to be updated/repaired. Go to 'Configuration' > '<a href=\"%link%\">Check Database</a>' to do this now."
+"The email configuration setting 'mailoptions' hasn't been set. Bolt may be unable to send password reset.": "The email configuration setting 'mailoptions' hasn't been set. Bolt may be unable to send password reset."
 "The field %field% has been changed to \"%newValue%\"": "The field %field% has been changed to \"%newValue%\""
+"The file '%s' doesn't exist.": "The file '%s' doesn't exist."
+"The file '%s' is not readable.": "The file '%s' is not readable."
 "The file '%s' is not writable. You will have to use your own editor to make modifications to this file.": "The file '%s' is not writable. You will have to use your own editor to make modifications to this file."
 "The folder '%s' could not be found, or is not readable.": "The folder '%s' could not be found, or is not readable."
 "The following file could not be read:": "The following file could not be read:"
@@ -410,26 +381,45 @@
 "The system log has been trimmed.": "The system log has been trimmed."
 "The translations file '%s' can't be created. You will have to use your own editor to make modifications to this file.": "The translations file '%s' can't be created. You will have to use your own editor to make modifications to this file."
 "The translations file '%s' is not readable.": "The translations file '%s' is not readable."
+"The value has to be at least “%MINVAL%”!": "The value has to be at least “%MINVAL%”!"
+"The value must not be greater than “%MAXVAL%”!": "The value must not be greater than “%MAXVAL%”!"
 "Theme successfully generated. You can now edit it directly from your theme folder.": "Theme successfully generated. You can now edit it directly from your theme folder."
 "There are no items on the Stack, yet.": "There are no items on the Stack, yet."
+"There are no saved changes, yet.": "There are no saved changes, yet."
 "There are no users in the database. Please create the first user.": "There are no users in the database. Please create the first user."
 "There are no users present in the system. Please create the first user, which will be granted root privileges.": "There are no users present in the system. Please create the first user, which will be granted root privileges."
+"There is no undo!": "There is no undo!"
 "There should always be at least one 'root' user. You have just been promoted. Congratulations!": "There should always be at least one 'root' user. You have just been promoted. Congratulations!"
 "This is a checkbox": "This is a checkbox"
+"This record is related to the following %CTNAME%:": "This record is related to the following %CTNAME%:"
 "This template adds new fields. Save, then refresh to see these changes.": "This template adds new fields. Save, then refresh to see these changes."
 "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.": "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>."
+"Thumbnail": "Thumbnail"
 "Time in 24h/12h format": "Time in 24h/12h format"
 "Timed publish": "Timed publish"
 "Tip:": "Tip:"
 "Title": "Title"
 "Translations": "Translations"
+"Trim Change Log": "Trim Change Log"
+"Trim System Log": "Trim System Log"
 "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page.": "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page."
 "Types": "Types"
+"Unable to create directory: %DIR%": "Unable to create directory: %DIR%"
+"Unable to create file: %FILE%": "Unable to create file: %FILE%"
+"Unable to delete directory: %DIR%": "Unable to delete directory: %DIR%"
+"Unable to delete file: %FILE%": "Unable to delete file: %FILE%"
+"Unable to duplicate file: %FILE%": "Unable to duplicate file: %FILE%"
+"Unable to get installation information for %PACKAGE% %VERSION%.": "Unable to get installation information for %PACKAGE% %VERSION%."
+"Unable to rename directory: %DIR%": "Unable to rename directory: %DIR%"
+"Unable to rename file: %FILE%": "Unable to rename file: %FILE%"
+"Unable to retrieve login session data. Please check your system's PHP session settings.": "Unable to retrieve login session data. Please check your system's PHP session settings."
+"Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>."
 "Update the database": "Update the database"
 "Upload": "Upload"
 "Upload a file to this folder": "Upload a file to this folder"
 "Upload file": "Upload file"
 "Upload image": "Upload image"
+"Upload not allowed": "Upload not allowed"
 "Uploaded files": "Uploaded files"
 "Uploading to this folder is not allowed.": "Uploading to this folder is not allowed."
 "Used Libraries / Components": "Used Libraries / Components"
@@ -442,6 +432,7 @@
 "Username": "Username"
 "Username or password not correct. Please check your input.": "Username or password not correct. Please check your input."
 "Users": "Users"
+"Users & Permissions": "Users & Permissions"
 "Video": "Video"
 "View (saved version) on site": "View (saved version) on site"
 "View Roles": "View Roles"
@@ -451,12 +442,16 @@
 "View/edit Templates": "View/edit Templates"
 "Warning": "Warning"
 "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling.": "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
+"Welcome to your new Bolt site, %USER%.": "Welcome to your new Bolt site, %USER%."
 "Written by <em>%name%</em> on %date%": "Written by <em>%name%</em> on %date%"
+"You cannot '%s' yourself.": "You cannot '%s' yourself."
 "You do not have the right privileges to edit that record.": "You do not have the right privileges to edit that record."
+"You do not have the right privileges to edit that user.": "You do not have the right privileges to edit that user."
 "You do not have the right privileges to view that page.": "You do not have the right privileges to view that page."
 "You don't have correct permissions to edit the file '%s'.": "You don't have correct permissions to edit the file '%s'."
 "You don't have the correct permissions to display the file or directory '%s'.": "You don't have the correct permissions to display the file or directory '%s'."
 "You have been logged out.": "You have been logged out."
+"You have unfinished changes on this page. If you continue without saving, you will lose these changes.": "You have unfinished changes on this page. If you continue without saving, you will lose these changes."
 "You may lose some of your template fields with this change. Go to the template section and note down the values before doing this.": "You may lose some of your template fields with this change. Go to the template section and note down the values before doing this."
 "You should set 'homepage:' in your 'app/config/config.yml' to an existing record. Make sure that the content is published, otherwise it will not be shown.": "You should set 'homepage:' in your 'app/config/config.yml' to an existing record. Make sure that the content is published, otherwise it will not be shown."
 "You've been logged on successfully.": "You've been logged on successfully."
@@ -466,6 +461,7 @@
 "and edited": "and edited"
 "back to editing": "back to editing"
 "by": "by"
+"filtered by <em>'%filter%'</em>": "filtered by <em>'%filter%'</em>"
 "general.about": "About"
 "general.about-bolt": "About Bolt"
 "general.bolt-documentation": "Bolt documentation"
@@ -478,6 +474,7 @@
 "no title …": "no title …"
 "none": "none"
 "of": "of"
+"or": "or"
 "show all": "show all"
 "users.actions-for-users": "Actions for Users"
 "users.your-password": "Your password"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -1,4 +1,4 @@
-# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-03-20 17:54:44 Europe/Berlin
+# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-03-20 18:19:20 Europe/Berlin
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
 #          at the moment. This is an ongoing process. Translations currently in the 
@@ -11,10 +11,10 @@
 #  no unused messages
 #  no untranslated messages
 #  no untranslated keyword based messages
-# 404 translations
-# 206 keyword based translations
+# 395 translations
+# 215 keyword based translations
 
-#--- 404 translations ---------------------------------------------------------
+#--- 395 translations ---------------------------------------------------------
 
 "%name% № %id%": "%name% № %id%"
 "(default template)": "(default template)"
@@ -404,24 +404,15 @@
 "back to editing": "back to editing"
 "by": "by"
 "filtered by <em>'%filter%'</em>": "filtered by <em>'%filter%'</em>"
-"general.about": "About"
-"general.about-bolt": "About Bolt"
-"general.bolt-documentation": "Bolt documentation"
-"general.bolt-on-github": "Bolt on GitHub"
-"general.visit-bolt": "Visit Bolt.cm"
 "line": "line"
-"logs.change-log": "Change Log"
-"logs.system-log": "System Log"
 "no content …": "no content …"
 "no title …": "no title …"
 "none": "none"
 "of": "of"
 "or": "or"
 "show all": "show all"
-"users.actions-for-users": "Actions for Users"
-"users.your-password": "Your password"
 
-#--- 206 keyword based translations -------------------------------------------
+#--- 215 keyword based translations -------------------------------------------
 
 component.changelog-detail.by: "by"
 component.changelog-detail.field: "Field"
@@ -497,8 +488,22 @@ field.video.pixel: "pixel"
 field.video.placeholder.url: "URL of video on Youtube, Vimeo or other video website"
 field.video.width: "Width"
 
+general.about: "About"
+
+general.about-bolt: "About Bolt"
+
+general.bolt-documentation: "Bolt documentation"
+
+general.bolt-on-github: "Bolt on GitHub"
+
+general.visit-bolt: "Visit Bolt.cm"
+
 generic.noscript.headline: "JavaScript disabled"
 generic.noscript.message: "JavaScript is currently disabled in your browser. Bolt requires JavaScript to function properly and continuing without it might corrupt or erase data."
+
+logs.change-log: "Change Log"
+
+logs.system-log: "System Log"
 
 menu.configuration.routing: "Routing set up"
 
@@ -647,3 +652,7 @@ panel.latest-activity.system: "Latest system activity"
 panel.latest-activity.unknown: "unknown"
 
 panel.user-actions.button.add: "Add a new user"
+
+users.actions-for-users: "Actions for Users"
+
+users.your-password: "Your password"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -1,20 +1,20 @@
-# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-03-16 11:41:56 Europe/Berlin
+# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-03-20 17:26:46 Europe/Berlin
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
+#          at the moment. This is an ongoing process. Translations currently in the 
+#          repository are automatically mapped to the new scheme. Be aware that there 
+#          can be a race condition between that process and your PR so that it's 
+#          eventually necessary to remap your translations. If you're planning on 
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#  56 unused messages
-# 108 untranslated messages
-#   3 untranslated keyword based messages
-# 297 translations
-# 204 keyword based translations
+#  55 unused messages
+# 109 untranslated messages
+#  no untranslated keyword based messages
+# 295 translations
+# 206 keyword based translations
 
-#--- 56 unused messages -------------------------------------------------------
+#--- 55 unused messages -------------------------------------------------------
 
 "%contenttypes% overview": "%contenttypes% overview"
 "Bolt Extension could not be found. Please check at %site% to ensure correct name.": "Bolt Extension could not be found. Please check at %site% to ensure correct name."
@@ -66,8 +66,13 @@
 "The Bolt extensions Repo at %repository% is currently unavailable. Check your connection and try again shortly.": "The Bolt extensions Repo at %repository% is currently unavailable. Check your connection and try again shortly."
 "This record is related to:": "This record is related to:"
 "page.ckeditor-browse-server.pixel": "px."
+"Repeat": #
+"Subsubtitle": #
+"Subtitle": #
+"%s files could not be deleted. You should delete them manually.": "%s files could not be deleted. You should delete them manually."
+"Deleted %s files from cache.": "Deleted %s files from cache."
 
-#--- 108 untranslated messages ------------------------------------------------
+#--- 109 untranslated messages ------------------------------------------------
 
 "Add Selected": #
 "An error occured while updating `%TABLE%`. The error is %ERROR%": #
@@ -86,6 +91,7 @@
 "Choose an entry": #
 "Clear Change Log": #
 "Clear System Log": #
+"Cleared cache.": #
 "Client error: %errormessage%": #
 "Close editor": #
 "Create File": #
@@ -100,6 +106,7 @@
 "Extension package %NAME% base class '%CLASS%' does not implement \\\\Bolt\\\\Extension\\\\ExtensionInterface and has been skipped.": #
 "Extension package %NAME% has an invalid class '%CLASS%' and has been skipped.": #
 "Extension server returned an error: %errormessage%": #
+"Failed to clear cache. You should delete it manually.": #
 "Failed to send password request. Please check the email settings.": #
 "Field “%FIELD_NAME%”:": #
 "File '%s' could not be saved, because the form wasn't valid.": #
@@ -114,6 +121,7 @@
 "Is required or needs to match a pattern!": #
 "Is required!": #
 "Keyword …": #
+"Link": #
 "Live Edit": #
 "Local extension set up incomplete. Please run 'Install all packages' on the Extensions page.": #
 "Menu item property \"add\" is deprecated. Use \"#\" under \"param\" instead.": #
@@ -133,7 +141,7 @@
 "Publish": #
 "Records": #
 "Related content:": #
-"Repeat": #
+"Repeater": #
 "Run PHP extension checks": #
 "Run all checks": #
 "Run directory checks": #
@@ -142,8 +150,6 @@
 "Selection (#):": #
 "Show proposed alterations": #
 "Something went wrong with logging in after first user creation!": #
-"Subsubtitle": #
-"Subtitle": #
 "System Configuration Checks": #
 "Testing connection to extension server failed: %errormessage%": #
 "The Bolt extensions composer.json isn't readable.": #
@@ -178,15 +184,9 @@
 "filtered by <em>'%filter%'</em>": #
 "or": #
 
-#--- 3 untranslated keyword based messages ------------------------------------
-
-"field.video.height": "Height"
-"field.video.width": "Width"
-
-#--- 297 translations ---------------------------------------------------------
+#--- 295 translations ---------------------------------------------------------
 
 "%name% № %id%": "%name% № %id%"
-"%s files could not be deleted. You should delete them manually.": "%s files could not be deleted. You should delete them manually."
 "(default template)": "(default template)"
 "(no category)": "(no category)"
 "(no group)": "(no group)"
@@ -250,7 +250,6 @@
 "Delete %filename%": "Delete %filename%"
 "Delete %foldername%": "Delete %foldername%"
 "Delete %username%": "Delete %username%"
-"Deleted %s files from cache.": "Deleted %s files from cache."
 "Depublication date:": "Depublication date:"
 "Deselect all": "Deselect all"
 "Detail template": "Detail template"
@@ -483,7 +482,7 @@
 "users.actions-for-users": "Actions for Users"
 "users.your-password": "Your password"
 
-#--- 204 keyword based translations -------------------------------------------
+#--- 206 keyword based translations -------------------------------------------
 
 component.changelog-detail.by: "by"
 component.changelog-detail.field: "Field"
@@ -550,12 +549,14 @@ field.slug.message.warning: "Editing this field might break existing links to th
 field.slug.permalink: "Permalink"
 field.slug.unique-alias: "Unique alias"
 
+field.video.height: "Height"
 field.video.label.preview: "Preview image"
 field.video.label.size: "Size"
 field.video.label.url: "URL of video to embed"
 field.video.matched-video: "Matched video"
 field.video.pixel: "pixel"
 field.video.placeholder.url: "URL of video on Youtube, Vimeo or other video website"
+field.video.width: "Width"
 
 generic.noscript.headline: "JavaScript disabled"
 generic.noscript.message: "JavaScript is currently disabled in your browser. Bolt requires JavaScript to function properly and continuing without it might corrupt or erase data."

--- a/src/Translation/TranslationFile.php
+++ b/src/Translation/TranslationFile.php
@@ -296,9 +296,9 @@ class TranslationFile
         ];
         foreach ($newTranslations as $key => $translation) {
             $set = ['trans' => $translation];
-            if (preg_match('%^([a-z0-9-]+)\.([a-z0-9-]+)\.([a-z0-9-]+)(?:\.([a-z0-9.-]+))?$%', $key, $match)) {
+            if (preg_match('%^[a-z0-9-]+\.[a-z0-9-.]+$%', $key)) {
                 $type = 'Key';
-                $set['key'] = array_slice($match, 1);
+                $set['key'] = preg_split('%\.%', $key);
             } else {
                 $type = 'Real';
             }

--- a/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
+++ b/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
@@ -161,7 +161,7 @@ class BackendDeveloperCest
         $I->amOnPage('/bolt/tr');
 
         // Go into edit mode
-        $I->see('contenttypes.general.choose-an-entry', 'textarea');
+        $I->see('page.login.button.forgot-password', 'textarea');
 
         // Edit the field
         $twig = $I->grabTextFrom('#form_contents', 'textarea');


### PR DESCRIPTION
Various fixups:

- Only use translatables in contenttypes.yml.dist for generation
- Removal of unused messages
- Untranslated messages set to "translated"
- Fix of an test that had checked for an removed key
- Fix detection of key based translations which didn't detect keys with just two parts
- Adding translations for block contenttype