### PR TITLE
Fix Upload Button for Templatefields

### DIFF
--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -127,7 +127,7 @@ class Edit
         $contentType['fields'] = $this->setCanUpload($contentType['fields']);
         $templateFields = $content->getTemplatefields();
         if ($templateFields instanceof TemplateFields && $templateFieldsData = $templateFields->getContenttype()->getFields()) {
-            $this->setCanUpload($templateFields->getContenttype());
+            $templateFields->getContenttype()['fields'] = $this->setCanUpload($templateFields->getContenttype()->getFields());
         }
 
         // Build context for Twig.


### PR DESCRIPTION
This reassigns the result of the `canUpload` check back to the fields array so that the check can be done on the field in the template.

Fixes: #5134 