### PR TITLE
Create custom exception for invalid repo, and throw this when accessed

### DIFF
--- a/src/Exception/InvalidRepositoryException.php
+++ b/src/Exception/InvalidRepositoryException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bolt\Exception;
+
+use Exception;
+
+/**
+ * Exceptions in Bolt\Storage.
+ */
+class InvalidRepositoryException extends Exception
+{
+}

--- a/src/Storage/EntityManager.php
+++ b/src/Storage/EntityManager.php
@@ -1,6 +1,8 @@
 <?php
 namespace Bolt\Storage;
 
+use Bolt\Exception\InvalidRepositoryException;
+use Bolt\Exception\StorageException;
 use Bolt\Legacy\Storage;
 use Bolt\Storage\Collection\CollectionManager;
 use Bolt\Storage\Mapping\ClassMetadata;
@@ -251,9 +253,13 @@ class EntityManager
     {
         $className = (string) $className;
         if (array_key_exists($className, $this->aliases)) {
-            $classMetadata = $this->getMapper()->loadMetadataForClass($this->aliases[$className]);
-        } else {
+            $className = $this->aliases[$className];
+        }
+
+        try {
             $classMetadata = $this->getMapper()->loadMetadataForClass($className);
+        } catch (StorageException $e) {
+            throw new InvalidRepositoryException("Attempted to load repository for invalid class or alias: $className. Check that the class, alias or contenttype definition is correct.");
         }
 
         if (array_key_exists($className, $this->repositories)) {

--- a/src/Storage/EntityManager.php
+++ b/src/Storage/EntityManager.php
@@ -246,8 +246,8 @@ class EntityManager
      * Gets the repository for a class.
      *
      * @param string $className
-     *
      * @return Repository
+     * @throws InvalidRepositoryException
      */
     public function getRepository($className)
     {


### PR DESCRIPTION
Small patch for issue discussed in #5537. 
Gives a more descriptive error message when an invalid repository is loaded.