### PR TITLE
Modify `checkFirstUser` to check for a valid logged in user, to prevent expensive test. 

### DIFF
--- a/src/Controller/Backend/BackendBase.php
+++ b/src/Controller/Backend/BackendBase.php
@@ -212,6 +212,11 @@ abstract class BackendBase extends Base
      */
     private function checkFirstUser(Application $app, $route)
     {
+        // If we have a valid, logged in user, we're going to assume we can skip this (expensive) test.
+        if ($app['users']->getCurrentUser() !== null) {
+            return true;
+        }
+
         // Check the database users table exists
         $tableExists = $app['schema']->hasUserTable();
 


### PR DESCRIPTION
Fixes #5648 