### PR TITLE
Fixed: Check for existence of `$this->values[$key]` to prevent warnings.

### DIFF
--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -518,7 +518,7 @@ trait ContentValuesTrait
 
         // Grab the first field of type 'image', and return that.
         foreach ($this->contenttype['fields'] as $key => $field) {
-            if ($field['type'] === 'image') {
+            if ($field['type'] === 'image' && isset($this->values[$key])) {
                 // After v1.5.1 we store image data as an array
                 if (is_array($this->values[$key]) && isset($this->values[$key]['file'])) {
                     return $this->values[$key]['file'];


### PR DESCRIPTION
Fix some warnings, if an image field is defined, but not set up yet. See screenshot: 

![screen shot 2016-09-21 at 16 13 50](https://cloud.githubusercontent.com/assets/1833361/18714671/d912a784-8016-11e6-8e12-fa668c1090ae.png)

