### PR TITLE
Do not hide error

### DIFF
--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -232,7 +232,7 @@ class Manager
     private function addManagedExtension(PackageDescriptor $descriptor)
     {
         $className = $descriptor->getClass();
-        if (@class_exists($className) === false) {
+        if (class_exists($className) === false) {
             if ($descriptor->getType() === 'local' && @class_exists('Wikimedia\Composer\MergePlugin') === false) {
                 $this->flashLogger->error(Trans::__('general.phrase.error-local-extension-set-up-incomplete', ['%NAME%' => $descriptor->getName(), '%CLASS%' => $className]));
             } else {


### PR DESCRIPTION
I ran into problems when writing an extension, where there was no error message. It turns out it was repressed. This PR removes the error hiding from `class_exists` so that I can now see my error:

```
PHP Fatal error:  Declaration of DTL\Bolt\Extension\Fixtures\DtlBoltFixturesExtension::register(Bolt\Application $app) must be compatible with Silex\ServiceProviderInterface::register(Silex\Application $app) in /home/daniel/www/fnair_asso_sf/extensions/local/dtl/bolt-fixtures/src/DtlBoltFixturesExtension.php on line 13
```

(which is good).

I do not know why that `@` was there?