### PR TITLE
[BUG] Wrong sorting in ArrayHandler::orderHelper()

### DIFF
--- a/src/Twig/Handler/ArrayHandler.php
+++ b/src/Twig/Handler/ArrayHandler.php
@@ -110,8 +110,8 @@ class ArrayHandler
                 return 0;
             }
 
-            $aVal = (is_array($a) ? $a[$this->order_on] : $a->{$this->order_on});
-            $bVal = (is_array($b) ? $b[$this->order_on] : $b->{$this->order_on});
+            $aVal = (is_array($a) ? $a[$this->order_on] : $a->{$this->order_on_secondary});
+            $bVal = (is_array($b) ? $b[$this->order_on] : $b->{$this->order_on_secondary});
 
             if ($aVal < $bVal) {
                 return !$this->order_ascending_secondary;

--- a/src/Twig/Handler/ArrayHandler.php
+++ b/src/Twig/Handler/ArrayHandler.php
@@ -96,8 +96,8 @@ class ArrayHandler
      */
     private function orderHelper($a, $b)
     {
-        $aVal = (is_array($a) ? $a[$this->order_on] : $a->{$this->order_on});
-        $bVal = (is_array($b) ? $b[$this->order_on] : $b->{$this->order_on});
+        $aVal = is_array($a) ? $a[$this->order_on] : $a->{$this->order_on};
+        $bVal = is_array($b) ? $b[$this->order_on] : $b->{$this->order_on};
 
         // Check the primary sorting criterium.
         if ($aVal < $bVal) {
@@ -110,8 +110,8 @@ class ArrayHandler
                 return 0;
             }
 
-            $aVal = (is_array($a) ? $a[$this->order_on] : $a->{$this->order_on_secondary});
-            $bVal = (is_array($b) ? $b[$this->order_on] : $b->{$this->order_on_secondary});
+            $aVal = is_array($a) ? $a[$this->order_on_secondary] : $a->{$this->order_on_secondary};
+            $bVal = is_array($b) ? $b[$this->order_on_secondary] : $b->{$this->order_on_secondary};
 
             if ($aVal < $bVal) {
                 return !$this->order_ascending_secondary;

--- a/src/Twig/Handler/ArrayHandler.php
+++ b/src/Twig/Handler/ArrayHandler.php
@@ -96,8 +96,8 @@ class ArrayHandler
      */
     private function orderHelper($a, $b)
     {
-        $aVal = $a[$this->order_on];
-        $bVal = $b[$this->order_on];
+        $aVal = (is_array($a) ? $a[$this->order_on] : $a->{$this->order_on});
+        $bVal = (is_array($b) ? $b[$this->order_on] : $b->{$this->order_on});
 
         // Check the primary sorting criterium.
         if ($aVal < $bVal) {
@@ -110,8 +110,8 @@ class ArrayHandler
                 return 0;
             }
 
-            $aVal = $a[$this->order_on_secondary];
-            $bVal = $b[$this->order_on_secondary];
+            $aVal = (is_array($a) ? $a[$this->order_on] : $a->{$this->order_on});
+            $bVal = (is_array($b) ? $b[$this->order_on] : $b->{$this->order_on});
 
             if ($aVal < $bVal) {
                 return !$this->order_ascending_secondary;


### PR DESCRIPTION
Using twig's `order()` helper method producing wrong sort order in case when trying to sort an array of `Bolt\Content` objects. 
## Details

In `Bolt\Twig\Handler\ArrayHandler`

``` php
/**
     * Helper function for sorting an array of \Bolt\Content.
     *
     * @param \Bolt\Content|array $a
     * @param \Bolt\Content|array $b
     *
     * @return boolean
     */
    private function orderHelper($a, $b)
```

accepts both object and array but currently we are addressing just as arrays like below

``` php
$aVal = $a[$this->order_on];
```
