### PR TITLE
Fixed invalid ExtensionInterface namespace in Controller Resolver

### DIFF
--- a/src/Routing/ControllerResolver.php
+++ b/src/Routing/ControllerResolver.php
@@ -22,7 +22,7 @@ class ControllerResolver extends Silex\ControllerResolver
     protected function instantiateController($class)
     {
         $refCls = new \ReflectionClass($class);
-        if ($refCls->implementsInterface('\Bolt\Extensions\ExtensionInterface')) {
+        if ($refCls->implementsInterface('\Bolt\Extension\ExtensionInterface')) {
             /** @var \Bolt\Extensions\ExtensionInterface[] $extensions */
             $extensions = $this->app['extensions']->getEnabled();
 


### PR DESCRIPTION
There is serious issue in Bolt v3.0, resulting in 

> Reflection Exception: Interface \Bolt\Extensions\ExtensionInterface does not exist

This happens, when someone tries to register controller in extension.
Namespace for this interface has been changed for Bolt v3.0, but no one updated interface path in \Bolt\Routing\ControllerResolver on line 25.

Correct interface path is: \Bolt\Extension\ExtensionInterface.

For future I'd recommend usage of ::class constant, rather than typing paths to classes/interfaces by hand. Thanks to that, if someone forgets to update paths in one file, fatal error during composer execution will occur, which will make programmer aware of the problem.

