### PR TITLE
Use the correct version for link to the docs

### DIFF
--- a/app/config/menu.yml.dist
+++ b/app/config/menu.yml.dist
@@ -1,5 +1,5 @@
 # This file defines the menus on the website. See the documentation for
-# details: http://docs.bolt.cm/menus
+# details: https://docs.bolt.cm/3.0/content/menus
 
 main:
     - label: Home


### PR DESCRIPTION
Fixes the link to the docs in the comments. I notice that some of the other links in the other config files also link to 404 page. Would you like those corrected as well?

[contenttypes.yml.dist](https://github.com/bolt/bolt/blob/release/3.0/app/config/contenttypes.yml.dist#L2)
[permissions.yml.dist](https://github.com/bolt/bolt/blob/release/3.0/app/config/permissions.yml.dist#L3)