### PR TITLE
Ensure entity is always named as a parameter in storage events

### DIFF
--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -432,7 +432,7 @@ class Repository implements ObjectRepository
 
         $this->getEntityBuilder()->createFromDatabaseValues($data, $entity);
 
-        $postEventArgs = new HydrationEvent($entity, ['data' => $data, 'repository' => $this]);
+        $postEventArgs = new HydrationEvent($entity, ['entity' => $entity, 'data' => $data, 'repository' => $this]);
         $this->event()->dispatch(StorageEvents::POST_HYDRATE, $postEventArgs);
 
         return $entity;


### PR DESCRIPTION
Small fix to ensure there's always an entity param passed into storage events even if it sometimes isn't the subject.

Fixes #5692