### PR TITLE
Fix contenttype slugs with underscores not loading correctly

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2326,15 +2326,12 @@ class Storage
         // See if we've either given the correct contenttype, or try to find it by name or singular_name.
         if (!$contenttype) {
             foreach ($this->app['config']->get('contenttypes') as $key => $ct) {
-                if (isset($ct['slug']) && ($contenttypeslug === $ct['slug'])) {
-                    $contenttype = $ct;
-                    break;
-                }
-                if (isset($ct['singular_slug']) && ($contenttypeslug === $ct['singular_slug'])) {
-                    $contenttype = $ct;
-                    break;
-                }
-                if ($contenttypeslug === $this->app['slugify']->slugify($ct['singular_name']) || $contenttypeslug == $this->app['slugify']->slugify($ct['name'])) {
+                if (
+                    (isset($ct['slug']) && ($contenttypeslug === $ct['slug'])) ||
+                    (isset($ct['singular_slug']) && ($contenttypeslug === $ct['singular_slug'])) ||
+                    $contenttypeslug === $this->app['slugify']->slugify($ct['name']) ||
+                    $contenttypeslug === $this->app['slugify']->slugify($ct['singular_name'])
+                ) {
                     $contenttype = $ct;
                     break;
                 }

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2314,8 +2314,6 @@ class Storage
      */
     public function getContentType($contenttypeslug)
     {
-        $contenttypeslug = $this->app['slugify']->slugify($contenttypeslug);
-
         // Return false if empty, can't find it.
         if (empty($contenttypeslug)) {
             return false;
@@ -2325,15 +2323,25 @@ class Storage
 
         // See if we've either given the correct contenttype, or try to find it by name or singular_name.
         if (!$contenttype) {
-            foreach ($this->app['config']->get('contenttypes') as $key => $ct) {
-                if (
-                    (isset($ct['slug']) && ($contenttypeslug === $ct['slug'])) ||
-                    (isset($ct['singular_slug']) && ($contenttypeslug === $ct['singular_slug'])) ||
-                    $contenttypeslug === $this->app['slugify']->slugify($ct['name']) ||
-                    $contenttypeslug === $this->app['slugify']->slugify($ct['singular_name'])
-                ) {
-                    $contenttype = $ct;
-                    break;
+            // Also check for the slugified version of the content type
+            $slugifiedContentType = $this->app['slugify']->slugify($contenttypeslug);
+            $contenttype = $this->app['config']->get('contenttypes/' . $slugifiedContentType);
+
+            if (!$contenttype) {
+                foreach ($this->app['config']->get('contenttypes') as $key => $ct) {
+                    if (
+                        (isset($ct['slug']) &&
+                            (($contenttypeslug === $ct['slug']) || ($slugifiedContentType === $ct['slug']))
+                        ) ||
+                        (isset($ct['singular_slug']) &&
+                            (($contenttypeslug === $ct['singular_slug']) || ($slugifiedContentType === $ct['singular_slug']))
+                        ) ||
+                        $slugifiedContentType === $this->app['slugify']->slugify($ct['name']) ||
+                        $slugifiedContentType === $this->app['slugify']->slugify($ct['singular_name'])
+                    ) {
+                        $contenttype = $ct;
+                        break;
+                    }
                 }
             }
         }

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2321,10 +2321,10 @@ class Storage
             return false;
         }
 
+        $contenttype = $this->app['config']->get('contenttypes/' . $contenttypeslug);
+
         // See if we've either given the correct contenttype, or try to find it by name or singular_name.
-        if ($this->app['config']->get('contenttypes/' . $contenttypeslug)) {
-            $contenttype = $this->app['config']->get('contenttypes/' . $contenttypeslug);
-        } else {
+        if (!$contenttype) {
             foreach ($this->app['config']->get('contenttypes') as $key => $ct) {
                 if (isset($ct['slug']) && ($contenttypeslug === $ct['slug'])) {
                     $contenttype = $ct;

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -245,8 +245,24 @@ class StorageTest extends BoltUnitTest
     {
     }
 
-    public function testGetContentType()
+    /**
+     * The legacy getContentType method should be able to find contenttypes by key, slugified key, slug, slugified slug,
+     * singular slug, slugified singular slug, singular name and name.
+
+     * @dataProvider contentTypeProvider
+     */
+    public function testGetContentType($contentType)
     {
+        /** @var \Bolt\Application */
+        $app = $this->getApp();
+
+        $app['config']->set('contenttypes/' . $contentType['key'], $contentType);
+
+        // We should be able to retrieve $contentType when querying getContentType() for its key, slug, singular
+        // slug, name and singular name
+        foreach ($contentType as $key => $value) {
+            $this->assertSame($contentType, $app['storage']->getContentType($value));
+        }
     }
 
     public function testGetTaxonomyType()
@@ -287,6 +303,33 @@ class StorageTest extends BoltUnitTest
 
     public function testGetPager()
     {
+    }
+
+    /**
+     * Seed some dummy content types for testing the contenttype query methods
+     */
+    public function contentTypeProvider()
+    {
+        return [
+            [
+                [
+                    'key'           => 'foo_bars',
+                    'slug'          => 'foo_bars',
+                    'singular_slug' => 'foo_bar',
+                    'name'          => 'FooBars',
+                    'singular_name' => 'Foo Bar'
+                ]
+            ],
+            [
+                [
+                    'key'           => 'somethingelse',
+                    'slug'          => 'things',
+                    'singular_slug' => 'thing',
+                    'name'          => 'Somethings',
+                    'singular_name' => 'Something'
+                ]
+            ]
+        ];
     }
 
     private function getDbMockBuilder(Connection $db)


### PR DESCRIPTION
This fixes `\Bolt\Legacy\Storage::getContentType` so that it works correctly with contenttype slugs containing underscores. `getContentType()` would always use Slugify to create a slug version of the queried `$contenttype` even if there was an exact match, causing some contenttypes to not load. I've also added a test covering this specific case.

Fixes: #5270