### PR TITLE
Allow pre-hydration data to be modified in event

### DIFF
--- a/src/Events/HydrationEvent.php
+++ b/src/Events/HydrationEvent.php
@@ -15,4 +15,15 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class HydrationEvent extends GenericEvent
 {
+    /**
+     * Encapsulate an event with $subject and $args.
+     *
+     * @param mixed $subject The subject of the event, where an array this will be passed by reference.
+     * @param array $arguments Arguments to store in the event.
+     */
+    public function __construct(&$subject = null, array $arguments = array())
+    {
+        $this->subject = $subject;
+        $this->arguments = $arguments;
+    }
 }


### PR DESCRIPTION
 Override the hydration event to support subject being passed by reference and thus can be modified in extensions.