### PR TITLE
fix too generic selector in filescreenuploader

### DIFF
--- a/app/src/sass/modules/_bolt.scss
+++ b/app/src/sass/modules/_bolt.scss
@@ -150,14 +150,12 @@ table.dataTable thead .sorting:after {
     padding: 3px 12px;
 }
 
-form#filescreenuploader {
-    div {
-        float: left;
-        margin-right: 6px;
-        margin-top: 6px;
-        display: inline;
-        width: 100%;
-    }
+form#filescreenuploader fieldset > div {
+    float: left;
+    margin-right: 6px;
+    margin-top: 6px;
+    display: inline;
+    width: 100%;
 }
 
 .relatedfiles {


### PR DESCRIPTION
Fixes #5715

This selector was catching the tooltip arrow too.

In the end we'd probably want to not use any of these generic selectors, but this should be "good enough for now™".