### PR TITLE
MySQL error in select fields populated from content types

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -14,16 +14,17 @@
 {% if option.values is iterable %}
     {% set values = option.values %}
 {% else %}
-    {% set lookuptype = option.values|split('/')|first %}
-    {% set lookupfield = option.values|split('/')|last %}
+    {% set lookuptype = option.values|split('/')|slice(0,1)|first %}
+    {% set lookupfield = option.values|split('/')|slice(1,1)|first %}
     {% if ',' in lookupfield %}
-        {% set lookupfield = lookupfield|split(',') %}
+        {% set lookupfieldlist = lookupfield|split(',') %}
     {% endif %}
-    {% set sortingorder = field.sort|default(lookupfield|first) %}
+    {% set sortingorder = field.sort|default(lookupfieldlist|first)|default(lookupfield)|default('id') %}
     {% set querylimit = field.limit|default(500) %}
     {% set wherefilter = field.filter|default({}) %}
     {% setcontent lookups = lookuptype where wherefilter order sortingorder nohydrate limit querylimit %}
-    {% set values = lookups|selectfield(lookupfield, option.multiple, field.keys|default('id')) %}
+    {% set valuefield = lookupfieldlist|first|default(lookupfield)|default('id') %}
+    {% set values = lookups|selectfield(valuefield, option.multiple, field.keys|default('id')) %}
 {% endif %}
 
 {# Get the current selection. Either a single value, or an array. #}


### PR DESCRIPTION
When Bolt uses MySQL database (or MariaDB), and we have a select field populated with records of given content type, then opening the record edit page throws an nasty SQL error like this:

> An exception has been thrown during the rendering of a template ("An exception occurred while executing 'SELECT bolt_entries.* FROM bolt_entries ORDER BY `t` LIMIT 500': SQLSTATE[42S22]: Column not found: 1054 Unknown column 't' in 'order clause'") in "@bolt/editcontent/fields/_select.twig" at line 25.

**How to reproduce it**
1. Configure Bolt to use MySQL-like database
2. Add to any content type a select field which lists some records
3. Try to edit or create a record of this content type

Example select field configuration:
```
manual:
    type: select
    multiple: false
    values: books/title
    label: Select a manual
```

**What is happening?**
Because of wrongly written select field the value slug (for example `books/title`) is badly interpreted. The second part is treated as an array which first field is used for display in options and eventually for sorting. That's why we get the `t` column instead of `title` in the error message. But why it was undetected, you ask? Because Sqlite, the database used for tests and development purposes, just ignore the the order clause when the given column doesn't exists! (tested with xerial/sqlite-jdbc). MySQL and MariaDB on the other hand throws an error as you see above.

**The solution**
This pull requests address this issue and make the code a little bit more error proof.

- `books/title` - use `books` records and displays them using `title` column
- `books/title,author` - the same, use `books` records and displays them using `title` column
- `books` - use books records BUT displays them using `id` column which always exists