### PR TITLE
Don't hide viewless from backend omnisearch

### DIFF
--- a/src/Storage.php
+++ b/src/Storage.php
@@ -783,9 +783,7 @@ class Storage
             $contenttypes = array_filter(
                 $contenttypes,
                 function ($ct) use ($appCt) {
-                    if ((isset($appCt[$ct]['searchable']) && $appCt[$ct]['searchable'] === false) ||
-                        (isset($appCt[$ct]['viewless']) && $appCt[$ct]['viewless'] === true)
-                    ) {
+                    if (isset($appCt[$ct]['searchable']) && $appCt[$ct]['searchable'] === false) {
                         return false;
                     }
 


### PR DESCRIPTION
Setting viewless: true on a contenttype hides it from backend omnisearch.
This is unwanted behaviour in my opinion.

Fixes: #5392 

According to related issue #2149 setting viewless: true should cause:

the contenttype is not associated with any template
the contenttype does not produce any frontend routes
there is no 'Preview' button in the backend for this contenttype
the contenttype does not appear in any search results or listings on the frontend
Unfortunately in practice this also means that the content of that type is hidden from the (backend) omnisearch.
