### PR TITLE
Add support for separate entity attribute, versus db column names.

### DIFF
--- a/src/Storage/CaseTransformTrait.php
+++ b/src/Storage/CaseTransformTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bolt\Storage;
+
+/**
+ *  This trait provides re-usable methods for converting strings between different case styles.
+ */
+trait CaseTransformTrait
+{
+    /**
+     * Converts a string from underscored to Camel Case.
+     *
+     * @param string $id A string to camelize
+     *
+     * @return string The camelized string
+     */
+    public function camelize($id)
+    {
+        return strtr(ucwords(strtr($id, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
+    }
+
+    /**
+     * Converts a string from camel case to underscored.
+     *
+     * @param string $id The string to underscore
+     *
+     * @return string The underscored string
+     */
+    public function underscore($id)
+    {
+        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], ['\\1_\\2', '\\1_\\2'], str_replace('_', '.', $id)));
+    }
+}

--- a/src/Storage/Entity/MagicAttributeTrait.php
+++ b/src/Storage/Entity/MagicAttributeTrait.php
@@ -1,6 +1,8 @@
 <?php
 namespace Bolt\Storage\Entity;
 
+use Bolt\Storage\CaseTransformTrait;
+
 /**
  * Provides access to entity attributes and the schema-less _fields
  * attribute via __get and __set magic methods.
@@ -9,6 +11,8 @@ namespace Bolt\Storage\Entity;
  */
 trait MagicAttributeTrait
 {
+    use CaseTransformTrait;
+
     public $_fields = [];
 
     public function __get($key)
@@ -49,10 +53,13 @@ trait MagicAttributeTrait
     {
         $var = lcfirst(substr($method, 3));
         $underscored = $this->underscore($var);
+        $camelized = $this->camelize($var);
 
         if (strncasecmp($method, 'get', 3) == 0) {
             if ($this->has($var) && property_exists($this, $var)) {
                 return $this->$var;
+            } elseif ($this->has($camelized) && property_exists($this, $camelized)) {
+                return $this->$camelized;
             } elseif ($this->has($underscored) && property_exists($this, $underscored)) {
                 return $this->$underscored;
             } elseif ($this->has($var)) {
@@ -111,27 +118,5 @@ trait MagicAttributeTrait
         return in_array($field, $this->getFields());
     }
 
-    /**
-     * Converts a string from underscored to Camel Case.
-     *
-     * @param string $id A string to camelize
-     *
-     * @return string The camelized string
-     */
-    public function camelize($id)
-    {
-        return strtr(ucwords(strtr($id, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
-    }
 
-    /**
-     * Converts a string from camel case to underscored.
-     *
-     * @param string $id The string to underscore
-     *
-     * @return string The underscored string
-     */
-    public function underscore($id)
-    {
-        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], ['\\1_\\2', '\\1_\\2'], str_replace('_', '.', $id)));
-    }
 }

--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -71,14 +71,11 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
      */
     public function persist(QuerySet $queries, $entity)
     {
-        if (isset($this->mapping['attribute'])) {
-            $key = $this->mapping['attribute'];
-        } else {
-            $key = $this->mapping['fieldname'];
-        }
+        $attribute = $this->getMappingAttribute();
+        $key = $this->mapping['fieldname'];
 
         $qb = &$queries[0];
-        $valueMethod = 'serialize' . ucfirst($key);
+        $valueMethod = 'serialize' . ucfirst($attribute);
         $value = $entity->$valueMethod();
 
         $type = $this->getStorageType();
@@ -159,6 +156,20 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
     public function getStorageOptions()
     {
         return [];
+    }
+
+    /**
+     * Gets the entity attribute name to be used for reading / persisting
+     *
+     * @return string
+     */
+    public function getMappingAttribute()
+    {
+        if (isset($this->mapping['attribute'])) {
+            return $this->mapping['attribute'];
+        }
+
+        return $this->mapping['fieldname'];
     }
 
     /**

--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -71,7 +71,12 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
      */
     public function persist(QuerySet $queries, $entity)
     {
-        $key = $this->mapping['fieldname'];
+        if (isset($this->mapping['attribute'])) {
+            $key = $this->mapping['attribute'];
+        } else {
+            $key = $this->mapping['fieldname'];
+        }
+
         $qb = &$queries[0];
         $valueMethod = 'serialize' . ucfirst($key);
         $value = $entity->$valueMethod();

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -2,6 +2,7 @@
 namespace Bolt\Storage\Mapping;
 
 use Bolt\Exception\StorageException;
+use Bolt\Storage\CaseTransformTrait;
 use Bolt\Storage\Database\Schema\Manager;
 use Bolt\Storage\Mapping\ClassMetadata as BoltClassMetadata;
 use Bolt\Storage\NamingStrategy;
@@ -19,6 +20,8 @@ use Doctrine\DBAL\Schema\Table;
  */
 class MetadataDriver implements MappingDriver
 {
+    use CaseTransformTrait;
+
     /** @var \Bolt\Storage\Database\Schema\Manager */
     protected $schemaManager;
     /** @var array */
@@ -160,6 +163,7 @@ class MetadataDriver implements MappingDriver
         foreach ($table->getColumns() as $colName => $column) {
             $mapping = [
                 'fieldname'        => $column->getName(),
+                'attribute'        => $this->camelize($column->getName()),
                 'type'             => $column->getType()->getName(),
                 'fieldtype'        => $this->getFieldTypeFor($table->getOption('alias'), $column),
                 'length'           => $column->getLength(),
@@ -212,6 +216,7 @@ class MetadataDriver implements MappingDriver
         foreach ($inputData as $key => $data) {
             $mapping = [
                 'fieldname'        => $key,
+                'attribute'        => $this->camelize($key),
                 'type'             => 'null',
                 'fieldtype'        => $this->typemap['repeater'],
                 'tables'           => [
@@ -281,10 +286,11 @@ class MetadataDriver implements MappingDriver
 
             $mapping = [
                 'fieldname' => $relationKey,
-                'type'      => 'null',
+                'attribute' => $this->camelize($relationKey),
+                'type' => 'null',
                 'fieldtype' => $this->typemap['relation'],
-                'entity'    => $this->resolveClassName($relationKey),
-                'target'    => $this->schemaManager->getTableName('relations'),
+                'entity' => $this->resolveClassName($relationKey),
+                'target' => $this->schemaManager->getTableName('relations'),
             ];
 
             $this->metadata[$className]['fields'][$relationKey] = $mapping;

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -286,7 +286,6 @@ class MetadataDriver implements MappingDriver
 
             $mapping = [
                 'fieldname' => $relationKey,
-                'attribute' => $this->camelize($relationKey),
                 'type' => 'null',
                 'fieldtype' => $this->typemap['relation'],
                 'entity' => $this->resolveClassName($relationKey),

--- a/tests/phpunit/unit/Storage/EntityTest.php
+++ b/tests/phpunit/unit/Storage/EntityTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bolt\Tests\Storage;
+
+use Bolt\Storage\Entity\Content;
+use Bolt\Tests\BoltUnitTest;
+
+/**
+ * Class to test src/Storage/Entity/Entity.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class EntityTest extends BoltUnitTest
+{
+    public function testCaseTransform()
+    {
+        $entity = new Content();
+        $underscore = 'bolt_field_example';
+        $camel = 'boltFieldExample';
+        $camel2 = 'BoltFieldExample';
+
+        $this->assertEquals('BoltFieldExample', $entity->camelize($underscore));
+        $this->assertEquals('bolt_field_example', $entity->underscore($camel));
+        $this->assertEquals('bolt_field_example', $entity->underscore($camel2));
+
+    }
+}


### PR DESCRIPTION
This is a feature that will improve the code consistency when accessing and setting attributes on an entity.

It separates the db column name eg:`bolt_field_example` from the entity attribute `boltFieldExample` and defaults to underscores for the db column but camel case for the entity attribute.

This means that extension developers making their own entities can now use camel case for attributes without needing to match the format of the database column.

Test included for new functionality, updates to the internal entities to use this new syntax will follow in a separate PR.