### PR TITLE
Lock paragonie/random_compat at 1.x, to keep it from breaking shit.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "ircmaxell/random-lib" : "~1.1",
         "monolog/monolog" : "~1.12",
         "nesbot/carbon" : "^1.20",
+        "paragonie/random_compat": "^1.4",
         "PasswordLib/PasswordLib": "^1.0@beta",
         "php" : ">=5.5.9",
         "silex/silex" : "^1.3",


### PR DESCRIPTION
Fixes #5361 🍻