### PR TITLE
Bolt changed to make image aliases work #3703

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -196,7 +196,7 @@ thumbnails:
     save_files: false
     allow_upscale: false
     exif_orientation: true
-    restrict_alias: false
+    only_aliases: false
 #    browser_cache_time: 2592000
 
 # Define the HTML tags and attributes that are allowed in 'cleaned' HTML. This

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -196,6 +196,7 @@ thumbnails:
     save_files: false
     allow_upscale: false
     exif_orientation: true
+    restrict_alias: false
 #    browser_cache_time: 2592000
 
 # Define the HTML tags and attributes that are allowed in 'cleaned' HTML. This

--- a/src/Config.php
+++ b/src/Config.php
@@ -1080,6 +1080,7 @@ class Config
                 'cropping'          => 'crop',
                 'notfound_image'    => 'view/img/default_notfound.png',
                 'error_image'       => 'view/img/default_error.png',
+                'restrict_alias'    => false,
             ],
             'accept_file_types'           => explode(',', 'twig,html,js,css,scss,gif,jpg,jpeg,png,ico,zip,tgz,txt,md,doc,docx,pdf,epub,xls,xlsx,csv,ppt,pptx,mp3,ogg,wav,m4a,mp4,m4v,ogv,wmv,avi,webm,svg'),
             'hash_strength'               => 10,

--- a/src/Config.php
+++ b/src/Config.php
@@ -1080,7 +1080,7 @@ class Config
                 'cropping'          => 'crop',
                 'notfound_image'    => 'view/img/default_notfound.png',
                 'error_image'       => 'view/img/default_error.png',
-                'restrict_alias'    => false,
+                'only_aliases'    => false,
             ],
             'accept_file_types'           => explode(',', 'twig,html,js,css,scss,gif,jpg,jpeg,png,ico,zip,tgz,txt,md,doc,docx,pdf,epub,xls,xlsx,csv,ppt,pptx,mp3,ogg,wav,m4a,mp4,m4v,ogv,wmv,avi,webm,svg'),
             'hash_strength'               => 10,

--- a/src/Provider/ThumbnailsServiceProvider.php
+++ b/src/Provider/ThumbnailsServiceProvider.php
@@ -70,7 +70,7 @@ class ThumbnailsServiceProvider implements ServiceProviderInterface
 
         $app['thumbnails.limit_upscaling'] = !$app['config']->get('general/thumbnails/allow_upscale', false);
 
-        $app['thumbnails.restrict_alias'] = $app['config']->get('general/thumbnails/restrict_alias', false);
+        $app['thumbnails.only_aliases'] = $app['config']->get('general/thumbnails/only_aliases', false);
 
         ImageResource::setNormalizeJpegOrientation($app['config']->get('general/thumbnails/exif_orientation', true));
         ImageResource::setQuality($app['config']->get('general/thumbnails/quality', 80));

--- a/src/Provider/ThumbnailsServiceProvider.php
+++ b/src/Provider/ThumbnailsServiceProvider.php
@@ -70,6 +70,8 @@ class ThumbnailsServiceProvider implements ServiceProviderInterface
 
         $app['thumbnails.limit_upscaling'] = !$app['config']->get('general/thumbnails/allow_upscale', false);
 
