### PR TITLE
Translation cache option

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -155,6 +155,10 @@ recordsperpage: 10
 #                  cases you should *NOT* enable this, because it will cause
 #                  side-effects if the website shows different content to
 #                  authenticated users.
+# - thumbnails:    Caches thumbnail generation.  
+# - translations:  Caches translation files. It is recommend to leave this 
+#                  enabled. Only if you develop extensions and work with 
+#                  translation files you should turn this off.   
 caching:
     config: true
     templates: true
@@ -162,6 +166,7 @@ caching:
     duration: 10
     authenticated: false
     thumbnails: true
+    translations: true
 
 # Set 'enabled' to 'true' to log all content changes in the database.
 #

--- a/src/Provider/TranslationServiceProvider.php
+++ b/src/Provider/TranslationServiceProvider.php
@@ -16,12 +16,21 @@ class TranslationServiceProvider implements ServiceProviderInterface
             $app->register(
                 new Silex\Provider\TranslationServiceProvider(),
                 [
-                    'translator.cache_dir' => $app['resources']->getPath('cache/trans'),
                     'locale_fallbacks'     => ['en_GB', 'en'],
                 ]
             );
         }
+        
+        $app['translator.caching'] = $app['config']->get('general/caching/translations');
+        
+        $app['translator.cache_dir'] = $app->share(function ($app) {
+            if ($app['translator.caching'] === false) {
+                return null;
+            }
 
+            return $app['resources']->getPath('cache/trans');
+        });
+        
         $app['translator'] = $app->share(
             $app->extend(
                 'translator',

--- a/src/Provider/TranslationServiceProvider.php
+++ b/src/Provider/TranslationServiceProvider.php
@@ -20,9 +20,12 @@ class TranslationServiceProvider implements ServiceProviderInterface
                 ]
             );
         }
-        
-        $app['translator.caching'] = $app['config']->get('general/caching/translations');
-        
+ 
+        $app['translator.caching'] = true;
+        if ($app['config']->get('general/caching/translations') === false) {
+            $app['translator.caching'] = false;
+        }
+
         $app['translator.cache_dir'] = $app->share(function ($app) {
             if ($app['translator.caching'] === false) {
                 return null;

--- a/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
@@ -74,7 +74,7 @@ class TranslationServiceProviderTest extends BoltUnitTest
      * @param Application $app
      */
     protected function registerTranslationServiceWithCachingDisabled(Application $app)
-    {    
+    {
         $app['config']->set('general/caching/translations', false);
     }
 

--- a/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
@@ -74,14 +74,8 @@ class TranslationServiceProviderTest extends BoltUnitTest
      * @param Application $app
      */
     protected function registerTranslationServiceWithCachingDisabled(Application $app)
-    {
-        $app->register(
-            new \Silex\Provider\TranslationServiceProvider(),
-            [
-                'translator.cache_dir' => null,
-                'locale_fallbacks'     => ['en_GB', 'en'],
-            ]
-        );
+    {    
+        $app['config']->set('general/caching/translations', false);
     }
 
     /**


### PR DESCRIPTION
If you develop extensions and work with translation files, it's tiring to clear cache all the time.

Now you can set `general/caching/translations` to `false` if you need it. Recommend only for extension development. Cache is enabled by default.