### PR TITLE
In fields, only apply the default to an actual null value

### DIFF
--- a/app/view/twig/editcontent/fields/_text.twig
+++ b/app/view/twig/editcontent/fields/_text.twig
@@ -29,7 +29,7 @@
         required:        option.required,
         title:           option.title,
         type:            (option.pattern in ['url', 'email']) ? option.pattern : 'text',
-        value:           context.content.get(contentkey)|default(field.default)|default(''),
+        value:           context.content.get(contentkey)|default(''),
     }
 } %}
 

--- a/app/view/twig/editcontent/fields/_textarea.twig
+++ b/app/view/twig/editcontent/fields/_textarea.twig
@@ -35,6 +35,6 @@
 
 {% block fieldset_controls %}
     <div class="col-xs-12">
-        <textarea{{ macro.attr(attributes.text) }}>{{ context.content.get(contentkey)|default(field.default)|default('') }}</textarea>
+        <textarea{{ macro.attr(attributes.text) }}>{{ context.content.get(contentkey)|default('') }}</textarea>
     </div>
 {% endblock fieldset_controls %}

--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -126,7 +126,7 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
     public function set($entity, $value)
     {
         $key = $this->mapping['fieldname'];
-        if (!$value && isset($this->mapping['data']['default'])) {
+        if ($value === null && isset($this->mapping['data']['default'])) {
             $value = $this->mapping['data']['default'];
         }
         $entity->$key = $value;


### PR DESCRIPTION
Hopefully this fixes #5795, only add a default value on real null values, not if we've replaced with an empty text field.