### PR TITLE
Timed publish tweak

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -176,6 +176,13 @@ caching:
     thumbnails: true
     translations: true
 
+# Performance specific settings
+#
+# performance:
+#     timed_records:
+#         interval: 3600    # Number of seconds in between timed record checks
+#         use_cron: false   # If set to `true`, timed record checks will only be done via the hourly cron job
+
 # Set 'enabled' to 'true' to log all content changes in the database.
 #
 # Unless you need to rigorously monitor every change to your site's content, it

--- a/src/Config.php
+++ b/src/Config.php
@@ -1194,6 +1194,12 @@ class Config
                 'allowed_tags'       => explode(',', 'div,span,p,br,hr,s,u,strong,em,i,b,li,ul,ol,mark,blockquote,pre,code,tt,h1,h2,h3,h4,h5,h6,dd,dl,dh,table,tbody,thead,tfoot,th,td,tr,a,img,address,abbr,iframe'),
                 'allowed_attributes' => explode(',', 'id,class,style,name,value,href,src,alt,title,width,height,frameborder,allowfullscreen,scrolling'),
             ],
+            'performance'                 => [
+                'timed_records' => [
+                    'interval' => 3660,
+                    'use_cron' => false,
+                ],
+            ],
         ];
     }
 

--- a/src/EventListener/AccessControlListener.php
+++ b/src/EventListener/AccessControlListener.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\EventListener;
 
+use Bolt\AccessControl\Token\Token;
 use Bolt\Events\StorageEvent;
 use Bolt\Events\StorageEvents;
 use Bolt\Filesystem\Exception\FileNotFoundException;
