### PR TITLE
Fix loading controllers without before/after middlewares

### DIFF
--- a/src/Routing/CallbackResolver.php
+++ b/src/Routing/CallbackResolver.php
@@ -58,7 +58,7 @@ class CallbackResolver extends \Silex\CallbackResolver
         if (isset($this->classmap[$cls])) {
             return true; // Will use service definition
         }
-        if (!class_exists($cls)) {
+        if (!class_exists($cls) || !method_exists($cls, $method)) {
             return false; // Can't handle this
         }
         $refMethod = new \ReflectionMethod($cls, $method);


### PR DESCRIPTION
When loading `routing.yml` if a controller is referenced that doesn't have `before` and `after` methods, an exception would be thrown. This fixes that to just do nothing in those cases.