### PR TITLE
Update filesystem and thumbs to beta. Prep index.php for composer-install fix.

### DIFF
--- a/app/nut
+++ b/app/nut
@@ -1,5 +1,8 @@
 #!/usr/bin/env php
 <?php
+/*
+ * This could be loaded on a very old version of PHP so no syntax/methods over 5.2 in this file.
+ */
 
 $minVersion = '5.5.9';
 if (version_compare(PHP_VERSION, $minVersion, '<')) {

--- a/app/web.php
+++ b/app/web.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * This could be loaded on a very old version of PHP so no syntax/methods over 5.2 in this file.
+ */
+
+if (version_compare(PHP_VERSION, '5.5.9', '<')) {
+    require dirname(__FILE__) . '/legacy.php';
+    exit(1);
+}
+
+if (PHP_SAPI === 'cli-server') {
+    if (is_file($_SERVER['DOCUMENT_ROOT'] . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']))) {
+        return false;
+    }
+}
+
+return require dirname(__FILE__) . '/bootstrap.php';

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     ],
     "license" : "MIT",
     "require" : {
-        "bolt/filesystem" : "^2.0@dev",
+        "bolt/filesystem" : "^2.0@beta",
         "bolt/package-wrapper": "^3.0",
         "bolt/pathogen" : "~0.6",
-        "bolt/thumbs" : "~3.0@dev",
+        "bolt/thumbs" : "~3.0@beta",
         "brandonwamboldt/utilphp" : "~1.0",
         "cocur/slugify" : "~1.0",
         "composer/composer" : "^1.0@beta",

--- a/index.php
+++ b/index.php
@@ -1,47 +1,14 @@
 <?php
-/**
- * Bolt entry script.
- *
- * Here we'll require in the first stage load script, which handles all the
- * tasks needed to return the app.  Once we get the app, we simply tell it
- * to run, building a beautiful web page for you and other visitors.
- *
- * We get things started by ensuring the PHP version we're running on
- * is supported by the app.  We'll display a friendly error page if not.
- *
- * Next, we'll check if the script is being run with PHP's built in web
- * server, and make sure static assets are handled gracefully.
- */
 
-/**
- * Version must be greater than 5.5.9.
- *
- * Note, we use `dirname(__FILE__)` instead of `__DIR__`. The latter was
- * introduced "only" in PHP 5.3, and we need to be able to show the notice to
- * the poor souls who are still on PHP 5.2.
- *
- * @see: https://github.com/bolt/bolt/issues/1531
- * @see: https://github.com/bolt/bolt/issues/3371
+/*
+ * `dirname(__FILE__)` is intentional to support PHP 5.2 until legacy.php can be shown.
  */
-if (version_compare(PHP_VERSION, '5.5.9', '<')) {
-    require dirname(__FILE__) . '/app/legacy.php';
+/** @var Silex\Application|false $app */
+$app = require dirname(__FILE__) . '/app/web.php';
 
+// If web.php returns false, meaning the path is a file, pass it along.
+if ($app === false) {
     return false;
 }
 
-/**
- * Return false if the requested file is available on the filesystem.
- *
- * @see: http://silex.sensiolabs.org/doc/web_servers.html#php-5-4
- */
-if (php_sapi_name() === 'cli-server') {
-    $filename = __DIR__ . preg_replace('#(\?.*)$#', '', $_SERVER['REQUEST_URI']);
-
-    if (is_file($filename)) {
-        return false;
-    }
-}
-
-/** @var \Silex\Application $app */
-$app = require __DIR__ . '/app/bootstrap.php';
 $app->run();


### PR DESCRIPTION
Currently `index.php` in composer-install doesn't handle files with php webserver or check minimum php version. This moves that logic to `app/web.php` so updates can be applied (since it isn't copied to actual installs).

Also, bolt/thumbs and filesystem beta. Woot!