### PR TITLE
Updated docs link..

### DIFF
--- a/app/config/contenttypes.yml.dist
+++ b/app/config/contenttypes.yml.dist
@@ -1,5 +1,5 @@
 # This file defines the contenttypes on the website. See the documentation for
-# details: https://docs.bolt.cm/manual/contenttypes
+# details: https://docs.bolt.cm/contenttypes/intro
 
 # Pages can be used for the more 'static' pages on your site. Things like
 # 'about us', 'contact' or a 'disclaimer'. This content-type has a 'templateselect'


### PR DESCRIPTION
The current link doesn't link to any relevant information. I believe https://docs.bolt.cm/contenttypes/intro this is the correct link for more information about `contenttypes`.

