### PR TITLE
Set list id to last id + 1 instead of list.length in file/imagelists

### DIFF
--- a/app/src/js/upload-files.js
+++ b/app/src/js/upload-files.js
@@ -101,11 +101,16 @@ var FilelistHolder = Backbone.View.extend({
     },
 
     add: function (filename, title) {
+        this.list.sort();
+        var nextid = 0;
+        if (this.list.models.length) {
+            nextid = this.list.models[this.list.models.length-1].get('id') + 1;
+        }
         this.list.add(
             new FileModel({
                 filename: filename,
                 title: title,
-                id: this.list.length
+                id: nextid
             })
         );
         this.render();


### PR DESCRIPTION
Bug recreation:

* Have a imagelist with two images. (they will have the id's 0,1)
* Remove the first image. (the remaining image still has the id 1)
* Add one image. (bolt will try to assign it the id 1 since the list length is 1)
* Bolt will silently fail to add the image since one with the id already exists.

The fix is to sort the list, get the last image and increment it's id by one.

This bug only seems to be in 2.2, not 3.0 and master