### PR TITLE
FieldValue json_array

### DIFF
--- a/src/Storage/ContentRequest/Save.php
+++ b/src/Storage/ContentRequest/Save.php
@@ -74,11 +74,13 @@ class Save
      * Do the save for a POSTed record.
      *
      * @param array   $formValues
-     * @param array   $contenttype  The contenttype data
-     * @param integer $id           The record ID
-     * @param boolean $new          If TRUE this is a new record
+     * @param array   $contenttype The contenttype data
+     * @param integer $id          The record ID
+     * @param boolean $new         If TRUE this is a new record
      * @param string  $returnTo
      * @param string  $editReferrer
+     *
+     * @throws AccessControlException
      *
      * @return Response
      */

--- a/src/Storage/Entity/FieldValue.php
+++ b/src/Storage/Entity/FieldValue.php
@@ -8,18 +8,38 @@ class FieldValue extends Entity
 {
     /** @var int */
     protected $id;
-    /** @var mixed */
-    protected $value;
+    /** @var string */
+    protected $contenttype;
+    /** @var int */
+    protected $content_id;
     /** @var string */
     protected $name;
+    /** @var int */
     protected $grouping;
     /** @var string */
     protected $fieldname;
     /** @var string */
     protected $fieldtype;
-    protected $contenttype;
-    /** @var int */
-    protected $content_id;
+
+    /** @var mixed */
+    protected $value;
+
+    /** @var string @internal Use $value instead */
+    protected $value_string;
+    /** @var string @internal Use $value instead */
+    protected $value_text;
+    /** @var integer @internal Use $value instead */
+    protected $value_integer;
+    /** @var double @internal Use $value instead */
+    protected $value_float;
+    /** @var integer @internal Use $value instead */
+    protected $value_decimal;
+    /** @var \DateTime @internal Use $value instead */
+    protected $value_date;
+    /** @var \DateTime @internal Use $value instead */
+    protected $value_datetime;
+    /** @var array @internal Use $value instead */
+    protected $value_json_array = [];
 
     /**
      * @return mixed

--- a/src/Storage/Repository/BaseLogRepository.php
+++ b/src/Storage/Repository/BaseLogRepository.php
@@ -53,7 +53,7 @@ abstract class BaseLogRepository extends Repository
         $qb = $this->createQueryBuilder();
         $query = $qb->getConnection()
             ->getDatabasePlatform()
-            ->getTruncateTableSql($this->getTableName());
+            ->getTruncateTableSQL($this->getTableName());
 
         return $qb->getConnection()->executeQuery($query)->execute();
     }

--- a/src/Storage/Repository/ContentRepository.php
+++ b/src/Storage/Repository/ContentRepository.php
@@ -7,6 +7,7 @@ use Bolt\Events\StorageEvents;
 use Bolt\Storage\ContentLegacyService;
 use Bolt\Storage\Mapping\ContentTypeTitleTrait;
 use Bolt\Storage\Repository;
+use Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * A Repository class that handles dynamically created content tables.

--- a/src/Storage/Repository/UsersRepository.php
+++ b/src/Storage/Repository/UsersRepository.php
@@ -68,6 +68,7 @@ class UsersRepository extends Repository
         }
 
         $query = $this->getUserQuery($userId);
+        /** @var Entity\Users $userEntity */
         if ($userEntity = $this->findOneWith($query)) {
             $this->unsetSensitiveFields($userEntity);
         }

--- a/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
+++ b/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
@@ -368,6 +368,29 @@ class BackendAdminCest extends AbstractAcceptanceTest
     }
 
     /**
+     * Check that admin user can create an empty showcase.
+     *
+     * @param \AcceptanceTester $I
+     */
+    public function canCreateEmptyShowcaseTest(\AcceptanceTester $I)
+    {
+        $I->wantTo('check that admin user can create an empty showcase');
+
+        // Set up the browser
+        $this->setLoginCookies($I);
+        $I->amOnPage('/bolt');
+
+        $I->see('New Showcase');
+        $I->click('New Showcase');
+
+        $I->fillField('#title',  'Showcase');
+
+        $I->click('Save Showcase', '#savecontinuebutton');
+
+        $I->see('The new Showcase has been saved.');
+    }
+
+    /**
      * Edit site permissions
      *
      * @param \AcceptanceTester $I


### PR DESCRIPTION
Fixes #5288

**Note to future self:** Some versions of MySQL can't handle defaults and some platforms won't handle allowing NULLs … so we're setting a default array on the `value_json_array` property.