### PR TITLE
Avoid dark-on-dark text by explicitly setting background-color

### DIFF
--- a/app/src/sass/editcontent/_field.scss
+++ b/app/src/sass/editcontent/_field.scss
@@ -96,6 +96,11 @@ fieldset.bolt-field-imagelist {
             }
         }
 
+        input.title {
+            border: 1px solid #f0f0f0;
+            background-color:#fbfbfb;
+        }
+
         // Remove button
         a.remove {
             padding: 5px;


### PR DESCRIPTION
The color of the input.title elements is set to a dark gray. With dark desktop themes, the default background color of input elements is often a similar shade, resulting in nearly-illegible text 

![screenshot showing nearly-illegible light grey text on gray background](https://cloud.githubusercontent.com/assets/11167504/17351726/f7e2be68-58e5-11e6-8d99-782a8a905f4c.png)

This commit explicitly sets the background-color of the input.title elements to a more suitable color, overriding any default styling:

![examp151](https://cloud.githubusercontent.com/assets/11167504/17356817/62ac5cd6-590e-11e6-8397-e625e1833001.png)

