### PR TITLE
Allow extra plugin for Ckeditor

### DIFF
--- a/app/src/js/modules/ckeditor.js
+++ b/app/src/js/modules/ckeditor.js
@@ -70,7 +70,7 @@
             config.resize_enabled = true;
             config.entities = false;
             config.fillEmptyBlocks = false;
-            config.extraPlugins = 'codemirror';
+            config.extraPlugins += (config.extraPlugins?',':'')+'codemirror'; // Allow to add extra plugin from default CKEDITOR.config.
 
             config.toolbar = list(
                 [                 { name: 'styles',      items: list( [                 'Format'        ],


### PR DESCRIPTION
For now, the `config.extraPlugin` of Ckeditor is set during the `initcke` without taking the default value.
The PR just check if there is a value in `config.extraPlugin` and if it does, it will not be ignore.

This allow you to set the default global `CKEDITOR.config.extraPlugin` without loosing it. (for example to add table advanced plugin).

If necessary, I can PR for 3.0 too.