### PR TITLE
trimText break on word boundary

### DIFF
--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -16,7 +16,7 @@ class Html
     public static function trimText($str, $desiredLength, $hellip = true)
     {
         if ($hellip) {
-            $ellipseStr = '…';
+            $ellipseStr = ' …';
             $newLength = $desiredLength - 1;
         } else {
             $ellipseStr = '';
@@ -33,7 +33,7 @@ class Html
                     $str = mb_substr($str, 0, $lastSpace);
                 }
             }
-            $str .= ' ' . $ellipseStr;
+            $str .= $ellipseStr;
         }
 
         return $str;

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -10,10 +10,11 @@ class Html
      * @param string $str           String to trim
      * @param int    $desiredLength Target string length
      * @param bool   $hellip        Add dots when the string is too long
+     * @param int    $cutOffCap     Maximum difference between string length when removing words
      *
      * @return string Trimmed string
      */
-    public static function trimText($str, $desiredLength, $hellip = true)
+    public static function trimText($str, $desiredLength, $hellip = true, $cutOffCap = 10)
     {
         if ($hellip) {
             $ellipseStr = ' …';
@@ -30,6 +31,11 @@ class Html
             $str = mb_substr($str, 0, $newLength);
             if ($nextChar != ' ') {
                 if (false !== ($lastSpace = mb_strrpos($str, ' '))) {
+                    // Check for to long cutoff
+                    if (mb_strlen($str) - $lastSpace >= $cutOffCap) {
+                        // Trim the ellipse, as we do not want a space now
+                        return $str . trim($ellipseStr);
+                    }
                     $str = mb_substr($str, 0, $lastSpace);
                 }
             }

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -26,7 +26,14 @@ class Html
         $str = trim(strip_tags($str));
 
         if (mb_strlen($str) > $desiredLength) {
-            $str = mb_substr($str, 0, $newLength) . $ellipseStr;
+            $nextChar = mb_substr($str, $newLength, 1);
+            $str = mb_substr($str, 0, $newLength);
+            if ($nextChar != ' ') {
+                if (false !== ($lastSpace = mb_strrpos($str, ' '))) {
+                    $str = mb_substr($str, 0, $lastSpace);
+                }
+            }
+            $str .= ' ' . $ellipseStr;
         }
 
         return $str;

--- a/tests/phpunit/unit/Helper/HtmlTest.php
+++ b/tests/phpunit/unit/Helper/HtmlTest.php
@@ -16,7 +16,7 @@ class HtmlTest extends BoltUnitTest
         // Simple text
         $input = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.';
         $this->assertEquals('Lorem ipsum', Html::trimText($input, 11, false));
-        $this->assertEquals('Lorem ipsum…', Html::trimText($input, 12, true));
+        $this->assertEquals('Lorem ipsum …', Html::trimText($input, 12, true));
 
         // Make sure tags are stripped
         $input = 'Lorem <strong>ipsum</strong> dolor sit amet, consectetur adipisicing elit.';

--- a/tests/phpunit/unit/Helper/HtmlTest.php
+++ b/tests/phpunit/unit/Helper/HtmlTest.php
@@ -21,6 +21,10 @@ class HtmlTest extends BoltUnitTest
         // Make sure tags are stripped
         $input = 'Lorem <strong>ipsum</strong> dolor sit amet, consectetur adipisicing elit.';
         $this->assertEquals('Lorem ipsum', Html::trimText($input, 11, false));
+
+        // Make sure long words (more than 10) are capped in the middle
+        $input = 'I suffer from hippopotomonstrosesquipedaliophobia.';
+        $this->assertEquals('I suffer from hippopotomonstrosesquiped…', Html::trimText($input, 40, true));
     }
 
     public function testDecorateTT()

--- a/tests/phpunit/unit/Twig/Handler/RecordHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/RecordHandlerTest.php
@@ -24,7 +24,7 @@ For the fulfillment of his martyrdom.
 GRINGALET;
     protected $excerpt = <<<GRINGALET
 But Gawain chose the lower road, and passed
-Along the desolate shore. The die was cast…
+Along the desolate shore. The die was …
 GRINGALET;
 
     /**


### PR DESCRIPTION
Currently, excerpt breaks words in the middle of it. This does not look nice. 

For example, with `"This is a text"|excerpt(12)` would become `This is a te...` With this PR. it will become `This is a ...`

When no space is found in the remaining text, there will be nothing extra cut.