### PR TITLE
Only skip htmlsnippets if we are returning a cached response

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -562,7 +562,7 @@ class Application extends Silex\Application
 
         // true if we need to consider adding html snippets
         // note we exclude cached requests where no additions should be made to the HTML
-        if (isset($this['htmlsnippets']) && ($this['htmlsnippets'] === true) && ($this['config']->get('general/caching/request') == false)) {
+        if (isset($this['htmlsnippets']) && ($this['htmlsnippets'] === true) && ($response->headers->get('Cache-Control') === "no-cache")) {
             // only add when content-type is text/html
             if (strpos($response->headers->get('Content-Type'), 'text/html') !== false) {
                 // Add our meta generator tag.


### PR DESCRIPTION
We set the cache-control here:
https://github.com/bolt/bolt/blob/2236c27440a4c52ca47591b1fba338cbc641f406/src/Render.php#L102 so if it is not set to a max-age we can be sure that we need to add the snippets.