### PR TITLE
Hide that we know the future in userlist (fix null in lastseen on user displaying as `now()`)

### DIFF
--- a/app/view/twig/users/_userlist.twig
+++ b/app/view/twig/users/_userlist.twig
@@ -27,7 +27,7 @@
                 </td>
 
                 <td class="hidden-xs">
-                    {{ user.lastseen|date('Y') > '1901' ? buic_moment(user.lastseen) : '-' }}
+                    {{ user.lastseen ? buic_moment(user.lastseen) : '-' }}
                 </td>
 
                 <td class="contenttypes">


### PR DESCRIPTION
Fixes another issue reported in slack. We can't tell people that we know the future...

The issue was that a null in the lastseen column gave the current date when run through the date filter, which moment.js then turned into "in a few seconds".

Oh, and this fixes #5546