### PR TITLE
Fix slash in taxonomies

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -219,6 +219,7 @@ general.bolt-third-party-libraries: "Below are the third party libraries that ar
 general.bolt-welcome-new-site: "Welcome to your new Bolt site, %USER%."
 
 general.phrase.access-denied-logged-out: "You have been logged out."
+general.phrase.invalid-taxonomy-slug: "In the taxonomy '%taxonomy%' the slug for option '%option%' contains a slash. Please edit taxonomy.yml, and correct this."
 general.phrase.access-denied-permissions-edit-file: "You don't have correct permissions to edit the file '%s'."
 general.phrase.access-denied-permissions-view-file-directory: "You don't have the correct permissions to display the file or directory '%s'."
 general.phrase.access-denied-privilege-edit-record: "You do not have the right privileges to edit that record."

--- a/src/Config.php
+++ b/src/Config.php
@@ -859,6 +859,26 @@ class Config
     }
 
     /**
+     * Sanity check for slashes in in taxonomy slugs.
+     */
+    public function checkTaxonomy()
+    {
+        foreach ($this->data['taxonomy'] as $key => $taxonomy) {
+            if (!empty($taxonomy['options']) && is_array($taxonomy['options'])) {
+                foreach ($taxonomy['options'] as $optionkey => $optionvalue) {
+                    if (strpos($optionkey, '/') !== false) {
+                        $error = Trans::__(
+                            'general.phrase.invalid-taxonomy-slug',
+                            ['%taxonomy%' => $key, '%option%' => $optionvalue]
+                        );
+                        $this->app['logger.flash']->error($error);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Sanity checks for doubles in in contenttypes.
      */
     public function checkConfig()

--- a/src/Config.php
+++ b/src/Config.php
@@ -861,7 +861,7 @@ class Config
     /**
      * Sanity check for slashes in in taxonomy slugs.
      */
-    public function checkTaxonomy()
+    private function checkTaxonomy()
     {
         foreach ($this->data['taxonomy'] as $key => $taxonomy) {
             if (empty($taxonomy['options']) || !is_array($taxonomy['options'])) {
@@ -1005,6 +1005,7 @@ class Config
                 }
             }
         }
+        $this->checkTaxonomy();
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -864,20 +864,23 @@ class Config
     public function checkTaxonomy()
     {
         foreach ($this->data['taxonomy'] as $key => $taxonomy) {
-            if (!empty($taxonomy['options']) && is_array($taxonomy['options'])) {
-                foreach ($taxonomy['options'] as $optionkey => $optionvalue) {
-                    if (strpos($optionkey, '/') !== false) {
-                        $error = Trans::__(
-                            'general.phrase.invalid-taxonomy-slug',
-                            ['%taxonomy%' => $key, '%option%' => $optionvalue]
-                        );
-                        $this->app['logger.flash']->error($error);
-                    }
+            if (empty($taxonomy['options']) || !is_array($taxonomy['options'])) {
+                continue;
+            }
+
+            foreach ($taxonomy['options'] as $optionKey => $optionValue) {
+                if (strpos($optionKey, '/') === false) {
+                    continue;
                 }
+
+                $error = Trans::__(
+                    'general.phrase.invalid-taxonomy-slug',
+                    ['%taxonomy%' => $key, '%option%' => $optionValue]
+                );
+                $this->app['logger.flash']->error($error);
             }
         }
     }
-
     /**
      * Sanity checks for doubles in in contenttypes.
      */

--- a/src/Controller/Backend/BackendBase.php
+++ b/src/Controller/Backend/BackendBase.php
@@ -71,7 +71,6 @@ abstract class BackendBase extends Base
         // Sanity checks for doubles in in contenttypes. This has to be done
         // here, because the 'translator' classes need to be initialised.
         $app['config']->checkConfig();
-        $app['config']->checkTaxonomy();
 
         // If we had to reload the config earlier on because we detected a
         // version change, display a notice.

--- a/src/Controller/Backend/BackendBase.php
+++ b/src/Controller/Backend/BackendBase.php
@@ -71,6 +71,7 @@ abstract class BackendBase extends Base
         // Sanity checks for doubles in in contenttypes. This has to be done
         // here, because the 'translator' classes need to be initialised.
         $app['config']->checkConfig();
+        $app['config']->checkTaxonomy();
 
         // If we had to reload the config earlier on because we detected a
         // version change, display a notice.

--- a/src/Storage/Collection/Taxonomy.php
+++ b/src/Storage/Collection/Taxonomy.php
@@ -83,6 +83,7 @@ class Taxonomy extends ArrayCollection
         $updated = [];
         // First give priority to already existing entities
         foreach ($collection as $entity) {
+            $entity->setSlug(str_replace('/', '', $entity->getSlug()));
             $master = $this->getOriginal($entity);
             $master->setSortorder($entity->getSortorder());
             $updated[] = $master;


### PR DESCRIPTION
Fixes #5673

In taxonomy slugs we basically allow any character (since we do not slugify them). One way to test this is to add a tag with a bunch of special chars or with a taxonomy like this:

```yaml
categories:
    name: Categories
    slug: categories
    singular_name: Category
    singular_slug: category
    behaves_like: categories
    options: {'test&%¤': test}
```

The only character that we cannot use or have is a slash since that denotes a separation of url portions.

This PR removes any slash found in a taxonomy slug (since that's how we do it in record slugs) and shows a warning flash message if a slash is put in a slug in taxonomy.yml.

PRing into 3.0 since this is a bug fix, let me know if I should retarget to 3.1.