### PR TITLE
[WIP] removes index.php from URL's for #5578

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -27,10 +27,34 @@ Options -Indexes
   # Some servers require the RewriteBase to be set. If so, set to the correct folder.
   # RewriteBase /
 
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteCond %{REQUEST_URI} !=/favicon.ico
-  RewriteRule ^ ./index.php [L]
+  RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
+  RewriteRule ^(.*) - [E=BASE:%1]
+
+  # Sets the HTTP_AUTHORIZATION header removed by Apache
+  RewriteCond %{HTTP:Authorization} .
+  RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+  # Redirect to URI without front controller to prevent duplicate content
+  # (with and without `/index.php`). Only do this redirect on the initial
+  # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
+  # endless redirect loop (request -> rewrite to front controller ->
+  # redirect -> request -> ...).
+  # So in case you get a "too many redirects" error or you always get redirected
+  # to the start page because your Apache does not expose the REDIRECT_STATUS
+  # environment variable, you have 2 choices:
+  # - disable this feature by commenting the following 2 lines or
+  # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
+  #   following RewriteCond (best solution)
+  RewriteCond %{ENV:REDIRECT_STATUS} ^$
+  RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=301,L]
+
+  # If the requested filename exists, simply serve it.
+  # We only want to let Apache serve files and not directories.
+  RewriteCond %{REQUEST_FILENAME} -f
+  RewriteRule ^ - [L]
+
+  # Rewrite all other queries to the front controller.
+  RewriteRule ^ %{ENV:BASE}/index.php [L]
 
 </IfModule>
 
@@ -46,8 +70,8 @@ Options -Indexes
 #  AddType application/font-woff2    woff2
 #</IfModule>
 
-# Block access to all hidden files and directories. These types of files 
-# usually contain user preferences and can include private information like, 
+# Block access to all hidden files and directories. These types of files
+# usually contain user preferences and can include private information like,
 # for example, the `.git` or `.svn` directories.
 <IfModule mod_rewrite.c>
    RewriteEngine On

--- a/.htaccess
+++ b/.htaccess
@@ -50,6 +50,8 @@ Options -Indexes
 
   # If the requested filename exists, simply serve it.
   # We only want to let Apache serve files and not directories.
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} !=/favicon.ico
   RewriteCond %{REQUEST_FILENAME} -f
   RewriteRule ^ - [L]
 


### PR DESCRIPTION
[WIP] Removes index.php from urls. Nginx would need documentation done for bolt.cm/docs.

Fixes URL'ls like:  

https://site.com/index.php  -> https://site.com
https://site.com/index.php/page/zenonis-est-inquam-hoc-stoici -> https://site.com/page/zenonis-est-inquam-hoc-stoici

Fixes: #5578


Details
-------

I don't know, or think at least that the part dealing with http authorization would be needed by bolt. I don't think it does but I left it there because I don't know haha. Figured you all would be better suited to determine that. 

```
 RewriteCond %{HTTP:Authorization} .
 RewriteRule ^ - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]  
```