### PR TITLE
Tokenise PHP version string to remove `-extra` on Debian

### DIFF
--- a/src/Composer/Action/BaseAction.php
+++ b/src/Composer/Action/BaseAction.php
@@ -192,7 +192,7 @@ abstract class BaseAction
     protected function findBestVersionForPackage($packageName, $targetPackageVersion = null, $returnArray = false)
     {
         $versionSelector = new VersionSelector($this->getPool());
-        $package = $versionSelector->findBestCandidate($packageName, $targetPackageVersion, PHP_VERSION, $this->getComposer()->getPackage()->getStability());
+        $package = $versionSelector->findBestCandidate($packageName, $targetPackageVersion, strtok(PHP_VERSION, '-'), $this->getComposer()->getPackage()->getStability());
         if (!$package) {
             if ($returnArray === false) {
                 throw new \InvalidArgumentException(


### PR DESCRIPTION
Additional fixes for #5511