### PR TITLE
Handle json_array for Sqlite separately

### DIFF
--- a/src/Storage/Database/Schema/Table/ContentType.php
+++ b/src/Storage/Database/Schema/Table/ContentType.php
@@ -57,8 +57,10 @@ class ContentType extends BaseTable
         $this->table->addColumn('username',       'string',     ['length' => 32, 'default' => '', 'notnull' => false]); // We need to keep this around for backward compatibility. For now.
         $this->table->addColumn('ownerid',        'integer',    ['notnull' => false]);
         $this->table->addColumn('status',         'string',     ['length' => 32]);
-        $this->table->addColumn('templatefields', 'json_array', []);
         // @codingStandardsIgnoreEnd
+
+        // Add template fields
+        $this->columnJson('templatefields');
     }
 
     /**
@@ -181,7 +183,11 @@ class ContentType extends BaseTable
      */
     private function columnJson($fieldName)
     {
-        $this->table->addColumn($fieldName, 'json_array', []);
+        if ($this->platform->getName() === 'sqlite') {
+            $this->table->addColumn($fieldName, 'json_array', ['default' => '[]']);
+        } else {
+            $this->table->addColumn($fieldName, 'json_array', []);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #5251

OK… Not really a fan of this approach, but DBAL currently `\Doctrine\DBAL\Platforms\SqlitePlatform` still uses `\Doctrine\DBAL\Platforms\AbstractPlatform::getJsonTypeDeclarationSQL` which just returns `CLOB`… 

@SahAssar & @rossriley if you could sanity check on available platforms. Adding any array field type to an **existing** table (with records) will trigger the problem.