### PR TITLE
Schema events on updating

### DIFF
--- a/src/Events/SchemaEvent.php
+++ b/src/Events/SchemaEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Bolt\Events;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Schema event.
+ *
+ * @internal
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class SchemaEvent extends Event
+{
+    /** @var array */
+    protected $creates;
+    /** @var array */
+    protected $alters;
+
+    /**
+     * Constructor.
+     *
+     * @param array $creates
+     * @param array $alters
+     */
+    public function __construct(array $creates, array $alters)
+    {
+        $this->creates = $creates;
+        $this->alters = $alters;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCreates()
+    {
+        return $this->creates;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAlters()
+    {
+        return $this->alters;
+    }
+}

--- a/src/Events/SchemaEvents.php
+++ b/src/Events/SchemaEvents.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bolt\Events;
+
+/**
+ * Schema event constants.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class SchemaEvents
+{
+    const UPDATE = 'schema.update';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Storage/Database/Schema/Manager.php
+++ b/src/Storage/Database/Schema/Manager.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Storage\Database\Schema;
 
+use Bolt\Events\SchemaEvent;
+use Bolt\Events\SchemaEvents;
 use Bolt\Storage\Database\Schema\Table\BaseTable;
 use Doctrine\DBAL\Schema\Schema;
 use Silex\Application;
@@ -149,6 +151,9 @@ class Manager
         $modifier = new TableModifier($this->connection, $this->app['logger.system'], $this->app['logger.flash']);
         $modifier->createTables($creates, $response);
         $modifier->alterTables($alters, $response);
+
+        $event = new SchemaEvent($creates, $alters);
+        $this->app['dispatcher']->dispatch(SchemaEvents::UPDATE, $event);
 
         // Recheck now that we've processed
         $fromTables = $this->getInstalledTables();


### PR DESCRIPTION
The concept/use-case here is that extensions might want to add data to tables after their own tables have been created. 

This would allow them to listen & react hen the update has been completed.