### PR TITLE
Add google maps api key option

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -297,6 +297,12 @@ wysiwyg:
         allowNbsp: false     # If set to 'false', the editor will strip out `&nbsp;` characters. If set to 'true', it will allow them. ¯\_(ツ)_/¯
         # viewSourceRoles: [ 'admin', 'developer' ] # The roles which are allowed to use the [Source]-button.
 
+# Bolt uses the Google maps API for it's geolocation field and Google now
+# requires that it be loaded with an API key on new domains. You can generate
+# a key at https://console.developers.google.com and enter it here to make sure
+# that the geolocation field work.
+# google_api_key:
+
 # Global option to enable/disable the live editor
 liveeditor: true
 

--- a/app/view/twig/editcontent/_includes-data.twig
+++ b/app/view/twig/editcontent/_includes-data.twig
@@ -35,7 +35,7 @@
 
 {% if 'geolocation' in used_fieldtypes %}
     {{ data('field.geolocation.title-pin', __('field.geolocation.title-pin')) }}
-    <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+    <script src="https://maps.google.com/maps/api/js?sensor=false{{app.config.get('google_api_key') ? '&key=' ~ app.config.get('google_api_key') : '' }}"></script>
 {% endif %}
 
 {% if 'slug' in used_fieldtypes %}


### PR DESCRIPTION
Backport of #5492, the docs should have been PR'ed to 2.2 instead of 3.0, but I'll backport them too.