### PR TITLE
Suggestion for better text in case the 'about-us' block is missing.

### DIFF
--- a/theme/base-2016/partials/_aside.twig
+++ b/theme/base-2016/partials/_aside.twig
@@ -32,7 +32,7 @@
 
                 <h5>{{ __('Alas, no about!') }}</h5>
 
-                <p>{{ __("If there was a Block with 'about-us' for a slug, it would've been shown here. But there isn't one, so that's why you're seeing this placeholder. In the Bolt backend, go to 'check database' and 'Add some sample Records', to create these automatically.") }}</p>
+                <p>{{ __("There currently is no Block with 'about-us' as its slug. If you create one, it will be shown here. Go to 'Configuration' > 'Check Database' and select 'Add sample Records' to automatically generate this Block.") }}</p>
 
             {% endif %}
 


### PR DESCRIPTION
Fixes #5039 
