### PR TITLE
Update _taxonomies.twig, correctly add fields with `group: taxonomy` in contenttypes break.

### DIFF
--- a/app/view/twig/editcontent/_taxonomies.twig
+++ b/app/view/twig/editcontent/_taxonomies.twig
@@ -40,5 +40,5 @@
 {% endfor %}
 
 {% if context.has.tabs and 'taxonomy' in context.contenttype.groups %}
-    {{ include('@bolt/editcontent/_fields.twig') }}
+    {{ include('@bolt/editcontent/_field.twig') }}
 {% endif %}


### PR DESCRIPTION
Fixes: #5368