### PR TITLE
[Feature] Automatic Translation Inclusion for Extensions

### DIFF
--- a/src/Extension/SimpleExtension.php
+++ b/src/Extension/SimpleExtension.php
@@ -34,7 +34,7 @@ abstract class SimpleExtension extends AbstractExtension implements ServiceProvi
         $this->extendMenuService();
         $this->extendAssetServices();
         $this->extendNutService();
-        $this->addTranslations();
+        $this->extendTranslatorService();
 
         $this->registerServices($app);
     }

--- a/src/Extension/SimpleExtension.php
+++ b/src/Extension/SimpleExtension.php
@@ -34,7 +34,7 @@ abstract class SimpleExtension extends AbstractExtension implements ServiceProvi
         $this->extendMenuService();
         $this->extendAssetServices();
         $this->extendNutService();
-        $this->extendTranslatorService();
+        $this->addTranslations();
 
         $this->registerServices($app);
     }

--- a/src/Extension/SimpleExtension.php
+++ b/src/Extension/SimpleExtension.php
@@ -22,6 +22,7 @@ abstract class SimpleExtension extends AbstractExtension implements ServiceProvi
     use MenuTrait;
     use NutTrait;
     use TwigTrait;
+    use TranslationTrait;
 
     /**
      * {@inheritdoc}
@@ -33,6 +34,7 @@ abstract class SimpleExtension extends AbstractExtension implements ServiceProvi
         $this->extendMenuService();
         $this->extendAssetServices();
         $this->extendNutService();
+        $this->addTranslations();
 
         $this->registerServices($app);
     }

--- a/src/Extension/TranslationTrait.php
+++ b/src/Extension/TranslationTrait.php
@@ -6,31 +6,64 @@ use Bolt\Filesystem\Handler\DirectoryInterface;
 use Pimple as Container;
 
 /**
- * Twig function/filter addition and interface functions for an extension.
+ * Automatic translation inclusion for an extension based upon three factors.
+ *  - All translations are in the translations dub-directory of the extension
+ *  - Translations are named as en.yml, en_GB.yml, or etc... based upon the locale
  *
- * @author Carson Full <carsonfull@gmail.com>
- * @author Gawain Lynch <gawain.lynch@gmail.com>
+ * @author Aaron Valandra <amvalandra@gmail.com>
  */
 trait TranslationTrait
 {
+
+    /** @var array $translations */
+    private $translations = [];
 
     /**
      * Call this in register method.
      *
      * @internal
      */
-    final protected function addTranslations()
+    final protected function extendTranslatorService()
+    {
+        $app = $this->getContainer();
+
+        $app['translator'] = $app->share(
+            $app->extend(
+                'translator',
+                function ($translator) {
+                    $this->loadTranslationsFromDefaultPath();
+
+                    if ($this->translations) {
+                        foreach ($this->translations as $translation) {
+                            $translator->addResource($translation[0], $translation[1], $translation[2]);
+                        }
+                    }
+
+                    return $translator;
+                }
+            )
+        );
+
+    }
+
+    /**
+     * Load translations from every extensions translations directory.
+     * Filenames must follow common naming conventions - en.yml, en_GB.yml, otherwise
+     *  function will need to be modified.
+     */
+    private function loadTranslationsFromDefaultPath()
     {
         $app = $this->getContainer();
 
         $translationDirectory = $this->getBaseDirectory()->getDir('translations');
         if ($translationDirectory->exists()) {
             foreach ($translationDirectory->getContents(true) as $fileInfo) {
-                $filename = explode('.', $fileInfo->getFilename());
                 if ($fileInfo->isFile()) {
-                    $translation = isset($filename[0]) ? $filename[0] : '';
+                    list($domain, $extension) = explode('.', $fileInfo->getFilename());
 
-                    $app['translator']->addResource('yml', $app['paths']['extensionspath'] . DIRECTORY_SEPARATOR . $fileInfo->getPath(), $translation);
+                    $path = $app['resources']->getPath('extensions' . DIRECTORY_SEPARATOR . $fileInfo->getPath());
+
+                    $this->translations[] = [$extension, $path, $domain];
                 }
             }
         }
@@ -39,9 +72,6 @@ trait TranslationTrait
 
     /** @return Container */
     abstract protected function getContainer();
-
-    /** @return string */
-    abstract public function getName();
 
     /** @return DirectoryInterface */
     abstract protected function getBaseDirectory();

--- a/src/Extension/TranslationTrait.php
+++ b/src/Extension/TranslationTrait.php
@@ -24,17 +24,12 @@ trait TranslationTrait
         $app = $this->getContainer();
 
         $translationDirectory = $this->getBaseDirectory()->getDir('translations');
-        if ($translationDirectory->exists())
-        {
+        if ($translationDirectory->exists()) {
             foreach ($translationDirectory->getContents(true) as $fileInfo) {
                 $filename = explode('.', $fileInfo->getFilename());
-                if ($fileInfo->isFile())
-                {
-                    if (isset($filename[0])) {
-                        $translation = $filename[0];
-                    } else {
-                        $translation = '';
-                    }
+                if ($fileInfo->isFile()) {
+                    $translation = isset($filename[0]) ? $filename[0] : '';
+
                     $app['translator']->addResource('yml', $app['paths']['extensionspath'] . DIRECTORY_SEPARATOR . $fileInfo->getPath(), $translation);
                 }
             }

--- a/src/Extension/TranslationTrait.php
+++ b/src/Extension/TranslationTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bolt\Extension;
+
+use Bolt\Filesystem\Handler\DirectoryInterface;
+use Pimple as Container;
+
+/**
+ * Twig function/filter addition and interface functions for an extension.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+trait TranslationTrait
+{
+
+    /**
+     * Call this in register method.
+     *
+     * @internal
+     */
+    final protected function addTranslations()
+    {
+        $app = $this->getContainer();
+
+        $translationDirectory = $this->getBaseDirectory()->getDir('translations');
+        if ($translationDirectory->exists())
+        {
+            foreach ($translationDirectory->getContents(true) as $fileInfo) {
+                $filename = explode('.', $fileInfo->getFilename());
+                if ($fileInfo->isFile())
+                {
+                    if (isset($filename[0])) {
+                        $translation = $filename[0];
+                    } else {
+                        $translation = '';
+                    }
+                    $app['translator']->addResource('yml', $app['paths']['extensionspath'] . DIRECTORY_SEPARATOR . $fileInfo->getPath(), $translation);
+                }
+            }
+        }
+
+    }
+
+    /** @return Container */
+    abstract protected function getContainer();
+
+    /** @return string */
+    abstract public function getName();
+
+    /** @return DirectoryInterface */
+    abstract protected function getBaseDirectory();
+}

--- a/src/Extension/TranslationTrait.php
+++ b/src/Extension/TranslationTrait.php
@@ -61,7 +61,8 @@ trait TranslationTrait
                 if ($fileInfo->isFile()) {
                     list($domain, $extension) = explode('.', $fileInfo->getFilename());
 
-                    $path = $app['resources']->getPath('extensions' . DIRECTORY_SEPARATOR . $fileInfo->getPath());
+                    $path = $app['filesystem']->getFileSystem('extensions')->getAdapter()->getPathPrefix();
+                    $path .= $fileInfo->getPath();
 
                     $this->translations[] = [$extension, $path, $domain];
                 }


### PR DESCRIPTION
At the current time translations are not automatically included by Bolt extensions. With this PR it allows for automatic inclusion of all translations included in the `translations` directory. They will need to follow standard filenames, otherwise it will default to ''. For example, the translations filename must be called `en.yml` or `sv.yml`,

Details
-------

- Bolt Version 3.1+
