### PR TITLE
Fix contenttype listing blocks

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -31,7 +31,7 @@
     nextgroup:      new_group|default(false),
     unordered:      request('order') == '',
     first:          loop.first,
-    last:           loop.last|default(loop.first)
+    last:           loop.last
 }%}
 
 {% set local = {


### PR DESCRIPTION
This patch should have been in #5022. I guess the :dog: has eaten it.