### PR TITLE
Fix issue with multi-value value selects

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -23,7 +23,7 @@
     {% set querylimit = field.limit|default(500) %}
     {% set wherefilter = field.filter|default({}) %}
     {% setcontent lookups = lookuptype where wherefilter order sortingorder nohydrate limit querylimit %}
-    {% set valuefield = lookupfieldlist|default([])|last|default(lookupfield)|default('id') %}
+    {% set valuefield = lookupfieldlist|default(lookupfield)|default('id') %}
     {% set values = lookups|selectfield(valuefield, option.multiple, field.keys|default('id')) %}
 {% endif %}
 


### PR DESCRIPTION
This fixes an issue raised in slack, caused by a pretty huge derp from me (I think?).

basically, having multiple fields as the value in a select field didn't work. I think it's been buggy for a while  (since #5407 I think, but not sure), and it seems like #5587 basically made it break always instead of sometimes...

This file really needs a refactor, too... Almost all of this should be in php IMO.