### PR TITLE
Implement a new option in nut's database:check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
         "symfony/yaml" : "^2.8",
         "tdammers/htmlmaid" : "~0.7",
         "twig/twig" : "^1.18",
-        "ua-parser/uap-php" : "~3.4"
+        "ua-parser/uap-php" : "~3.4",
+        "jdorn/sql-formatter": "^1.2"
     },
     "require-dev" : {
         "bolt/codingstyle" : "~1.0",

--- a/src/Nut/DatabaseCheck.php
+++ b/src/Nut/DatabaseCheck.php
@@ -2,8 +2,11 @@
 
 namespace Bolt\Nut;
 
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
 
 /**
  * Nut command to perform a database consistency check command
@@ -18,6 +21,7 @@ class DatabaseCheck extends BaseCommand
         $this
             ->setName('database:check')
             ->setDescription('Check the database for missing tables and/or columns.')
+            ->addOption('show-changes', 's', InputOption::VALUE_NONE, 'Show proposed schema changes')
         ;
     }
 
@@ -37,6 +41,68 @@ class DatabaseCheck extends BaseCommand
                 $output->writeln('<info> - ' . $messages . '</info>');
             }
             $output->writeln("<comment>One or more fields/tables are missing from the Database. Please run 'nut database:update' to fix this.</comment>");
+        }
+
+        if ($input->getOption('show-changes')) {
+            $output->writeln('<comment>Proposed modifications:</comment>');
+            $output->writeln("\n");
+            $this->showDiffs($output);
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    protected function showDiffs(OutputInterface $output)
+    {
+        $this->showCreates($output);
+        $this->showAlterations($output);        
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    protected function showCreates($output)
+    {
+        $creates = $this->app['schema.comparator']->getCreates();
+        if ($creates) {
+            $output->writeln('<info>Tables to be created:</info>');
+            foreach ($creates as $tableName => $sql) {
+                $output->writeln("\n");
+                $output->writeln(\SqlFormatter::format($sql[0]));
+                $output->writeln("\n");
+            }
+        }
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    protected function showAlterations($output)
+    {
+        $alters = $this->app['schema.comparator']->getAlters();
+        if ($alters) {
+            $output->writeln('<info>Tables to be altered:</info>');
+
+            $table = new Table($output);
+            $table->setHeaders(['Table Name', 'Alter Query']);
+
+            $tableCount = count($alters);
+
+            foreach ($alters as $tableName => $sql) {
+                foreach ($sql as $query) {
+                    $table->addRow([
+                        $tableName,
+                        \SqlFormatter::highlight($query)
+                    ]);
+                }
+                
+                if (--$tableCount) {
+                    $table->addRow(new TableSeparator());
+                }
+            }
+
+            $table->render();
         }
     }
 }

--- a/src/Nut/DatabaseCheck.php
+++ b/src/Nut/DatabaseCheck.php
@@ -56,7 +56,7 @@ class DatabaseCheck extends BaseCommand
     protected function showDiffs(OutputInterface $output)
     {
         $this->showCreates($output);
-        $this->showAlterations($output);        
+        $this->showAlterations($output);
     }
 
     /**
@@ -96,7 +96,7 @@ class DatabaseCheck extends BaseCommand
                         \SqlFormatter::highlight($query)
                     ]);
                 }
-                
+
                 if (--$tableCount) {
                     $table->addRow(new TableSeparator());
                 }


### PR DESCRIPTION
This relates to Issue 5995 - implemented an option for database:check
which will cause the database statements to be output on the console
with nut.

Changes include:
 - Adding jdorn/sql-formatter to composer, so that queries are more
   legible
 - Making changes to DatabaseCheck, to add the new option and outputs.

Future enhancement could include using the SqlFormatter class within the
web backend to achieve formatting and colourized output in
/dbcheck?debug=1.  Unfortunately, I'm not good enough with the way Twig is used in the backend to get that integrated.