### PR TITLE
[2.2] Enforce relative schema on Twig {{ url() }} calls

### DIFF
--- a/app/view/twig/components/panel-stack.twig
+++ b/app/view/twig/components/panel-stack.twig
@@ -36,7 +36,7 @@
                 <input id="fileupload-stack"
                        type="file"
                        name="files[]"
-                       data-url="{{ url('upload', {namespace: context.namespace}) }}"
+                       data-url="{{ url('upload', {namespace: context.namespace}, true) }}"
                        accept=".{{ context.filetypes|join(',.') }}">
             </span>
         </div>

--- a/app/view/twig/editcontent/fields/_file.twig
+++ b/app/view/twig/editcontent/fields/_file.twig
@@ -23,7 +23,7 @@
 {% set attr_upload = {
     accept:       option.extensions ? '.' ~ option.extensions|join(',.') : '',
     data_upload:  {type: 'File', key: key}|json_encode(),
-    data_url:     url('upload', {'handler': option.upload}),
+    data_url:     url('upload', {'handler': option.upload}, true),
     id:           'fileupload-' ~ key,
     name:         'files[]',
     type:         'file',

--- a/app/view/twig/editcontent/fields/_filelist.twig
+++ b/app/view/twig/editcontent/fields/_filelist.twig
@@ -13,7 +13,7 @@
 {% set attr_fileupload = {
     accept:       option.extensions ? '.' ~ option.extensions|join(',.') : '',
     data_upload:  {type: 'FileList', key: key}|json_encode(),
-    data_url:     url('upload', {'handler': option.upload}),
+    data_url:     url('upload', {'handler': option.upload}, true),
     id:           'fileupload-' ~ key,
     name:         'files[]',
     type:         'file',

--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -30,7 +30,7 @@
 {% set attr_upload = {
     accept:       option.extensions ? '.' ~ option.extensions|join(',.') : '',
     data_upload:  {type: 'Image', key: key, width: preview_w, height: preview_h}|json_encode(),
-    data_url:     url('upload', {'handler': option.upload}),
+    data_url:     url('upload', {'handler': option.upload}, true),
     id:           'fileupload-' ~ key,
     name:         'files[]',
     type:         'file',

--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -13,7 +13,7 @@
 {% set attr_fileupload = {
     accept:      option.extensions ? '.' ~ option.extensions|join(',.') : '',
     data_upload: {type: 'ImageList', key: key}|json_encode(),
-    data_url:    url('upload', {'handler': option.upload}),
+    data_url:    url('upload', {'handler': option.upload}, true),
     id:          'fileupload-' ~ key,
     name:        'files[]',
     type:        'file',


### PR DESCRIPTION
If a site's admin area is served over strict HTTP2 certain URLs are generated with `http://`. This forces the `{{ url() }}` call to return a relative schme to work around this

See [upstream](https://github.com/symfony/twig-bridge/blob/2.8/Extension/RoutingExtension.php#L48-L51)