### PR TITLE
We shouldn't assume 'page/1' is the homepage.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1035,7 +1035,6 @@ class Config
                 'randomfunction' => '',
             ],
             'sitename'                    => 'Default Bolt site',
-            'homepage'                    => 'page/1',
             'locale'                      => 'en_GB',
             'recordsperpage'              => 10,
             'recordsperdashboardwidget'   => 5,


### PR DESCRIPTION
With this line present, Bolt will fall back to 'page/1' as the homepage, regardless of whether it exists or not. This is black magic, because to the end user it's not clear at all why this happens, if you explicitly _remove_ `homepage:` from your `config.yml`. 