### PR TITLE
Fixed: Add `'name'` to query to fetch popular tags, to prevent SQL error.

### DIFF
--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -219,7 +219,7 @@ class General extends AsyncBase
             ->select('name, COUNT(slug) AS count')
             ->from($table)
             ->where('taxonomytype = :taxonomytype')
-            ->groupBy('name', 'slug')
+            ->groupBy('name')
             ->orderBy('count', 'DESC')
             ->setMaxResults($request->query->getInt('limit', 20))
             ->setParameters([

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -219,7 +219,7 @@ class General extends AsyncBase
             ->select('name, COUNT(slug) AS count')
             ->from($table)
             ->where('taxonomytype = :taxonomytype')
-            ->groupBy('slug')
+            ->groupBy('name', 'slug')
             ->orderBy('count', 'DESC')
             ->setMaxResults($request->query->getInt('limit', 20))
             ->setParameters([


### PR DESCRIPTION
Fixes #5749