### PR TITLE
Remove nodes from contenttypes.yml

### DIFF
--- a/app/config/contenttypes.yml.dist
+++ b/app/config/contenttypes.yml.dist
@@ -230,63 +230,6 @@ blocks:
     icon_many: "fa:cubes"
     icon_one: "fa:cube"
 
-
-# Using YAML repeated nodes
-#
-# YAML allows the defining of "repeated nodes". These allow you to define a 'node'
-# with a 'key: &name' and referenced later with '<<: *name'
-#
-# Bolt allows you to define this with the special entry of '__nodes:' that itself
-# won't create a Contenttype, but will allow you to use it in actual contenttypes
-# to prevent repeating yourself.
-#
-# To achieve this, first create a key '__nodes:'
-#__nodes:
-#    field_defaults: &field_defaults
-#        title:
-#            type: text
-#            class: large
-#            group: main
-#        slug:
-#            type: slug
-#            uses: title
-#    template_defaults: &template_defaults
-#        template:
-#            type: templateselect
-#            filter: '*.twig'
-#            group: meta
-#
-# Then, as an example, you could create a Contenttype with default fields, with
-# an additional 'image' field.
-#
-#contenttype_abc:
-#    name: Contenttype Abc
-#    fields:
-#        <<: *field_defaults
-#        image:
-#            type: image
-#            attrib: title
-#            extensions: [ gif, jpg, png ]
-#        <<: *template_defaults
-#    taxonomy: [ chapters ]
-#    recordsperpage: 10
-#
-# Alternatively, or additionally, you then can then create a Contenttype with
-# default fields, and a 'select' field, and a different 'templateselect' option.
-#
-#contenttype_xyz:
-#    name: Contenttype Xyz
-#    fields:
-#        <<: *field_defaults
-#        selectfield:
-#            type: select
-#            values: [ none, foo, bar ]
-#        template:
-#            type: templateselect
-#            filter: '*_xyz.twig'
-#    taxonomy: [ tags ]
-#    recordsperpage: 20
-
 # Possible field types:
 #
 # text - varchar(256) - input type text.


### PR DESCRIPTION
Remove documention of YAML nodes from contenttypes.yml per #5164 and since it is documented here: https://docs.bolt.cm/release-2-2/contenttypes-and-records#advanced-yaml-repeated-nodes