### PR TITLE
Reset moved ckeditor instances in repeaters

### DIFF
--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -1,8 +1,9 @@
 /**
  * @param {Object} $    - Global jQuery object
  * @param {Object} bolt - The Bolt module
+ * @param {Object} cke  - CKEDITOR global or undefined
  */
-(function ($, bolt) {
+(function ($, bolt, cke) {
     'use strict';
 
     /**
@@ -108,6 +109,7 @@
 
                 setToMove.insertBefore(setToMove.prev('.repeater-group'));
                 self._renumber();
+                self._resetEditors(setToMove);
             });
 
             self.element.on('click', '.move-down', function () {
@@ -115,6 +117,7 @@
 
                 setToMove.insertAfter(setToMove.next('.repeater-group'));
                 self._renumber();
+                self._resetEditors(setToMove);
             });
 
             // Add initial groups until minimum number is reached.
@@ -206,6 +209,24 @@
         },
 
         /**
+         * Reset ckeditors within a given context.
+         *
+         * @private
+         * @function clone
+         * @memberof Bolt.fields.repeater
+         *
+         * @param {Object} container - jQuery context object
+         */
+        _resetEditors: function (container) {
+            var editors = container.find('.ckeditor');
+
+            editors.each(function (editor) {
+                cke.instances[editor.id].destroy();
+                cke.replace(editor.id);
+            });
+        },
+
+        /**
          * Adds a vlaue to the group counter and adjust button states according to it.
          *
          * @private
@@ -231,4 +252,4 @@
             }
         }
     });
-})(jQuery, Bolt);
+})(jQuery, Bolt, typeof CKEDITOR !== 'undefined' ? CKEDITOR : undefined);

--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -227,7 +227,7 @@
         },
 
         /**
-         * Adds a vlaue to the group counter and adjust button states according to it.
+         * Adds a value to the group counter and adjust button states according to it.
          *
          * @private
          * @function clone

--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -220,7 +220,7 @@
         _resetEditors: function (container) {
             var editors = container.find('.ckeditor');
 
-            editors.each(function (editor) {
+            editors.each(function (i, editor) {
                 cke.instances[editor.id].destroy();
                 cke.replace(editor.id);
             });


### PR DESCRIPTION
Reset moved ckeditor instances in repeaters.

Fixes: #5162 

Details
-------

CKEditor doesn't bode too well when moved, due to the way some events are bound in it.  Because of this, sorting a repeater would break any ckeditor moved within.  Simply destroying and re-adding the instance after a move keeps things working.
