### PR TITLE
Fix hyphenated field names for repeating fields

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -85,7 +85,10 @@ class RepeaterType extends FieldTypeBase
         $values = [];
         foreach ($vals as $fieldKey) {
             $split = explode('_', $fieldKey);
-            $values[$split[0]][$split[1]][] = $split[2];
+            $id = array_pop($split);
+            $group = array_pop($split);
+            $field = join('_', $split);
+            $values[$field][$group][] = $id;
         }
 
         $collection = new RepeatingFieldCollection($this->em, $this->mapping);


### PR DESCRIPTION
Fixes a bug whereby the parsing of the select query was failing on hyphenated and underscored repeating field names.

Fixes: #5348