### PR TITLE
Cast to string in thumbnail handling, prevent "substr() expects parameter 1 to be string"

### DIFF
--- a/src/Helpers/Image/Thumbnail.php
+++ b/src/Helpers/Image/Thumbnail.php
@@ -212,7 +212,7 @@ class Thumbnail
     public function setScale($scale)
     {
         $valid = ['b', 'c', 'f', 'r'];
-        $scale = substr($scale, 0, 1);
+        $scale = substr((string) $scale, 0, 1);
         $scale = in_array($scale, $valid)
             ? $scale
             : (!empty($this->thumbConf['cropping']) ? substr($this->thumbConf['cropping'], 0, 1) : 'c');


### PR DESCRIPTION
Fixes #5329