### PR TITLE
Setting 'provided_link', allowing for more flexibility in "branding"

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -228,15 +228,14 @@ accept_file_types: [ twig, html, js, css, scss, gif, jpg, jpeg, png, ico, zip, t
 
 # If you want to 'brand' the Bolt backend for a client, you can change some key
 # variables here, that determine the name of the backend, and adds a primary
-# support/contact link to the footer.
+# support/contact link to the footer.  Add a scheme, like `mailto:` or
+# `https://` to the email or URL.
 #
-# Additionally you can change the mount
-# point for the backend, either for convenience or to obscure it from prying
-# eyes.
+# Additionally you can change the mount point for the backend, either for
+# convenience or to obscure it from prying eyes.
 #
-# The Bolt backend is accessible as /bolt/ by default, if you change it here,
+# The Bolt backend is accessible as `/bolt/` by default. If you change it here,
 # it will only be accessible through the value set in 'path'.
-#
 # Keep the path simple: lowercase only, no extra slashes or other special
 # characters.
 # branding:
@@ -367,7 +366,7 @@ hash_strength: 10
 
 # Bolt sets the `X-Frame-Options` and `Frame-Options` to `SAMEORIGIN` by
 # default, to prevent the web browser from rendering an iframe if origin
-# mismatch (i.e. iframe source refers to a different domain). 
+# mismatch (i.e. iframe source refers to a different domain).
 #
 # Setting this to 'false', will prevent the setting of these headers.
 # headers:

--- a/app/view/twig/_nav/_footer.twig
+++ b/app/view/twig/_nav/_footer.twig
@@ -1,10 +1,8 @@
-{% if app.config.get('general/branding/provided_by/0') is not empty %}
+{% if app.config.get('general/branding/provided_link') is not empty %}
 
     <footer id="bolt-footer" class="hidden-xs {% if app.request.cookies.get('sidebar') %}bolt-footer-hidden{% endif %}">
         {{ __('general.phrase.provided-by-colon') }}
-        <a href="mailto:{{ app.config.get('general/branding/provided_by/0') }}">
-            {{ app.config.get('general/branding/provided_by/1') }}
-        </a> &ndash;
+        {{ app.config.get('general/branding/provided_link')|raw }} &ndash;
         <i class="fa fa-cog"></i> <b>Bolt {{ bolt_version }}</b>:
         <i class="fa fa-heart"></i > <a href="{{ path('about') }}">{{ __('general.about') }}</a> &ndash;
         <i class="fa fa-external-link-square"></i> <a href="http://bolt.cm" target="_blank">Bolt.cm</a>

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,6 +6,7 @@ use Bolt;
 use Bolt\Controller\Zone;
 use Bolt\Exception\LowlevelException;
 use Bolt\Helpers\Arr;
+use Bolt\Helpers\Html;
 use Bolt\Helpers\Str;
 use Bolt\Translation\Translator;
 use Bolt\Translation\Translator as Trans;
@@ -351,6 +352,11 @@ class Config
 
         // Make sure Bolt's mount point is OK:
         $general['branding']['path'] = '/' . Str::makeSafe($general['branding']['path']);
+
+        // Set the link in branding, if provided_by is set.
+        $general['branding']['provided_link'] = Html::providerLink(
+                $general['branding']['provided_by']
+        );
 
         $general['database'] = $this->parseDatabase($general['database']);
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -355,7 +355,7 @@ class Config
 
         // Set the link in branding, if provided_by is set.
         $general['branding']['provided_link'] = Html::providerLink(
-                $general['branding']['provided_by']
+            $general['branding']['provided_by']
         );
 
         $general['database'] = $this->parseDatabase($general['database']);

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -96,7 +96,7 @@ class Html
     {
         // If nothing is provided, we don't make a link.
         if (empty($providedby) || !is_array($providedby)) {
-            return "";
+            return '';
         }
 
         // If we forgot the second element in the array, substitute the first for it.

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -100,7 +100,7 @@ class Html
         }
 
         // If we forgot the second element in the array, substitute the first for it.
-        if (empty($providedby[1])) {
+        if (empty(strip_tags($providedby[1]))) {
             $providedby[1] = $providedby[0];
         }
 
@@ -121,7 +121,7 @@ class Html
         }
 
         // Add the label and closing tag.
-        $link .= $providedby[1] . '</a>';
+        $link .= strip_tags($providedby[1]) . '</a>';
 
         return $link;
     }

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -83,4 +83,38 @@ class Html
 
         return $url;
     }
