### PR TITLE
Fix TemplateChooser templates existence checks

### DIFF
--- a/src/TemplateChooser.php
+++ b/src/TemplateChooser.php
@@ -84,16 +84,14 @@ class TemplateChooser
         // Third candidate: a template with the same filename as the name of
         // the contenttype.
         if (isset($record->contenttype['singular_slug'])) {
-            $templatefile = $this->app['resources']->getPath('templatespath/' . $record->contenttype['singular_slug'] . '.twig');
-            if (is_readable($templatefile)) {
+            if ($this->app['render']->hasTemplate($record->contenttype['singular_slug'] . '.twig')) {
                 $template = $record->contenttype['singular_slug'] . '.twig';
             }
         }
 
         // Fourth candidate: defined specificaly in the contenttype.
         if (isset($record->contenttype['record_template'])) {
-            $templatefile = $this->app['resources']->getPath('templatespath/' . $record->contenttype['record_template']);
-            if (file_exists($templatefile)) {
+            if ($this->app['render']->hasTemplate($record->contenttype['record_template'])) {
                 $template = $record->contenttype['record_template'];
             }
         }
@@ -142,8 +140,7 @@ class TemplateChooser
 
         // Third candidate: a template with the same filename as the name of
         // the contenttype.
-        $filename = $this->app['resources']->getPath('templatespath/' . $contenttype['slug'] . '.twig');
-        if (file_exists($filename) && is_readable($filename)) {
+        if ($this->app['render']->hasTemplate($contenttype['slug'] . '.twig')) {
             $template = $contenttype['slug'] . '.twig';
         }
 

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -6,6 +6,7 @@ use Bolt\Application;
 use Bolt\Configuration as Config;
 use Bolt\Configuration\Standard;
 use Bolt\Legacy\Storage;
+use Bolt\Render;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Bolt\Twig\Handler\AdminHandler;
@@ -147,26 +148,26 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
         $app['users']->users = [];
     }
 
-    protected function getMockTwig()
+    protected function getRenderMock(Application $app)
     {
-        $twig = $this->getMock('Twig_Environment', ['render', 'fetchCachedRequest']);
-        $twig->expects($this->any())
+        $render = $this->getMock(Render::class, ['render', 'fetchCachedRequest'], [$app]);
+        $render->expects($this->any())
             ->method('fetchCachedRequest')
             ->will($this->returnValue(false));
 
-        return $twig;
+        return $render;
     }
 
-    protected function checkTwigForTemplate($app, $testTemplate)
+    protected function checkTwigForTemplate(Application $app, $testTemplate)
     {
-        $twig = $this->getMockTwig();
+        $render = $this->getRenderMock($app);
 
-        $twig->expects($this->any())
+        $render->expects($this->atLeastOnce())
             ->method('render')
             ->with($this->equalTo($testTemplate))
             ->will($this->returnValue(new Response()));
 
-        $app['render'] = $twig;
+        $app['render'] = $render;
     }
 
     protected function allowLogin($app)

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -74,7 +74,7 @@ class GeneralTest extends ControllerUnitTest
 
     public function testDashboard()
     {
-        $twig = $this->getMockTwig();
+        $render = $this->getRenderMock($this->getApp());
         $phpunit = $this;
         $testHandler = function ($template, $context) use ($phpunit) {
             $phpunit->assertEquals('@bolt/dashboard/dashboard.twig', $template);
@@ -85,12 +85,12 @@ class GeneralTest extends ControllerUnitTest
             return new Response();
         };
 
-        $twig->expects($this->any())
+        $render->expects($this->atLeastOnce())
             ->method('render')
             ->will($this->returnCallback($testHandler));
         $this->allowLogin($this->getApp());
 
-        $this->setService('render', $twig);
+        $this->setService('render', $render);
 
         $this->setRequest(Request::create('/bolt'));
         $this->controller()->dashboard();

--- a/tests/phpunit/unit/Controller/Backend/LogTest.php
+++ b/tests/phpunit/unit/Controller/Backend/LogTest.php
@@ -49,7 +49,8 @@ class LogTest extends ControllerUnitTest
         $this->assertEquals('/bolt/changelog', $response->getTargetUrl());
 
         $this->setRequest(Request::create('/bolt/changelog'));
-        $this->checkTwigForTemplate($this->getApp(), 'activity/changelog.twig');
+        $this->checkTwigForTemplate($this->getApp(), '@bolt/activity/changelog.twig');
+        $this->controller()->changeOverview($this->getRequest());
     }
 
     public function testChangeRecord()
@@ -182,7 +183,8 @@ class LogTest extends ControllerUnitTest
         $this->assertEquals('/bolt/systemlog', $response->getTargetUrl());
 
         $this->setRequest(Request::create('/bolt/systemlog'));
-        $this->checkTwigForTemplate($this->getApp(), 'activity/systemlog.twig');
+        $this->checkTwigForTemplate($this->getApp(), '@bolt/activity/systemlog.twig');
+        $this->controller()->systemOverview($this->getRequest());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/ControllerUnitTest.php
+++ b/tests/phpunit/unit/Controller/ControllerUnitTest.php
@@ -42,7 +42,6 @@ abstract class ControllerUnitTest extends BoltUnitTest
     {
         $app = parent::makeApp();
         $app->initialize();
-        $app['twig.loader'] = new \Twig_Loader_Chain([new \Twig_Loader_String()]);
         $app->boot();
 
         return $app;

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -59,9 +59,9 @@ class FrontendTest extends ControllerUnitTest
         $this->assertSame('index.twig', $response->getTemplateName());
     }
 
-
     public function testConfiguredThemeHomepageTemplate()
     {
+        $this->getService('filesystem')->put('theme://custom-home.twig', '');
         $this->getService('config')->set('theme/homepage_template', 'custom-home.twig');
         $this->setRequest(Request::create('/'));
 
@@ -370,24 +370,13 @@ class FrontendTest extends ControllerUnitTest
         $this->assertNotEmpty($response->getGlobalContext());
     }
 
+    /**
+     * @expectedException \Twig_Error_Loader
+     * @expectedExceptionMessage Template "nonexistent.twig" is not defined.
+     */
     public function testFailingTemplateRender()
     {
-        $this->setRequest(Request::create('/example'));
-
-        // Test that the failure gets logged too.
-//         $logger = $this->getMock('Bolt\DataCollector\TwigDataCollector', ['setTrackedValue'], [$this->getApp()]);
-//         $logger->expects($this->once())
-//             ->method('setTrackedValue')
-//             ->with('templateerror');
-//         $this->setService('twig.logger', $logger);
-
-//         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'failed');
-
-        $response = $this->controller()->template('nonexistent');
-
-        $this->assertTrue($response instanceof BoltResponse);
-        $this->assertSame('nonexistent.twig', $response->getTemplateName());
-        $this->assertNotEmpty($response->getGlobalContext());
+        $this->controller()->template('nonexistent');
     }
 
     public function testSearchListing()


### PR DESCRIPTION
Updated TemplateChooser to check if templates exist from twig environment. This is better as there can be additional loaders, that are in different locations than standard. Only checking the path breaks that abstraction anyways.