### PR TITLE
First clean, then parse {{ twig }} snippets.

### DIFF
--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -148,10 +148,8 @@ class Content implements \ArrayAccess
 
             switch ($fieldtype) {
                 case 'markdown':
-                    $value = $this->preParse($this->values[$name], $allowtwig);
-
                     // Parse the field as Markdown, return HTML
-                    $value = $this->app['markdown']->text($value);
+                    $value = $this->app['markdown']->text($this->values[$name]);
 
                     $config = $this->app['config']->get('general/htmlcleaner');
                     $allowed_tags = !empty($config['allowed_tags']) ? $config['allowed_tags'] :
@@ -168,6 +166,10 @@ class Content implements \ArrayAccess
                         ]
                     );
                     $value = $maid->clean($value);
+
+                    // If we allow Twig in content, we parse the field as a Twig template.
+                    $value = $this->preParse($value, $allowtwig);
+
                     $value = new \Twig_Markup($value, 'UTF-8');
                     break;
 


### PR DESCRIPTION
Fixes #5271.

Note, this is related to #5339. If we change that, We’ll need to update this accordingly. 

Also, this change will shift responsibilities: Before, the cleaner cleaned _after_ snippets were applied, breaking extensions. This fix changes the order, so that cruft passed in by extensions will de passed on into the rendered page. I don’t think this is a problem, but it needs to be considered. 