### PR TITLE
Fix overwriting of key variable for repeating field metadata

### DIFF
--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -213,8 +213,8 @@ class MetadataDriver implements MappingDriver
             ];
 
             if ($data['type'] === 'repeater') {
-                foreach ($data['fields'] as $key => &$value) {
-                    $value['fieldname'] = $key;
+                foreach ($data['fields'] as $rkey => &$value) {
+                    $value['fieldname'] = $rkey;
                     if (isset($this->typemap[$value['type']])) {
                         $value['fieldtype'] = $this->typemap[$value['type']];
                     } else {


### PR DESCRIPTION
Ok, this ended up being a silly, but hard to find error. 

Metadata for repeating fields was being corrupted by one of the inner loops which was writing back to the parent metadata, rather than the data for the repeating field.

Fixes: #5072 

