### PR TITLE
Add scripts to run grunt without global

### DIFF
--- a/app/src/package.json
+++ b/app/src/package.json
@@ -46,6 +46,8 @@
         "select2": "~4.0.3"
     },
     "scripts": {
+        "start": "grunt",
+        "grunt": "grunt",
         "install": "napa"
     },
     "napa": {


### PR DESCRIPTION
This makes it so that you don't need to have grunt installed globally to be able to run the backend JS/CSS build. Instead of `grunt` one can (optionally) run `npm run grunt` or `npm start`. You can also run the subscripts by doing `npm start -- prepareCkeditor` or `npm run grunt -- prepareCkeditor`.

Of course it will still work if one wants to use the global version, but this makes it easier if someone has multiple projects that require different versions of grunt.

This is how it's setup in base-2016, see #5189

ping @rarila