### PR TITLE
Hydrate repeater in templatefields

### DIFF
--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -297,10 +297,8 @@ trait ContentValuesTrait
                 }
 
                 if (is_array($unserdata)) {
-                    $templateContent = new \Bolt\Legacy\Content($this->app, $this->getTemplateFieldsContentType(), [], false);
-                    $value = $templateContent;
-                    $this->populateTemplateFieldsContenttype($value);
-                    $templateContent->setValues($unserdata);
+                    $value = new \Bolt\Legacy\Content($this->app, $this->getTemplateFieldsContentType(), [], false);
+                    $value->setValues($unserdata);
                 } else {
                     $value = null;
                 }

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -241,7 +241,7 @@ trait ContentValuesTrait
             }
         }
 
-        if ($key == 'id') {
+        if ($key === 'id') {
             $this->id = $value;
         }
 
@@ -277,7 +277,7 @@ trait ContentValuesTrait
             if (!preg_match("/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/", $value)) {
                 // @todo Try better date-parsing, instead of just setting it to
                 // 'now' (or 'the past' for datedepublish)
-                if ($key == 'datedepublish') {
+                if ($key === 'datedepublish') {
                     $value = null;
                 } else {
                     $value = date('Y-m-d H:i:s');
@@ -354,8 +354,8 @@ trait ContentValuesTrait
         ];
         // Check if the values need to be unserialized, and pre-processed.
         foreach ($this->values as $key => $value) {
-            if ((in_array($this->fieldtype($key), $serializedFieldTypes)) || ($key == 'templatefields')) {
-                if (!empty($value) && is_string($value) && (substr($value, 0, 2) == 'a:' || $value[0] === '[' || $value[0] === '{')) {
+            if ((in_array($this->fieldtype($key), $serializedFieldTypes)) || ($key === 'templatefields')) {
+                if (!empty($value) && is_string($value) && (substr($value, 0, 2) === 'a:' || $value[0] === '[' || $value[0] === '{')) {
                     try {
                         $unserdata = Lib::smartUnserialize($value);
                     } catch (\Exception $e) {
@@ -368,7 +368,7 @@ trait ContentValuesTrait
                 }
             }
 
-            if ($this->fieldtype($key) == 'video' && is_array($this->values[$key]) && !empty($this->values[$key]['url'])) {
+            if ($this->fieldtype($key) === 'video' && is_array($this->values[$key]) && !empty($this->values[$key]['url'])) {
                 $video = $this->values[$key];
 
                 // update the HTML, according to given width and height
@@ -397,7 +397,7 @@ trait ContentValuesTrait
                 $this->values[$key] = $video;
             }
 
-            if ($this->fieldtype($key) == 'repeater' && is_array($this->values[$key]) && !$this->isRootType) {
+            if ($this->fieldtype($key) === 'repeater' && is_array($this->values[$key]) && !$this->isRootType) {
                 $originalMapping = null;
                 $originalMapping[$key]['fields'] = $this->contenttype['fields'][$key]['fields'];
                 $originalMapping[$key]['type'] = 'repeater';
@@ -413,7 +413,7 @@ trait ContentValuesTrait
                 $this->values[$key] = $repeater;
             }
 
-            if ($this->fieldtype($key) == 'date' || $this->fieldtype($key) == 'datetime') {
+            if ($this->fieldtype($key) === 'date' || $this->fieldtype($key) === 'datetime') {
                 if ($this->values[$key] === '') {
                     $this->values[$key] = null;
                 }
@@ -518,7 +518,7 @@ trait ContentValuesTrait
 
         // Grab the first field of type 'image', and return that.
         foreach ($this->contenttype['fields'] as $key => $field) {
-            if ($field['type'] == 'image') {
+            if ($field['type'] === 'image') {
                 // After v1.5.1 we store image data as an array
                 if (is_array($this->values[$key]) && isset($this->values[$key]['file'])) {
                     return $this->values[$key]['file'];
@@ -596,7 +596,7 @@ trait ContentValuesTrait
         // Otherwise, grab the first field of type 'text', and assume that's the title.
         if (!empty($this->contenttype['fields'])) {
             foreach ($this->contenttype['fields'] as $key => $field) {
-                if ($field['type'] == 'text') {
+                if ($field['type'] === 'text') {
                     return [$key];
                 }
             }


### PR DESCRIPTION
This is done very much like https://github.com/bolt/bolt/commit/e28c253ad5d07f07c75f896a41c8634099071e8d in #5542, so hopefully this is mostly correct.

I've tested that it works with multiple repeaters in the same templatefields and that normal repeaters are uneffected.

This also removes the `populateTemplateFieldsContenttype` call since that method was removed in 	2f28f16 in the original template specific fields PR.