### PR TITLE
Allow use of string class names in app bootstrap

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -118,7 +118,7 @@ return call_user_func(function () {
 
     // Create the 'Bolt application'
     $appClass = Application::class;
-    if ($config['application'] !== null && is_a($config['application'], Silex\Application::class, true)) {
+    if ($config['application'] !== null && is_subclass_of($config['application'], Silex\Application::class)) {
         $appClass = $config['application'];
     }
     $app = new $appClass(['resources' => $resources]);


### PR DESCRIPTION
Credit to @helman for this one.

Fixes #5725