### PR TITLE
Fix bidirectional relations and relations affecting each other

### DIFF
--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -14,7 +14,7 @@
 
 {# Output 'incoming' relations #}
 {% if context.has.incoming_relations %}
-    {% for incoming_contenttype, incoming_records in context.incoming_not_inv %}
+    {% for incoming_contenttype, incoming_records in context.incoming_not_inv if incoming_contenttype not in context.contenttype.relations|keys %}
         {% set name = __(['contenttypes', incoming_contenttype, 'name', 'plural'], {DEFAULT: incoming_contenttype}) %}
 
         <p>{{ __('general.phrase.record-related-to-variable', {'%CTNAME%': name}) }}</p>

--- a/app/view/twig/editcontent/fields/_relationship.twig
+++ b/app/view/twig/editcontent/fields/_relationship.twig
@@ -11,7 +11,7 @@
 {# Currently selected relationship values #}
 {% set relselect = [] %}
 {% for item in values %}
-    {% set relselect =  relselect|merge([item.getToId()]) %}
+    {% set relselect =  relselect|merge([item.toid]) %}
 {% endfor %}
 
 {# Build the select options array #}

--- a/app/view/twig/editcontent/fields/_relationship.twig
+++ b/app/view/twig/editcontent/fields/_relationship.twig
@@ -6,9 +6,8 @@
 {# Use option groups #}
 {% set groupby = relation.groupby|default(false) %}
 
-{% set values = context.content.relation.getField(relcontenttype, true, context.contenttype.slug, context.content.id)|default([]) %}
-
 {# Currently selected relationship values #}
+{% set values = context.content.relation.getField(relcontenttype, true, context.contenttype.slug, context.content.id)|default([]) %}
 {% set relselect = [] %}
 {% for item in values %}
     {# We use item.toid instead of item.to_id here to make sure that inversed relations are picked up correctly #}

--- a/app/view/twig/editcontent/fields/_relationship.twig
+++ b/app/view/twig/editcontent/fields/_relationship.twig
@@ -11,6 +11,7 @@
 {# Currently selected relationship values #}
 {% set relselect = [] %}
 {% for item in values %}
+    {# We use item.toid instead of item.to_id here to make sure that inversed relations are picked up correctly #}
     {% set relselect =  relselect|merge([item.toid]) %}
 {% endfor %}
 

--- a/app/view/twig/editcontent/fields/_relationship.twig
+++ b/app/view/twig/editcontent/fields/_relationship.twig
@@ -6,10 +6,12 @@
 {# Use option groups #}
 {% set groupby = relation.groupby|default(false) %}
 
+{% set values = context.content.relation.getField(relcontenttype, true, context.contenttype.slug, context.content.id)|default([]) %}
+
 {# Currently selected relationship values #}
 {% set relselect = [] %}
-{% for item in context.content.relation.getField(relcontenttype, true)|default([]) %}
-    {% set relselect =  relselect|merge([item.to_id]) %}
+{% for item in values %}
+    {% set relselect =  relselect|merge([item.getToId()]) %}
 {% endfor %}
 
 {# Build the select options array #}

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -104,29 +104,6 @@ class Relations extends ArrayCollection
     }
 
     /**
-     * This takes an array resultset of existing inverse relations, that is incoming relations that already exist in
-     * the database but pointing towards this entity. For historic reasons Bolt has treated these as interchangeable
-     * so for backwards compatibility we allow an incoming relation to behave as an outgoing one, but we don't want
-     * to overwrite it in the database. This method takes any affected entity out of the collection before the write
-     * to the database.
-     *
-     * @param $inverse
-     */
-    public function filterInverseValues($inverse)
-    {
-        foreach ($inverse as $inverseItem) {
-            foreach ($this as $collectionItem) {
-                if (
-                    $collectionItem->to_contenttype === $inverseItem['from_contenttype'] &&
-                    $collectionItem->to_id == $inverseItem['from_id']
-                ) {
-                    $this->removeElement($collectionItem);
-                }
-            }
-        }
-    }
-
-    /**
      * This loops over the existing collection to see if the properties in the incoming
      * are already available on a saved record. To do this it checks the four key properties
      * if there's a match it returns the original, otherwise

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -157,17 +157,24 @@ class Relations extends ArrayCollection
      *
      * @param $fieldname
      * @param bool $biDirectional
+     * @param string $contenttypeSlug
+     * @param int $contenttypeId
      *
      * @return Relations
      */
-    public function getField($fieldname, $biDirectional = false)
+    public function getField($fieldname, $biDirectional = false, $contenttypeSlug = null, $contenttypeId = null)
     {
         if ($biDirectional) {
-            return $this->filter(function ($el) use ($fieldname) {
-                if ($el->getTo_contenttype() == $fieldname) {
+            return $this->filter(function ($el) use ($fieldname, $contenttypeSlug, $contenttypeId) {
+                if ($el->getFrom_contenttype() === $fieldname && $el->getFrom_contenttype() === $el->getTo_contenttype() && $el->getTo_id() == $contenttypeId) {
+                    $el->actAsInverse();
+
                     return true;
                 }
-                if ($el->getFrom_contenttype() == $fieldname) {
+                if ($el->getTo_contenttype() === $fieldname && $el->getFrom_contenttype() === $contenttypeSlug) {
+                    return true;
+                }
+                if ($el->getFrom_contenttype() === $fieldname && $el->getTo_contenttype() === $contenttypeSlug) {
                     $el->actAsInverse();
 
                     return true;
@@ -176,7 +183,7 @@ class Relations extends ArrayCollection
         }
 
         return $this->filter(function ($el) use ($fieldname) {
-            return $el->getTo_contenttype() == $fieldname;
+            return $el->getTo_contenttype() === $fieldname;
         });
     }
 

--- a/src/Storage/Collection/Relations.php
+++ b/src/Storage/Collection/Relations.php
@@ -117,7 +117,7 @@ class Relations extends ArrayCollection
         foreach ($inverse as $inverseItem) {
             foreach ($this as $collectionItem) {
                 if (
-                    $collectionItem->to_contenttype == $inverseItem['from_contenttype'] &&
+                    $collectionItem->to_contenttype === $inverseItem['from_contenttype'] &&
                     $collectionItem->to_id == $inverseItem['from_id']
                 ) {
                     $this->removeElement($collectionItem);
@@ -141,8 +141,8 @@ class Relations extends ArrayCollection
         foreach ($this as $k => $existing) {
             if (
                 $existing->getFromId() == $entity->getFromId() &&
-                $existing->getFromContenttype() == $entity->getFromContenttype() &&
-                $existing->getToContenttype() == $entity->getToContenttype() &&
+                $existing->getFromContenttype() === $entity->getFromContenttype() &&
+                $existing->getToContenttype() === $entity->getToContenttype() &&
                 $existing->getTo_id() == $entity->getToId()
             ) {
                 return $existing;

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -129,7 +129,8 @@ class RelationType extends FieldTypeBase
         $collection->setFromDatabaseValues($existingDB);
         $toDelete = $collection->update($relations);
         $repo = $this->em->getRepository('Bolt\Storage\Entity\Relations');
-        
+
+        // If we have bidirectional relations we need to delete the old inverted relations
         $inverseCollection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
         $inverseCollection->setFromDatabaseValues($existingInverse);
 

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -132,7 +132,6 @@ class RelationType extends FieldTypeBase
         
         $inverseCollection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
         $inverseCollection->setFromDatabaseValues($existingInverse);
-        $inverseCollection->filterInverseValues($existingDB);
 
         // Add a listener to the main query save that sets the from ID on save and then saves the relations
         $queries->onResult(

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -128,7 +128,6 @@ class RelationType extends FieldTypeBase
         $collection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
         $collection->setFromDatabaseValues($existingDB);
         $toDelete = $collection->update($relations);
-        $collection->filterInverseValues($existingInverse);
         $repo = $this->em->getRepository('Bolt\Storage\Entity\Relations');
         
         $inverseCollection = $this->em->createCollection('Bolt\Storage\Entity\Relations');

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -124,18 +124,27 @@ class RelationType extends FieldTypeBase
         // Fetch existing relations and create two sets of records, updates and deletes.
         $existingDB = $this->getExistingRelations($entity) ?: [];
         $existingInverse = $this->getInverseRelations($entity) ?: [];
+
         $collection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
         $collection->setFromDatabaseValues($existingDB);
         $toDelete = $collection->update($relations);
         $collection->filterInverseValues($existingInverse);
         $repo = $this->em->getRepository('Bolt\Storage\Entity\Relations');
+        
+        $inverseCollection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
+        $inverseCollection->setFromDatabaseValues($existingInverse);
+        $inverseCollection->filterInverseValues($existingDB);
 
         // Add a listener to the main query save that sets the from ID on save and then saves the relations
         $queries->onResult(
-            function ($query, $result, $id) use ($repo, $collection, $toDelete) {
+            function ($query, $result, $id) use ($repo, $collection, $toDelete, $inverseCollection) {
                 foreach ($collection as $entity) {
                     $entity->from_id = $id;
                     $repo->save($entity);
+                }
+
+                foreach ($inverseCollection as $entity) {
+                    $repo->delete($entity);
                 }
 
                 foreach ($toDelete as $entity) {
@@ -192,9 +201,11 @@ class RelationType extends FieldTypeBase
             ->from($this->mapping['target'])
             ->where('to_id = :to_id')
             ->andWhere('to_contenttype = :to_contenttype')
+            ->andWhere('from_contenttype = :from_contenttype')
             ->setParameters([
-                'to_id'          => $entity->id,
-                'to_contenttype' => $entity->getContenttype(),
+                'to_id'            => $entity->id,
+                'to_contenttype'   => $entity->getContenttype(),
+                'from_contenttype' => $this->mapping['fieldname'],
             ]);
         $result = $query->execute()->fetchAll();
 


### PR DESCRIPTION
Fixes #5636 and (in my testing at least) #5541.

This makes bidirectional relations work as they did in 2.2 (one could show/delete relations from either record if they both had the relation defined), fixes intra-contenttype relations, and also introduces a number of checks to make sure that multiple relations on the same contenttype don't affect one another.