### PR TITLE
Before removing existing taxonomies, check the slugified value too.

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -2514,6 +2514,7 @@ class Storage
                 $slugkey = '/' . $configTaxonomies[$taxonomytype]['slug'] . '/' . $slug;
 
                 if (!in_array($slug, $newSlugsNormalised)
+                    && !in_array($this->app['slugify']->slugify($slug), $newSlugsNormalised)
                     && !in_array($valuewithorder, $newSlugsNormalised)
                     && !array_key_exists($slugkey, $newSlugsNormalised)) {
                     $this->app['db']->delete($tablename, array('id' => $id));


### PR DESCRIPTION
Fixes #5283

Due to inconsistent use of `-` vs `_` in taxonomies, the values weren’t checked correctly before deleting. 

This fix isn’t pretty, but it should fix the problem for Bolt 2.2. 

I’ll check to see if this is also a problem in Bolt 3. 