### PR TITLE
fix link to menu documentation

### DIFF
--- a/app/config/menu.yml.dist
+++ b/app/config/menu.yml.dist
@@ -1,5 +1,5 @@
 # This file defines the menus on the website. See the documentation for
-# details: https://docs.bolt.cm/content/menus
+# details: https://docs.bolt.cm/configuration/menus
 
 main:
     - label: Home


### PR DESCRIPTION
Hi,
the link to the documentation for menus was out of date.

