### PR TITLE
Enable Use of repeaters inside Templatefields

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -8,7 +8,6 @@ use Bolt\Storage\QuerySet;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Types\Type;
 
-
 /**
  * This is one of a suite of basic Bolt field transformers that handles
  * the lifecycle of a field from pre-query to persist.

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -86,7 +86,7 @@ class RepeaterType extends FieldTypeBase
         if ($this->isJson($data[$key])) {
             $originalMapping[$key]['fields'] = $this->mapping['fields'];
             $originalMapping[$key]['type'] = 'repeater';
-            $mapping['data'] = $this->em->getMapper()->getRepeaterMapping($originalMapping);
+            $mapping = $this->em->getMapper()->getRepeaterMapping($originalMapping);
 
             $decoded = json_decode($data[$key], true);
             $collection = new RepeatingFieldCollection($this->em, $mapping);

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -6,6 +6,8 @@ use Bolt\Storage\Field\Collection\RepeatingFieldCollection;
 use Bolt\Storage\Mapping\ClassMetadata;
 use Bolt\Storage\QuerySet;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Types\Type;
+
 
 /**
  * This is one of a suite of basic Bolt field transformers that handles
@@ -81,6 +83,25 @@ class RepeaterType extends FieldTypeBase
     public function hydrate($data, $entity)
     {
         $key = $this->mapping['fieldname'];
+        if ($this->isJson($data[$key])) {
+            $originalMapping[$key]['fields'] = $this->mapping['fields'];
+            $originalMapping[$key]['type'] = 'repeater';
+            $mapping['data'] = $this->em->getMapper()->getRepeaterMapping($originalMapping);
+
+            $decoded = json_decode($data[$key], true);
+            $collection = new RepeatingFieldCollection($this->em, $mapping);
+            $collection->setName($key);
+
+            if (isset($decoded) && count($decoded)) {
+                foreach ($decoded as $group => $repdata) {
+                    $collection->addFromArray($repdata, $group);
+                }
+            }
+
+            $this->set($entity, $collection);
+            return;
+        }
+
         $vals = array_filter(explode(',', $data[$key]));
         $values = [];
         foreach ($vals as $fieldKey) {
@@ -167,7 +188,7 @@ class RepeaterType extends FieldTypeBase
     protected function getPlatformGroupConcat($alias, QueryBuilder $query)
     {
         $platform = $query->getConnection()->getDatabasePlatform()->getName();
-        
+
         $field = $this->mapping['fieldname'];
         $dummy = 'f_' . $field;
 
@@ -298,5 +319,13 @@ class RepeaterType extends FieldTypeBase
         $mapping = $this->mapping['data']['fields'][$field];
 
         return $mapping['type'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStorageType()
+    {
+        return Type::getType('json_array');
     }
 }

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -185,7 +185,7 @@ class MetadataDriver implements MappingDriver
             $this->setIncomingRelations($contentKey, $className);
             $this->setTaxonomies($contentKey, $className, $table);
             $this->setTemplatefields($contentKey, $className, $table);
-            $this->setRepeaters($contentKey, $className, $table);
+            $this->setRepeaters($contentKey, $className);
         }
 
         foreach ($this->getAliases() as $alias => $table) {
@@ -195,13 +195,21 @@ class MetadataDriver implements MappingDriver
         }
     }
 
-    public function setRepeaters($contentKey, $className, $table)
+    public function setRepeaters($contentKey, $className, $inputData = null)
     {
-        if (!isset($this->contenttypes[$contentKey])) {
+        $standalone = false;
+
+        if ($inputData === null && !isset($this->contenttypes[$contentKey])) {
             return;
         }
 
-        foreach ($this->contenttypes[$contentKey]['fields'] as $key => $data) {
+        if ($inputData === null) {
+            $inputData = $this->contenttypes[$contentKey]['fields'];
+        } else {
+            $standalone = true;
+        }
+
+        foreach ($inputData as $key => $data) {
             $mapping = [
                 'fieldname'        => $key,
                 'type'             => 'null',
@@ -227,10 +235,29 @@ class MetadataDriver implements MappingDriver
                     }
                 }
 
+                if ($standalone) {
+                    return $data;
+                }
+
                 $this->metadata[$className]['fields'][$key] = $mapping;
                 $this->metadata[$className]['fields'][$key]['data'] = $data;
             }
         }
+    }
+
+
+    /**
+     * This is a helper method to get a correct mapping from an array config. It's designed to take raw array config
+     * to generate a correct format mapping for repeaters.
+     * @param array $config
+     * @return array
+     */
+    public function getRepeaterMapping(array $config)
+    {
+        $mapping = ['data' => null];
+        $mapping['data'] = $this->setRepeaters(null, null, $config);
+
+        return $mapping;
     }
 
     /**


### PR DESCRIPTION
This is a temporary solution to enable repeater fields to work inside templatefields. Storage is via JSON rather than the new field value storage system, but this can then be refactored when we tackle a bigger templatefields fix.

Fixes: #5320