+
+    /**
+     * Create 'provider' link, as used in the footer, to link to either an
+     * email address or website URL.
+     *
+     * @param array $providedby
+     *
+     * @return string
+     */
+    public static function providerLink($providedby)
+    {
+        // If nothing is provided, we don't make a link.
+        if (empty($providedby)) {
+            return "";
+        }
+
+        $scheme = parse_url($providedby[0], PHP_URL_SCHEME);
+
+        if ($scheme === 'http' || $scheme === 'https') {
+            // Link is OK, just add a target
+            $link = sprintf('<a href="%s" target="_blank">', $providedby[0]);
+        } elseif ($scheme === 'mailto') {
+            // Already a `mailto:` include.
+            $link = sprintf('<a href="%s">', $providedby[0]);
+        } else {
+            // Fall back to old behaviour, assume an e-mail address
+            $link = sprintf('<a href="mailto:%s">', $providedby[0]);
+        }
+
+        // Add the label and closing tag.
+        $link .= $providedby[1] . '</a>';
+
+        return $link;
+    }
 }

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -95,8 +95,13 @@ class Html
     public static function providerLink($providedby)
     {
         // If nothing is provided, we don't make a link.
-        if (empty($providedby)) {
+        if (empty($providedby) || !is_array($providedby)) {
             return "";
+        }
+
+        // If we forgot the second element in the array, substitute the first for it.
+        if (empty($providedby[1])) {
+            $providedby[1] = $providedby[0];
         }
 
         $scheme = parse_url($providedby[0], PHP_URL_SCHEME);
@@ -107,6 +112,9 @@ class Html
         } elseif ($scheme === 'mailto') {
             // Already a `mailto:` include.
             $link = sprintf('<a href="%s">', $providedby[0]);
+        } elseif (self::isURL($providedby[0])) {
+            // An URL, without a scheme
+            $link = sprintf('<a href="http://%s" target="_blank">', $providedby[0]);
         } else {
             // Fall back to old behaviour, assume an e-mail address
             $link = sprintf('<a href="mailto:%s">', $providedby[0]);

--- a/src/Profiler/BoltDataCollector.php
+++ b/src/Profiler/BoltDataCollector.php
@@ -46,10 +46,9 @@ class BoltDataCollector extends DataCollector
 
         if ($this->app['config']->get('general/branding/provided_by/0')) {
             $this->data['branding'] = sprintf(
-                '%s <a href="mailto:%s">%s</a>',
+                '%s %s',
                 Trans::__('general.phrase.provided-by-colon'),
-                $this->app['config']->get('general/branding/provided_by/0'),
-                $this->app['config']->get('general/branding/provided_by/1')
+                $this->app['config']->get('general/branding/provided_link')
             );
         }
 

--- a/tests/phpunit/unit/Helper/HtmlTest.php
+++ b/tests/phpunit/unit/Helper/HtmlTest.php
@@ -104,7 +104,14 @@ class HtmlTest extends BoltUnitTest
             '<a href="http://example.org" target="_blank">http://example.org</a>',
             Html::providerLink(['http://example.org'])
         );
-
+        $this->assertEquals(
+            '<a href="http://example.org" target="_blank">no html, please!</a>',
+            Html::providerLink(['http://example.org', '<blink>no html, please!</blink>'])
+        );
+        $this->assertEquals(
+            '<a href="http://example.org" target="_blank">http://example.org</a>',
+            Html::providerLink(['http://example.org', '<b malformed HTML'])
+        );
     }
 
 }

--- a/tests/phpunit/unit/Helper/HtmlTest.php
+++ b/tests/phpunit/unit/Helper/HtmlTest.php
@@ -65,4 +65,46 @@ class HtmlTest extends BoltUnitTest
         $this->assertEquals('https://example.org', Html::addScheme('https://example.org'));
         $this->assertEquals('mailto:bob@bolt.cm', Html::addScheme('mailto:bob@bolt.cm'));
     }
+
+    public function testProviderLink()
+    {
+        $this->assertEquals(
+            '',
+            Html::providerLink([])
+        );
+        $this->assertEquals(
+            '',
+            Html::providerLink(false)
+        );
+        $this->assertEquals(
+            '',
+            Html::providerLink("foo")
+        );
+        $this->assertEquals(
+            '<a href="mailto:supercool@example.org">Supercool Webdesign Co.</a>',
+            Html::providerLink(['supercool@example.org', 'Supercool Webdesign Co.'])
+        );
+        $this->assertEquals(
+            '<a href="mailto:supercool@example.org">Supercool Webdesign Co.</a>',
+            Html::providerLink(['mailto:supercool@example.org', 'Supercool Webdesign Co.'])
+        );
+        $this->assertEquals(
+            '<a href="http://example.org" target="_blank">Supercool Webdesign Co.</a>',
+            Html::providerLink(['example.org', 'Supercool Webdesign Co.'])
+        );
+        $this->assertEquals(
+            '<a href="http://example.org" target="_blank">Supercool Webdesign Co.</a>',
+            Html::providerLink(['http://example.org', 'Supercool Webdesign Co.'])
+        );
+        $this->assertEquals(
+            '<a href="https://www.example.org" target="_blank">Supercool Webdesign Co.</a>',
+            Html::providerLink(['https://www.example.org', 'Supercool Webdesign Co.'])
+        );
+        $this->assertEquals(
+            '<a href="http://example.org" target="_blank">http://example.org</a>',
+            Html::providerLink(['http://example.org'])
+        );
+
+    }
+
 }

--- a/tests/phpunit/unit/Profiler/BoltDataCollectorTest.php
+++ b/tests/phpunit/unit/Profiler/BoltDataCollectorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Tests\Profiler;
 
+use Bolt\Helpers\Html;
 use Bolt\Profiler\BoltDataCollector;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,11 +43,13 @@ class BoltDataCollectorTest extends BoltUnitTest
         $app = $this->getApp();
         $app['config']->set('general/branding/provided_by/0', 'testperson');
         $app['config']->set('general/branding/provided_by/1', 'testemail');
+        $app['config']->set('general/branding/provided_link', Html::providerLink(['testperson', 'testemail']));
         $request = Request::create('/', 'GET');
         $response = $app->handle($request);
 
         $data = new BoltDataCollector($app);
         $data->collect($request, $response);
+
         $this->assertRegExp('/testperson/', $data->getBranding());
         $this->assertRegExp('/testemail/', $data->getBranding());
     }


### PR DESCRIPTION
~~WIP: Don't merge yet, needs some tests for the new bit of code.~~ 

Allow for using URLs as well as email addresses in the `branding` part of `config.yml`. Fixes #5343 