### PR TITLE
Hotfix filesystem plugins

### DIFF
--- a/src/Controller/Backend/FileManager.php
+++ b/src/Controller/Backend/FileManager.php
@@ -150,8 +150,12 @@ class FileManager extends BackendBase
         $filesystem = $this->filesystem()->getFilesystem($namespace);
 
         if (!$filesystem->authorized($path)) {
-            $error = Trans::__('general.phrase.access-denied-permissions-view-file-directory', ['%s' => $path]);
-            $this->abort(Response::HTTP_FORBIDDEN, $error);
+            if (empty($path)) {
+                $path = $namespace;
+            }
+            
+            $this->flashes()->error(Trans::__('general.phrase.access-denied-permissions-view-file-directory', ['%s' => $path]));
+            return new RedirectResponse($this->generateUrl('dashboard'));
         }
 
         if (!$this->isAllowed('files:uploads')) {

--- a/src/Filesystem/FilePermissions.php
+++ b/src/Filesystem/FilePermissions.php
@@ -36,6 +36,7 @@ class FilePermissions
             'config',
             'files',
             'theme',
+            'themes',
         ];
 
         $this->blocked = [

--- a/src/Filesystem/Plugin/AdapterPlugin.php
+++ b/src/Filesystem/Plugin/AdapterPlugin.php
@@ -5,6 +5,7 @@ namespace Bolt\Filesystem\Plugin;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\FilesystemInterface;
 use Bolt\Filesystem\PluginInterface;
+use Bolt\Filesystem\MountPointAwareInterface;
 use Silex\Application;
 
 abstract class AdapterPlugin implements PluginInterface
@@ -25,6 +26,10 @@ abstract class AdapterPlugin implements PluginInterface
     public function setFilesystem(FilesystemInterface $filesystem)
     {
         $this->filesystem = $filesystem;
+        
+        if ($this->filesystem instanceof MountPointAwareInterface) {
+            $this->namespace = $this->filesystem->getMountPoint();
+        }
     }
 
     public function getDefault()

--- a/tests/phpunit/unit/FilePermissions/FilePermissionsTest.php
+++ b/tests/phpunit/unit/FilePermissions/FilePermissionsTest.php
@@ -16,6 +16,7 @@ class FilePermissionsTest extends BoltUnitTest
         $app = $this->getApp();
         $fp = new FilePermissions($app['config']);
         $this->assertTrue($fp->authorized('config', 'test.yml'));
+        $this->assertFalse($fp->authorized('cache', ''));
         $this->assertFalse($fp->authorized('something', '/path/to/.htaccess'));
     }
 

--- a/tests/phpunit/unit/Filesystem/Plugin/AuthorizedTest.php
+++ b/tests/phpunit/unit/Filesystem/Plugin/AuthorizedTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bolt\Tests\Filesystem\Plugin;
+
+use Bolt\Filesystem\Adapter\Local;
+use Bolt\Filesystem\Filesystem;
+use Bolt\Filesystem\Manager;
+use Bolt\Filesystem\Plugin;
+use Bolt\Tests\BoltUnitTest;
+
+class AuthorizedTest extends BoltUnitTest
+{
+    public function testSetup()
+    {
+        $app = $this->getApp();
+
+        $adapter = new Local(PHPUNIT_ROOT . '/resources');
+        $fs1 = new Filesystem($adapter);
+        $fs2 = new Filesystem($adapter);
+        $fs3 = new Filesystem($adapter);
+
+        $manager = new Manager([]);
+        $manager->mountFilesystem('files', $fs1);
+        $manager->mountFilesystem('cache', $fs2);
+        $manager->mountFilesystem('something', $fs3);
+        $manager->addPlugin(new Plugin\Authorized($app));
+
+        $this->assertTrue($fs1->authorized(''));
+        $this->assertFalse($fs2->authorized(''));
+        $this->assertFalse($fs3->authorized(''));
+    }
+
+}

--- a/tests/phpunit/unit/Filesystem/Plugin/AuthorizedTest.php
+++ b/tests/phpunit/unit/Filesystem/Plugin/AuthorizedTest.php
@@ -29,5 +29,4 @@ class AuthorizedTest extends BoltUnitTest
         $this->assertFalse($fs2->authorized(''));
         $this->assertFalse($fs3->authorized(''));
     }
-
 }


### PR DESCRIPTION
This PR set correct mount point / namespace in AdapterPlugin before plugin methods executes.
Fixes: #5449 

Details
-------
- Add test to check correct namespace authorization over Authorized Plugin.

Questions / Remarks
--------
- If plugin method from an filesystem object is invoked, then `setFilesystem` is called. I think its right place to fix this here. 
- Parameter `namespace` in AdapterPlugin constructor is not used anymore (insofar as I can evaluate all code :wink: ).
- Suggestion: Filesystem manager should mount a filesystem object only once, otherwise mount point is overwrite and end in a wrong behaviour, too.
