### PR TITLE
fix link to available locales

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -22,7 +22,7 @@ theme: base-2016
 
 # The locale that'll be used by the application. If no locale is set the
 # fallback locale is 'en_GB'. For available options, see:
-# http://docs.bolt.cm/locales
+# https://docs.bolt.cm/other/locales#version-changer
 #
 # In some cases it may be needed to specify (non-standard) variations of the
 # locale to get everything to work as desired.


### PR DESCRIPTION
Hi,

while creating my first bolt project i noticed that the link in the config.yml which should list the available locales is 404-ing.

PS: For what it's worth, i don't like brown M&M's 😂 
