### PR TITLE
Fix for multiple select fields in repeater collection

### DIFF
--- a/src/Storage/Field/Collection/RepeatingFieldCollection.php
+++ b/src/Storage/Field/Collection/RepeatingFieldCollection.php
@@ -122,6 +122,7 @@ class RepeatingFieldCollection extends ArrayCollection
         foreach ($collection->flatten() as $entity) {
             $master = $this->getOriginal($entity);
             $master->setValue($entity->getValue());
+            $master->setFieldtype($entity->getFieldtype());
             $master->handleStorage($this->getFieldType($entity->getFieldname()));
 
             $updated[] = $master;

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -215,6 +215,11 @@ class MetadataDriver implements MappingDriver
             if ($data['type'] === 'repeater') {
                 foreach ($data['fields'] as $rkey => &$value) {
                     $value['fieldname'] = $rkey;
+
+                    if ($value['type'] === 'select' && isset($value['multiple']) && $value['multiple'] === true) {
+                        $value['type'] = 'selectmultiple';
+                    }
+
                     if (isset($this->typemap[$value['type']])) {
                         $value['fieldtype'] = $this->typemap[$value['type']];
                     } else {


### PR DESCRIPTION
This handles the metadata parsing for repeater fields so that fields with `multiple: true` are typed to the `selectmultiple` field type.

There's also a fix that allows moving between the two types on config change. 

Fixes: #5225