### PR TITLE
Upload exceptions

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -1,10 +1,10 @@
 # app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-05-29 15:05:42 Europe/Amsterdam
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
@@ -636,6 +636,7 @@ page.file-management.message.save-failed-colon: "File '%s' could not be saved:"
 page.file-management.message.save-failed-invalid-form: "File '%s' could not be saved, because the form wasn't valid."
 page.file-management.message.save-failed-unknown: "File '%s' could not be saved, for some reason."
 page.file-management.message.save-success: "File '%s' has been saved."
+page.file-management.message.upload-not-writable: "Unable to write to upload destination. Check permissions on %TARGET%"
 page.file-management.message.upload-success: "File '%file%' was uploaded successfully."
 page.file-management.title: "Files"
 

--- a/src/Controller/Backend/FileManager.php
+++ b/src/Controller/Backend/FileManager.php
@@ -153,7 +153,7 @@ class FileManager extends BackendBase
             if (empty($path)) {
                 $path = $namespace;
             }
-            
+
             $this->flashes()->error(Trans::__('general.phrase.access-denied-permissions-view-file-directory', ['%s' => $path]));
 
             return new RedirectResponse($this->generateUrl('dashboard'));
@@ -344,7 +344,14 @@ class FileManager extends BackendBase
         $this->app['upload.namespace'] = $namespace;
         $handler = $this->app['upload'];
         $handler->setPrefix($path . '/');
-        $result = $handler->process($fileToProcess);
+        try {
+            $result = $handler->process($fileToProcess);
+        } catch (IOException $e) {
+            $message = Trans::__('page.file-management.message.upload-not-writable', ['%TARGET%' => $namespace . '://']);
+            $this->flashes()->error($message);
+
+            return ;
+        }
 
         if ($result->isValid()) {
             $this->flashes()->info(

--- a/src/Filesystem/UploadContainer.php
+++ b/src/Filesystem/UploadContainer.php
@@ -55,17 +55,15 @@ class UploadContainer implements ContainerInterface
     /**
      * {@inheritdoc}
      *
+     * @throws IOException
+     *
      * This is called from \Sirius\Upload\Handler::processSingleFile() which expects a boolean return value,
      * and as \Bolt\FilesystemInterface::putStream only returns void or throws an error, we catch
      * IOExceptions here and return a false on exception.
      */
     public function moveUploadedFile($localFile, $destination)
     {
-        try {
-            $this->filesystem->putStream($destination, fopen($localFile, 'r+'));
-        } catch (IOException $e) {
-            return false;
-        }
+        $this->filesystem->putStream($destination, fopen($localFile, 'r+'));
 
         return true;
     }

--- a/src/Provider/UploadServiceProvider.php
+++ b/src/Provider/UploadServiceProvider.php
@@ -2,9 +2,7 @@
 
 namespace Bolt\Provider;
 
-use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
-use Bolt\Filesystem\Handler;
 use Bolt\Filesystem\UploadContainer;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -54,18 +52,6 @@ class UploadServiceProvider implements ServiceProviderInterface
             function () use ($app) {
                 /** @var Filesystem $filesystem */
                 $filesystem = $app['filesystem']->getFilesystem($app['upload.namespace']);
-                /** @var Handler\Directory $uploadDir */
-                $uploadDir = $filesystem->getDir('/');
-                /** @var Local $adapter */
-                $adapter = $filesystem->getAdapter();
-
-                if ($uploadDir->isPrivate()) {
-                    if ($adapter instanceof Local) {
-                        throw new \RuntimeException(sprintf('Unable to write to upload destination. Check permissions on %s', $adapter->getPathPrefix()));
-                    }
-                    throw new \RuntimeException(sprintf('Unable to write to upload destination. Check permissions on %s://', $app['upload.namespace']));
-                }
-
                 $container = new UploadContainer($filesystem);
 
                 return $container;

--- a/tests/phpunit/unit/Controller/Backend/UploadTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UploadTest.php
@@ -86,18 +86,6 @@ class UploadTest extends ControllerUnitTest
         $this->assertRegExp('/extension/i', $file->error);
     }
 
-    public function testBadDefaultLocation()
-    {
-        $this->getApp()->flush();
-        $this->getService('filesystem')->getDir('files://')->setVisibility('private');
-
-        $this->getFileRequest();
-
-        $this->setExpectedException('RuntimeException', 'Unable to write to upload destination');
-
-        $this->controller()->uploadNamespace($this->getRequest(), 'files');
-    }
-
     public function testHandlerParsing()
     {
         $this->getApp()->flush();


### PR DESCRIPTION
@CarsonF pointed out that doing this check during the service construction creates a two+ requests for the filesystem … which on local is no big deal, but on remotes like S3 it's a different story.