### PR TITLE
[FEEDBACK] Separated `Directives` from `Handlers`.

### DIFF
--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -3,18 +3,18 @@
 namespace Bolt\Storage\Query;
 
 use Bolt\Storage\EntityManager;
+use Bolt\Storage\Query\Directive\HydrateDirective;
+use Bolt\Storage\Query\Directive\OrderDirective;
+use Bolt\Storage\Query\Directive\PagingDirective;
+use Bolt\Storage\Query\Directive\PrintQueryDirective;
+use Bolt\Storage\Query\Directive\ReturnSingleDirective;
 use Bolt\Storage\Query\Handler\FirstQueryHandler;
-use Bolt\Storage\Query\Handler\GetQueryHandler;
-use Bolt\Storage\Query\Handler\HydrateHandler;
+use Bolt\Storage\Query\Directive\GetQueryDirective;
 use Bolt\Storage\Query\Handler\IdentifiedSelectHandler;
 use Bolt\Storage\Query\Handler\LatestQueryHandler;
-use Bolt\Storage\Query\Handler\LimitHandler;
+use Bolt\Storage\Query\Directive\LimitDirective;
 use Bolt\Storage\Query\Handler\NativeSearchHandler;
-use Bolt\Storage\Query\Handler\OrderHandler;
-use Bolt\Storage\Query\Handler\PagingHandler;
-use Bolt\Storage\Query\Handler\PrintQueryHandler;
 use Bolt\Storage\Query\Handler\RandomQueryHandler;
-use Bolt\Storage\Query\Handler\ReturnSingleHandler;
 use Bolt\Storage\Query\Handler\SearchQueryHandler;
 use Bolt\Storage\Query\Handler\SelectQueryHandler;
 
@@ -78,13 +78,13 @@ class ContentQueryParser
         $this->addHandler('nativesearch', new NativeSearchHandler());
         $this->addHandler('namedselect', new IdentifiedSelectHandler());
 
-        $this->addDirectiveHandler('getquery', new GetQueryHandler());
-        $this->addDirectiveHandler('hydrate', new HydrateHandler());
-        $this->addDirectiveHandler('limit', new LimitHandler());
-        $this->addDirectiveHandler('order', new OrderHandler());
-        $this->addDirectiveHandler('paging', new PagingHandler());
-        $this->addDirectiveHandler('printquery', new PrintQueryHandler());
-        $this->addDirectiveHandler('returnsingle', new ReturnSingleHandler());
+        $this->addDirectiveHandler('getquery', new GetQueryDirective());
+        $this->addDirectiveHandler('hydrate', new HydrateDirective());
+        $this->addDirectiveHandler('limit', new LimitDirective());
+        $this->addDirectiveHandler('order', new OrderDirective());
+        $this->addDirectiveHandler('paging', new PagingDirective());
+        $this->addDirectiveHandler('printquery', new PrintQueryDirective());
+        $this->addDirectiveHandler('returnsingle', new ReturnSingleDirective());
     }
     /**
      * Sets the input query.

--- a/src/Storage/Query/Directive/GetQueryDirective.php
+++ b/src/Storage/Query/Directive/GetQueryDirective.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Bolt\Storage\Query\Handler;
+namespace Bolt\Storage\Query\Directive;
 
 use Bolt\Storage\Query\QueryInterface;
 
 /**
- *  Handler that allows running of a callback on query.
+ *  Directive that allows running of a callback on query.
  */
-class GetQueryHandler
+class GetQueryDirective
 {
     /**
      * @param QueryInterface $query

--- a/src/Storage/Query/Directive/HydrateDirective.php
+++ b/src/Storage/Query/Directive/HydrateDirective.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Bolt\Storage\Query\Handler;
+namespace Bolt\Storage\Query\Directive;
 
 use Bolt\Storage\Query\QueryInterface;
 
 /**
- *  Handler to add a limit modifier to the query.
+ *  Directive to add a limit modifier to the query.
  */
-class HydrateHandler
+class HydrateDirective
 {
     /**
      * @param QueryInterface $query

--- a/src/Storage/Query/Directive/LimitDirective.php
+++ b/src/Storage/Query/Directive/LimitDirective.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Bolt\Storage\Query\Handler;
+namespace Bolt\Storage\Query\Directive;
 
 use Bolt\Storage\Query\QueryInterface;
 
 /**
- *  Handler to add a limit modifier to the query.
+ *  Directive to add a limit modifier to the query.
  */
-class PagingHandler
+class LimitDirective
 {
     /**
      * @param QueryInterface $query
@@ -15,6 +15,6 @@ class PagingHandler
      */
     public function __invoke(QueryInterface $query, $limit)
     {
-        // Not implemented yet
+        $query->getQueryBuilder()->setMaxResults($limit);
     }
 }

--- a/src/Storage/Query/Directive/OrderDirective.php
+++ b/src/Storage/Query/Directive/OrderDirective.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Bolt\Storage\Query\Handler;
+namespace Bolt\Storage\Query\Directive;
 
 use Bolt\Storage\Query\QueryInterface;
 
 /**
- *  Handler to alter query based on 'order' parameter.
+ *  Directive to alter query based on 'order' parameter.
  *
  *  eg: 'pages', ['order'=>'-datepublish']
  */
-class OrderHandler
+class OrderDirective
 {
     /**
      * @param QueryInterface $query

--- a/src/Storage/Query/Directive/PagingDirective.php
+++ b/src/Storage/Query/Directive/PagingDirective.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Bolt\Storage\Query\Handler;
+namespace Bolt\Storage\Query\Directive;
 
 use Bolt\Storage\Query\QueryInterface;
 
 /**
- *  Handler to add a limit modifier to the query.
+ *  Directive to add a limit modifier to the query.
  */
-class LimitHandler
+class PagingDirective
 {
     /**
      * @param QueryInterface $query
@@ -15,6 +15,6 @@ class LimitHandler
      */
     public function __invoke(QueryInterface $query, $limit)
     {
-        $query->getQueryBuilder()->setMaxResults($limit);
+        // Not implemented yet
     }
 }

--- a/src/Storage/Query/Directive/PrintQueryDirective.php
+++ b/src/Storage/Query/Directive/PrintQueryDirective.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Bolt\Storage\Query\Handler;
+namespace Bolt\Storage\Query\Directive;
 
 use Bolt\Storage\Query\QueryInterface;
 
 /**
- *  Handler a raw output of the generated query.
+ *  Directive a raw output of the generated query.
  */
-class PrintQueryHandler
+class PrintQueryDirective
 {
     /**
      * @param QueryInterface $query

--- a/src/Storage/Query/Directive/ReturnSingleDirective.php
+++ b/src/Storage/Query/Directive/ReturnSingleDirective.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Bolt\Storage\Query\Handler;
+namespace Bolt\Storage\Query\Directive;
 
 use Bolt\Storage\Query\QueryInterface;
 
 /**
- *  Handler to specify that a single object, rather than an array should be returned
+ *  Directive to specify that a single object, rather than an array should be returned
  */
-class ReturnSingleHandler
+class ReturnSingleDirective
 {
     /**
      * @param QueryInterface $query


### PR DESCRIPTION
This isn't an issue, just a refactoring. This could break V3 extensions if they extend upon any of the current directives.

The purpose of this is to separate the logic from `Handlers` and `Directives`. I think the two should be split up since they do different things. Here are my definitions of `Handlers` and `Directives`:

*Handlers* - Short segments of code that execute queries AND returns data from the db
*Directives* - Short segments of code that manipulate queries

Thoughts?