### PR TITLE
[RFC] Set the 'default' choice to overwrite the .gitignore to 'no'.

### DIFF
--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -205,7 +205,7 @@ class ScriptHandler
             '<info>Do you want to import the <comment>.gitignore</comment> file from <comment>%s</comment>] </info>',
             $boltDir
         );
-        $confirm = $event->getIO()->askConfirmation($question, true);
+        $confirm = $event->getIO()->askConfirmation($question, false);
         if ($confirm) {
             $fs = new Filesystem();
             $fs->copy($boltDir . '.gitignore', getcwd() . '/.gitignore', true);

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -202,8 +202,7 @@ class ScriptHandler
     {
         $boltDir = sprintf('%s/bolt/bolt/', $event->getComposer()->getConfig()->get('vendor-dir'));
         $question = sprintf(
-            '<info>Do you want to import the <comment>.gitignore</comment> file from <comment>%s</comment>] </info>',
-            $boltDir
+            '<info>Do you want to override the existing <comment>.gitignore</comment> file with the more restrictive one from <comment>vendor/bolt/bolt</comment>?</info>'
         );
         $confirm = $event->getIO()->askConfirmation($question, false);
         if ($confirm) {


### PR DESCRIPTION
This PR is part of #5752

When running `composer create-project`, all default choices result in default locations for the files and folders. The last question feels like it's the other way around: The default option overwrites the existing `.gitignore` with the one from `bolt/bolt`, instead of keeping the one in `bolt/composer-install`. 

I'd like 'n' to be the default, so that this is what it does when running the packaging script for the "end users".