### PR TITLE
Missing space after URL

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -309,7 +309,7 @@
 "Stack": "Stack"
 "Status": "Status"
 "Status:": "Status:"
-"System cURL library doesn't support TLS, or the Certificate Authority setup has not been completed (%ERROR%). See http://curl.haxx.se/docs/sslcerts.htmlfor more details. Downgrading to HTTP.": "System cURL library doesn't support TLS, or the Certificate Authority setup has not been completed (%ERROR%). See http://curl.haxx.se/docs/sslcerts.htmlfor more details. Downgrading to HTTP."
+"System cURL library doesn't support TLS, or the Certificate Authority setup has not been completed (%ERROR%). See http://curl.haxx.se/docs/sslcerts.html for more details. Downgrading to HTTP.": "System cURL library doesn't support TLS, or the Certificate Authority setup has not been completed (%ERROR%). See http://curl.haxx.se/docs/sslcerts.html for more details. Downgrading to HTTP."
 "Tag": "Tag"
 "Tags": "Tags"
 "Taxonomy": "Taxonomy"


### PR DESCRIPTION
Details
-------
 'release/2.2' for Bolt 2.2.19.

String near line 312 
"System cURL library doesn't support TLS, or the Certificate Authority setup has not been completed (...)
 is missing a space after the URL