### PR TITLE
Fix #5218 – Bad default values for list types

### DIFF
--- a/app/view/twig/editcontent/fields/_filelist.twig
+++ b/app/view/twig/editcontent/fields/_filelist.twig
@@ -21,11 +21,7 @@
     }
 } %}
 
-{% if context.content.get(contentkey) is defined %}
-    {% set list = context.content.get(contentkey) %}
-{% else %}
-    {% set list = [] %}
-{% endif %}
+{% set list = context.content.get(contentkey)|default([]) %}
 
 {% set can_upload = context.can.upload and option.can_upload %}
 

--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -21,11 +21,7 @@
     }
 } %}
 
-{% if context.content.get(contentkey) is defined %}
-    {% set list = context.content.get(contentkey) %}
-{% else %}
-    {% set list = [] %}
-{% endif %}
+{% set list = context.content.get(contentkey)|default([]) %}
 
 {#=== TEMPLATES ======================================================================================================#}
 


### PR DESCRIPTION
This is a little bit hacky. ``context.content.get(key)`` should always be set and and return a working default. At the moment it returns an empty string instead of an empty array. So the correct fix would be to change that on the part and remove those ``|default([])`` afterwards. But this should work meanwhile.

:bell: Ping @rossriley 

Fixes #5218