### PR TITLE
Always return something in getTitleColumnName

### DIFF
--- a/src/Storage/Mapping/ContentTypeTitleTrait.php
+++ b/src/Storage/Mapping/ContentTypeTitleTrait.php
@@ -45,5 +45,8 @@ trait ContentTypeTitleTrait
                 return $name;
             }
         }
+
+        // If this is a contenttype without any textfields
+        return reset(array_keys($fields));
     }
 }


### PR DESCRIPTION
Prevents errors like `An exception occurred while executing 'SELECT id, as title FROM bolt_kommentarer kommentarer': SQLSTATE[HY000]: General error: 1 near "as": syntax error`. in relations in editcontent when bolt can't find a column to use as title.