### PR TITLE
Improve Select Queries Across Joins

### DIFF
--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -215,11 +215,11 @@ class RelationType extends FieldTypeBase
         $platform = $query->getConnection()->getDatabasePlatform()->getName();
         switch ($platform) {
             case 'mysql':
-                return "GROUP_CONCAT(DISTINCT $column) as $alias";
+                return "GROUP_CONCAT($column) as $alias";
             case 'sqlite':
-                return "GROUP_CONCAT(DISTINCT $column) as $alias";
+                return "GROUP_CONCAT($column) as $alias";
             case 'postgresql':
-                return "string_agg(DISTINCT $column, ',') as $alias";
+                return "string_agg($column, ',') as $alias";
         }
     }
 }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -181,11 +181,11 @@ class TaxonomyType extends FieldTypeBase
 
         switch ($platform) {
             case 'mysql':
-                return "GROUP_CONCAT(DISTINCT $column ORDER BY $order ASC) as $alias";
+                return "GROUP_CONCAT($column ORDER BY $order ASC) as $alias";
             case 'sqlite':
-                return "GROUP_CONCAT(DISTINCT $column) as $alias";
+                return "GROUP_CONCAT($column) as $alias";
             case 'postgresql':
-                return "string_agg(DISTINCT $column, ',' ORDER BY $order) as $alias";
+                return "string_agg($column, ',' ORDER BY $order) as $alias";
         }
     }
 


### PR DESCRIPTION
This improves the queries across the relations and taxonomy queries. Originally they could be selected DISTINCT using the db engine but with the addition of extra fields this often gives unwanted behaviour.

So the DISTINCT call has been removed and the cleaning is all done in the `normalizeData()` method instead.

Fixes: #5084
