### PR TITLE
Return an empty array rather than false from findWith

### DIFF
--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -186,7 +186,7 @@ class Repository implements ObjectRepository
     /**
      * Method to hydrate and return a QueryBuilder query.
      *
-     * @return array Entity | false
+     * @return array Entity
      **/
     public function findWith(QueryBuilder $query)
     {
@@ -196,7 +196,7 @@ class Repository implements ObjectRepository
         if ($result) {
             return $this->hydrateAll($result, $query);
         } else {
-            return false;
+            return [];
         }
     }
 

--- a/tests/phpunit/unit/Controller/Backend/LogTest.php
+++ b/tests/phpunit/unit/Controller/Backend/LogTest.php
@@ -87,7 +87,7 @@ class LogTest extends ControllerUnitTest
 
         $context = $response->getContext();
 
-        $this->assertFalse($context['context']['entries']);
+        $this->assertEmpty($context['context']['entries']);
         $this->assertNull($context['context']['content']);
         $this->assertEquals('Pages', $context['context']['title']);
         $this->assertEquals('pages', $context['context']['contenttype']['slug']);


### PR DESCRIPTION
Minor fix to return an iterable empty array rather than false from the result of a `findWith` query.

Fixes: #5555 