### PR TITLE
Incoming relations must be checked with both contenttype and id.

### DIFF
--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -190,7 +190,7 @@ class Relations extends ArrayCollection
     public function incoming($entity)
     {
         return $this->filter(function ($el) use ($entity) {
-            return $el->getTo_contenttype() == (string) $entity->getContenttype();
+            return $el->getTo_contenttype() == (string) $entity->getContenttype() && $el->getTo_id() === $entity->getId();
         });
     }
 


### PR DESCRIPTION
Fixes part of #5636, where intra-contenttype relations will show as related to themselves.