### PR TITLE
Fixed: Files without recognised extensions don't break the file browser. 

### DIFF
--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -90,6 +90,7 @@ class ResourceManager
         $this->setUrl('upload', '/upload/');
         $this->setUrl('bolt', '/bolt/');
         $this->setUrl('theme', '/theme/');
+        $this->setUrl('themes', '/theme/'); // Deprecated, here for BC. See #5759
 
         $this->setPath('web', '');
         $this->setPath('cache', 'app/cache');

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -90,7 +90,7 @@ class ResourceManager
         $this->setUrl('upload', '/upload/');
         $this->setUrl('bolt', '/bolt/');
         $this->setUrl('theme', '/theme/');
-        $this->setUrl('themes', '/theme/'); // Deprecated, here for BC. See #5759
+        $this->setUrl('themes', '/theme/'); // Needed for filebrowser. See #5759
 
         $this->setPath('web', '');
         $this->setPath('cache', 'app/cache');

--- a/src/Filesystem/Plugin/PublicUrl.php
+++ b/src/Filesystem/Plugin/PublicUrl.php
@@ -13,8 +13,7 @@ class PublicUrl extends AdapterPlugin
 
     public function getLocalUrl($path)
     {
-        $filesystem = $this->app['filesystem']->getFilesystem($this->namespace);
-        $prefix = '' // <- I guess something like $filesystem->getPath();
+        $prefix = $this->app['resources']->getUrl($this->namespace);
 
         return $prefix . Lib::safeFilename($path);
     }

--- a/src/Filesystem/Plugin/PublicUrl.php
+++ b/src/Filesystem/Plugin/PublicUrl.php
@@ -13,7 +13,8 @@ class PublicUrl extends AdapterPlugin
 
     public function getLocalUrl($path)
     {
-        $prefix = $this->app['resources']->getUrl($this->namespace);
+        $filesystem = $this->app['filesystem']->getFilesystem($this->namespace);
+        $prefix = '' // <- I guess something like $filesystem->getPath();
 
         return $prefix . Lib::safeFilename($path);
     }


### PR DESCRIPTION
Fixes: #5759, until a better solution lands. 