### PR TITLE
Fix invalid translation (Finnish)

### DIFF
--- a/app/resources/translations/fi/messages.fi.yml
+++ b/app/resources/translations/fi/messages.fi.yml
@@ -505,7 +505,7 @@ contenttypes:
         publish: "Julkaise %contenttype%"
         recent: "Uudet %contenttypes%"
         recent-changes-one: "Viimeisimmät muutokset %contenttype%"
-        recently-edited: "Viimeksi muokatut %contenttype%"
+        recently-edited: "Viimeksi muokatut %contenttypes%"
         reserved-name: "Sisältötyypissä '%contenttype%' kenttä '%field%' on määrietty varatulla nimellä. Muokkaa contenttypes.yml korjataksesi tämän."
         save: "Tallenna %contenttype%"
         saved-changes: "Muokkaukset sisältötyyppiin on tallennettu."


### PR DESCRIPTION
Details
-------

- Updated from 2.2.19-pl1 to 2.2.20. The dashboard's main view looks like this, before and after the fix:

Before:
![chrome_2016-04-30_09-55-21](https://cloud.githubusercontent.com/assets/2226144/14934488/35902faa-0eba-11e6-8216-238c44f80b45.png)

After:
![chrome_2016-04-30_10-00-18](https://cloud.githubusercontent.com/assets/2226144/14934500/782886d2-0eba-11e6-95e5-72c73f5f053d.png)

---

I checked other languages/translations, and they all have `%contenttypes%` (so no need for fixing).