### PR TITLE
Fix named templatefields without burning the whole thing down 🚒

### DIFF
--- a/src/Twig/Handler/RecordHandler.php
+++ b/src/Twig/Handler/RecordHandler.php
@@ -178,20 +178,7 @@ class RecordHandler
             return null;
         }
 
-        // Get the active themeconfig
-        $themeConfig = $this->app['config']->get('theme/templateselect/templates', false);
         $files = [];
-
-        // Check: Are the templates for template chooser defined?
-        if ($themeConfig) {
-            foreach ($themeConfig as $templateFile) {
-                if (!empty($templateFile['name']) && !empty($templateFile['filename'])) {
-                    $files[$templateFile['filename']] = $templateFile['name'];
-                }
-            }
-
-            return $files;
-        }
 
         $name = $filter ? Glob::toRegex($filter, false, false) : '/^[a-zA-Z0-9]\V+\.twig$/';
         $finder = new Finder();
@@ -209,6 +196,18 @@ class RecordHandler
         foreach ($finder as $file) {
             $name = $file->getRelativePathname();
             $files[$name] = $name;
+        }
+
+        // Get the active themeconfig
+        $themeConfig = $this->app['config']->get('theme/templateselect/templates', false);
+        
+        // Check: Have we defined names for any of the matched templates?
+        if ($themeConfig) {
+            foreach ($themeConfig as $templateFile) {
+                if (!empty($templateFile['name']) && !empty($templateFile['filename']) && in_array($templateFile['filename'], $files)) {
+                    $files[$templateFile['filename']] = $templateFile['name'];
+                }
+            }
         }
 
         return $files;

--- a/tests/phpunit/unit/Twig/Handler/RecordHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/RecordHandlerTest.php
@@ -490,22 +490,23 @@ GRINGALET;
         $app = $this->getApp();
         $app['config']->set('theme/templateselect/templates', [
             'koala' => [
-                'name'     => 'koala.twig',
-                'filename' => 'koala.twig',
+                'name'     => 'Koala',
+                'filename' => 'extrafields.twig',
             ],
             'clippy' => [
-                'name'     => 'clippy.twig',
-                'filename' => 'clippy.twig',
+                'name'     => 'Clippy',
+                'filename' => 'anotherextrafields.twig',
             ],
         ]);
         $handler = new RecordHandler($app);
 
-        $result = $handler->listTemplates('*.twig', false);
-        $this->assertArrayHasKey('koala.twig', $result);
-        $this->assertArrayHasKey('clippy.twig', $result);
+        $result = $handler->listTemplates('*extra*', false);
+        $this->assertArrayHasKey('extrafields.twig', $result);
+        $this->assertArrayHasKey('anotherextrafields.twig', $result);
+        $this->assertContains('Koala', $result);
+        $this->assertContains('Clippy', $result);
 
         $this->assertArrayNotHasKey('entry.twig', $result);
-        $this->assertArrayNotHasKey('extrafields.twig', $result);
         $this->assertArrayNotHasKey('index.twig', $result);
         $this->assertArrayNotHasKey('listing.twig', $result);
         $this->assertArrayNotHasKey('record.twig', $result);


### PR DESCRIPTION
This makes it so that named templates are just named, everything else is the same as if you hadn't named any templates at all. Filtering works, it shows unnamed templates, and we don't need to burn anything down :wink: 

Fixes #5119, #4577 
Closes #5126