### PR TITLE
Fix to working Bolt with PostgreSQL database.

### DIFF
--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -87,10 +87,37 @@ class Repository implements ObjectRepository
     public function find($id)
     {
         $qb = $this->getLoadQuery();
-        $result = $qb->where($this->getAlias() . '.id = :id')
-            ->setParameter('id', $id)
-            ->execute()
-            ->fetch();
+        
+        // Hard fix to working Bolt with PostgreSQL database.
+        // Function string_agg required string values to use, but table `bolt_relations`
+        // contains integer fields for identifiers. Therefore database generate error.
+        // This fix is not some beauty and needs to ideas.
+        try {
+            $result = $qb->where($this->getAlias() . '.id = :id')
+                ->setParameter('id', $id)
+                ->execute()
+                ->fetch();
+        } catch (DriverException $e) {
+            if ($e->getCode() === 0 && $e->getErrorCode() === 7 && (int) $e->getSQLState() === 42883) {
+                $qb->where($this->getAlias() . '.id = :id')
+                    ->setParameter('id', $id);
+                
+                $replace = [
+                    'string_agg(incomingrelation.id, \',\') as _incomingrelation_id' => 'string_agg(incomingrelation.id::character varying, \',\') as _incomingrelation_id',
+                    'string_agg(incomingrelation.from_id, \',\') as _incomingrelation_fromid' => 'string_agg(incomingrelation.from_id::character varying, \',\') as _incomingrelation_fromid',
+                ];
+                
+                $sql = str_replace(array_keys($replace), array_values($replace),$qb->getSQL());
+                
+                $stmt = $this->em->getConnection()->prepare($sql);
+                $stmt->bindParam('id', $id);
+                $stmt->execute();
+                
+                $result = $stmt->fetch();
+            } else {
+                throw $e;
+            }
+        }
 
         if ($result) {
             return $this->hydrate($result, $qb);

--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -11,6 +11,7 @@ use Bolt\Storage\Mapping\ClassMetadata;
 use Bolt\Storage\Query\QueryInterface;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Query\QueryBuilder;
 
 /**

--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -107,7 +107,7 @@ class Repository implements ObjectRepository
                     'string_agg(incomingrelation.from_id, \',\') as _incomingrelation_fromid' => 'string_agg(incomingrelation.from_id::character varying, \',\') as _incomingrelation_fromid',
                 ];
                 
-                $sql = str_replace(array_keys($replace), array_values($replace),$qb->getSQL());
+                $sql = str_replace(array_keys($replace), array_values($replace), $qb->getSQL());
                 
                 $stmt = $this->em->getConnection()->prepare($sql);
                 $stmt->bindParam('id', $id);


### PR DESCRIPTION
By default, Bolt don't works correctly with `bolt_relations` table when uses PostgreSQL provider.