### PR TITLE
Don't emit autoloader warnings from class_exists()

### DIFF
--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -232,8 +232,8 @@ class Manager
     private function addManagedExtension(PackageDescriptor $descriptor)
     {
         $className = $descriptor->getClass();
-        if (class_exists($className) === false) {
-            if ($descriptor->getType() === 'local' && class_exists('Wikimedia\Composer\MergePlugin') === false) {
+        if (@class_exists($className) === false) {
+            if ($descriptor->getType() === 'local' && @class_exists('Wikimedia\Composer\MergePlugin') === false) {
                 $this->flashLogger->error(Trans::__('general.phrase.error-local-extension-set-up-incomplete', ['%NAME%' => $descriptor->getName(), '%CLASS%' => $className]));
             } else {
                 $this->flashLogger->error(Trans::__("Extension package %NAME% has an invalid class '%CLASS%' and has been skipped.", ['%NAME%' => $descriptor->getName(), '%CLASS%' => $className]));


### PR DESCRIPTION
I know we all hate using the `@` silencer, but when removing an extension manually things get annoying and the warnings are note useful in this context… 'cause PHP.

```
PHP Warning:  include([snip]extensions/vendor/composer/../clippy/clippy/src/ClippyExtension.php): 
failed to open stream: No such file or directory in [snip]vendor/composer/ClassLoader.php on line 412
PHP Stack trace:
PHP   1. {main}() [snip]app/nut:0
PHP   2. require() [snip]app/nut:14
PHP   3. call_user_func:{[snip]app/bootstrap.php:131}() [snip]app/bootstrap.php:131
PHP   4. Bolt\{closure}() [snip]app/bootstrap.php:131
PHP   5. Bolt\Application->initialize() [snip]app/bootstrap.php:127
PHP   6. Bolt\Application->initExtensions() [snip]src/Application.php:116
PHP   7. Bolt\Extension\Manager->addManagedExtensions() [snip]src/Application.php:256
PHP   8. Bolt\Extension\Manager->addManagedExtension() [snip]src/Extension/Manager.php:170
PHP   9. class_exists() [snip]src/Extension/Manager.php:235
PHP  10. spl_autoload_call() [snip]src/Extension/Manager.php:235
PHP  11. Composer\Autoload\ClassLoader->loadClass() [snip]src/Extension/Manager.php:235
PHP  12. Composer\Autoload\includeFile() [snip]vendor/composer/ClassLoader.php:301
PHP Warning:  include(): Failed opening '[snip]extensions/vendor/composer/../gawain/clippy/src/ClippyExtension.php' 
for inclusion (include_path='[snip]vendor/phpunit/dbunit:[snip]vendor/symfony/yaml:.:/usr/share/pear:/usr/share/php') 
in [snip]vendor/composer/ClassLoader.php on line 412
PHP Stack trace:
PHP   1. {main}() [snip]app/nut:0
PHP   2. require() [snip]app/nut:14
PHP   3. call_user_func:{[snip]app/bootstrap.php:131}() [snip]app/bootstrap.php:131
PHP   4. Bolt\{closure}() [snip]app/bootstrap.php:131
PHP   5. Bolt\Application->initialize() [snip]app/bootstrap.php:127
PHP   6. Bolt\Application->initExtensions() [snip]src/Application.php:116
PHP   7. Bolt\Extension\Manager->addManagedExtensions() [snip]src/Application.php:256
PHP   8. Bolt\Extension\Manager->addManagedExtension() [snip]src/Extension/Manager.php:170
PHP   9. class_exists() [snip]src/Extension/Manager.php:235
PHP  10. spl_autoload_call() [snip]src/Extension/Manager.php:235
PHP  11. Composer\Autoload\ClassLoader->loadClass() [snip]src/Extension/Manager.php:235
PHP  12. Composer\Autoload\includeFile() [snip]vendor/composer/ClassLoader.php:301
```