### PR TITLE
Allow taxonomies in contentlinks again

### DIFF
--- a/src/Storage/Entity/ContentRouteTrait.php
+++ b/src/Storage/Entity/ContentRouteTrait.php
@@ -142,10 +142,21 @@ trait ContentRouteTrait
                 if ('\d{4}-\d{2}-\d{2}' === $requirement) {
                     // Special case, if we need to have a date
                     $params[$fieldName] = substr($this->get($fieldName), 0, 10);
+                } elseif ($this->getTaxonomy() !== null && !$this->getTaxonomy()->getField($fieldName)->isEmpty()) {
+                    // This is for new storage handling of taxonomies in
+                    // contentroutes. If in legacy it will fall back to the one
+                    // below.
+                    $params[$fieldName] = $this->getTaxonomy()->getField($fieldName)->first()->getSlug();
+                } elseif (isset($this->taxonomy[$fieldName])) {
+                    // Turn something like '/groups/meta' to 'meta'. This is
+                    // only for legacy storage.
+                    $tempKeys = array_keys($this->taxonomy[$fieldName]);
+                    $tempValues = explode('/', array_shift($tempKeys));
+                    $params[$fieldName] = array_pop($tempValues);
                 } elseif ($this->get($fieldName)) {
                     $params[$fieldName] = $this->get($fieldName);
                 } else {
-                    // unkown
+                    // unknown
                     $params[$fieldName] = null;
                 }
             }

--- a/src/Storage/Entity/ContentTaxonomyTrait.php
+++ b/src/Storage/Entity/ContentTaxonomyTrait.php
@@ -24,7 +24,7 @@ trait ContentTaxonomyTrait
      *
      * @param string $taxonomyType
      */
-    public function getTaxonomy($taxonomyType)
+    public function getTaxonomy($taxonomyType = null)
     {
     }
 


### PR DESCRIPTION
This reintroduces taxonomies in contentlinks which was ripped out in #5593 because it seemed to not work. It contains one case for legacy and one for the new storage as opposed to the old one removed in 5593 which only worked in legacy. The issue was reported on slack by techwilk.

Example route:

```
category:
    path: /{groups}/{slug}
    defaults:
        _controller: controller.frontend:record
        contenttypeslug: pages
        groups: none
    requirements:
        groups: [ controller.requirement:singleTaxonomy, [groups] ]
    contenttype: pages
```