### PR TITLE
Don't throw a fatal exception on missing table

### DIFF
--- a/src/AccessControl/AccessChecker.php
+++ b/src/AccessControl/AccessChecker.php
@@ -155,7 +155,11 @@ class AccessChecker
 
         // Remove all auth tokens when logging off a user
         if ($sessionAuth = $this->session->get('authentication')) {
-            $this->repositoryAuthtoken->deleteTokens($sessionAuth->getUser()->getUsername());
+            try {
+                $this->repositoryAuthtoken->deleteTokens($sessionAuth->getUser()->getUsername());
+            } catch (TableNotFoundException $e) {
+                // Database tables have been dropped
+            }
         }
 
         $this->session->remove('authentication');


### PR DESCRIPTION
Corner case, but happens when you drop tables with cookies still set.