### PR TITLE
Assets… Remove outdated v2 functionality

### DIFF
--- a/src/Asset/Snippet/Snippet.php
+++ b/src/Asset/Snippet/Snippet.php
@@ -20,8 +20,6 @@ class Snippet implements SnippetAssetInterface
     /** @var array */
     protected $callbackArguments;
     /** @var string */
-    protected $extension = 'core';
-    /** @var string */
     protected $zone = Zone::FRONTEND;
 
     /**
@@ -111,34 +109,6 @@ class Snippet implements SnippetAssetInterface
     /**
      * {@inheritdoc}
      */
-    public function getExtension()
-    {
-        return $this->extension;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setExtension($extensionName)
-    {
-        $this->extension = $extensionName;
-
-        return $this;
-    }
-
-    /**
-     * Check if the snippet is for core or an extension.
-     *
-     * @return boolean
-     */
-    public function isCore()
-    {
-        return $this->extension === 'core';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getZone()
     {
         return $this->zone;
@@ -163,37 +133,19 @@ class Snippet implements SnippetAssetInterface
      */
     private function getCallableResult()
     {
-        if ($this->extension === 'core' && is_callable($this->callback)) {
-            // Snippet is a callback in the 'global scope'
+        if (is_callable($this->callback)) {
             return call_user_func_array($this->callback, (array) $this->callbackArguments);
-        } elseif ($callable = $this->getCallable()) {
-            // Snippet is defined in the extension itself.
-            return call_user_func_array($callable, (array) $this->callbackArguments);
         } elseif (is_string($this->callback) || $this->callback instanceof \Twig_Markup) {
             // Insert the 'callback' as a string.
             return (string) $this->callback;
         }
 
         try {
-            $msg = sprintf('Snippet loading failed for %s with callable %s', $this->extension, serialize($this->callback));
+            $msg = sprintf('Snippet loading failed with callable %s', serialize($this->callback));
         } catch (\Exception $e) {
-            $msg = sprintf('Snippet loading failed for %s with an unknown callback.', $this->extension);
+            $msg = sprintf('Snippet loading failed with an unknown callback.');
         }
 
         throw new \RuntimeException($msg);
-    }
-
-    /**
-     * Check for a valid snippet callback.
-     *
-     * @return callable|null
-     */
-    private function getCallable()
-    {
-        if (is_callable($this->callback)) {
-            return $this->callback;
-        } elseif (is_callable([$this->extension, $this->callback])) {
-            return [$this->extension, $this->callback];
-        }
     }
 }

--- a/src/Asset/Snippet/SnippetAssetInterface.php
+++ b/src/Asset/Snippet/SnippetAssetInterface.php
@@ -57,20 +57,4 @@ interface SnippetAssetInterface extends AssetInterface
      * @return Snippet
      */
     public function setCallbackArguments($callbackArguments);
-
-    /**
-     * Get the extension name that this connects to.
-     *
-     * @return string
-     */
-    public function getExtension();
-
-    /**
-     * Set the extension name that this connects to.
-     *
-     * @param string $extensionName
-     *
-     * @return Snippet
-     */
-    public function setExtension($extensionName);
 }

--- a/tests/phpunit/unit/Extensions/AssetsProviderTest.php
+++ b/tests/phpunit/unit/Extensions/AssetsProviderTest.php
@@ -491,7 +491,6 @@ HTML;
         $snippet = (new Snippet())
             ->setLocation($location)
             ->setCallback($callback)
-            ->setExtension($extensionName)
             ->setCallbackArguments($callbackArguments)
         ;
 

--- a/tests/phpunit/unit/Extensions/Mock/BadExtensionSnippets.php
+++ b/tests/phpunit/unit/Extensions/Mock/BadExtensionSnippets.php
@@ -17,7 +17,6 @@ class BadExtensionSnippets extends Extension
         $snippet = (new Snippet())
             ->setLocation(Target::END_OF_HEAD)
             ->setCallback([$this, 'badSnippetCallBack'])
-            ->setExtension(__CLASS__)
         ;
         $app['asset.queue.snippet']->add($snippet);
     }

--- a/tests/phpunit/unit/Extensions/Mock/Extension.php
+++ b/tests/phpunit/unit/Extensions/Mock/Extension.php
@@ -18,7 +18,6 @@ class Extension extends BaseExtension
         $snippet = (new Snippet())
             ->setLocation(Target::END_OF_HEAD)
             ->setCallback([$this, 'snippetCallBack'])
-            ->setExtension(__CLASS__)
         ;
         $app['asset.queue.snippet']->add($snippet);
     }

--- a/tests/phpunit/unit/Extensions/Mock/SnippetCallbackExtension.php
+++ b/tests/phpunit/unit/Extensions/Mock/SnippetCallbackExtension.php
@@ -17,7 +17,6 @@ class SnippetCallbackExtension extends Extension
         $snippet = (new Snippet())
             ->setLocation(Target::START_OF_HEAD)
             ->setCallback([$this, 'snippetCallBack'])
-            ->setExtension(__CLASS__)
         ;
         $app['asset.queue.snippet']->add($snippet);
     }


### PR DESCRIPTION
This was only left in place for 2.3… now that we've ripped out the old extension classes this stuff is just wasted space.