### PR TITLE
[WIP] Test Reorganization

### DIFF
--- a/tests/phpunit/nutty
+++ b/tests/phpunit/nutty
@@ -3,9 +3,11 @@
 
 namespace Bolt\Tests;
 
+use Bolt\Tests\BoltFunctionalTestCase;
+
 require_once __DIR__ . '/bootstrap.php';
 
-class Nutty extends BoltUnitTest
+class Nutty extends BoltFunctionalTestCase
 {
     public function getApp($boot = true)
     {

--- a/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
+++ b/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class AccessCheckerTest extends BoltUnitTest
+class AccessCheckerTest extends BoltFunctionalTestCase
 {
     public function tearDown()
     {

--- a/tests/phpunit/unit/AccessControl/LoginTest.php
+++ b/tests/phpunit/unit/AccessControl/LoginTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class LoginTest extends BoltUnitTest
+class LoginTest extends BoltFunctionalTestCase
 {
     public function tearDown()
     {

--- a/tests/phpunit/unit/AccessControl/PasswordTest.php
+++ b/tests/phpunit/unit/AccessControl/PasswordTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class PasswordTest extends BoltUnitTest
+class PasswordTest extends BoltFunctionalTestCase
 {
     public function tearDown()
     {

--- a/tests/phpunit/unit/AccessControl/TokenGeneratorTest.php
+++ b/tests/phpunit/unit/AccessControl/TokenGeneratorTest.php
@@ -8,7 +8,7 @@ use Bolt\AccessControl\Token\Generator;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class TokenGeneratorTest extends BoltUnitTest
+class TokenGeneratorTest extends BoltFunctionalTestCase
 {
     public function testGenerateEverything()
     {

--- a/tests/phpunit/unit/AccessControl/TokenTokenTest.php
+++ b/tests/phpunit/unit/AccessControl/TokenTokenTest.php
@@ -9,7 +9,7 @@ use Bolt\Storage\Entity;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class TokenTokenTest extends BoltUnitTest
+class TokenTokenTest extends BoltFunctionalTestCase
 {
     public function testConstructor()
     {

--- a/tests/phpunit/unit/Asset/Widget/WidgetTest.php
+++ b/tests/phpunit/unit/Asset/Widget/WidgetTest.php
@@ -3,14 +3,14 @@
 namespace Bolt\Tests\Asset\Widget;
 
 use Bolt\Asset\Widget\Widget;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Bolt\Asset\Widget\Widget tests.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class WidgetTest extends BoltUnitTest
+class WidgetTest extends BoltFunctionalTestCase
 {
     public function testWidgetBasicSetup()
     {

--- a/tests/phpunit/unit/BoltFunctionalTestCase.php
+++ b/tests/phpunit/unit/BoltFunctionalTestCase.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  **/
-abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
+abstract class BoltFunctionalTestCase extends \PHPUnit_Framework_TestCase
 {
     private $app;
 

--- a/tests/phpunit/unit/Cache/CacheTest.php
+++ b/tests/phpunit/unit/Cache/CacheTest.php
@@ -3,10 +3,10 @@
 namespace Bolt\Tests\Cache;
 
 use Bolt\Cache;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Eloquent\Pathogen\FileSystem\Factory\PlatformFileSystemPathFactory;
 
-class CacheTest extends BoltUnitTest
+class CacheTest extends BoltFunctionalTestCase
 {
     /**
      * @var \Bolt\Cache

--- a/tests/phpunit/unit/Composer/Action/ActionUnitTest.php
+++ b/tests/phpunit/unit/Composer/Action/ActionUnitTest.php
@@ -1,9 +1,9 @@
 <?php
 namespace Bolt\Tests\Composer\Action;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
-abstract class ActionUnitTest extends BoltUnitTest
+abstract class ActionUnitTest extends BoltFunctionalTestCase
 {
     public function setUp()
     {

--- a/tests/phpunit/unit/Composer/PackageManagerTest.php
+++ b/tests/phpunit/unit/Composer/PackageManagerTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Composer;
 
 use Bolt\Composer\PackageManager;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Composer/CommandRunner.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class PackageManagerTest extends BoltUnitTest
+class PackageManagerTest extends BoltFunctionalTestCase
 {
     public function testConstruct()
     {

--- a/tests/phpunit/unit/Composer/Satis/QueryServiceTest.php
+++ b/tests/phpunit/unit/Composer/Satis/QueryServiceTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Composer\Satis;
 
 use Bolt\Composer\Satis\QueryService;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Composer/Satis/QueryService.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class QueryServiceTest extends BoltUnitTest
+class QueryServiceTest extends BoltFunctionalTestCase
 {
     public function testPackageInfoValid()
     {

--- a/tests/phpunit/unit/Composer/Satis/StatServiceTest.php
+++ b/tests/phpunit/unit/Composer/Satis/StatServiceTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace Bolt\Tests\Extensions;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Composer/Satis/StatService.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class StatServiceTest extends BoltUnitTest
+class StatServiceTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Configuration/LowlevelChecksTest.php
+++ b/tests/phpunit/unit/Configuration/LowlevelChecksTest.php
@@ -5,7 +5,7 @@ use Bolt\Configuration\LowlevelChecks;
 use Bolt\Configuration\ResourceManager;
 use Bolt\Configuration\Standard;
 use Bolt\Exception\LowlevelException;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Configuration/LowlevelChecks.php.
@@ -14,7 +14,7 @@ use Bolt\Tests\BoltUnitTest;
  *
  * @runTestsInSeparateProcesses
  */
-class LowlevelChecksTest extends BoltUnitTest
+class LowlevelChecksTest extends BoltFunctionalTestCase
 {
     protected $errorResponses = [];
 

--- a/tests/phpunit/unit/Content/ContentTest.php
+++ b/tests/phpunit/unit/Content/ContentTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Content;
 
 use Bolt\Legacy\Content;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage.
@@ -10,7 +10,7 @@ use Bolt\Tests\BoltUnitTest;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ContentTest extends BoltUnitTest
+class ContentTest extends BoltFunctionalTestCase
 {
     public function testgetValues()
     {

--- a/tests/phpunit/unit/Controller/ControllerUnitTest.php
+++ b/tests/phpunit/unit/Controller/ControllerUnitTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace Bolt\Tests\Controller;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
-abstract class ControllerUnitTest extends BoltUnitTest
+abstract class ControllerUnitTest extends BoltFunctionalTestCase
 {
     private $app;
 

--- a/tests/phpunit/unit/Events/ControllerEventsTest.php
+++ b/tests/phpunit/unit/Events/ControllerEventsTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Events;
 
 use Bolt\Events\ControllerEvents;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test Bolt\Events\ControllerEvents
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ControllerEventsTest extends BoltUnitTest
+class ControllerEventsTest extends BoltFunctionalTestCase
 {
     public function testConstant()
     {

--- a/tests/phpunit/unit/Events/CronEventTest.php
+++ b/tests/phpunit/unit/Events/CronEventTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Events;
 use Bolt\Cache;
 use Bolt\Events\CronEvent;
 use Bolt\Events\CronEvents;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 /**
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class CronEventTest extends BoltUnitTest
+class CronEventTest extends BoltFunctionalTestCase
 {
     public function testCronCalls()
     {

--- a/tests/phpunit/unit/Events/MountEventTest.php
+++ b/tests/phpunit/unit/Events/MountEventTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Events;
 
 use Bolt\Events\MountEvent;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
@@ -14,7 +14,7 @@ use Silex\Route;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class MountEventTest extends BoltUnitTest
+class MountEventTest extends BoltFunctionalTestCase
 {
     public function testConstructor()
     {

--- a/tests/phpunit/unit/Events/StorageEventTest.php
+++ b/tests/phpunit/unit/Events/StorageEventTest.php
@@ -3,14 +3,14 @@ namespace Bolt\Tests\Events;
 
 use Bolt\Events\StorageEvent;
 use Bolt\Legacy\Content;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Events/StorageEvent.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class StorageEventTest extends BoltUnitTest
+class StorageEventTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Extension/AbstractExtensionTest.php
+++ b/tests/phpunit/unit/Extension/AbstractExtensionTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Extension;
 
 use Bolt\Filesystem\Handler\Directory;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Extension\Mock\BasicExtension;
 use Bolt\Tests\Extension\Mock\Extension;
 
@@ -12,7 +12,7 @@ use Bolt\Tests\Extension\Mock\Extension;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class AbstractExtensionTest extends BoltUnitTest
+class AbstractExtensionTest extends BoltFunctionalTestCase
 {
     public function testClassProperties()
     {

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -9,7 +9,7 @@ use Bolt\Asset\Widget\Widget;
 use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\Handler\Directory;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Extension\Mock\AssetExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
 
@@ -18,7 +18,7 @@ use Bolt\Tests\Extension\Mock\NormalExtension;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class AssetTraitTest extends BoltUnitTest
+class AssetTraitTest extends BoltFunctionalTestCase
 {
     public function testRegisterAssetsNoOverride()
     {

--- a/tests/phpunit/unit/Extension/ConfigTraitTest.php
+++ b/tests/phpunit/unit/Extension/ConfigTraitTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Extension;
 
 use Bolt\Filesystem\Handler\Directory;
 use Bolt\Filesystem\Handler\YamlFile;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Extension\Mock\ConfigExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
 
@@ -13,7 +13,7 @@ use Bolt\Tests\Extension\Mock\NormalExtension;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ConfigTraitTest extends BoltUnitTest
+class ConfigTraitTest extends BoltFunctionalTestCase
 {
     protected function setUp()
     {

--- a/tests/phpunit/unit/Extension/ControllerMountTraitTest.php
+++ b/tests/phpunit/unit/Extension/ControllerMountTraitTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Extension;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Extension\Mock\ControllerMountExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
 
@@ -11,7 +11,7 @@ use Bolt\Tests\Extension\Mock\NormalExtension;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ControllerMountTraitTest extends BoltUnitTest
+class ControllerMountTraitTest extends BoltFunctionalTestCase
 {
     public function testControllerMountDefault()
     {

--- a/tests/phpunit/unit/Extension/ControllerTraitTest.php
+++ b/tests/phpunit/unit/Extension/ControllerTraitTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Extension;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Extension\Mock\ControllerExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
 
@@ -11,7 +11,7 @@ use Bolt\Tests\Extension\Mock\NormalExtension;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ControllerTraitTest extends BoltUnitTest
+class ControllerTraitTest extends BoltFunctionalTestCase
 {
     public function testRoutesDefault()
     {

--- a/tests/phpunit/unit/Extension/ManagerTest.php
+++ b/tests/phpunit/unit/Extension/ManagerTest.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Extension;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test Bolt\Extension\Manager
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ManagerTest extends BoltUnitTest
+class ManagerTest extends BoltFunctionalTestCase
 {
     public function test()
     {

--- a/tests/phpunit/unit/Extension/MenuTraitTest.php
+++ b/tests/phpunit/unit/Extension/MenuTraitTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Extension;
 
 use Bolt\Menu\MenuEntry;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Extension\Mock\MenuExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
 
@@ -12,7 +12,7 @@ use Bolt\Tests\Extension\Mock\NormalExtension;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class MenuTraitTest extends BoltUnitTest
+class MenuTraitTest extends BoltFunctionalTestCase
 {
     public function testEmptyMenus()
     {

--- a/tests/phpunit/unit/Extension/NutTraitTest.php
+++ b/tests/phpunit/unit/Extension/NutTraitTest.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Extension;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test Bolt\Extension\NutTrait
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class NutTraitTest extends BoltUnitTest
+class NutTraitTest extends BoltFunctionalTestCase
 {
     public function test()
     {

--- a/tests/phpunit/unit/Extension/ResolvedExtensionTest.php
+++ b/tests/phpunit/unit/Extension/ResolvedExtensionTest.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Extension;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test Bolt\Extension\ResolvedExtension
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ResolvedExtensionTest extends BoltUnitTest
+class ResolvedExtensionTest extends BoltFunctionalTestCase
 {
     public function test()
     {

--- a/tests/phpunit/unit/Extension/SimpleExtensionTest.php
+++ b/tests/phpunit/unit/Extension/SimpleExtensionTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Extension;
 
 use Bolt\Events\ControllerEvents;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Extension\Mock\NormalExtension;
 
 /**
@@ -11,7 +11,7 @@ use Bolt\Tests\Extension\Mock\NormalExtension;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class SimpleExtensionTest extends BoltUnitTest
+class SimpleExtensionTest extends BoltFunctionalTestCase
 {
     public function testRegister()
     {

--- a/tests/phpunit/unit/Extension/TwigTraitTest.php
+++ b/tests/phpunit/unit/Extension/TwigTraitTest.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Extension;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test Bolt\Extension\TwigTrait
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class TwigTraitTest extends BoltUnitTest
+class TwigTraitTest extends BoltFunctionalTestCase
 {
     public function test()
     {

--- a/tests/phpunit/unit/Extensions/AbstractExtensionsUnitTest.php
+++ b/tests/phpunit/unit/Extensions/AbstractExtensionsUnitTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bolt\Tests\Extensions;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @runTestsInSeparateProcesses
  */
-abstract class AbstractExtensionsUnitTest extends BoltUnitTest
+abstract class AbstractExtensionsUnitTest extends BoltFunctionalTestCase
 {
     public function setup()
     {

--- a/tests/phpunit/unit/Extensions/SnippetLocationTest.php
+++ b/tests/phpunit/unit/Extensions/SnippetLocationTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Extensions;
 
 use Bolt\Extensions\Snippets\Location;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Extensions/StatService.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class SnippetLocationTest extends BoltUnitTest
+class SnippetLocationTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Field/BaseFieldTest.php
+++ b/tests/phpunit/unit/Field/BaseFieldTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Field;
 
 use Bolt\Storage\Field\Base;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Field/Base.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class BaseFieldTest extends BoltUnitTest
+class BaseFieldTest extends BoltFunctionalTestCase
 {
     public function testFieldSetup()
     {

--- a/tests/phpunit/unit/Field/ManagerTest.php
+++ b/tests/phpunit/unit/Field/ManagerTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Field;
 
 use Bolt\Storage\Field\Manager;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Field/Manager.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ManagerTest extends BoltUnitTest
+class ManagerTest extends BoltFunctionalTestCase
 {
     public function testManagerDefaultsSetup()
     {

--- a/tests/phpunit/unit/FilePermissions/FilePermissionsTest.php
+++ b/tests/phpunit/unit/FilePermissions/FilePermissionsTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\FilePermissions;
 
 use Bolt\Filesystem\FilePermissions;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/FilePermissions.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class FilePermissionsTest extends BoltUnitTest
+class FilePermissionsTest extends BoltFunctionalTestCase
 {
     public function testBasicAuth()
     {

--- a/tests/phpunit/unit/Filesystem/FilesystemProviderTest.php
+++ b/tests/phpunit/unit/Filesystem/FilesystemProviderTest.php
@@ -9,7 +9,7 @@ use Eloquent\Pathogen\FileSystem\Factory\PlatformFileSystemPathFactory;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class FilesystemProviderTest extends BoltUnitTest
+class FilesystemProviderTest extends BoltFunctionalTestCase
 {
     public function testAppRegistries()
     {

--- a/tests/phpunit/unit/Filesystem/Plugin/AuthorizedTest.php
+++ b/tests/phpunit/unit/Filesystem/Plugin/AuthorizedTest.php
@@ -6,9 +6,9 @@ use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\Manager;
 use Bolt\Filesystem\Plugin;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
-class AuthorizedTest extends BoltUnitTest
+class AuthorizedTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Filesystem/Plugin/ThumbnailUrlTest.php
+++ b/tests/phpunit/unit/Filesystem/Plugin/ThumbnailUrlTest.php
@@ -6,9 +6,9 @@ use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\Manager;
 use Bolt\Filesystem\Plugin;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
-class ThumbnailUrlTest extends BoltUnitTest
+class ThumbnailUrlTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Filesystem/UploadContainerTest.php
+++ b/tests/phpunit/unit/Filesystem/UploadContainerTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Filesystem;
 
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\UploadContainer;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use League\Flysystem\Adapter\NullAdapter;
 
 /**
@@ -12,7 +12,7 @@ use League\Flysystem\Adapter\NullAdapter;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class UploadContainerTest extends BoltUnitTest
+class UploadContainerTest extends BoltFunctionalTestCase
 {
     /** @var UploadContainer */
     private $container;

--- a/tests/phpunit/unit/Helper/ArrTest.php
+++ b/tests/phpunit/unit/Helper/ArrTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Helper;
 
 use Bolt\Helpers\Arr;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Helper/Arr.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ArrTest extends BoltUnitTest
+class ArrTest extends BoltFunctionalTestCase
 {
     public function testMakeValuePairs()
     {

--- a/tests/phpunit/unit/Helper/HtmlTest.php
+++ b/tests/phpunit/unit/Helper/HtmlTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Helper;
 
 use Bolt\Helpers\Html;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Helper/Html.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class HtmlTest extends BoltUnitTest
+class HtmlTest extends BoltFunctionalTestCase
 {
     public function testTrimText()
     {

--- a/tests/phpunit/unit/Helper/InputTest.php
+++ b/tests/phpunit/unit/Helper/InputTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Helper;
 
 use Bolt\Helpers\Input;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Helper/Input.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class InputTest extends BoltUnitTest
+class InputTest extends BoltFunctionalTestCase
 {
     public function testCleanPostedData()
     {

--- a/tests/phpunit/unit/Helper/StrTest.php
+++ b/tests/phpunit/unit/Helper/StrTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Helper;
 
 use Bolt\Helpers\Str;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Helper/Str.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class StrTest extends BoltUnitTest
+class StrTest extends BoltFunctionalTestCase
 {
     public function testBasicMakeSafe()
     {

--- a/tests/phpunit/unit/Library/BoltLibraryTest.php
+++ b/tests/phpunit/unit/Library/BoltLibraryTest.php
@@ -3,7 +3,7 @@ namespace Bolt\Tests\Library;
 
 use Bolt\Exception\LowlevelException;
 use Bolt\Library;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class BoltLibraryTest extends BoltUnitTest
+class BoltLibraryTest extends BoltFunctionalTestCase
 {
     protected function tearDown()
     {

--- a/tests/phpunit/unit/Logger/ChangeLogTest.php
+++ b/tests/phpunit/unit/Logger/ChangeLogTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Logger;
 
 use Bolt\Storage;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ChangeLogTest extends BoltUnitTest
+class ChangeLogTest extends BoltFunctionalTestCase
 {
     public function setUp()
     {

--- a/tests/phpunit/unit/Logger/LogManagerTest.php
+++ b/tests/phpunit/unit/Logger/LogManagerTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Logger;
 
 use Bolt\Logger\Manager;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Mocks\DoctrineMockBuilder;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class LogManagerTest extends BoltUnitTest
+class LogManagerTest extends BoltFunctionalTestCase
 {
     public function setUp()
     {

--- a/tests/phpunit/unit/Logger/RecordChangeHandlerTest.php
+++ b/tests/phpunit/unit/Logger/RecordChangeHandlerTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Logger;
 
 use Bolt\Logger\Handler\RecordChangeHandler;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Mocks\DoctrineMockBuilder;
 use Monolog\Logger;
 
@@ -11,7 +11,7 @@ use Monolog\Logger;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class RecordChangeHandlerTest extends BoltUnitTest
+class RecordChangeHandlerTest extends BoltFunctionalTestCase
 {
     public function testSetupInitialize()
     {

--- a/tests/phpunit/unit/Logger/SystemHandlerTest.php
+++ b/tests/phpunit/unit/Logger/SystemHandlerTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Logger;
 
 use Bolt\Logger\Handler\SystemHandler;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Mocks\DoctrineMockBuilder;
 use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class SystemHandlerTest extends BoltUnitTest
+class SystemHandlerTest extends BoltFunctionalTestCase
 {
     public function testSetupInitialize()
     {

--- a/tests/phpunit/unit/Mapping/MetadataDriverTest.php
+++ b/tests/phpunit/unit/Mapping/MetadataDriverTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Mapping;
 
 use Bolt\Storage\Mapping\MetadataDriver;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Mapping/MetadataDriver.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class MetadataDriverTest extends BoltUnitTest
+class MetadataDriverTest extends BoltFunctionalTestCase
 {
     public function testConstruct()
     {

--- a/tests/phpunit/unit/Menu/MenuBuilderTest.php
+++ b/tests/phpunit/unit/Menu/MenuBuilderTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Menu;
 
 use Bolt\Menu\MenuBuilder;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Sufijen Bani <bolt@sbani.net>
  */
-class MenuBuilderTest extends BoltUnitTest
+class MenuBuilderTest extends BoltFunctionalTestCase
 {
     /**
      * @return array

--- a/tests/phpunit/unit/Menu/MenuEntryTest.php
+++ b/tests/phpunit/unit/Menu/MenuEntryTest.php
@@ -3,14 +3,14 @@
 namespace Bolt\Tests\Menu;
 
 use Bolt\Menu\MenuEntry;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Menu/MenuEntry.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class MenuEntryTest extends BoltUnitTest
+class MenuEntryTest extends BoltFunctionalTestCase
 {
     public function testCreateRoot()
     {

--- a/tests/phpunit/unit/Nut/CacheClearTest.php
+++ b/tests/phpunit/unit/Nut/CacheClearTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\CacheClear;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class CacheClearTest extends BoltUnitTest
+class CacheClearTest extends BoltFunctionalTestCase
 {
     public function testSuccessfulClear()
     {

--- a/tests/phpunit/unit/Nut/ConfigGetTest.php
+++ b/tests/phpunit/unit/Nut/ConfigGetTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Nut;
 use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Nut\ConfigGet;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ConfigGetTest extends BoltUnitTest
+class ConfigGetTest extends BoltFunctionalTestCase
 {
     public function testGet()
     {

--- a/tests/phpunit/unit/Nut/ConfigSetTest.php
+++ b/tests/phpunit/unit/Nut/ConfigSetTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Nut;
 use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Nut\ConfigSet;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ConfigSetTest extends BoltUnitTest
+class ConfigSetTest extends BoltFunctionalTestCase
 {
     public function testSet()
     {

--- a/tests/phpunit/unit/Nut/CronRunnerTest.php
+++ b/tests/phpunit/unit/Nut/CronRunnerTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\CronRunner;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class CronRunnerTest extends BoltUnitTest
+class CronRunnerTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/DatabaseCheckTest.php
+++ b/tests/phpunit/unit/Nut/DatabaseCheckTest.php
@@ -3,7 +3,7 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\DatabaseCheck;
 use Bolt\Storage\Database\Schema\Table;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class DatabaseCheckTest extends BoltUnitTest
+class DatabaseCheckTest extends BoltFunctionalTestCase
 {
     public function testRunNormal()
     {

--- a/tests/phpunit/unit/Nut/DatabaseRepairTest.php
+++ b/tests/phpunit/unit/Nut/DatabaseRepairTest.php
@@ -3,7 +3,7 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\DatabaseRepair;
 use Bolt\Storage\Database\Schema\Table;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class DatabaseRepairTest extends BoltUnitTest
+class DatabaseRepairTest extends BoltFunctionalTestCase
 {
     public function testRunNormal()
     {

--- a/tests/phpunit/unit/Nut/ExtensionsDumpAutoloadTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsDumpAutoloadTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\ExtensionsDumpAutoload;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ExtensionsDumpAutoloadTest extends BoltUnitTest
+class ExtensionsDumpAutoloadTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/ExtensionsInstallTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsInstallTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\ExtensionsInstall;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ExtensionsInstallTest extends BoltUnitTest
+class ExtensionsInstallTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/ExtensionsSetupTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsSetupTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\ExtensionsSetup;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ExtensionsSetupTest extends BoltUnitTest
+class ExtensionsSetupTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/ExtensionsTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\Extensions;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Composer\Package\CompletePackage;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\TableHelper;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ExtensionsTest extends BoltUnitTest
+class ExtensionsTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/ExtensionsUninstallTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsUninstallTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\ExtensionsUninstall;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ExtensionsUninstallTest extends BoltUnitTest
+class ExtensionsUninstallTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/InfoTest.php
+++ b/tests/phpunit/unit/Nut/InfoTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\Info;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class InfoTest extends BoltUnitTest
+class InfoTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/LogClearTest.php
+++ b/tests/phpunit/unit/Nut/LogClearTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\LogClear;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class LogClearTest extends BoltUnitTest
+class LogClearTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/LogTrimTest.php
+++ b/tests/phpunit/unit/Nut/LogTrimTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\LogTrim;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class LogTrimTest extends BoltUnitTest
+class LogTrimTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/TestRunnerTest.php
+++ b/tests/phpunit/unit/Nut/TestRunnerTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\TestRunner;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class TestRunnerTest extends BoltUnitTest
+class TestRunnerTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/UserAddTest.php
+++ b/tests/phpunit/unit/Nut/UserAddTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserAdd;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use PasswordLib\PasswordLib;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class UserAddTest extends BoltUnitTest
+class UserAddTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/UserManageTest.php
+++ b/tests/phpunit/unit/Nut/UserManageTest.php
@@ -3,7 +3,7 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserManage;
 use Bolt\Storage\Repository\UsersRepository;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class UserManageTest extends BoltUnitTest
+class UserManageTest extends BoltFunctionalTestCase
 {
     public function testListing()
     {

--- a/tests/phpunit/unit/Nut/UserResetPasswordTest.php
+++ b/tests/phpunit/unit/Nut/UserResetPasswordTest.php
@@ -3,7 +3,7 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserResetPassword;
 use Bolt\Storage\Entity;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use PasswordLib\PasswordLib;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class UserResetPasswordTest extends BoltUnitTest
+class UserResetPasswordTest extends BoltFunctionalTestCase
 {
     public function testRun()
     {

--- a/tests/phpunit/unit/Nut/UserRoleAddTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleAddTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserRoleAdd;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class UserRoleAddTest extends BoltUnitTest
+class UserRoleAddTest extends BoltFunctionalTestCase
 {
     public function testAdd()
     {

--- a/tests/phpunit/unit/Nut/UserRoleRemoveTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleRemoveTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserRoleRemove;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class UserRoleRemoveTest extends BoltUnitTest
+class UserRoleRemoveTest extends BoltFunctionalTestCase
 {
     public function testRemove()
     {

--- a/tests/phpunit/unit/Pager/PagerManagerTestBase.php
+++ b/tests/phpunit/unit/Pager/PagerManagerTestBase.php
@@ -4,10 +4,10 @@ namespace Bolt\Tests\Pager;
 
 use Bolt\Pager\Pager;
 use Bolt\Pager\PagerManager;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-abstract class PagerManagerTestBase extends BoltUnitTest
+abstract class PagerManagerTestBase extends BoltFunctionalTestCase
 {
     protected function createPagerManager()
     {

--- a/tests/phpunit/unit/Profiler/BoltDataCollectorTest.php
+++ b/tests/phpunit/unit/Profiler/BoltDataCollectorTest.php
@@ -3,7 +3,7 @@ namespace Bolt\Tests\Profiler;
 
 use Bolt\Helpers\Html;
 use Bolt\Profiler\BoltDataCollector;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class BoltDataCollectorTest extends BoltUnitTest
+class BoltDataCollectorTest extends BoltFunctionalTestCase
 {
     public function testBasicData()
     {

--- a/tests/phpunit/unit/Profiler/DatabaseDataCollectorTest.php
+++ b/tests/phpunit/unit/Profiler/DatabaseDataCollectorTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Profiler;
 
 use Bolt\Profiler\DatabaseDataCollector;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Doctrine\DBAL\Logging\DebugStack;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class DatabaseDataCollectorTest extends BoltUnitTest
+class DatabaseDataCollectorTest extends BoltFunctionalTestCase
 {
     public function testBasicData()
     {

--- a/tests/phpunit/unit/Provider/CacheServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/CacheServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\CacheServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/CacheServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class CacheServiceProviderTest extends BoltUnitTest
+class CacheServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/ConfigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ConfigServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\ConfigServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/ConfigServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ConfigServiceProviderTest extends BoltUnitTest
+class ConfigServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/CronServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/CronServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\CronServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/CronServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class CronServiceProviderTest extends BoltUnitTest
+class CronServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/DatabaseSchemaServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/DatabaseSchemaServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\DatabaseSchemaServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/DatabaseSchemaServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class DatabaseSchemaServiceProviderTest extends BoltUnitTest
+class DatabaseSchemaServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/ExtensionServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ExtensionServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\ExtensionServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/ExtensionServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ExtensionServiceProviderTest extends BoltUnitTest
+class ExtensionServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/FilePermissionsServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/FilePermissionsServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\FilePermissionsServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/FilePermissionsServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class FilePermissionsServiceProviderTest extends BoltUnitTest
+class FilePermissionsServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/FilesystemServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/FilesystemServiceProviderTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\FilesystemServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test Bolt\Provider\FilesystemServiceProvider.
@@ -10,7 +10,7 @@ use Bolt\Tests\BoltUnitTest;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
  */
-class FilesystemServiceProviderTest extends BoltUnitTest
+class FilesystemServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/LoggerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/LoggerServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\LoggerServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/NutServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class LoggerServiceProviderTest extends BoltUnitTest
+class LoggerServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/MenuServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/MenuServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\MenuServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/MenuServiceProvider
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class MenuServiceProviderTest extends BoltUnitTest
+class MenuServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/NutServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/NutServiceProviderTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\NutServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Console;
 use Symfony\Component\Console\Command\Command;
 
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Command\Command;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
  */
-class NutServiceProviderTest extends BoltUnitTest
+class NutServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/OmnisearchServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/OmnisearchServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\OmnisearchServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/OmnisearchServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class OmnisearchServiceProviderTest extends BoltUnitTest
+class OmnisearchServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/PagerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PagerServiceProviderTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\PagerServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Rix Beck <rix@neologik.hu>
  */
-class PagerServiceProviderTest extends BoltUnitTest
+class PagerServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/PathServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PathServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\PathServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/PathServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class PathServiceProviderTest extends BoltUnitTest
+class PathServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/PermissionsServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PermissionsServiceProviderTest.php
@@ -3,14 +3,14 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\AccessControl\Permissions;
 use Bolt\Provider\PermissionsServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/PermissionsServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class PermissionsServiceProviderTest extends BoltUnitTest
+class PermissionsServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/ProfilerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ProfilerServiceProviderTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\ProfilerServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/DatabaseProfilerServiceProvider.
@@ -10,7 +10,7 @@ use Bolt\Tests\BoltUnitTest;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
  */
-class ProfilerServiceProviderTest extends BoltUnitTest
+class ProfilerServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/RenderServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/RenderServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\RenderServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/RenderServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class RenderServiceProviderTest extends BoltUnitTest
+class RenderServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/SessionServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/SessionServiceProviderTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Provider;
 use Bolt\Provider\SessionServiceProvider;
 use Bolt\Session\Generator\GeneratorInterface;
 use Bolt\Session\Serializer\SerializerInterface;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
  */
-class SessionServiceProviderTest extends BoltUnitTest
+class SessionServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/SlugifyProviderTest.php
+++ b/tests/phpunit/unit/Provider/SlugifyProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bolt\Tests\Provider;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Cocur\Slugify\Bridge\Silex\SlugifyServiceProvider;
 
 /**
@@ -9,7 +9,7 @@ use Cocur\Slugify\Bridge\Silex\SlugifyServiceProvider;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class SlugifyProviderTest extends BoltUnitTest
+class SlugifyProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/StackServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/StackServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\StackServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/StackServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class StackServiceProviderTest extends BoltUnitTest
+class StackServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/StorageServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/StorageServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\StorageServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/StorageServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class StorageServiceProviderTest extends BoltUnitTest
+class StorageServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/TemplateChooserServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TemplateChooserServiceProviderTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\TemplateChooserServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/TemplateChooserServiceProvider.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class TemplateChooserServiceProviderTest extends BoltUnitTest
+class TemplateChooserServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Provider;
 use Bolt\Application;
 use Bolt\Configuration\ResourceManager;
 use Bolt\Provider\TranslationServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -12,7 +12,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class TranslationServiceProviderTest extends BoltUnitTest
+class TranslationServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\TwigServiceProvider;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Provider/TwigServiceProvider.
@@ -12,7 +12,7 @@ use Bolt\Tests\BoltUnitTest;
  *
  * @covers \Bolt\Provider\TwigServiceProvider
  */
-class TwigServiceProviderTest extends BoltUnitTest
+class TwigServiceProviderTest extends BoltFunctionalTestCase
 {
     public function testProvider()
     {

--- a/tests/phpunit/unit/Response/BoltResponseTest.php
+++ b/tests/phpunit/unit/Response/BoltResponseTest.php
@@ -3,9 +3,9 @@
 namespace Bolt\Tests\Response;
 
 use Bolt\Response\BoltResponse;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
-class BoltResponseTest extends BoltUnitTest
+class BoltResponseTest extends BoltFunctionalTestCase
 {
     public function testCreate()
     {

--- a/tests/phpunit/unit/Routing/CallbackResolverTest.php
+++ b/tests/phpunit/unit/Routing/CallbackResolverTest.php
@@ -3,9 +3,9 @@
 namespace Bolt\Tests\Routing;
 
 use Bolt\Routing\CallbackResolver;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
-class CallbackResolverTest extends BoltUnitTest
+class CallbackResolverTest extends BoltFunctionalTestCase
 {
     public function testService()
     {

--- a/tests/phpunit/unit/Routing/UrlGeneratorFragmentWrapperTest.php
+++ b/tests/phpunit/unit/Routing/UrlGeneratorFragmentWrapperTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Routing;
 
 use Bolt\Routing\LazyUrlGenerator;
 use Bolt\Routing\UrlGeneratorFragmentWrapper;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Silex\Route;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
 use Symfony\Component\Routing\Generator\UrlGenerator;
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\RouteCollection;
 /**
  * @author Carson Full <carsonfull@gmail.com>
  */
-class UrlGeneratorFragmentWrapperTest extends BoltUnitTest
+class UrlGeneratorFragmentWrapperTest extends BoltFunctionalTestCase
 {
     public function testUrlGeneratorInterface()
     {

--- a/tests/phpunit/unit/Session/FileHandlerTest.php
+++ b/tests/phpunit/unit/Session/FileHandlerTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Session;
 
 use Bolt\Session\Handler\FileHandler;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Session/Handler/FileHandler.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class FileHandlerTest extends BoltUnitTest
+class FileHandlerTest extends BoltFunctionalTestCase
 {
     /** @var string */
     protected $savePath;

--- a/tests/phpunit/unit/Session/NativeGeneratorTest.php
+++ b/tests/phpunit/unit/Session/NativeGeneratorTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Session;
 
 use Bolt\Session\Generator\NativeGenerator;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Session/Generator/NativeGenerator.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class NativeGeneratorTest extends BoltUnitTest
+class NativeGeneratorTest extends BoltFunctionalTestCase
 {
     public function testGenerateId()
     {

--- a/tests/phpunit/unit/Session/NativeSerializerTest.php
+++ b/tests/phpunit/unit/Session/NativeSerializerTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Session;
 
 use Bolt\Session\Serializer\NativeSerializer;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Session/Serializer/NativeSerializer.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class NativeSerializerTest extends BoltUnitTest
+class NativeSerializerTest extends BoltFunctionalTestCase
 {
     public function testSerialize()
     {

--- a/tests/phpunit/unit/Session/OptionsBagTest.php
+++ b/tests/phpunit/unit/Session/OptionsBagTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Session;
 
 use Bolt\Session\OptionsBag;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Session/OptionsBag.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class OptionsBagTest extends BoltUnitTest
+class OptionsBagTest extends BoltFunctionalTestCase
 {
     public function testInstanceOf()
     {

--- a/tests/phpunit/unit/Session/RandomGeneratorTest.php
+++ b/tests/phpunit/unit/Session/RandomGeneratorTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Session;
 
 use Bolt\Session\Generator\RandomGenerator;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Session/Generator/RandomGenerator.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class RandomGeneratorTest extends BoltUnitTest
+class RandomGeneratorTest extends BoltFunctionalTestCase
 {
     public function testConstructor()
     {

--- a/tests/phpunit/unit/Session/SessionListenerTest.php
+++ b/tests/phpunit/unit/Session/SessionListenerTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace Bolt\Tests\Session;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Session/SessionListener.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class SessionListenerTest extends BoltUnitTest
+class SessionListenerTest extends BoltFunctionalTestCase
 {
     public function test()
     {

--- a/tests/phpunit/unit/Session/SessionStorageTest.php
+++ b/tests/phpunit/unit/Session/SessionStorageTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace Bolt\Tests\Session;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Session/SessionStorage.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class SessionStorageTest extends BoltUnitTest
+class SessionStorageTest extends BoltFunctionalTestCase
 {
     public function test()
     {

--- a/tests/phpunit/unit/Stack/StackTest.php
+++ b/tests/phpunit/unit/Stack/StackTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Stack;
 
 use Bolt\Stack;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Users;
 
 /**
@@ -10,7 +10,7 @@ use Bolt\Users;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class StackTest extends BoltUnitTest
+class StackTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Storage/EntityBuilderTest.php
+++ b/tests/phpunit/unit/Storage/EntityBuilderTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace Bolt\Tests\Storage;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Repository and field transforms for load and hydrate
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class EntityBuilderTest extends BoltUnitTest
+class EntityBuilderTest extends BoltFunctionalTestCase
 {
     public function testBuilderCreate()
     {

--- a/tests/phpunit/unit/Storage/EntityManagerTest.php
+++ b/tests/phpunit/unit/Storage/EntityManagerTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Storage\EntityManager;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/EntityManager.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class EntityManagerTest extends BoltUnitTest
+class EntityManagerTest extends BoltFunctionalTestCase
 {
     public function testConnect()
     {

--- a/tests/phpunit/unit/Storage/FieldLoadTest.php
+++ b/tests/phpunit/unit/Storage/FieldLoadTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Legacy\Storage;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class FieldLoadTest extends BoltUnitTest
+class FieldLoadTest extends BoltFunctionalTestCase
 {
     public function testRelationsLoad()
     {

--- a/tests/phpunit/unit/Storage/FieldSaveTest.php
+++ b/tests/phpunit/unit/Storage/FieldSaveTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Legacy\Storage;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class FieldSaveTest extends BoltUnitTest
+class FieldSaveTest extends BoltFunctionalTestCase
 {
     public function testRelationsSave()
     {

--- a/tests/phpunit/unit/Storage/FieldSetTest.php
+++ b/tests/phpunit/unit/Storage/FieldSetTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Legacy\Storage;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Repository and field transforms for load and hydrate
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class FieldSetTest extends BoltUnitTest
+class FieldSetTest extends BoltFunctionalTestCase
 {
     public function testSetWithNormalValues()
     {

--- a/tests/phpunit/unit/Storage/PrefillTest.php
+++ b/tests/phpunit/unit/Storage/PrefillTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Storage;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use GuzzleHttp\Message\MessageFactory;
 use GuzzleHttp\Psr7\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class PrefillTest extends BoltUnitTest
+class PrefillTest extends BoltFunctionalTestCase
 {
     public function testUrl()
     {

--- a/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
@@ -3,14 +3,14 @@
 namespace Bolt\Tests\Storage\Query;
 
 use Bolt\Storage\Query\ContentQueryParser;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/ContentQueryParser.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ContentQueryParserTest extends BoltUnitTest
+class ContentQueryParserTest extends BoltFunctionalTestCase
 {
     public function testQueryParse()
     {

--- a/tests/phpunit/unit/Storage/Query/NativeSearchTest.php
+++ b/tests/phpunit/unit/Storage/Query/NativeSearchTest.php
@@ -3,14 +3,14 @@
 namespace Bolt\Tests\Storage\Query;
 
 use Bolt\Storage\Query\Adapter\PostgresSearch;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/QueryTest.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class NativeSearchTest extends BoltUnitTest
+class NativeSearchTest extends BoltFunctionalTestCase
 {
     public function testPostgresQueryBuild()
     {

--- a/tests/phpunit/unit/Storage/Query/QueryFieldDelegationTest.php
+++ b/tests/phpunit/unit/Storage/Query/QueryFieldDelegationTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Storage\Query;
 
 use Bolt\Legacy\Storage;
 use Bolt\Storage\Query\ContentQueryParser;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class QueryFieldDelegationTest extends BoltUnitTest
+class QueryFieldDelegationTest extends BoltFunctionalTestCase
 {
     public function testTaxonomyFilter()
     {

--- a/tests/phpunit/unit/Storage/Query/QueryParameterParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/QueryParameterParserTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Storage\Query;
 
 use Bolt\Storage\Query\QueryParameterParser;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/QueryParameterParser.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class QueryParameterParserTest extends BoltUnitTest
+class QueryParameterParserTest extends BoltFunctionalTestCase
 {
     public function testValueParse()
     {

--- a/tests/phpunit/unit/Storage/Query/QueryResultsetTest.php
+++ b/tests/phpunit/unit/Storage/Query/QueryResultsetTest.php
@@ -3,14 +3,14 @@
 namespace Bolt\Tests\Storage\Query;
 
 use Bolt\Storage\Query\QueryResultset;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/QueryTest.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class QueryResultsetTest extends BoltUnitTest
+class QueryResultsetTest extends BoltFunctionalTestCase
 {
     public function testSimpleMerge()
     {

--- a/tests/phpunit/unit/Storage/Query/QueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/QueryTest.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Storage\Query;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/QueryTest.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class QueryTest extends BoltUnitTest
+class QueryTest extends BoltFunctionalTestCase
 {
     public function testgetContent()
     {

--- a/tests/phpunit/unit/Storage/Query/SearchConfigTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchConfigTest.php
@@ -3,14 +3,14 @@
 namespace Bolt\Tests\Storage\Query;
 
 use Bolt\Storage\Query\SearchConfig;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/QueryTest.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class SearchConfigTest extends BoltUnitTest
+class SearchConfigTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Storage\Query;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/SearchQuery.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class SearchQueryTest extends BoltUnitTest
+class SearchQueryTest extends BoltFunctionalTestCase
 {
     public function testQuery()
     {

--- a/tests/phpunit/unit/Storage/Query/SearchWeighterTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchWeighterTest.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Storage\Query;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/SelectQuery.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class SearchWeighterTest extends BoltUnitTest
+class SearchWeighterTest extends BoltFunctionalTestCase
 {
     public function testSimpleWeight()
     {

--- a/tests/phpunit/unit/Storage/Query/SelectQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SelectQueryTest.php
@@ -3,14 +3,14 @@
 namespace Bolt\Tests\Storage\Query;
 
 use Bolt\Storage\Query\SelectQuery;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Query/SelectQuery.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class SelectQueryTest extends BoltUnitTest
+class SelectQueryTest extends BoltFunctionalTestCase
 {
     public function testQuery()
     {

--- a/tests/phpunit/unit/Storage/Repository/AuthtokenRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/AuthtokenRepositoryTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace Bolt\Tests\Storage\Repository;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Repository/AuthtokenRepository
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class AuthtokenRepositoryTest extends BoltUnitTest
+class AuthtokenRepositoryTest extends BoltFunctionalTestCase
 {
     public function testRepositoryQueries()
     {

--- a/tests/phpunit/unit/Storage/Repository/ContentRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/ContentRepositoryTest.php
@@ -3,14 +3,14 @@ namespace Bolt\Tests\Storage\Repository;
 
 use Bolt\Storage\Entity\Content;
 use Bolt\Storage\Repository;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Repository/Content
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ContentRepositoryTest extends BoltUnitTest
+class ContentRepositoryTest extends BoltFunctionalTestCase
 {
     public function testConstruct()
     {

--- a/tests/phpunit/unit/Storage/Repository/LogChangeRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/LogChangeRepositoryTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace Bolt\Tests\Storage\Repository;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Repository/LogChangeRepository
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class LogChangeRepositoryTest extends BoltUnitTest
+class LogChangeRepositoryTest extends BoltFunctionalTestCase
 {
     public function testRepositoryQueries()
     {

--- a/tests/phpunit/unit/Storage/Repository/LogSystemRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/LogSystemRepositoryTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bolt\Tests\Storage\Repository;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Psr\Log\LogLevel;
 
 /**
@@ -9,7 +9,7 @@ use Psr\Log\LogLevel;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class LogSystemRepositoryTest extends BoltUnitTest
+class LogSystemRepositoryTest extends BoltFunctionalTestCase
 {
     public function testRepositoryQueries()
     {

--- a/tests/phpunit/unit/Storage/Repository/UsersRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/UsersRepositoryTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace Bolt\Tests\Storage\Repository;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Repository/UsersRepository
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class UsersRepositoryTest extends BoltUnitTest
+class UsersRepositoryTest extends BoltFunctionalTestCase
 {
     public function testRepositoryQueries()
     {

--- a/tests/phpunit/unit/Storage/RepositoryTest.php
+++ b/tests/phpunit/unit/Storage/RepositoryTest.php
@@ -2,14 +2,14 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Storage\Repository;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test src/Storage/Repository.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class RepositoryTest extends BoltUnitTest
+class RepositoryTest extends BoltFunctionalTestCase
 {
     public $eventCount = [];
 

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Storage;
 use Bolt\Events\StorageEvents;
 use Bolt\Legacy\Content;
 use Bolt\Legacy\Storage;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class StorageTest extends BoltUnitTest
+class StorageTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Translation/TranslationFileTest.php
+++ b/tests/phpunit/unit/Translation/TranslationFileTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bolt\Tests\Translation;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Translation\TranslationFile;
 use Symfony\Component\Yaml\Yaml;
 
@@ -10,7 +10,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class TranslationFileTest extends BoltUnitTest
+class TranslationFileTest extends BoltFunctionalTestCase
 {
     public function testSetup()
     {

--- a/tests/phpunit/unit/Translation/TranslatorTest.php
+++ b/tests/phpunit/unit/Translation/TranslatorTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bolt\Tests\Translation;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Translation\Translator;
 
 /**
@@ -9,7 +9,7 @@ use Bolt\Translation\Translator;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class TranslatorTest extends BoltUnitTest
+class TranslatorTest extends BoltFunctionalTestCase
 {
     public function testSimpleTranslate()
     {

--- a/tests/phpunit/unit/Twig/Handler/AdminHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/AdminHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Twig;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\AdminHandler;
 use Silex\Translator;
 
@@ -11,7 +11,7 @@ use Silex\Translator;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class AdminHandlerTest extends BoltUnitTest
+class AdminHandlerTest extends BoltFunctionalTestCase
 {
     public function testBuic()
     {

--- a/tests/phpunit/unit/Twig/Handler/ArrayHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ArrayHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Twig;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\ArrayHandler;
 
 /**
@@ -10,7 +10,7 @@ use Bolt\Twig\Handler\ArrayHandler;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ArrayHandlerTest extends BoltUnitTest
+class ArrayHandlerTest extends BoltFunctionalTestCase
 {
     public function setUp()
     {

--- a/tests/phpunit/unit/Twig/Handler/HtmlHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/HtmlHandlerTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Twig;
 
 use Bolt\Legacy\Content;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\HtmlHandler;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class HtmlHandlerTest extends BoltUnitTest
+class HtmlHandlerTest extends BoltFunctionalTestCase
 {
     public function testDecorateTT()
     {

--- a/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ImageHandlerTest.php
@@ -4,7 +4,7 @@ namespace Bolt\Tests\Twig;
 
 use Bolt\Filesystem\Handler\Image;
 use Bolt\Filesystem\Handler\ImageInterface;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\ImageHandler;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -13,7 +13,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ImageHandlerTest extends BoltUnitTest
+class ImageHandlerTest extends BoltFunctionalTestCase
 {
     protected function setUp()
     {

--- a/tests/phpunit/unit/Twig/Handler/RecordHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/RecordHandlerTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Twig;
 
 use Bolt\Asset\Snippet\Snippet;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\RecordHandler;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class RecordHandlerTest extends BoltUnitTest
+class RecordHandlerTest extends BoltFunctionalTestCase
 {
     protected $original = <<<GRINGALET
 But Gawain chose the lower road, and passed

--- a/tests/phpunit/unit/Twig/Handler/TextHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/TextHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Twig;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\TextHandler;
 
 /**
@@ -10,7 +10,7 @@ use Bolt\Twig\Handler\TextHandler;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class TextHandlerTest extends BoltUnitTest
+class TextHandlerTest extends BoltFunctionalTestCase
 {
     public function setUp()
     {

--- a/tests/phpunit/unit/Twig/Handler/UserHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/UserHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Twig;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\UserHandler;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class UserHandlerTest extends BoltUnitTest
+class UserHandlerTest extends BoltFunctionalTestCase
 {
     protected function setUp()
     {

--- a/tests/phpunit/unit/Twig/Handler/UtilsHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/UtilsHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Twig;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\UtilsHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\VarDumper\VarDumper;
@@ -12,7 +12,7 @@ use Symfony\Component\VarDumper\VarDumper;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class UtilsHandlerTest extends BoltUnitTest
+class UtilsHandlerTest extends BoltFunctionalTestCase
 {
     protected function tearDown()
     {

--- a/tests/phpunit/unit/Twig/Handler/WidgetHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/WidgetHandlerTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Twig;
 
 use Bolt\Asset\Widget\Widget;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\Handler\WidgetHandler;
 
 /**
@@ -11,7 +11,7 @@ use Bolt\Twig\Handler\WidgetHandler;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class WidgetHandlerTest extends BoltUnitTest
+class WidgetHandlerTest extends BoltFunctionalTestCase
 {
     public function testCountWidgets()
     {

--- a/tests/phpunit/unit/Twig/SetcontentTest.php
+++ b/tests/phpunit/unit/Twig/SetcontentTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bolt\Tests\Twig;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\SetcontentTokenParser;
 use Twig_Compiler;
 use Twig_Environment;
@@ -15,7 +15,7 @@ use Twig_TokenStream;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class SetcontentTest extends BoltUnitTest
+class SetcontentTest extends BoltFunctionalTestCase
 {
     public function testClass()
     {

--- a/tests/phpunit/unit/Twig/TwigExtensionTest.php
+++ b/tests/phpunit/unit/Twig/TwigExtensionTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Twig;
 
 use Bolt\Legacy\Content;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Bolt\Twig\TwigExtension;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class TwigExtensionTest extends BoltUnitTest
+class TwigExtensionTest extends BoltFunctionalTestCase
 {
     public function testTwigInterface()
     {

--- a/tests/phpunit/unit/Users/AuthenticationTest.php
+++ b/tests/phpunit/unit/Users/AuthenticationTest.php
@@ -2,7 +2,7 @@
 namespace Bolt\Tests\Users;
 
 use Bolt\Events\AccessControlEvent;
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Steven de Vries <info@stevendevries.nl>
  **/
-class AuthenticationTest extends BoltUnitTest
+class AuthenticationTest extends BoltFunctionalTestCase
 {
     /**
      * @var array

--- a/tests/phpunit/unit/Users/CreateUsersTest.php
+++ b/tests/phpunit/unit/Users/CreateUsersTest.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Users;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Test creating new users
  *
  * @author Chris Hilsdon <chris@koolserve.uk>
  **/
-class CreateUsersTest extends BoltUnitTest
+class CreateUsersTest extends BoltFunctionalTestCase
 {
     /**
      * @see \PHPUnit_Framework_TestCase::setUp

--- a/tests/phpunit/unit/Users/UsersTest.php
+++ b/tests/phpunit/unit/Users/UsersTest.php
@@ -1,14 +1,14 @@
 <?php
 namespace Bolt\Tests\Users;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\BoltFunctionalTestCase;
 
 /**
  * Class to test correct operation of src/Users.
  *
  * @author Steven de Vries <info@stevendevries.nl>
  **/
-class UsersTest extends BoltUnitTest
+class UsersTest extends BoltFunctionalTestCase
 {
     /**
      * @var array


### PR DESCRIPTION
Fixes https://github.com/bolt/bolt/issues/5487 and as discussed breifly at an IRC meeting.

This PR aims to reorganize the tests, with the specific aim of making a diferentiation between `functional` and `unit` tests.

In this case defined as:
- **functional**: Requiring the bolt application to be booted.
- **unit**: Extends `\PHPUnit_Framework_TestCase`; generally no non-mocked dependencies.

Currently all tests are functional tests under a folder named `unit`.

Practical benefits of this reorganization will be allowing and encourging unit tests to be written - encouraging because people may be less likely to write functional tests when a unit test would be more suitable (sometimes it may be desirable to have both).

Unit tests are many times faster than functional tests, and as they do not depend on application state, are much more able to fully test all code paths in any given class.
