### PR TITLE
Remove the Foreign Key Constraint properties from diffs when supportsForeignKeyConstraints() is false

### DIFF
--- a/src/Storage/Database/Schema/Comparison/BaseComparator.php
+++ b/src/Storage/Database/Schema/Comparison/BaseComparator.php
@@ -225,6 +225,7 @@ abstract class BaseComparator
         $tableName = $fromTable->getName();
         $diff = (new Comparator())->diffTable($fromTable, $toTable);
         if ($diff !== false) {
+            $this->removeIgnoredChanges($diff);
             $this->diffs[$tableName] = $diff;
         }
     }

--- a/src/Storage/Database/Schema/Comparison/Sqlite.php
+++ b/src/Storage/Database/Schema/Comparison/Sqlite.php
@@ -30,5 +30,15 @@ class Sqlite extends BaseComparator
      */
     protected function removeIgnoredChanges(TableDiff $diff)
     {
+        /**
+         * @see https://github.com/doctrine/dbal/pull/242
+         *      \Doctrine\DBAL\Platforms\SqlitePlatform::supportsForeignKeyConstraints
+         *      https://www.sqlite.org/foreignkeys.html
+         */
+        if ($this->connection->getDatabasePlatform()->supportsForeignKeyConstraints() === false) {
+            $diff->addedForeignKeys = [];
+            $diff->changedForeignKeys = [];
+            $diff->removedForeignKeys = [];
+        }
     }
 }


### PR DESCRIPTION
See:
  *  https://github.com/doctrine/dbal/pull/242
  *  https://www.sqlite.org/foreignkeys.html