### PR TITLE
Change YAMLupdater regex to be non-greedy

### DIFF
--- a/src/Configuration/YamlUpdater.php
+++ b/src/Configuration/YamlUpdater.php
@@ -87,7 +87,7 @@ class YamlUpdater
         }
 
         $line = substr_count($this->file->read(), "\n", 0, $index);
-        $this->yaml[$line] = preg_replace('/^(.*):(.*)/', '$1: ' . $this->prepareValue($value), $this->yaml[$line]);
+        $this->yaml[$line] = preg_replace('/^(.*?):(.*)/', '$1: ' . $this->prepareValue($value), $this->yaml[$line]);
 
         return $this->save($makebackup);
     }


### PR DESCRIPTION
Change the YAMLupdater regex to be non-greedy. Example below:

If you have `canonical: 'https://example.com'` in a config the current regex matches `canonical: 'https` as the key as it is is greedy and will therefore create invalid YAML (that is not written to file, but instead exits nut with an error message).

The same issue seems to apply for `example: { test: test }` as it will there read `example: { test` as the key.