### PR TITLE
Remove number from contenttypes.yml

### DIFF
--- a/app/config/contenttypes.yml.dist
+++ b/app/config/contenttypes.yml.dist
@@ -306,5 +306,3 @@ blocks:
 # select - varchar(256) - select with predefined values
 # templateselect - varchar(256) - select with template filenames
 # checkbox - integer - checkbox-field which is 1 (checked) or 0 (unchecked)
-
-# number (deprecated) - input type decimal(18,9), useful for storing number that need to be sortable


### PR DESCRIPTION
It's been deprecated since about 3 years back (I couldn't be bothered to blame all the way through the history, but #420 from May 18, 2013 references it as deprecated).