### PR TITLE
Missing space after URL - PackageManager file

### DIFF
--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -613,7 +613,7 @@ class PackageManager
         $this->getFactory()->downgradeSsl = true;
 
         $this->messages[] = Trans::__(
-            "System cURL library doesn't support TLS, or the Certificate Authority setup has not been completed (%ERROR%). See http://curl.haxx.se/docs/sslcerts.htmlfor more details. Downgrading to HTTP.",
+            "System cURL library doesn't support TLS, or the Certificate Authority setup has not been completed (%ERROR%). See http://curl.haxx.se/docs/sslcerts.html for more details. Downgrading to HTTP.",
             array('%ERROR%' => trim($err)));
 
         return Response::HTTP_OK;


### PR DESCRIPTION
Details
-------
 - 'release/2.2' for Bolt 2.2.19.

Missing space after URL
See line 616 - Translation string already fixed (Related to PR https://github.com/bolt/bolt/pull/5157 )