### PR TITLE
Fix #5652

### DIFF
--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -72,7 +72,7 @@
             input: {
                 class:  'form-control',
                 id:     uid,
-                name:   key ~ '[' ~ aid ~ ']',
+                name:   name ~ '[' ~ aid ~ ']',
                 type:   'text',
                 value:  image[aid]|default(''),
             }


### PR DESCRIPTION
Fixes #5652, The name should not use the key.

This was actually an issue in all repeaters, not just templatefields.

Monkeytested that it works in normal imagefields, imagefields in repeaters and imagefields in repeaters in templatefields