### PR TITLE
Initialize variable

### DIFF
--- a/src/Storage/Entity/ContentSearchTrait.php
+++ b/src/Storage/Entity/ContentSearchTrait.php
@@ -88,6 +88,7 @@ trait ContentSearchTrait
         $searchableTypes = ['text', 'textarea', 'html', 'markdown'];
 
         $fields = [];
+        $slugFields = [];
 
         // The field(s) that are used by the slug need to be bumped, unless configured explicitly
         foreach ($this->contenttype['fields'] as $config) {


### PR DESCRIPTION
When developing with a high level this uninitialized var causes lots of errors on the search page.