### PR TITLE
Fix error for repository findBy query

### DIFF
--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -113,7 +113,6 @@ class Repository implements ObjectRepository
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
         $qb = $this->findWithCriteria($criteria, $orderBy, $limit, $offset);
-        $qb->select('*');
 
         $result = $qb->execute()->fetchAll();
 


### PR DESCRIPTION
No need to overwrite the select parameters since this is handled by the `getLoadQuery` method.

This fixes an error where the ids of rows were being overwritten in some cases.