### PR TITLE
Allow callables to be registered as repository classes

### DIFF
--- a/src/Storage/EntityManager.php
+++ b/src/Storage/EntityManager.php
@@ -258,7 +258,9 @@ class EntityManager
 
         if (array_key_exists($className, $this->repositories)) {
             $repoClass = $this->repositories[$className];
-
+            if (is_callable($repoClass)) {
+                return call_user_func_array($repoClass, [$this, $classMetadata]);
+            }
             return new $repoClass($this, $classMetadata);
         }
 


### PR DESCRIPTION
This allows a callable factory to be registered as a Repository. It should hopefully allow a workaround for scenarios such as in #5506 where you may want to return a different repository instance based on the contenttype.

