### PR TITLE
Fix dashboard news timeout

### DIFF
--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -2,7 +2,6 @@
 namespace Bolt\Controller\Async;
 
 use Bolt;
-use Bolt\Pager;
 use GuzzleHttp\Exception\RequestException;
 use Silex\ControllerCollection;
 use Symfony\Component\HttpFoundation\Request;
@@ -298,108 +297,119 @@ class General extends AsyncBase
     }
 
     /**
-     * Get the news from either cache or Bolt HQ.
+     * Get the news from Bolt HQ (with caching).
      *
      * @param string $hostname
      *
-     * @return array|string
+     * @return array
      */
     private function getNews($hostname)
     {
-        /** @var \Bolt\Cache $cache */
-        $cache = $this->app['cache'];
-
         // Cached for two hours.
-        $news = $cache->fetch('dashboardnews');
-
-        // If not cached, get fresh news.
+        $news = $this->app['cache']->fetch('dashboardnews');
         if ($news !== false) {
             $this->app['logger.system']->info('Using cached data', ['event' => 'news']);
 
             return $news;
-        } else {
-            $source = $this->getOption('general/branding/news_source', 'http://news.bolt.cm/');
-            $curl = $this->getDashboardCurlOptions($hostname, $source);
-
-            $this->app['logger.system']->info('Fetching from remote server: ' . $source, ['event' => 'news']);
-
-            try {
-                $fetchedNewsData = $this->app['guzzle.client']->get($curl['url'], ['config' => ['curl' => $curl['options']]])->getBody(true);
-                if ($this->getOption('general/branding/news_variable')) {
-                    $newsVariable = $this->getOption('general/branding/news_variable');
-                    $fetchedNewsItems = json_decode($fetchedNewsData)->$newsVariable;
-                } else {
-                    $fetchedNewsItems = json_decode($fetchedNewsData);
-                }
-                if ($fetchedNewsItems) {
-                    $news = [];
-
-                    // Iterate over the items, pick the first news-item that
-                    // applies and the first alert we need to show
-                    foreach ($fetchedNewsItems as $item) {
-                        $type = ($item->type === 'alert') ? 'alert' : 'information';
-                        if (!isset($news[$type])
-                            && (empty($item->target_version) || Bolt\Version::compare($item->target_version, '>'))
-                        ) {
-                            $news[$type] = $item;
-                        }
-                    }
-
-                    $cache->save('dashboardnews', $news, 7200);
-                } else {
-                    $this->app['logger.system']->error('Invalid JSON feed returned', ['event' => 'news']);
-                }
-
-                return $news;
-            } catch (RequestException $e) {
-                $this->app['logger.system']->critical(
-                    'Error occurred during newsfeed fetch',
-                    ['event' => 'exception', 'exception' => $e]
-                );
-
-                return ['error' => ['type' => 'error', 'title' => 'Unable to fetch news!', 'teaser' => "<p>Unable to connect to $source</p>"]];
-            }
         }
+
+        // If not cached, get fresh news.
+        $news = $this->fetchNews($hostname);
+
+        $this->app['cache']->save('dashboardnews', $news, 7200);
+
+        return $news;
     }
 
     /**
-     * Get the cURL options.
+     * Get the news from Bolt HQ.
      *
      * @param string $hostname
-     * @param string $source
      *
      * @return array
      */
