### PR TITLE
Refinements for content fetching 

### DIFF
--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -6,6 +6,7 @@ use Bolt\Storage\EntityManager;
 use Bolt\Storage\Query\Handler\FirstQueryHandler;
 use Bolt\Storage\Query\Handler\GetQueryHandler;
 use Bolt\Storage\Query\Handler\HydrateHandler;
+use Bolt\Storage\Query\Handler\IdentifiedSelectHandler;
 use Bolt\Storage\Query\Handler\LatestQueryHandler;
 use Bolt\Storage\Query\Handler\LimitHandler;
 use Bolt\Storage\Query\Handler\NativeSearchHandler;
@@ -29,7 +30,7 @@ class ContentQueryParser
 
     protected $query;
 
-    protected $params;
+    protected $params = [];
 
     protected $contentTypes = [];
 
@@ -75,6 +76,7 @@ class ContentQueryParser
         $this->addHandler('first', new FirstQueryHandler());
         $this->addHandler('latest', new LatestQueryHandler());
         $this->addHandler('nativesearch', new NativeSearchHandler());
+        $this->addHandler('namedselect', new IdentifiedSelectHandler());
 
         $this->addDirectiveHandler('getquery', new GetQueryHandler());
         $this->addDirectiveHandler('hydrate', new HydrateHandler());
@@ -171,6 +173,10 @@ class ContentQueryParser
             $this->identifier = implode(',', $queryParts);
         } else {
             $this->identifier = implode(',', $queryParts);
+        }
+
+        if (!empty($this->identifier)) {
+            $operation = 'namedselect';
         }
 
         $this->operation = $operation;

--- a/src/Storage/Query/Handler/IdentifiedSelectHandler.php
+++ b/src/Storage/Query/Handler/IdentifiedSelectHandler.php
@@ -22,7 +22,7 @@ class IdentifiedSelectHandler
         } else {
             $contentQuery->setParameter('slug', $contentQuery->getIdentifier());
         }
-        if(count($contentQuery->getContentTypes()) === 1) {
+        if (count($contentQuery->getContentTypes()) === 1) {
             $contentQuery->setDirective('returnsingle', true);
         }
 

--- a/src/Storage/Query/Handler/IdentifiedSelectHandler.php
+++ b/src/Storage/Query/Handler/IdentifiedSelectHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Bolt\Storage\Query\Handler;
+
+use Bolt\Storage\Query\ContentQueryParser;
+use Bolt\Storage\Query\QueryInterface;
+
+/**
+ *  Handler to fetch a single record if an identifier is set in the query.
+ */
+class IdentifiedSelectHandler
+{
+    /**
+     * @param ContentQueryParser $contentQuery
+     * @internal param $identifier
+     * @return mixed
+     */
+    public function __invoke(ContentQueryParser $contentQuery)
+    {
+        if (is_numeric($contentQuery->getIdentifier())) {
+            $contentQuery->setParameter('id', $contentQuery->getIdentifier());
+        } else {
+            $contentQuery->setParameter('slug', $contentQuery->getIdentifier());
+        }
+        if(count($contentQuery->getContentTypes()) === 1) {
+            $contentQuery->setDirective('returnsingle', true);
+        }
+
+
+        return call_user_func_array($contentQuery->getHandler('select'), [$contentQuery]);
+    }
+}

--- a/src/Storage/Query/SearchQuery.php
+++ b/src/Storage/Query/SearchQuery.php
@@ -47,7 +47,7 @@ class SearchQuery extends SelectQuery
      *
      * @param array $params
      */
-    public function setParameters($params)
+    public function setParameters(array $params)
     {
         $this->params = $params;
     }

--- a/src/Storage/Query/SelectQuery.php
+++ b/src/Storage/Query/SelectQuery.php
@@ -49,7 +49,7 @@ class SelectQuery implements QueryInterface
      *
      * @param array $params
      */
-    public function setParameters($params)
+    public function setParameters(array $params)
     {
         $this->params = array_filter($params);
         $this->processFilters();

--- a/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
@@ -27,7 +27,7 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb->setQuery('page/about');
         $qb->parse();
         $this->assertEquals(['page'], $qb->getContentTypes());
-        $this->assertEquals('select', $qb->getOperation());
+        $this->assertEquals('namedselect', $qb->getOperation());
         $this->assertEquals('about', $qb->getIdentifier());
 
         $qb = new ContentQueryParser($app['storage']);
@@ -48,7 +48,7 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb->setQuery('pages,entries/about');
         $qb->parse();
         $this->assertEquals(['pages', 'entries'], $qb->getContentTypes());
-        $this->assertEquals('select', $qb->getOperation());
+        $this->assertEquals('namedselect', $qb->getOperation());
         $this->assertEquals('about', $qb->getIdentifier());
 
         $qb = new ContentQueryParser($app['storage']);
@@ -70,7 +70,7 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb->setQuery('page/5');
         $qb->parse();
         $this->assertEquals(['page'], $qb->getContentTypes());
-        $this->assertEquals('select', $qb->getOperation());
+        $this->assertEquals('namedselect', $qb->getOperation());
         $this->assertEquals('5', $qb->getIdentifier());
 
         $qb = new ContentQueryParser($app['storage']);
@@ -247,5 +247,22 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb->setParameters(['filter' => 'lorem ipsum']);
         $res = $qb->fetch();
         $this->assertEquals(4, $res->count());
+    }
+
+    public function testSingleItemMode()
+    {
+        $app = $this->getApp();
+
+        $qb = new ContentQueryParser($app['storage'], $app['query.select']);
+        $qb->setQuery('pages/5');
+        $qb->setParameter('printquery', true);
+        $qb->parse();
+        $this->assertEquals(['pages'], $qb->getContentTypes());
+        $this->assertEquals('namedselect', $qb->getOperation());
+        $this->assertEquals('5', $qb->getIdentifier());
+
+        $this->expectOutputString('SELECT pages.* FROM bolt_pages pages WHERE pages.id = :id_1');
+        $res = $qb->fetch();
+        $this->assertInstanceOf('Bolt\Storage\Entity\Content', $res);
     }
 }


### PR DESCRIPTION
This implements the missing named record select in the new storage engine.

It includes the intelligence to drop into single record mode where appropriate and thus means the following queries will all work correctly.

`$page = $app['query']->getContent('pages/2'); // returns a single page with an id of 2`

`$page = $app['query']->getContent('pages/lorem-ipsum'); // returns a single page with aslug of 'lorem-ipsum'`

`$pages = $app['query']->getContent('pages,entries/2'); // returns multiple records where id is 2`

Fixes: #5395 

There's also corresponding test updates to reflect these changes, which should have no BC implications since it was functionality that was not correctly implemented before.