### PR TITLE
Remove the last references to listcontent

### DIFF
--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -73,7 +73,6 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
             new \Twig_SimpleFunction('ismobileclient',     [$this, 'isMobileClient']),
             new \Twig_SimpleFunction('last',               'twig_last',            $env + $deprecated),
             new \Twig_SimpleFunction('link',               [$this, 'link'],        $safe),
-            new \Twig_SimpleFunction('listcontent',        [$this, 'listContent']),
             new \Twig_SimpleFunction('listtemplates',      [$this, 'listTemplates']),
             new \Twig_SimpleFunction('markdown',           [$this, 'markdown'],    $safe),
             new \Twig_SimpleFunction('menu',               [$this, 'menu'],        $env + $safe),
@@ -377,14 +376,6 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
     public function link($location, $label = '[link]')
     {
         return $this->handlers['html']->link($location, $label);
-    }
-
-    /**
-     * @see \Bolt\Twig\Handler\RecordHandler::listContent()
-     */
-    public function listContent($contenttype, $relationoptions, $content)
-    {
-        return $this->handlers['record']->listContent($contenttype, $relationoptions, $content);
     }
 
     /**

--- a/tests/phpunit/unit/Twig/TwigExtensionTest.php
+++ b/tests/phpunit/unit/Twig/TwigExtensionTest.php
@@ -322,16 +322,6 @@ class TwigExtensionTest extends BoltUnitTest
         $twig->jsonDecode(null);
     }
 
-    public function testListContent()
-    {
-        $app = $this->getApp();
-        $handlers = $this->getTwigHandlers($app);
-        $handlers['record'] = $this->getMockHandler('RecordHandler', 'listContent');
-        $twig = new TwigExtension($app, $handlers, true);
-
-        $twig->listContent(null, null, null);
-    }
-
     public function testListTemplates()
     {
         $app = $this->getApp();


### PR DESCRIPTION
Listcontent was removed in https://github.com/bolt/bolt/commit/66a21490ea9a38ee5a37e1cf2f9c44bfb99c6045 but still remained in TwigExtension. This removes that and the associated test.

~~Still, I have no idea why tests were passing while the test in TwigExtensionTest was still there, can anyone enlighten me?~~ Ah, I see it now. The test didn't actually test anything.

See #5628