### PR TITLE
Don't return nbsp in ImageHandler

### DIFF
--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -100,7 +100,7 @@ class ImageHandler
     public function popup($fileName = null, $width = null, $height = null, $crop = null, $title = null)
     {
         if (empty($fileName)) {
-            return '&nbsp;';
+            return '';
         }
 
         $thumbconf = $this->app['config']->get('general/thumbnails');
@@ -151,7 +151,7 @@ class ImageHandler
     public function showImage($fileName = null, $width = null, $height = null, $crop = null)
     {
         if (empty($fileName)) {
-            return '&nbsp;';
+            return '';
         }
         $thumb = $this->getThumbnail($fileName, $width, $height, $crop);
 

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -120,7 +120,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->popup();
-        $this->assertSame('&nbsp;', $result);
+        $this->assertSame('', $result);
     }
 
     public function testPopupFileNameOnly()
@@ -209,7 +209,7 @@ class ImageHandlerTest extends BoltUnitTest
         $handler = new ImageHandler($app);
 
         $result = $handler->showImage();
-        $this->assertSame('&nbsp;', $result);
+        $this->assertSame('', $result);
     }
 
     public function testShowImageFileNameOnly()


### PR DESCRIPTION
when image/popup is called with an empty filename. It can cause weird breaks in templates when we do, so instead return an empty string.