### PR TITLE
Bugfix for HTML fields inside repeaters

### DIFF
--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -45,6 +45,7 @@
                     </div>
                 {% endif %}
 
+                {{ include('@bolt/editcontent/fielddata/_' ~ rfield.type ~ '.twig', ignore_missing = true) }}
                 {{ include(context.fields[rfield.type].template, rcontext) }}
 
                 {# Postfix #}

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -45,7 +45,6 @@
                     </div>
                 {% endif %}
 
-                {{ include('@bolt/editcontent/fielddata/_' ~ rfield.type ~ '.twig', ignore_missing = true) }}
                 {{ include(context.fields[rfield.type].template, rcontext) }}
 
                 {# Postfix #}

--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -13,7 +13,7 @@
     <legend class="sr-only">{{ labelkey }}</legend>
     <label class="main col-xs-12">{{ labelkey }}</label>
     {% if 'html' not in context.fieldtypes %}
-        {{ include('@bolt/editcontent/fielddata/_html.twig', ignore_missing = true) }}
+        {{ include('@bolt/editcontent/fielddata/_html.twig') }}
     {% endif %}
 
     {# Prefix #}

--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -12,9 +12,9 @@
 <fieldset class="bolt-field-repeater" data-bolt-widget="{{ data_bolt_widget|json_encode }}">
     <legend class="sr-only">{{ labelkey }}</legend>
     <label class="main col-xs-12">{{ labelkey }}</label>
-    {{ dump(context.fieldtypes) }}
-    {{ include('@bolt/editcontent/fielddata/_html.twig', ignore_missing = true) }}
-
+    {% if 'html' not in context.fieldtypes %}
+        {{ include('@bolt/editcontent/fielddata/_html.twig', ignore_missing = true) }}
+    {% endif %}
 
     {# Prefix #}
     {% if field.prefix is defined and field.prefix is not empty %}

--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -12,6 +12,9 @@
 <fieldset class="bolt-field-repeater" data-bolt-widget="{{ data_bolt_widget|json_encode }}">
     <legend class="sr-only">{{ labelkey }}</legend>
     <label class="main col-xs-12">{{ labelkey }}</label>
+    {{ dump(context.fieldtypes) }}
+    {{ include('@bolt/editcontent/fielddata/_html.twig', ignore_missing = true) }}
+
 
     {# Prefix #}
     {% if field.prefix is defined and field.prefix is not empty %}


### PR DESCRIPTION
This addrresses a bug whereby HTML fields in repeaters would fail if they appear early in the order before ckeditor initialisation has happened.

Fixes: #5596
