### PR TITLE
Fix ImageHandler imageInfo method for some rare cases.

### DIFF
--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -116,7 +116,9 @@ class ImageHandler
 
         try {
             // Get the EXIF data of the image
-            $exif = $reader->read($fullpath);
+            if (false === $exif = $reader->read($fullpath)) {
+                throw new \RuntimeException();
+            }
         } catch (\RuntimeException $e) {
             // No EXIF data… create an empty object.
             $exif = new Exif();


### PR DESCRIPTION
In some cases, the `Reader` return `false` and of course, the rest of the method cant work cause it try to use `$exif` as an object but it is a `boolean`.

Only an error on `2.2` cause the method is changed on `3.0`.