### PR TITLE
Fix #5226: Placing the delay parameter accordingly to reduce the amount of cance…

### DIFF
--- a/app/src/js/modules/omnisearch.js
+++ b/app/src/js/modules/omnisearch.js
@@ -30,11 +30,11 @@
 
         $('.omnisearch select').select2({
             width: '100%',
-            delay: 250,
             placeholder: bolt.data('omnisearch.placeholder'),
             minimumInputLength: 3,
             multiple: true, // this is for better styling …
             ajax: {
+                delay: 600,
                 url: bolt.conf('paths.async') + 'omnisearch',
                 dataType: 'json',
                 data: function (params) {


### PR DESCRIPTION
Placing the delay parameter accordingly to reduce the amount of cancelled XHRs (fixes #5226)

**Problem:**
Current implementation issues a server-request on every keystroke and is cancelling already running requests. This results an a overload of requests not being processed.

**Solution:**
The `delay` parameter is being placed within the `ajax` object to take affect.

**Reminder**:
[ ] Run `grunt updateBolt` and compile assets to make the fix take affect


Best regards,
Benedikt