### PR TITLE
Refactor the hydration event to use an ArrayObject

### DIFF
--- a/src/Events/HydrationEvent.php
+++ b/src/Events/HydrationEvent.php
@@ -15,15 +15,4 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class HydrationEvent extends GenericEvent
 {
-    /**
-     * Encapsulate an event with $subject and $args.
-     *
-     * @param mixed $subject   The subject of the event, where an array this will be passed by reference.
-     * @param array $arguments Arguments to store in the event.
-     */
-    public function __construct(&$subject = null, array $arguments = [])
-    {
-        $this->subject = $subject;
-        $this->arguments = $arguments;
-    }
 }

--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Storage;
 
+use ArrayObject;
 use Bolt\Events\HydrationEvent;
 use Bolt\Events\StorageEvent;
 use Bolt\Events\StorageEvents;
@@ -419,6 +420,7 @@ class Repository implements ObjectRepository
     {
         $entity = $this->getEntityBuilder()->getEntity();
 
+        $data = new ArrayObject($data);
         $preEventArgs = new HydrationEvent($data, ['entity' => $entity, 'repository' => $this]);
         $this->event()->dispatch(StorageEvents::PRE_HYDRATE, $preEventArgs);
 


### PR DESCRIPTION
Apologies, this is a replacement for #5510 the approache used there wasn't successful since the GenericEvent in symfony was dereferencing the subject.

This is a better approach, since it ensures that the object will always be passed by reference down the line.