### PR TITLE
Fix domain cookie value with http port

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -325,10 +325,10 @@ class Config
 
         // Make sure the cookie_domain for the sessions is set properly.
         if (empty($general['cookies_domain'])) {
-            if (isset($_SERVER['HTTP_HOST'])) {
-                $hostname = $_SERVER['HTTP_HOST'];
-            } elseif (isset($_SERVER['SERVER_NAME'])) {
+            if (isset($_SERVER['SERVER_NAME'])) {
                 $hostname = $_SERVER['SERVER_NAME'];
+            } elseif (isset($_SERVER['HTTP_HOST'])) {
+                $hostname = reset(explode(':', $_SERVER['HTTP_HOST']));
             } else {
                 $hostname = '';
             }

--- a/src/Config.php
+++ b/src/Config.php
@@ -328,7 +328,8 @@ class Config
             if (isset($_SERVER['SERVER_NAME'])) {
                 $hostname = $_SERVER['SERVER_NAME'];
             } elseif (isset($_SERVER['HTTP_HOST'])) {
-                $hostname = reset(explode(':', $_SERVER['HTTP_HOST']));
+                $hostSegments = explode(':', $_SERVER['HTTP_HOST']);
+                $hostname = reset($hostSegments);
             } else {
                 $hostname = '';
             }


### PR DESCRIPTION
Default cookie domain value can't contain server's http port number.
Resolves partially #5014 and resolves #5114 
