### PR TITLE
Tweak exception classes thrown for access control

### DIFF
--- a/src/AccessControl/PermissionParser.php
+++ b/src/AccessControl/PermissionParser.php
@@ -141,7 +141,8 @@ class PermissionParser
      *
      * @param $what
      *
-     * @throws Exception Parser or lexer errors are thrown as
+     * @throws PermissionLexerException
+     * @throws PermissionParserException
      *
      * @return array A parse tree.
      */
@@ -155,7 +156,7 @@ class PermissionParser
      *
      * @param $query
      *
-     * @throws \Bolt\Exception\PermissionLexerException
+     * @throws PermissionLexerException
      *
      * @return array
      */

--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\AccessControl;
 
+use Bolt\Exception\AccessControlException;
 use Bolt\Legacy\Content;
 use Bolt\Storage\Entity;
 use Bolt\Translation\Translator as Trans;
@@ -145,7 +146,7 @@ class Permissions
      * @param array   $user    An array as returned by Users::getUser()
      * @param Content $content An optional Content object to check ownership
      *
-     * @throws \Exception
+     * @throws AccessControlException
      *
      * @return array An associative array of roles for the given user
      */
@@ -153,7 +154,7 @@ class Permissions
     {
         $userRoleNames = $user['roles'];
         if (!is_array($userRoleNames)) {
-            throw new \Exception('Expected a user-like array, but the "roles" property is not an array');
+            throw new AccessControlException('Expected a user-like array, but the "roles" property is not an array');
         }
         $userRoleNames[] = self::ROLE_EVERYONE;
         if ($content && $content['user'] && $content['user']['id'] === $user['id']) {
@@ -569,7 +570,7 @@ class Permissions
      * @param string               $contenttypeSlug
      * @param integer              $contentid
      *
-     * @throws \Exception
+     * @throws AccessControlException
      *
      * @return boolean
      */
@@ -599,7 +600,7 @@ class Permissions
 
                 return true;
             default:
-                throw new \Exception('Invalid permission check rule of type ' . $rule['type'] . ', expected P_SIMPLE, P_AND or P_OR');
+                throw new AccessControlException('Invalid permission check rule of type ' . $rule['type'] . ', expected P_SIMPLE, P_AND or P_OR');
         }
     }
 
@@ -720,7 +721,7 @@ class Permissions
      * @param string $fromStatus
      * @param string $toStatus
      *
-     * @throws \Exception
+     * @throws AccessControlException
      *
      * @return string|null The name of the required permission suffix (e.g.
      *                     'publish'), or NULL if no permission is required.
@@ -742,7 +743,7 @@ class Permissions
                 return 'publish';
 
             default:
-                throw new \Exception("Invalid content status transition: '$fromStatus' -> '$toStatus'");
+                throw new AccessControlException("Invalid content status transition: '$fromStatus' -> '$toStatus'");
         }
     }
 


### PR DESCRIPTION
Just to avoid BC lock-in for 3.x, and make trapping stuff easier