### PR TITLE
fix #5398

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -562,7 +562,10 @@ class Application extends Silex\Application
 
         // true if we need to consider adding html snippets
         // note we exclude cached requests where no additions should be made to the HTML
-        if (isset($this['htmlsnippets']) && ($this['htmlsnippets'] === true) && ($response->headers->get('Cache-Control') === "no-cache")) {
+        if (isset($this['htmlsnippets'])
+            && ($this['htmlsnippets'] === true)
+            && (in_array($response->headers->get('Cache-Control'), ['no-cache','private, must-revalidate']))
+        ) {
             // only add when content-type is text/html
             if (strpos($response->headers->get('Content-Type'), 'text/html') !== false) {
                 // Add our meta generator tag.


### PR DESCRIPTION
there is case where the header cache-control can be either 
"no-cache" either "private, must-revalidate" 

see : /vendor/symfony/http-foundation/Symfony/Component/HttpFoundation/ResponseHeaderBag.php::computeCacheControlValue() method for more information

we must handle that possibility to correctly insert some html snippet.

( This bug is present in bolt 2.2.23 ( and previous i think ) but i dont know for bolt 3 because the application.php file does not work the same !

