### PR TITLE
Remove content edit link from toolbar.

### DIFF
--- a/app/view/toolbar/bolt.html.twig
+++ b/app/view/toolbar/bolt.html.twig
@@ -57,14 +57,6 @@
         </div>
         {% endif %}
 
-        {% if collector.editlink %}
-        <div class="sf-toolbar-info-piece">
-            <hr style="margin: 8px 0 12px; padding: 0; border: 0; border-bottom: 1px solid #777;">
-            <span> Edit: <a href="{{ collector.editlink }}">{{ collector.edittitle|excerpt(40)|default("(no title)") }}</a> </span>
-        </div>
-        {% endif %}
-
-
     {% endset %}
     {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}

--- a/src/Application.php
+++ b/src/Application.php
@@ -69,10 +69,6 @@ class Application extends Silex\Application
         $locales = (array) $this['config']->get('general/locale');
         $this['locale'] = reset($locales);
 
-        // Initialize the 'editlink' and 'edittitle'.
-        $this['editlink'] = '';
-        $this['edittitle'] = '';
-
         // Initialize the JavaScript data gateway.
         $this['jsdata'] = [];
     }

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -183,10 +183,6 @@ class Frontend extends ConfigurableBase
         }
         $this->app['resources']->setUrl('canonicalurl', $url);
 
-        // Setting the editlink
-        $this->app['editlink'] = $this->generateUrl('editcontent', ['contenttypeslug' => $contenttype['slug'], 'id' => $content->id]);
-        $this->app['edittitle'] = $content->getTitle();
-
         // Make sure we can also access it as {{ page.title }} for pages, etc. We set these in the global scope,
         // So that they're also available in menu's and templates rendered by extensions.
         $globals = [

--- a/src/Profiler/BoltDataCollector.php
+++ b/src/Profiler/BoltDataCollector.php
@@ -40,8 +40,6 @@ class BoltDataCollector extends DataCollector
             'payoff'        => 'Sophisticated, lightweight & simple CMS',
             'dashboardlink' => sprintf('<a href="%s">%s</a>', $this->app['url_generator']->generate('dashboard'), 'Dashboard'),
             'branding'      => null,
-            'editlink'      => null,
-            'edittitle'     => null,
         ];
 
         if ($this->app['config']->get('general/branding/provided_by/0')) {
@@ -50,11 +48,6 @@ class BoltDataCollector extends DataCollector
                 Trans::__('general.phrase.provided-by-colon'),
                 $this->app['config']->get('general/branding/provided_link')
             );
-        }
-
-        if (!empty($this->app['editlink'])) {
-            $this->data['editlink'] = $this->app['editlink'];
-            $this->data['edittitle'] = $this->app['edittitle'];
         }
     }
 
@@ -96,25 +89,5 @@ class BoltDataCollector extends DataCollector
     public function getDashboardlink()
     {
         return $this->data['dashboardlink'];
-    }
-
-    /**
-     * Getter for editlink.
-     *
-     * @return string
-     */
-    public function getEditlink()
-    {
-        return $this->data['editlink'];
-    }
-
-    /**
-     * Getter for edittitle.
-     *
-     * @return string
-     */
-    public function getEdittitle()
-    {
-        return $this->data['edittitle'];
     }
 }

--- a/tests/phpunit/unit/Profiler/BoltDataCollectorTest.php
+++ b/tests/phpunit/unit/Profiler/BoltDataCollectorTest.php
@@ -34,8 +34,6 @@ class BoltDataCollectorTest extends BoltUnitTest
         $this->assertNotEmpty($data->getVersion());
         $this->assertNotEmpty($data->getPayoff());
         $this->assertNotEmpty($data->getDashboardLink());
-        $this->assertEmpty($data->getEditLink());
-        $this->assertEmpty($data->getEditTitle());
     }
 
     public function testBrandingData()
@@ -52,18 +50,5 @@ class BoltDataCollectorTest extends BoltUnitTest
 
         $this->assertRegExp('/testperson/', $data->getBranding());
         $this->assertRegExp('/testemail/', $data->getBranding());
-    }
-
-    public function testEditLinks()
-    {
-        $app = $this->getApp();
-        $app['editlink'] = 'editlink';
-        $app['edittitle'] = 'edittitle';
-        $request = Request::create('/', 'GET');
-        $response = $app->handle($request);
-        $data = new BoltDataCollector($app);
-        $data->collect($request, $response);
-        $this->assertEquals('editlink', $data->getEditlink());
-        $this->assertEquals('edittitle', $data->getEdittitle());
     }
 }


### PR DESCRIPTION
The toolbar is not the right place for it. It's available to the templates from the record object, which is even already used in the base-2016 theme.
