### PR TITLE
Fixed issue when searching multiple contentypes in Bolt V3 Storage Layer

### DIFF
--- a/src/Storage/Query/Handler/SearchQueryHandler.php
+++ b/src/Storage/Query/Handler/SearchQueryHandler.php
@@ -19,8 +19,10 @@ class SearchQueryHandler
     {
         $set = new SearchQueryResultset();
 
+        $cleanSearchQuery = $contentQuery->getService('search');
+
         foreach ($contentQuery->getContentTypes() as $contenttype) {
-            $query = $contentQuery->getService('search');
+            $query = clone $cleanSearchQuery;
             $repo = $contentQuery->getEntityManager()->getRepository($contenttype);
             $query->setQueryBuilder($repo->createQueryBuilder($contenttype));
             $query->setContentType($contenttype);


### PR DESCRIPTION
When searching multiple content types in the Bolt V3 storage layer, it is being overwritten by the previous query. This should correct the issue by cloning a fresh instance of `SearchQuery` to be used each time in the `foreach` loop.

Fixes: #5391 
