### PR TITLE
Fix for recursive join bug in repeaters

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -44,7 +44,7 @@ class RepeaterType extends FieldTypeBase
                 $alias,
                 $this->mapping['tables']['field_value'],
                 $dummy,
-                $dummy . ".content_id = $alias.id AND " . $dummy . ".contenttype='$boltname'"
+                $dummy . ".content_id = $alias.id AND " . $dummy . ".contenttype='$boltname' AND " . $dummy . ".name = '$field'"
             );
     }
 

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -81,7 +81,7 @@ class RepeaterType extends FieldTypeBase
     public function hydrate($data, $entity)
     {
         $key = $this->mapping['fieldname'];
-        $vals = array_filter(explode(',', $data['fields']));
+        $vals = array_filter(explode(',', $data[$key]));
         $values = [];
         foreach ($vals as $fieldKey) {
             $split = explode('_', $fieldKey);

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -39,7 +39,7 @@ class RepeaterType extends FieldTypeBase
 
         $dummy = 'f_' . $field;
 
-        $query->addSelect($this->getPlatformGroupConcat('fields', $query))
+        $query->addSelect($this->getPlatformGroupConcat($field, $query))
             ->leftJoin(
                 $alias,
                 $this->mapping['tables']['field_value'],


### PR DESCRIPTION
This fixes a nasty recursion bug in the repeating field query. Each select is now aliased and restricted to the name of the field.

Fixes: #5214 