### PR TITLE
Bumping grunt-eol to v1.1.3

### DIFF
--- a/app/src/package.json
+++ b/app/src/package.json
@@ -25,7 +25,7 @@
         "grunt-contrib-uglify": "~2.0.0",
         "grunt-contrib-watch": "~1.0.0",
         "grunt-endline": "~0.6.1",
-        "grunt-eol": "~1.1.2",
+        "grunt-eol": "~1.1.3",
         "grunt-html": "~8.0.2",
         "grunt-jsdoc": "~2.1.0",
         "grunt-phpdocumentor": "~0.4.1",


### PR DESCRIPTION
An upstream fix makes [grunt-eol](https://github.com/psyrendust/grunt-eol) install on windows again.

PS: The two remaining ones with grunt v1.0 problems (``grunt-phpdocumentor`` and ``grunt-remove``) have pull requests in the pipeline but seem somewhat abandoned. As a workaround you can use ``npm`` v3 to turn the install error into a warning.