### PR TITLE
Fix .bolt being allowed to specify application as string

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -117,7 +117,7 @@ return call_user_func(function () {
 
     // Create the 'Bolt application'
     $appClass = Application::class;
-    if ($config['application'] !== null && is_a($config['application'], Silex\Application::class)) {
+    if ($config['application'] !== null && is_a($config['application'], Silex\Application::class, true)) {
         $appClass = $config['application'];
     }
     $app = new $appClass(['resources' => $resources]);


### PR DESCRIPTION
.bolt files should be allowed to specify application as string. This fixes the check to ensure the string is a class name that extends Silex\Application.