### PR TITLE
Add the ability to skip over certain directives

### DIFF
--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -207,13 +207,16 @@ class ContentQueryParser
      * This runs the callbacks attached to each directive command.
      *
      * @param QueryInterface $query
+     * @param array $skipDirective
      */
-    public function runDirectives(QueryInterface $query)
+    public function runDirectives(QueryInterface $query, array $skipDirective = [])
     {
         foreach ($this->directives as $key => $value) {
-            if ($this->hasDirectiveHandler($key)) {
-                if (is_callable($this->getDirectiveHandler($key))) {
-                    call_user_func_array($this->getDirectiveHandler($key), [$query, $value]);
+            if (! in_array($key, $skipDirective)) {
+                if ($this->hasDirectiveHandler($key)) {
+                    if (is_callable($this->getDirectiveHandler($key))) {
+                        call_user_func_array($this->getDirectiveHandler($key), [$query, $value]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This would allow you to skip over certain directives when running the function `runDirectives`. The reason behind this is say I want to create a new query handler based upon the original query without some directive. For example, a paging handler - the Paging handler allows you to paginate the select query. In the query I want to find a count of all results so my simple query might be `SELECT COUNT(*) FROM bolt_pages;`. Then I want to add a few directives in there, like the `WHERE` clause. The only way to do that would be to `runDirectives`, clone the query, set maxResults and firstResults to `null`, and then then run the query. If we could ignore some directives, then we could skip over a directive and run that directive later with our main query.

Code Example of How it would be done CURRENTLY
-------
```php

$queryParameters = array_merge($this->parameters->getQueryParameters(), ['paginate' => $page]);

//Query
$this->query
            ->getContent("pages/pager", $queryParameters);

//Add to provider
$app['query.parser']->addDirectiveHandler('paginate', new PagerHandler());
$app['query.parser']->addHandler('pager', new PagingHandler());
$app['query.parser']->addOperation('pager');

namespace Bolt\Extension\Bolt\JsonApi\Storage\Query\Handler\Directive;

use Bolt\Extension\Bolt\JsonApi\Converter\Parameter\Type\Page;
use Bolt\Storage\Query\QueryInterface;

class PagerHandler
{
    /**
     * @param QueryInterface $query
     * @param Page           $page
     */
    public function __invoke(QueryInterface $query, Page $page)
    {
        //Get offset
        $offset = ($page->getNumber()-1) * $page->getSize();

        $query->getQueryBuilder()->setFirstResult($offset);
        $query->getQueryBuilder()->setMaxResults($page->getSize());
    }
}

namespace Bolt\Extension\Bolt\JsonApi\Storage\Query\Handler;

use Bolt\Extension\Bolt\JsonApi\Converter\Parameter\Type\Page;
use Bolt\Extension\Bolt\JsonApi\Storage\Query\PagingResultSet;
use Bolt\Storage\Query\ContentQueryParser;

class PagingHandler
{

    public function __invoke(ContentQueryParser $contentQuery)
    {
        $set = new PagingResultSet();

        foreach ($contentQuery->getContentTypes() as $contenttype) {
            $query = $contentQuery->getService('select');
            $repo = $contentQuery->getEntityManager()->getRepository($contenttype);
            $query->setQueryBuilder($repo->createQueryBuilder($contenttype));
            $query->setContentType($contenttype);
            $query->setParameters($contentQuery->getParameters());

            $contentQuery->runDirectives($query);

            $query2 = clone $query->getQueryBuilder();
            $qb = clone $query->getQueryBuilder();

            $query2
                ->setMaxResults(null)
                ->setFirstResult(null)
                ->select("COUNT(*) as total");

            $query->setQueryBuilder($query2);

            $totalItems = $query->build()->execute()->fetch();
            $totalItems = $totalItems['total'];

            $query->setQueryBuilder($qb);
            $result = $repo->queryWith($query);
            if ($result) {
                $set->add($result, $contenttype);
                $set->setTotalResults($totalItems);

                /** @var Page $page */
                $page = $contentQuery->getDirective('paginate');
                $set->setTotalPages($totalItems, $page->getSize());
            }

            return $set;
        }
    }
}
```

Code Example of How it would be done with PR in PagingHandler
-------
```php

namespace Bolt\Extension\Bolt\JsonApi\Storage\Query\Handler;

use Bolt\Extension\Bolt\JsonApi\Converter\Parameter\Type\Page;
use Bolt\Extension\Bolt\JsonApi\Storage\Query\PagingResultSet;
use Bolt\Storage\Query\ContentQueryParser;

class PagingHandler
{

    public function __invoke(ContentQueryParser $contentQuery)
    {
        $set = new PagingResultSet();

        foreach ($contentQuery->getContentTypes() as $contenttype) {
            $query = $contentQuery->getService('select');
            $repo = $contentQuery->getEntityManager()->getRepository($contenttype);
            $query->setQueryBuilder($repo->createQueryBuilder($contenttype));
            $query->setContentType($contenttype);
            $query->setParameters($contentQuery->getParameters());

            //Changes here
            $contentQuery->runDirectives($query, ['paginate']);

            $query2
                ->select("COUNT(*) as total");

            $query->setQueryBuilder($query2);

            $totalItems = $query->build()->execute()->fetch();
            $totalItems = $totalItems['total'];

            $query->setQueryBuilder($qb);
             //Changes here
            $contentQuery->runDirectives($query);
            $result = $repo->queryWith($query);
            if ($result) {
                $set->add($result, $contenttype);
                $set->setTotalResults($totalItems);

                /** @var Page $page */
                $page = $contentQuery->getDirective('paginate');
                $set->setTotalPages($totalItems, $page->getSize());
            }

            return $set;
        }
    }
}
```