### PR TITLE
Theme overrides (homepage and taxonomy_sort)

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -95,8 +95,9 @@ class Frontend extends ConfigurableBase
      */
     public function homepage(Request $request)
     {
-        $listingparameters = $this->getListingParameters($request, $this->getOption('general/homepage'));
-        $content = $this->getContent($this->getOption('general/homepage'), $listingparameters);
+        $homepage = $this->getOption('theme/homepage') ?: $this->getOption('general/homepage');
+        $listingparameters = $this->getListingParameters($request, $homepage);
+        $content = $this->getContent($homepage, $listingparameters);
 
         $template = $this->templateChooser()->homepage($content);
         $globals = [];

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1086,7 +1086,7 @@ class Storage
         // Sort on either 'ascending' or 'descending'
         // Make sure we set the order.
         $order = 'ASC';
-        $taxonomysort = strtoupper($this->app['config']->get('general/taxonomy_sort'));
+        $taxonomysort = strtoupper($this->app['config']->get('theme/taxonomy_sort') ?: $this->app['config']->get('general/taxonomy_sort'));
         if ($taxonomysort == 'DESC') {
             $order = 'DESC';
         }

--- a/src/Storage/Entity/ContentRouteTrait.php
+++ b/src/Storage/Entity/ContentRouteTrait.php
@@ -95,7 +95,7 @@ trait ContentRouteTrait
      */
     public function isHome()
     {
-        $homepage = $this->app['config']->get('general/homepage');
+        $homepage = $this->app['config']->get('theme/homepage') ?: $this->app['config']->get('general/homepage');
         $uriID = $this->contenttype['singular_slug'] . '/' . $this->get('id');
         $uriSlug = $this->contenttype['singular_slug'] . '/' . $this->get('slug');
 

--- a/theme/base-2016/theme.yml
+++ b/theme/base-2016/theme.yml
@@ -8,7 +8,8 @@ layout:
   main_width: 8 # out of 12
   variant: centered # wide or centered
 
-# Setting the header image. The default images in this theme all came from Visualhunt: https://visualhunt.com/
+# Setting the header image. The default images in this theme all came from
+# Visualhunt: https://visualhunt.com/
 headerimage:
  - 01.jpg
  - 02.jpg
@@ -28,8 +29,17 @@ listing_template: listing.twig
 search_results_template: search.twig
 notfound: notfound.twig
 
-# Extra 'templatefields' can be specified for use in the records / contenttypes that make use of a 
-# specific template. This allows editors to add additional fields to a certain page, but not to others.
+# Optional overrides. These override the ones in config.yml, but can be set in
+# either place.
+# taxonomy_sort: DESC
+# homepage: page/1
+# listing_sort: datepublish DESC
+# listing_records: 6
+# search_results_records: 10
+
+# Extra 'templatefields' can be specified for use in the records / contenttypes
+# that make use of a specific template. This allows editors to add additional
+# fields to a certain page, but not to others.
 templatefields:
     extrafields.twig:
         section_1:
@@ -50,8 +60,8 @@ templatefields:
         image:
             type: image
 
-# Templates can be named for display in the template selector, to allow editors to pick 
-# from easier to understand names.
+# Templates can be named for display in the template selector, to allow editors
+# to pick from easier to understand names.
 templateselect:
     templates:
          - name: 'Template with extra fields'


### PR DESCRIPTION
Allow theme to override homepage and taxonomy_sort and add examples to theme.yml for taxonomy_sort, homepage, listing_sort, listing_records and search_results_records. Also fix some wrapping in theme.yml.