### PR TITLE
Ensure the id is unique in repeater fields

### DIFF
--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -27,7 +27,7 @@
         {% for rkey, rfield in field.fields %}
             {% set rfield = defaults|merge(rfield) %}
             {% set rcontext = {
-                'key':        rkey,
+                'key':        name ~ '_' ~ index ~ '_' ~ rkey,
                 'name':       name ~ '[' ~ index ~ '][' ~ rkey ~ ']',
                 'contentkey': rkey,
                 'field':      rfield,


### PR DESCRIPTION
This fixes the various bugs reported relating to HTML fields (and possibly others that use js in some way)
doubling up when a normal field and a repeater field have the same name.

Now the repeater field will generate a unique id eg `repeater_0_body` so there's no chance of a duplicate id appearing elsewhere.