-    private function getDashboardCurlOptions($hostname, $source)
+    private function fetchNews($hostname)
     {
-        $driver = $this->app['db']->getDatabasePlatform()->getName();
+        $source = $this->getOption('general/branding/news_source', 'http://news.bolt.cm/');
+        $options = $this->fetchNewsOptions($hostname);
 
-        $url = sprintf(
-            '%s?v=%s&p=%s&db=%s&name=%s',
-            $source,
-            rawurlencode(Bolt\Version::VERSION),
-            phpversion(),
-            $driver,
-            base64_encode($hostname)
-        );
+        $this->app['logger.system']->info('Fetching from remote server: ' . $source, ['event' => 'news']);
 
-        // Standard option(s)
-        $options = [CURLOPT_CONNECTTIMEOUT => 5, CURLOPT_TIMEOUT => 10];
+        try {
+            $fetchedNewsData = (string) $this->app['guzzle.client']->get($source, $options)->getBody(true);
+        } catch (RequestException $e) {
+            $this->app['logger.system']->error(
+                'Error occurred during newsfeed fetch',
+                ['event' => 'exception', 'exception' => $e]
+            );
 
-        // Options valid if using a proxy
-        if ($this->getOption('general/httpProxy')) {
-            $proxies = [
-                CURLOPT_PROXY        => $this->getOption('general/httpProxy/host'),
-                CURLOPT_PROXYTYPE    => CURLPROXY_HTTP,
-                CURLOPT_PROXYUSERPWD => $this->getOption('general/httpProxy/user') . ':' .
-                $this->getOption('general/httpProxy/password'),
+            return [
+                'error' => [
+                    'type'   => 'error',
+                    'title'  => 'Unable to fetch news!',
+                    'teaser' => "<p>Unable to connect to $source</p>",
+                ],
             ];
         }
 
-        return [
-            'url'     => $url,
-            'options' => !empty($proxies) ? array_merge($options, $proxies) : $options,
+        $fetchedNewsItems = json_decode($fetchedNewsData);
+        if ($newsVariable = $this->getOption('general/branding/news_variable')) {
+            $fetchedNewsItems = $fetchedNewsItems->$newsVariable;
+        }
+
+        $news = [];
+        if (!$fetchedNewsItems) {
+            $this->app['logger.system']->error('Invalid JSON feed returned', ['event' => 'news']);
+
+            return $news;
+        }
+
+        // Iterate over the items, pick the first news-item that
+        // applies and the first alert we need to show
+        foreach ($fetchedNewsItems as $item) {
+            $type = ($item->type === 'alert') ? 'alert' : 'information';
+            if (!isset($news[$type])
+                && (empty($item->target_version) || Bolt\Version::compare($item->target_version, '>'))
+            ) {
+                $news[$type] = $item;
+            }
+        }
+
+        return $news;
+    }
+
+    /**
+     * Get the guzzle options.
+     *
+     * @param string $hostname
+     *
+     * @return array
+     */
+    private function fetchNewsOptions($hostname)
+    {
+        $driver = $this->app['db']->getDatabasePlatform()->getName();
+
+        $options = [
+            'query' => [
+                'v'    => Bolt\Version::VERSION,
+                'p'    => phpversion(),
+                'db'   => $driver,
+                'name' => $hostname,
+            ],
+            'connect_timeout' => 5,
+            'timeout'         => 10,
         ];
+
+        if ($this->getOption('general/httpProxy')) {
+            $options['proxy'] = sprintf(
+                '%s:%s@%s',
+                $this->getOption('general/httpProxy/user'),
+                $this->getOption('general/httpProxy/password'),
+                $this->getOption('general/httpProxy/host')
+            );
+        }
+
+        return $options;
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Async/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Async/GeneralTest.php
@@ -80,19 +80,20 @@ class GeneralTest extends ControllerUnitTest
 
         $changeRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogChange');
         $systemRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogSystem');
-        $logger = $this->getMock('Bolt\Logger\Manager', ['info', 'critical'], [$app, $changeRepository, $systemRepository]);
+        $logger = $this->getMock('Bolt\Logger\Manager', ['info', 'error'], [$app, $changeRepository, $systemRepository]);
 
         $logger->expects($this->at(1))
-            ->method('critical')
+            ->method('error')
             ->with($this->stringContains('Error occurred'));
         $app['logger.system'] = $logger;
-        $response = $this->controller()->dashboardNews($this->getRequest());
+        $this->controller()->dashboardNews($this->getRequest());
     }
 
     public function testDashboardNewsWithInvalidJson()
     {
         $this->setRequest(Request::create('/async/dashboardnews'));
         $app = $this->getApp();
+        $app['cache']->flushAll();
         $testGuzzle = $this->getMock('GuzzleHttp\Client', ['get'], []);
         $testRequest = $this->getMock('GuzzleHttp\Message', ['getBody']);
         $testRequest->expects($this->any())
@@ -111,7 +112,7 @@ class GeneralTest extends ControllerUnitTest
             ->method('error')
             ->with($this->stringContains('Invalid JSON'));
         $app['logger.system'] = $logger;
-        $response = $this->controller()->dashboardNews($this->getRequest());
+        $this->controller()->dashboardNews($this->getRequest());
     }
 
     public function testDashboardNewsWithVariable()


### PR DESCRIPTION
Fixed Guzzle options and made them work with other handlers besides cURL. Caching errors as well so each request doesn't have to wait 10 secs if the server is down. Cleaned up method with early returns.

The only thing I'm not sure about is proxy option. Specifically if `general/httpProxy/host` has a `http://` prefixed or not and if it's needed in final string. Can someone with a proxy test? Either way it was broken before so this wouldn't introduce a break to that.