### PR TITLE
Extend Page Exceptions

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -1,4 +1,4 @@
-# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-05-09 07:28:38 Europe/Amsterdam
+# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-05-12 09:35:59 Europe/Amsterdam
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
 #          at the moment. This is an ongoing process. Translations currently in the 
@@ -12,7 +12,7 @@
 #   3 untranslated messages
 #   1 untranslated keyword based messages
 #  87 translations
-# 511 keyword based translations
+# 512 keyword based translations
 
 #--- 3 untranslated messages --------------------------------------------------
 
@@ -114,7 +114,7 @@
 "You've been logged on successfully.": "You've been logged on successfully."
 "filtered by <em>'%filter%'</em>": "filtered by <em>'%filter%'</em>"
 
-#--- 511 keyword based translations -------------------------------------------
+#--- 512 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Actions for %contenttypes%"
 contenttypes.generic.actions-one: "Actions for this %contenttype%"
@@ -592,6 +592,7 @@ page.extend.message.installing: "Preparing to install package …"
 page.extend.message.installing-selected-package: "Installing selected package version (this may take up to 60 seconds)."
 page.extend.message.installs-all-listed-packages: "This will make sure all packages listed are installed. Use this if you've recently moved to a new server or if you have manually added an extension."
 page.extend.message.installs-updates: "This will install all available updates."
+page.extend.message.invalid-theme-source-dir: "Invalid theme source directory: %SOURCE%"
 page.extend.message.latest-version: "The version listed below is the latest stable release as marked by the developer, which is compatible with the version of Bolt you are currently using."
 page.extend.message.loading-disabled: "Extensions loading has been disabled by an administrator in the %CONFIG% file. You may install, update and uninstall extensions but they will not load until this setting has been changed."
 page.extend.message.maintenance: "Maintenance"

--- a/src/Composer/Action/CheckPackage.php
+++ b/src/Composer/Action/CheckPackage.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Composer\Action;
 
+use Bolt\Exception\PackageManagerException;
 use Composer\Package\PackageInterface;
 
 /**
@@ -35,7 +36,15 @@ final class CheckPackage extends BaseAction
         if (!empty($jsonpack)) {
             foreach ($jsonpack as $packageName => $packageInfo) {
                 if (!array_key_exists($packageName, $rootPackage)) {
-                    $remote = $this->findBestVersionForPackage($packageName);
+                    try {
+                        $remote = $this->findBestVersionForPackage($packageName);
+                    } catch (\Exception $e) {
+                        $msg = sprintf('%s recieved an error from Composer: %s in %s::%s', __METHOD__, $e->getMessage(), $e->getFile(), $e->getLine());
+                        $this->app['logger.system']->critical($msg, ['event' => 'exception', 'exception' => $e]);
+
+                        throw new PackageManagerException($e->getMessage(), $e->getCode(), $e);
+                    }
+
 
                     // If a 'best' version is found, and there is a version mismatch then
                     // propose as an update. Making the assumption that Composer isn't
@@ -49,7 +58,14 @@ final class CheckPackage extends BaseAction
 
         // For installed packages, see if there is a valid update
         foreach ($rootPackage as $packageName => $data) {
-            $remote = $this->findBestVersionForPackage($packageName);
+            try {
+                $remote = $this->findBestVersionForPackage($packageName);
+            } catch (\Exception $e) {
+                $msg = sprintf('%s recieved an error from Composer: %s in %s::%s', __METHOD__, $e->getMessage(), $e->getFile(), $e->getLine());
+                $this->app['logger.system']->critical($msg, ['event' => 'exception', 'exception' => $e]);
+
+                throw new PackageManagerException($e->getMessage(), $e->getCode(), $e);
+            }
 
             /** @var PackageInterface $package */
             $package = $remote['package'];

--- a/src/Composer/Action/CheckPackage.php
+++ b/src/Composer/Action/CheckPackage.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Composer\Action;
 
+use Composer\Package\PackageInterface;
+
 /**
  * Checks for installable, or upgradeable packages.
  *
@@ -19,7 +21,7 @@ final class CheckPackage extends BaseAction
         $packages = ['updates' => [], 'installs' => []];
 
         // Get known installed packages
-        $rootpack = $this->app['extend.action']['show']->execute('installed');
+        $rootPackage = $this->app['extend.action']['show']->execute('installed');
 
         /** @var \Bolt\Filesystem\Handler\JsonFile $jsonFile */
         $jsonFile = $this->getOptions()->composerJson();
@@ -31,9 +33,9 @@ final class CheckPackage extends BaseAction
         // Find the packages that are NOT part of the root install yet and mark
         // them as pending installs
         if (!empty($jsonpack)) {
-            foreach ($jsonpack as $package => $packageInfo) {
-                if (!array_key_exists($package, $rootpack)) {
-                    $remote = $this->findBestVersionForPackage($package);
+            foreach ($jsonpack as $packageName => $packageInfo) {
+                if (!array_key_exists($packageName, $rootPackage)) {
+                    $remote = $this->findBestVersionForPackage($packageName);
 
                     // If a 'best' version is found, and there is a version mismatch then
                     // propose as an update. Making the assumption that Composer isn't
@@ -46,13 +48,16 @@ final class CheckPackage extends BaseAction
         }
 
         // For installed packages, see if there is a valid update
-        foreach ($rootpack as $package => $data) {
-            $remote = $this->findBestVersionForPackage($package);
+        foreach ($rootPackage as $packageName => $data) {
+            $remote = $this->findBestVersionForPackage($packageName);
+
+            /** @var PackageInterface $package */
+            $package = $remote['package'];
 
             // If a 'best' version is found, and there is a version mismatch then
             // propose as an update. Making the assumption that Composer isn't
             // going to offer us an older version.
-            if (is_array($remote) && ($remote['package']->getVersion() != $data['package']->getVersion())) {
+            if (is_array($remote) && ($package->getVersion() !== $package->getVersion())) {
                 $packages['updates'][] = $remote;
             }
         }


### PR DESCRIPTION
This should remove the Extend page dependency on Whoops being enabled, as well as preventing random useless garbage like:
![image](https://cloud.githubusercontent.com/assets/1427081/15207319/a44f0316-1825-11e6-92d1-507ca70710a3.png)
