### PR TITLE
Update bootstrap to check non-hidden config files

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -95,9 +95,9 @@ return call_user_func(function () {
 
     // An extra handler if a PHP bootstrap is provided, allow the bootstrap file to return
     // a pre-initialized Bolt Application rather than the config array.
-    if ($php !== null && is_array($php)) {
+    if (isset($php) && is_array($php)) {
         $config = array_replace_recursive($config, $php);
-    } elseif ($php !== null && $php instanceof Silex\Application) {
+    } elseif (isset($php) && $php instanceof Silex\Application) {
         return $php;
     }
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -95,9 +95,9 @@ return call_user_func(function () {
 
     // An extra handler if a PHP bootstrap is provided, allow the bootstrap file to return
     // a pre-initialized Bolt Application rather than the config array.
-    if (is_array($php)) {
+    if ($php !== null && is_array($php)) {
         $config = array_replace_recursive($config, $php);
-    } elseif ($php instanceof Silex\Application) {
+    } elseif ($php !== null && $php instanceof Silex\Application) {
         return $php;
     }
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -84,11 +84,21 @@ return call_user_func(function () {
     if (file_exists($rootPath . '/.bolt.yml')) {
         $yaml = Yaml::parse(file_get_contents($rootPath . '/.bolt.yml')) ?: [];
         $config = array_replace_recursive($config, $yaml);
+    } elseif (file_exists($rootPath . '/bolt.yml')) {
+        $yaml = Yaml::parse(file_get_contents($rootPath . '/bolt.yml')) ?: [];
+        $config = array_replace_recursive($config, $yaml);
     } elseif (file_exists($rootPath . '/.bolt.php')) {
         $php = include $rootPath . '/.bolt.php';
-        if (is_array($php)) {
-            $config = array_replace_recursive($config, $php);
-        }
+    } elseif (file_exists($rootPath . '/bolt.php')) {
+        $php = include $rootPath . '/bolt.php';
+    }
+
+    // An extra handler if a PHP bootstrap is provided, allow the bootstrap file to return
+    // a pre-initialized Bolt Application rather than the config array.
+    if (is_array($php)) {
+        $config = array_replace_recursive($config, $php);
+    } elseif ($php instanceof Silex\Application) {
+        return $php;
     }
 
     // If application object is provided, assume it is ready to go.

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -113,7 +113,7 @@ class ScriptHandler
 
         $filesystem = new Filesystem();
 
-        $filesystem->dumpFile('.bolt.yml', Yaml::dump($config));
+        $filesystem->dumpFile('bolt.yml', Yaml::dump($config));
 
         $chmodDirs = [
             'extensions',


### PR DESCRIPTION
As discussed in #5729 Check for alternative non-dot versions of `.bolt.yml` and `.bolt.php`.

There's an additional minor improvement here and that allows a `bolt.php` file to just return a pre-constructed application rather than array. This is optional but simplifies the flow of php bootstrap files that will normally take care of creating an instance of `Bolt\Application`.