### PR TITLE
Fixes for {{ dump() }}

### DIFF
--- a/src/Twig/Handler/UtilsHandler.php
+++ b/src/Twig/Handler/UtilsHandler.php
@@ -170,9 +170,9 @@ class UtilsHandler
 
     /**
      * Helper function to determine if we're supposed to allow `dump`, `backtrace`
-     * and `firebug`. If `$safe` is set, we don't allow it. Otherwise we show
-     * them only to _logged on_ users, _or_ non-authenticated users, but then
-     * `debug_show_loggedoff` needs to be set.
+     * and `firebug`. If `$safe` is set or `$this->app['debug']` is false, we
+     * don't allow it. Otherwise we show only to _logged on_ users, _or_
+     * non-authenticated users, but then `debug_show_loggedoff` needs to be set.
      *
      * @param string $safe
      *
@@ -181,8 +181,8 @@ class UtilsHandler
     private function allowDebug($safe)
     {
         return (
-            !$safe &&
-            ( ($this->app['debug'] && $this->app['users']->getCurrentUser()) ||
+            !$safe && $this->app['debug'] &&
+            ($this->app['users']->getCurrentUser() ||
             $this->app['config']->get('general/debug_show_loggedoff') ) );
     }
 

--- a/src/Twig/Handler/UtilsHandler.php
+++ b/src/Twig/Handler/UtilsHandler.php
@@ -178,7 +178,8 @@ class UtilsHandler
      *
      * @return boolean
      */
-    private function allowDebug($safe) {
+    private function allowDebug($safe)
+    {
         return (
             !$safe &&
             ( ($this->app['debug'] && $this->app['users']->getCurrentUser()) ||

--- a/src/Twig/Handler/UtilsHandler.php
+++ b/src/Twig/Handler/UtilsHandler.php
@@ -67,7 +67,7 @@ class UtilsHandler
      */
     public function printBacktrace($depth, $safe)
     {
-        if ($safe || !$this->app['debug']) {
+        if (!$this->allowDebug($safe)) {
             return null;
         }
 
@@ -84,7 +84,7 @@ class UtilsHandler
      */
     public function printDump($var, $safe)
     {
-        if ($safe || !$this->app['debug']) {
+        if (!$this->allowDebug($safe)) {
             return null;
         }
 
@@ -102,19 +102,16 @@ class UtilsHandler
      */
     public function printFirebug($var, $msg, $safe)
     {
-        if ($safe) {
+        if (!$this->allowDebug($safe)) {
             return null;
         }
-        if ($this->app['debug']) {
-            if (is_array($var)) {
-                $this->app['logger.firebug']->info($msg, $var);
-            } elseif (is_string($var)) {
-                $this->app['logger.firebug']->info($var);
-            } else {
-                $this->app['logger.firebug']->info($msg, (array) $var);
-            }
+
+        if (is_array($var)) {
+            $this->app['logger.firebug']->info($msg, $var);
+        } elseif (is_string($var)) {
+            $this->app['logger.firebug']->info($var);
         } else {
-            return null;
+            $this->app['logger.firebug']->info($msg, (array) $var);
         }
     }
 
@@ -170,4 +167,22 @@ class UtilsHandler
 
         return $request;
     }
+
+    /**
+     * Helper function to determine if we're supposed to allow `dump`, `backtrace`
+     * and `firebug`. If `$safe` is set, we don't allow it. Otherwise we show
+     * them only to _logged on_ users, _or_ non-authenticated users, but then
+     * `debug_show_loggedoff` needs to be set.
+     *
+     * @param string $safe
+     *
+     * @return boolean
+     */
+    private function allowDebug($safe) {
+        return (
+            !$safe &&
+            ( ($this->app['debug'] && $this->app['users']->getCurrentUser()) ||
+            $this->app['config']->get('general/debug_show_loggedoff') ) );
+    }
+
 }

--- a/tests/phpunit/unit/Twig/BoltTwigHelpersTest.php
+++ b/tests/phpunit/unit/Twig/BoltTwigHelpersTest.php
@@ -65,6 +65,7 @@ class BoltTwigHelpersTest extends BoltUnitTest
 
         // Now test with debug enabled
         $app = $this->getApp();
+        $app['config']->set('general/debug_show_loggedoff', true);
         $handlers = $this->getTwigHandlers($app);
         $twig = new TwigExtension($app, $handlers, false);
         $this->assertEquals($list, $twig->printDump($list));
@@ -89,6 +90,7 @@ class BoltTwigHelpersTest extends BoltUnitTest
 
         // Debug mode
         $app = $this->getApp();
+        $app['config']->set('general/debug_show_loggedoff', true);
         $handlers = $this->getTwigHandlers($app);
         $twig = new TwigExtension($app, $handlers, false);
         $this->assertNotEmpty($twig->printBacktrace());


### PR DESCRIPTION
- Don’t show dump when user not logged on.
- Honor `debug_show_loggedoff` setting
- Apply the same for `firebug` and `backtrace`. Not just `dump`.

Fixes #5122