### PR TITLE
Improve config replacement performance

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -244,20 +244,20 @@ class Config
         if (is_string($value)) {
             $serviceName = substr($value, 1, strlen($value) - 2);
 
-            if (!isset($this->app[$serviceName])) {
-                return;
-            }
-
             if (strpos($serviceName, ":") !== false) {
                 list($serviceName, $params) = explode(':', $serviceName);
             } else {
                 $params = [];
             }
 
+            if (!isset($this->app[$serviceName])) {
+                return;
+            }
+
             $service = $this->app[$serviceName];
 
             if (is_callable($service)) {
-                return call_user_func_array($service, $params);
+                return call_user_func_array($service, [$params]);
             } else {
                 return $service;
             }

--- a/src/Config.php
+++ b/src/Config.php
@@ -222,7 +222,7 @@ class Config
     {
         if ($value === null) {
             $this->data = $this->doReplacements($this->data);
-            dump($this->data); exit;
+
             return;
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -212,7 +212,10 @@ class Config
     }
 
     /**
-     * replaces placeholders in config values %foo% will be resolved to $app['foo'] from the container
+     * Replaces placeholders in config values %foo% will be resolved to $app['foo'] from the container
+     *
+     * @internal This is only public so that it can be called from the service provider boot method.
+     * Do not access this directly since the API is liable to be changed at short notice.
      *
      * @param mixed $value
      *

--- a/src/Provider/ConfigServiceProvider.php
+++ b/src/Provider/ConfigServiceProvider.php
@@ -40,5 +40,6 @@ class ConfigServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
+        $app['config']->doReplacements();
     }
 }


### PR DESCRIPTION
This PR offers some optimisation of the config replacement functionality as well as some enhancements to make it much more useful.

References: #5071 

Details
-------

This PR does the compilation of config replacements just once at boot time, rather than on every call to `config->get()`

As an additional bonus it also now respects callables so if your replacement is a callable, eg:

`somepathconfig: %twig.path%`

Then the service will be called and the result returned.
 