### PR TITLE
Handle exception when table is missing

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Connection as DoctrineConn;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Exception;
 use Silex\Application;
 use utilphp\util;
 
@@ -2720,9 +2721,12 @@ class Storage
             foreach ($contenttype['fields'] as $fieldkey => $field) {
                 if ($field['type'] == 'repeater') {
                     $collection = new RepeatingFieldCollection($this->app['storage'], $field);
-                    $existingFields = $repo->getExistingFields($id, $contenttypeslug, $fieldkey) ?: [];
-                    foreach ($existingFields as $group => $ids) {
-                        $collection->addFromReferences($ids, $group);
+                    try {
+                        $existingFields = $repo->getExistingFields($id, $contenttypeslug, $fieldkey) ?: [];
+                        foreach ($existingFields as $group => $ids) {
+                            $collection->addFromReferences($ids, $group);
+                        }
+                    } catch (Exception $e) {
                     }
                     $content[$id]->setValue($fieldkey, $collection);
                 }


### PR DESCRIPTION
This prevents the bug whereby users upgrading to 3.0 with an old db were getting a fatal error on the dashboard. If the table is missing now it will be silently caught and the normal 'Database needs to be repaired' error will show.

Fixes: #5199

