### PR TITLE
Trim <a>'s text content and remove redundant <strong>

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -76,12 +76,10 @@
                 <strong>
                     {% if modifiable %}
                         <a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id}) }}" title="Slug: {{ content.slug }}">
-                            {{ title }}
+                            {{ title -}}
                         </a>
                     {% else %}
-                        <strong>
-                            {{ title }}
-                        </strong>
+                        {{ title }}
                      {% endif %}
                 </strong>
                 {{ content.excerpt(excerptlength - title|length) }}


### PR DESCRIPTION
In the dashboard, the links have trailing whitespace and it looks ugly on hover. While at it, I also removed the redundant `<strong>` tags.

This had been bothering me way too much. :smile: 

Details
-------

- Bolt 2.2.20. Bolt 3 probably needs this fix as well (the code is almost the same), though I haven't installed it so I'm not sure.

Before:
![chrome_2016-04-30_10-10-45](https://cloud.githubusercontent.com/assets/2226144/14934588/9ed8e378-0ebd-11e6-95de-d4df5bc0674f.png)

After:
![chrome_2016-04-30_10-11-16](https://cloud.githubusercontent.com/assets/2226144/14934589/a3c248b6-0ebd-11e6-84c5-abfbd85dd44c.png)