### PR TITLE
fix postgres string aggregation to force cast

### DIFF
--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -219,7 +219,7 @@ class RelationType extends FieldTypeBase
             case 'sqlite':
                 return "GROUP_CONCAT($column) as $alias";
             case 'postgresql':
-                return "string_agg($column, ',') as $alias";
+                return "string_agg($column"."::character varying, ',') as $alias";
         }
     }
 }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -185,7 +185,7 @@ class TaxonomyType extends FieldTypeBase
             case 'sqlite':
                 return "GROUP_CONCAT($column) as $alias";
             case 'postgresql':
-                return "string_agg($column, ',' ORDER BY $order) as $alias";
+                return "string_agg($column"."::character varying, ',' ORDER BY $order) as $alias";
         }
     }
 


### PR DESCRIPTION
Takes care of force casting id fields to strings so they can be concatenated in Postgres.

Fixes: #5335 
Closes: #5344 