### PR TITLE
Increase MySQL group_concat_max_len variable

### DIFF
--- a/src/EventListener/DoctrineListener.php
+++ b/src/EventListener/DoctrineListener.php
@@ -78,6 +78,13 @@ class DoctrineListener implements EventSubscriber
             // see: http://stackoverflow.com/questions/1566602/is-set-character-set-utf8-necessary
             $db->executeQuery('SET NAMES utf8');
             $db->executeQuery('SET CHARACTER_SET_CONNECTION = utf8');
+
+            // Increase group_concat_max_len to 100000. By default, MySQL
+            // sets this to a low value – 1024 – which causes issues with
+            // certain Bolt content types – particularly repeaters – where
+            // the outcome of a GROUP_CONCAT() query will be more than 1024 bytes.
+            // See also: http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_group_concat_max_len
+            $db->executeQuery('SET SESSION group_concat_max_len = 100000');
         } elseif ($platform === 'postgresql') {
             /**
              * @link https://github.com/doctrine/dbal/pull/828


### PR DESCRIPTION
I've been seeing some issues with the repeater content type; in essence, adding more than 10 or so bits of content seems to cause it to fail to save properly – repeater sections end up missing.

@rossriley did some investigation after I brought this up on Slack (thanks Ross!) and reached the conclusion that this was due to the result of a GROUP_CONCAT() operation exceeding 1024 bytes in MySQL. When this happens, by default MySQL silently starts chopping off extra bytes from the result of the query. 

This adds an extra query to the `postConnect()` callback of `EventListener\DoctrineListener` which increases the GROUP_CONCAT() result limit to 100,000 bytes if we're connected to a MySQL server, which should mitigate this from happening.

There could be a better (and somewhat less hacky) way of stopping this happening, however this appears to be the most reliable with minimal code change. If there's a better solution, please let me know – my PHP is somewhat rusty and Bolt knowledge lacking.