### PR TITLE
Case-insensitive username lookup at login

### DIFF
--- a/src/Storage/Repository/UsersRepository.php
+++ b/src/Storage/Repository/UsersRepository.php
@@ -94,7 +94,10 @@ class UsersRepository extends Repository
         if (is_numeric($userId)) {
             $qb->where('id = :userId');
         } else {
-            $qb->where('username = :userId')->orWhere('email = :userId');
+            $qb
+                ->where($qb->expr()->like('username', ':userId'))
+                ->orWhere('email = :userId')
+            ;
         }
         $qb->setParameter('userId', $userId);
 

--- a/tests/phpunit/unit/Storage/Repository/UsersRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/UsersRepositoryTest.php
@@ -27,7 +27,7 @@ class UsersRepositoryTest extends BoltUnitTest
         $this->assertEquals('SELECT * FROM bolt_users users WHERE id = :userId', $queryGetUserByID->getSql());
 
         $queryGetUserByName = $repo->getUserQuery('user');
-        $this->assertEquals('SELECT * FROM bolt_users users WHERE (username = :userId) OR (email = :userId)', $queryGetUserByName->getSql());
+        $this->assertEquals('SELECT * FROM bolt_users users WHERE (username LIKE :userId) OR (email = :userId)', $queryGetUserByName->getSql());
 
         $queryHasUsers = $repo->hasUsersQuery();
         $this->assertEquals('SELECT COUNT(id) as count FROM bolt_users users', $queryHasUsers->getSql());


### PR DESCRIPTION
For the record, I am 1,000% **against** this being done in core.

Nonetheless this implements the database check for the username case-insensitively.

Closes #5695