### PR TITLE
Postgres Fix: add missing second parameter to string_agg call

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -177,7 +177,7 @@ class RepeaterType extends FieldTypeBase
             case 'sqlite':
                 return 'GROUP_CONCAT(DISTINCT ' . $dummy . ".name||'_'||" . $dummy . ".grouping||'_'||" . $dummy . ".id) as $alias";
             case 'postgresql':
-                return 'string_agg(DISTINCT ' . $dummy . ".name||'_'||" . $dummy . ".grouping||'_'||" . $dummy . ".id) as $alias";
+                return 'string_agg(DISTINCT ' . $dummy . ".name||'_'||" . $dummy . ".grouping||'_'||" . $dummy . ".id, ',') as $alias";
         }
     }
 


### PR DESCRIPTION
There may be a #1555 lurking in here.

Fixes: #5462


