### PR TITLE
Fix attempts to access values via $this->values in storage

### DIFF
--- a/src/Storage/Entity/ContentRouteTrait.php
+++ b/src/Storage/Entity/ContentRouteTrait.php
@@ -141,16 +141,9 @@ trait ContentRouteTrait
             foreach ($route['requirements'] as $fieldName => $requirement) {
                 if ('\d{4}-\d{2}-\d{2}' === $requirement) {
                     // Special case, if we need to have a date
-                    $params[$fieldName] = substr($this->values[$fieldName], 0, 10);
-                } elseif (isset($this->taxonomy[$fieldName])) {
-                    // Turn something like '/groups/meta' to 'meta'. Note: we use
-                    // two temp vars here, to prevent "Only variables should be passed
-                    // by reference"-notices.
-                    $tempKeys = array_keys($this->taxonomy[$fieldName]);
-                    $tempValues = explode('/', array_shift($tempKeys));
-                    $params[$fieldName] = array_pop($tempValues);
-                } elseif (isset($this->values[$fieldName])) {
-                    $params[$fieldName] = $this->values[$fieldName];
+                    $params[$fieldName] = substr($this->get($fieldName), 0, 10);
+                } elseif ($this->get($fieldName)) {
+                    $params[$fieldName] = $this->get($fieldName);
                 } else {
                     // unkown
                     $params[$fieldName] = null;


### PR DESCRIPTION
Fixes #5466

I took out the taxonomy based routing because as far as I can tell it hasn't worked in 2.2 or 3.0 (tried with tags and groups, seems to not have worked for quite a while), but if there is some quick way to get it to work or if I'm wrong then please let me know.
