### PR TITLE
Fix backend publish process quirks (#5085)

### DIFF
--- a/app/src/js/widgets/buic/buicListing.js
+++ b/app/src/js/widgets/buic/buicListing.js
@@ -37,21 +37,25 @@
          */
         modifyRecords: function (action, ids, buttonText) {
             var self = this,
-                modifications = {},
+                safeQuery = true,
                 actions = {
                     'delete': {
+                        'safe': false,
                         'name': bolt.data('recordlisting.action.delete', {'%CTNAME%': this.contentTypeName}),
                         'cmd': {'delete': null}
                     },
                     'publish': {
+                        'safe': true,
                         'name': bolt.data('recordlisting.action.publish', {'%CTNAME%': this.contentTypeName}),
                         'cmd': {'modify': {'status': 'published'}}
                     },
                     'depublish': {
+                        'safe': true,
                         'name': bolt.data('recordlisting.action.depublish'),
                         'cmd': {'modify': {'status': 'held'}}
                     },
                     'draft': {
+                        'safe': true,
                         'name': bolt.data('recordlisting.action.draft'),
                         'cmd': {'modify': {'status': 'draft'}}
                     }
@@ -59,9 +63,13 @@
                 msg;
 
             // Build POST data.
-            modifications[self.contentType] = {};
+            self.modifications = {};
+            self.modifications[self.contentType] = {};
             $(ids).each(function () {
-                modifications[self.contentType][this] = actions[action].cmd;
+                if(!actions[action].safe){
+                    safeQuery = false;
+                }
+                self.modifications[self.contentType][this] = actions[action].cmd;
             });
 
             // Build message:
@@ -72,57 +80,65 @@
             }
             msg = msg + '<br><br><b>' + bolt.data('recordlisting.confirm.no-undo') + '</b>';
 
-            bootbox.dialog({
-                message: msg,
-                title: actions[action].name,
-                buttons: {
-                    cancel: {
-                        label: bolt.data('recordlisting.action.cancel'),
-                        className: 'btn-default'
-                    },
-                    ok: {
-                        label: buttonText,
-                        className: 'btn-primary',
-                        callback: function () {
-                            var url = bolt.conf('paths.async') + 'content/action' + window.location.search;
-
-                            $.ajax({
-                                url: url,
-                                type: 'POST',
-                                data: {
-                                    'bolt_csrf_token': self.csrfToken,
-                                    'contenttype': self.contentType,
-                                    'actions': modifications
-                                },
-                                success: function (data) {
-                                    self.element.html(data);
-                                    self.element.find('table.listing tbody').buicListingPart();
-
-                                    /*
-                                     Commented out for now - it has to be decided if functionality is wanted
-                                    // Restore selection state.
-                                    $(table).find('td input:checkbox[name="checkRow"]').each(function () {
-                                        var id = $(this).parents('tr').attr('id').substr(5);
-
-                                        if (id && ids.indexOf(id) >= 0) {
-                                            this.checked = true;
-                                            self._rowSelection(this);
-                                        }
-                                    });
-                                    $(table).find('tbody').each(function () {
-                                        self._handleSelectionState(this);
-                                    });
-                                    */
-                                },
-                                error: function (jqXHR, textStatus, errorThrown) {
-                                    console.log(jqXHR.status + ' (' + errorThrown + '):');
-                                    console.log(JSON.parse(jqXHR.responseText));
-                                },
-                                dataType: 'html'
-                            });
+            if(!safeQuery){
+                bootbox.dialog({
+                    message: msg,
+                    title: actions[action].name,
+                    buttons: {
+                        cancel: {
+                            label: bolt.data('recordlisting.action.cancel'),
+                            className: 'btn-default'
+                        },
+                        ok: {
+                            label: buttonText,
+                            className: 'btn-primary',
+                            callback: function(){
+                                self.sendQuery();
+                            }
                         }
                     }
-                }
+                });
+            }else{
+                self.sendQuery();
+            }
+        },
+        sendQuery: function () {
+            var self = this,
+                url = bolt.conf('paths.async') + 'content/action' + window.location.search;
+
+            $.ajax({
+                url: url,
+                type: 'POST',
+                data: {
+                    'bolt_csrf_token': self.csrfToken,
+                    'contenttype': self.contentType,
+                    'actions': self.modifications
+                },
+                success: function (data) {
+                    self.element.html(data);
+                    self.element.find('table.listing tbody').buicListingPart();
+
+                    /*
+                        Commented out for now - it has to be decided if functionality is wanted
+                    // Restore selection state.
+                    $(table).find('td input:checkbox[name="checkRow"]').each(function () {
+                        var id = $(this).parents('tr').attr('id').substr(5);
+
+                        if (id && ids.indexOf(id) >= 0) {
+                            this.checked = true;
+                            self._rowSelection(this);
+                        }
+                    });
+                    $(table).find('tbody').each(function () {
+                        self._handleSelectionState(this);
+                    });
+                    */
+                },
+                error: function (jqXHR, textStatus, errorThrown) {
+                    console.log(jqXHR.status + ' (' + errorThrown + '):');
+                    console.log(JSON.parse(jqXHR.responseText));
+                },
+                dataType: 'html'
             });
         }
     });

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1402,8 +1402,8 @@ class Storage
         // When using from the frontend, we assume (by default) that we only want published items,
         // unless something else is specified explicitly
         $request = $this->app['request_stack']->getCurrentRequest();
-        $isBackend = $request ? Zone::isBackend($request) : false;
-        if (!$isBackend && empty($ctypeParameters['status'])) {
+        $isFrontend = $request ? Zone::isFrontend($request) : true;
+        if ($isFrontend && empty($ctypeParameters['status'])) {
             $ctypeParameters['status'] = 'published';
         }
 


### PR DESCRIPTION
Fixes #5085 and #5468

This does two things:
1. check if the request is safe (status change) or unsafe (delete) in listing actions and only ask the user to confirm if it is unsafe.
2. Allow unpublished records in the async zone, since all async routes are also backend routes (right?) and should therefore show unpublished too.

Since it's a bugfix I targeted release/3.0, lemme know if this should go in 3.1 instead.