### PR TITLE
Fix case error in entity hydration

### DIFF
--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -159,7 +159,7 @@ class MetadataDriver implements MappingDriver
         $this->metadata[$className]['boltname'] = $contentKey;
         foreach ($table->getColumns() as $colName => $column) {
             $mapping = [
-                'fieldname'        => $colName,
+                'fieldname'        => $column->getName(),
                 'type'             => $column->getType()->getName(),
                 'fieldtype'        => $this->getFieldTypeFor($table->getOption('alias'), $column),
                 'length'           => $column->getLength(),


### PR DESCRIPTION
This takes care of the error where database hydration was happening in a case-insensitive manner meaning that only lowercase column names were correctly hydrated.

This defers to the original column name rather than the key generated by doctrine dbal.

Fixes: #5117 