@@ -51,7 +52,7 @@ class AccessControlListener implements EventSubscriberInterface
     {
         /** @var Entity\Users $userEntity */
         $userEntity = $event->getContent();
-        if (!$userEntity instanceof \Bolt\Storage\Entity\Users) {
+        if (!$userEntity instanceof Entity\Users) {
             return;
         }
 
@@ -70,7 +71,7 @@ class AccessControlListener implements EventSubscriberInterface
     {
         /** @var Entity\Users $userEntity */
         $userEntity = $event->getContent();
-        if (!$userEntity instanceof \Bolt\Storage\Entity\Users) {
+        if (!$userEntity instanceof Entity\Users) {
             return;
         }
 
@@ -110,7 +111,7 @@ class AccessControlListener implements EventSubscriberInterface
             if (!isset($data['_sf2_attributes']['authentication'])) {
                 continue;
             }
-            if (!$data['_sf2_attributes']['authentication'] instanceof \Bolt\AccessControl\Token\Token) {
+            if (!$data['_sf2_attributes']['authentication'] instanceof Token) {
                 continue;
             }
             /** @var \Bolt\AccessControl\Token\Token $token */

--- a/src/EventListener/StorageEventListener.php
+++ b/src/EventListener/StorageEventListener.php
@@ -36,6 +36,8 @@ class StorageEventListener implements EventSubscriberInterface
     protected $passwordFactory;
     /** @var integer */
     protected $hashStrength;
+    /** @var bool */
+    protected $timedRecordsEnabled;
 
     /**
      * Constructor.
@@ -46,6 +48,7 @@ class StorageEventListener implements EventSubscriberInterface
      * @param FlashLoggerInterface          $loggerFlash
      * @param PasswordFactory               $passwordFactory
      * @param integer                       $hashStrength
+     * @param bool                          $timedRecordsEnabled
      */
     public function __construct(
         EventProcessor\TimedRecord $timedRecord,
@@ -53,7 +56,8 @@ class StorageEventListener implements EventSubscriberInterface
         UrlGeneratorInterface $urlGenerator,
         FlashLoggerInterface $loggerFlash,
         PasswordFactory $passwordFactory,
-        $hashStrength
+        $hashStrength,
+        $timedRecordsEnabled
     ) {
         $this->timedRecord = $timedRecord;
         $this->schemaManager = $schemaManager;
@@ -61,6 +65,7 @@ class StorageEventListener implements EventSubscriberInterface
         $this->loggerFlash = $loggerFlash;
         $this->passwordFactory = $passwordFactory;
         $this->hashStrength = $hashStrength;
+        $this->timedRecordsEnabled = $timedRecordsEnabled;
     }
 
     /**
@@ -115,10 +120,10 @@ class StorageEventListener implements EventSubscriberInterface
         $this->schemaCheck($event);
 
         // Check if we need to 'publish' any 'timed' records, or 'hold' any expired records.
-        if ($this->timedRecord->isDuePublish()) {
+        if ($this->timedRecordsEnabled && $this->timedRecord->isDuePublish()) {
             $this->timedRecord->publishTimedRecords();
         }
-        if ($this->timedRecord->isDueHold()) {
+        if ($this->timedRecordsEnabled && $this->timedRecord->isDueHold()) {
             $this->timedRecord->holdExpiredRecords();
         }
     }

--- a/src/Events/CronEvent.php
+++ b/src/Events/CronEvent.php
@@ -70,6 +70,15 @@ class CronEvent extends Event
      */
     private function cronHourly()
     {
+        $timedRecords = $this->app['storage.event_processor.timed'];
+        if ($timedRecords->isDuePublish()) {
+            $this->notify('Publishing timed records');
+            $timedRecords->publishTimedRecords();
+        }
+        if ($timedRecords->isDueHold()) {
+            $this->notify('De-publishing timed records');
+            $timedRecords->holdExpiredRecords();
+        }
     }
 
     /**

--- a/src/Events/CronEvent.php
+++ b/src/Events/CronEvent.php
@@ -8,6 +8,8 @@ use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Event class for system compulsory cron jobs.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
 class CronEvent extends Event
 {
@@ -29,11 +31,11 @@ class CronEvent extends Event
         $this->output = $output;
 
         // Add listeners
-        $this->app['dispatcher']->addListener(CronEvents::CRON_HOURLY, [$this, 'doRunScheduledJobs']);
-        $this->app['dispatcher']->addListener(CronEvents::CRON_DAILY, [$this, 'doRunScheduledJobs']);
-        $this->app['dispatcher']->addListener(CronEvents::CRON_WEEKLY, [$this, 'doRunScheduledJobs']);
+        $this->app['dispatcher']->addListener(CronEvents::CRON_HOURLY,  [$this, 'doRunScheduledJobs']);
+        $this->app['dispatcher']->addListener(CronEvents::CRON_DAILY,   [$this, 'doRunScheduledJobs']);
+        $this->app['dispatcher']->addListener(CronEvents::CRON_WEEKLY,  [$this, 'doRunScheduledJobs']);
         $this->app['dispatcher']->addListener(CronEvents::CRON_MONTHLY, [$this, 'doRunScheduledJobs']);
-        $this->app['dispatcher']->addListener(CronEvents::CRON_YEARLY, [$this, 'doRunScheduledJobs']);
+        $this->app['dispatcher']->addListener(CronEvents::CRON_YEARLY,  [$this, 'doRunScheduledJobs']);
     }
 
     /**

--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -280,7 +280,8 @@ class StorageServiceProvider implements ServiceProviderInterface
                     $app['url_generator.lazy'],
                     $app['logger.flash'],
                     $app['password_factory'],
-                    $app['access_control.hash.strength']
+                    $app['access_control.hash.strength'],
+                    $app['config']->get('general/performance/timed_records/use_cron', false)
                 );
             }
         );

--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -288,7 +288,7 @@ class StorageServiceProvider implements ServiceProviderInterface
         $app['storage.event_processor.timed'] = $app->share(
             function ($app) {
                 $contentTypes = array_keys($app['config']->get('contenttypes', []));
-                $interval = $app['config']->get('general/caching/duration', 10) * 60;
+                $interval = $app['config']->get('general/performance/timed_records/interval');
 
                 return new EventProcessor\TimedRecord(
                     $contentTypes,


### PR DESCRIPTION
This makes the parameters for timed publishing checks independent of caching.

**[RFC]**
This PR introduces the `performance` configuration key, as a grouping for these types of parameters, with a sub key of `dispatchers` … thoughts on naming?

These should be considered advanced user territory.
