### PR TITLE
(In select fields with content values) the valuefield is last and defaultception

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -19,11 +19,11 @@
     {% if ',' in lookupfield %}
         {% set lookupfieldlist = lookupfield|split(',') %}
     {% endif %}
-    {% set sortingorder = field.sort|default(lookupfieldlist|first)|default(lookupfield)|default('id') %}
+    {% set sortingorder = field.sort|default(lookupfieldlist|default([])|first)|default(lookupfield)|default('id') %}
     {% set querylimit = field.limit|default(500) %}
     {% set wherefilter = field.filter|default({}) %}
     {% setcontent lookups = lookuptype where wherefilter order sortingorder nohydrate limit querylimit %}
-    {% set valuefield = lookupfieldlist|first|default(lookupfield)|default('id') %}
+    {% set valuefield = lookupfieldlist|default([])|last|default(lookupfield)|default('id') %}
     {% set values = lookups|selectfield(valuefield, option.multiple, field.keys|default('id')) %}
 {% endif %}
 


### PR DESCRIPTION
Fixes #5517.

The valuefield is the last one, not the first one, and we can't assume that `lookupfieldlist` is set so, unfortunately we need some defaultception until this code is rewritten.

Also prevents certain twig errors in some cases because of that defaultception.