+        $app['thumbnails.restrict_alias'] = $app['config']->get('general/thumbnails/restrict_alias', false);
+
         ImageResource::setNormalizeJpegOrientation($app['config']->get('general/thumbnails/exif_orientation', true));
         ImageResource::setQuality($app['config']->get('general/thumbnails/quality', 80));
     }

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -39,6 +39,11 @@ class ImageHandler
      */
     public function image($filename = null, $width = null, $height = null, $crop = null)
     {
+        //Check if it's an alias as the only parameter after $filename
+        if($width && !$height && !$crop && $this->isAlias($width)) {
+            return $this->getAliasedUri($filename, $width);
+        }
+
         if ($width || $height) {
             // You don't want the image, you just want a thumbnail.
             return $this->thumbnail($filename, $width, $height, $crop);
@@ -199,6 +204,11 @@ class ImageHandler
      */
     public function thumbnail($fileName = null, $width = null, $height = null, $crop = null)
     {
+        //Check if it's an alias as the only parameter after $filename
+        if($width && !$height && !$crop && $this->isAlias($width)) {
+            return $this->getAliasedUri($fileName, $width);
+        }
+
         $thumb = $this->getThumbnail($fileName, $width, $height, $crop);
 
         return $this->getThumbnailUri($thumb);
@@ -249,5 +259,26 @@ class ImageHandler
                 'file'   => $thumb->getFileName(),
             ]
         );
+    }
+
+    private function getAliasedUri($filename, $alias)
+    {
+
+        if (!$this->isAlias($alias)) {
+            return false;
+        }
+
+        return $this->app['url_generator']->generate(
+            'alias',
+            [
+                'alias'  => $alias,
+                'file'   => $filename,
+            ]
+        );
+    }
+
+    private function isAlias($alias)
+    {
+        return (bool)$this->app["config"]->get("theme/image_aliases/".$alias, false);
     }
 }

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -40,7 +40,7 @@ class ImageHandler
     public function image($filename = null, $width = null, $height = null, $crop = null)
     {
         //Check if it's an alias as the only parameter after $filename
-        if($width && !$height && !$crop && $this->isAlias($width)) {
+        if ($width && !$height && !$crop && $this->isAlias($width)) {
             return $this->getAliasedUri($filename, $width);
         }
 
@@ -205,7 +205,7 @@ class ImageHandler
     public function thumbnail($fileName = null, $width = null, $height = null, $crop = null)
     {
         //Check if it's an alias as the only parameter after $filename
-        if($width && !$height && !$crop && $this->isAlias($width)) {
+        if ($width && !$height && !$crop && $this->isAlias($width)) {
             return $this->getAliasedUri($fileName, $width);
         }
 
@@ -279,6 +279,6 @@ class ImageHandler
 
     private function isAlias($alias)
     {
-        return (bool)$this->app["config"]->get("theme/image_aliases/".$alias, false);
+        return (bool)$this->app["config"]->get("theme/thumbnails/aliases/".$alias, false);
     }
 }

--- a/src/Twig/Handler/ImageHandler.php
+++ b/src/Twig/Handler/ImageHandler.php
@@ -269,7 +269,7 @@ class ImageHandler
         }
 
         return $this->app['url_generator']->generate(
-            'alias',
+            'thumb_alias',
             [
                 'alias'  => $alias,
                 'file'   => $filename,

--- a/theme/base-2016/theme.yml
+++ b/theme/base-2016/theme.yml
@@ -71,7 +71,8 @@ templateselect:
 
 # Aliases can be set to restrict images to a specific set of available
 # resolutions or to decouple image sizes from template files.
-image_aliases:
-    myimageformat:
-        size: [400,300]
-        cropping: crop
+thumbnails:
+    aliases:
+        myimageformat:
+            size: [400,300]
+            cropping: crop

--- a/theme/base-2016/theme.yml
+++ b/theme/base-2016/theme.yml
@@ -68,3 +68,10 @@ templateselect:
            filename: 'extrafields.twig'
          - name: 'Another template with extra fields'
            filename: 'anotherextrafields.twig'
+
+# Aliases can be set to restrict images to a specific set of available
+# resolutions or to decouple image sizes from template files.
+image_aliases:
+    myimageformat:
+        size: [400,300]
+        cropping: crop


### PR DESCRIPTION
Changes to the default configuration and to the twig filters image and thumbnail to allow aliases for image resolutions as discussed in #3703. 

The new config value `restrict_alias` is set in all the old style `$app["myconfig param name"] things in the providers to keep it in line with current code. **But** the code will only use the $app->["config"]->get()` methods to access them like the new code does.