### PR TITLE
Less assumptions for configuration

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -283,7 +283,7 @@ debuglog:
 
 # Use strict variables. This will make Bolt complain if you use {{ foo }},
 # when foo doesn't exist.
-strict_variables: true
+#strict_variables: false
 
 # There are several options for giving editors more options to insert images,
 # video, etc in the WYSIWYG areas. But, as you give them more options, that

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -266,6 +266,9 @@ debug_permission_audit_mode: false
 debug_error_level: -1 # equivalent to E_ALL
 debug_error_use_profiler: false # When set to true, Symfony Profiler will be used for exception display when possible
 
+# error level when debug is disabled
+#production_error_level: 8181 # = E_ALL &~ E_NOTICE &~ E_WARNING &~ E_DEPRECATED &~ E_USER_DEPRECATED
+
 # System debug logging
 # This will enable intensive logging of Silex functions and will be very hard on
 # performance and log file size.    The log file will be created in your cache

--- a/src/Application.php
+++ b/src/Application.php
@@ -119,14 +119,14 @@ class Application extends Silex\Application
         // Initialize Twig and our rendering Provider.
         $this->initRendering();
 
-        // Initialize debugging
-        $this->initDebugging();
-
         // Initialize the Database Providers.
         $this->initDatabase();
 
         // Initialize the rest of the Providers.
         $this->initProviders();
+
+        // Initialize debugging
+        $this->initDebugging();
 
         // Do a version check
         $this['config.environment']->checkVersion();
@@ -264,9 +264,6 @@ class Application extends Silex\Application
         );
     }
 
-    /**
-     * @deprecated Deprecated since 3.0, to be removed in 4.0. Use {@see ControllerEvents::MOUNT} instead.
-     */
     public function initExtensions()
     {
         $this['extensions']->addManagedExtensions();

--- a/src/Application.php
+++ b/src/Application.php
@@ -195,7 +195,9 @@ class Application extends Silex\Application
         }
 
         // Set the error_reporting to the level specified in config.yml
-        error_reporting($this['config']->get('general/debug_error_level'));
+        if (($errorLevel = $this['config']->get('general/debug_error_level')) !== null) {
+            error_reporting($errorLevel);
+        }
 
         $this->register(new Provider\DumperServiceProvider());
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -189,7 +189,9 @@ class Application extends Silex\Application
     public function initDebugging()
     {
         if (!$this['debug']) {
-            error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+            if (($errorLevel = $this['config']->get('general/production_error_level')) !== null) {
+                error_reporting($errorLevel);
+            }
 
             return;
         }

--- a/src/Application.php
+++ b/src/Application.php
@@ -193,11 +193,11 @@ class Application extends Silex\Application
             error_reporting($errorLevel);
         }
 
+        $this->register(new Provider\DumperServiceProvider());
+
         if (!$this['debug']) {
             return;
         }
-
-        $this->register(new Provider\DumperServiceProvider());
 
         // Initialize Web Profiler providers
         $this->initProfiler();

--- a/src/Application.php
+++ b/src/Application.php
@@ -188,17 +188,13 @@ class Application extends Silex\Application
      */
     public function initDebugging()
     {
-        if (!$this['debug']) {
-            if (($errorLevel = $this['config']->get('general/production_error_level')) !== null) {
-                error_reporting($errorLevel);
-            }
-
-            return;
+        // Set the error_reporting to the level specified in config.yml
+        if (($errorLevel = $this['config']->get($this['debug'] ? 'general/debug_error_level' : 'production_error_level')) !== null) {
+            error_reporting($errorLevel);
         }
 
-        // Set the error_reporting to the level specified in config.yml
-        if (($errorLevel = $this['config']->get('general/debug_error_level')) !== null) {
-            error_reporting($errorLevel);
+        if (!$this['debug']) {
+            return;
         }
 
         $this->register(new Provider\DumperServiceProvider());

--- a/src/Application.php
+++ b/src/Application.php
@@ -66,8 +66,10 @@ class Application extends Silex\Application
             $this['environment'] = $this['debug'] ? 'development' : 'production';
         }
 
-        $locales = (array) $this['config']->get('general/locale');
-        $this['locale'] = reset($locales);
+        if (($locales = $this['config']->get('general/locale')) !== null) {
+            $locales = (array) $locales;
+            $this['locale'] = reset($locales);
+        }
 
         // Initialize the 'editlink' and 'edittitle'.
         $this['editlink'] = '';

--- a/src/Application.php
+++ b/src/Application.php
@@ -59,7 +59,10 @@ class Application extends Silex\Application
         $this->initLogger();
         $this['resources']->initialize();
 
-        $this['debug'] = $this['config']->get('general/debug', false);
+        if (($debugOverride = $this['config']->get('general/debug')) !== null) {
+            $this['debug'] = $debugOverride;
+        }
+
         // Re-register the shutdown functions now that we know our debug setting
         ShutdownHandler::register($this['debug']);
         if (!isset($this['environment'])) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -1122,6 +1122,7 @@ class Config
             'debug'                       => false,
             'debug_show_loggedoff'        => false,
             'debug_error_level'           => null,
+            'production_error_level'      => null,
             'debug_enable_whoops'         => false, /** @deprecated. Deprecated since 3.2, to be removed in 4.0 */
             'debug_error_use_profiler'    => false,
             'debug_permission_audit_mode' => false,

--- a/src/Config.php
+++ b/src/Config.php
@@ -1119,7 +1119,7 @@ class Config
                 'level'    => 'DEBUG',
                 'filename' => 'bolt-debug.log',
             ],
-            'debug'                       => false,
+            'debug'                       => null,
             'debug_show_loggedoff'        => false,
             'debug_error_level'           => null,
             'production_error_level'      => null,

--- a/src/Config.php
+++ b/src/Config.php
@@ -1121,7 +1121,7 @@ class Config
             ],
             'debug'                       => false,
             'debug_show_loggedoff'        => false,
-            'debug_error_level'           => 8181,  // equivalent to E_ALL &~ E_NOTICE &~ E_DEPRECATED &~ E_USER_DEPRECATED &~ E_WARNING
+            'debug_error_level'           => null,
             'debug_enable_whoops'         => false, /** @deprecated. Deprecated since 3.2, to be removed in 4.0 */
             'debug_error_use_profiler'    => false,
             'debug_permission_audit_mode' => false,

--- a/src/Config.php
+++ b/src/Config.php
@@ -1105,7 +1105,7 @@ class Config
                 'randomfunction' => '',
             ],
             'sitename'                    => 'Default Bolt site',
-            'locale'                      => 'en_GB',
+            'locale'                      => null,
             'recordsperpage'              => 10,
             'recordsperdashboardwidget'   => 5,
             'systemlog'                   => [

--- a/src/Config.php
+++ b/src/Config.php
@@ -1126,7 +1126,7 @@ class Config
             'debug_enable_whoops'         => false, /** @deprecated. Deprecated since 3.2, to be removed in 4.0 */
             'debug_error_use_profiler'    => false,
             'debug_permission_audit_mode' => false,
-            'strict_variables'            => false,
+            'strict_variables'            => null,
             'theme'                       => 'base-2016',
             'listing_template'            => 'listing.twig',
             'listing_records'             => '5',

--- a/src/Configuration/Validation/Apache.php
+++ b/src/Configuration/Validation/Apache.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Configuration\Validation;
 
+use Bolt\Configuration\LowlevelChecks;
 use Bolt\Configuration\ResourceManager;
 use Bolt\Controller\ExceptionControllerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,7 +31,9 @@ class Apache implements ValidationInterface, ResourceManagerAwareInterface
         $request = Request::createFromGlobals();
         $serverSoftware = $request->server->get('SERVER_SOFTWARE', '');
         $isApache = strpos($serverSoftware, 'Apache') !== false;
-        if ($this->resourceManager->getVerifier()->disableApacheChecks === true || !$isApache) {
+        /** @var LowlevelChecks $verifier */
+        $verifier = $this->resourceManager->getVerifier();
+        if ($verifier && $verifier->disableApacheChecks === true || !$isApache) {
             return null;
         }
 

--- a/src/Controller/Exception.php
+++ b/src/Controller/Exception.php
@@ -26,26 +26,13 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class Exception extends Base implements ExceptionControllerInterface
 {
     /**
-     * Connect to the application.
-     *
-     * @param Application $app
-     *
-     * @return ControllerCollection
-     */
-    public function connect(Application $app)
-    {
-        $this->app = $app;
-        $this->app->after([$this, 'afterKernelException'], Application::LATE_EVENT);
-
-        return $app['controllers_factory'];
-    }
-
-    /**
      * {@inheritdoc}
      */
     protected function addRoutes(ControllerCollection $c)
     {
         $c->value(Zone::KEY, Zone::FRONTEND);
+
+        $this->app->after([$this, 'afterKernelException'], Application::LATE_EVENT);
     }
 
     /**

--- a/src/Provider/DumperServiceProvider.php
+++ b/src/Provider/DumperServiceProvider.php
@@ -24,11 +24,23 @@ class DumperServiceProvider implements ServiceProviderInterface
     {
         $app['dump'] = $app->protect(
             function ($var) use ($app) {
+                if (!$app['debug']) {
+                    return;
+                }
                 $app['dumper']->dump($app['dumper.cloner']->cloneVar($var));
             }
         );
 
-        VarDumper::setHandler($app['dump']);
+        VarDumper::setHandler(
+            function ($var) use ($app) {
+                /*
+                 * Referencing $app['dump'] in anonymous function
+                 * so the closure can be replaced in $app without
+                 * breaking the reference here.
+                 */
+                return $app['dump']($var);
+            }
+        );
 
         $app['dumper'] = $app->share(
             function ($app) {

--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -103,14 +103,21 @@ class EventListenerServiceProvider implements ServiceProviderInterface
         /** @var EventDispatcherInterface $dispatcher */
         $dispatcher = $app['dispatcher'];
 
-        $dispatcher->addSubscriber($app['listener.access_control']);
-        $dispatcher->addSubscriber($app['listener.general']);
-        $dispatcher->addSubscriber($app['listener.exception']);
-        $dispatcher->addSubscriber($app['listener.not_found']);
-        $dispatcher->addSubscriber($app['listener.snippet']);
-        $dispatcher->addSubscriber($app['listener.redirect']);
-        $dispatcher->addSubscriber($app['listener.flash_logger']);
-        $dispatcher->addSubscriber($app['listener.zone_guesser']);
-        $dispatcher->addSubscriber($app['listener.pager']);
+        $listeners = [
+            'general',
+            'exception',
+            'not_found',
+            'snippet',
+            'redirect',
+            'flash_logger',
+            'zone_guesser',
+            'pager'
+        ];
+
+        foreach ($listeners as $name) {
+            if (isset($app['listener.' . $name])) {
+                $dispatcher->addSubscriber($app['listener.' . $name]);
+            }
+        }
     }
 }

--- a/src/Provider/TranslationServiceProvider.php
+++ b/src/Provider/TranslationServiceProvider.php
@@ -83,8 +83,7 @@ class TranslationServiceProvider implements ServiceProviderInterface
         // Set locales for native php...not sure why?
         setlocale(LC_ALL, $locales);
 
-        // Set the default timezone if provided in the Config
-        date_default_timezone_set($app['config']->get('general/timezone') ?: ini_get('date.timezone') ?: 'UTC');
+        $this->setDefaultTimezone($app);
 
         // for javascript datetime calculations, timezone offset. e.g. "+02:00"
         $app['timezone_offset'] = date('P');
@@ -187,5 +186,31 @@ class TranslationServiceProvider implements ServiceProviderInterface
         }
 
         return $locales;
+    }
+
+    protected function setDefaultTimezone(Application $app)
+    {
+        if (($timezone = $app['config']->get('general/timezone')) !== null) {
+            date_default_timezone_set($timezone);
+            return;
+        }
+
+        // PHP 7.0+ doesn't emit warning for no timezone set.
+        if (PHP_MAJOR_VERSION > 5) {
+            return;
+        }
+
+        // Run check to see if a default timezone has been set
+        $hasDefault = true;
+        set_error_handler(function () use (&$hasDefault) {
+            $hasDefault = false;
+        });
+        date_default_timezone_get();
+        restore_error_handler();
+
+        // If no default, set to UTC to prevent default not defined warnings
+        if (!$hasDefault) {
+            date_default_timezone_set('UTC');
+        }
     }
 }

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -117,19 +117,18 @@ class TwigServiceProvider implements ServiceProviderInterface
 
         // Twig options
         $app['twig.options'] = function () use ($app) {
+            $options = [];
+
             // Should we cache or not?
             if ($app['config']->get('general/caching/templates')) {
-                $cache = $app['resources']->getPath('cache/' . $app['environment'] . '/twig');
-            } else {
-                $cache = false;
+                $options['cache'] = $app['resources']->getPath('cache/' . $app['environment'] . '/twig');
             }
 
-            return [
-                'debug'            => true,
-                'cache'            => $cache,
-                'strict_variables' => $app['config']->get('general/strict_variables'),
-                'autoescape'       => 'html',
-            ];
+            if (($strict = $app['config']->get('general/strict_variables')) !== null) {
+                $options['strict_variables'] = $strict;
+            }
+
+            return $options;
         };
 
         $app['safe_twig.bolt_extension'] = function () use ($app) {

--- a/src/Session/Handler/FilesystemHandler.php
+++ b/src/Session/Handler/FilesystemHandler.php
@@ -62,6 +62,10 @@ class FilesystemHandler implements \SessionHandlerInterface
      */
     public function gc($maxlifetime)
     {
+        if (!$this->directory->exists()) {
+            return;
+        }
+
         $files = $this->directory->find()
             ->files()
             ->ignoreDotFiles(false)

--- a/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
@@ -39,6 +39,6 @@ class TwigServiceProviderTest extends BoltUnitTest
 
         $app['config']->set('general/caching/templates', false);
         $app->register(new TwigServiceProvider());
-        $this->assertFalse($app['twig.options']['cache']);
+        $this->assertArrayNotHasKey('cache', $app['twig.options']);
     }
 }

--- a/tests/phpunit/unit/Twig/Handler/UtilsHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/UtilsHandlerTest.php
@@ -2,10 +2,10 @@
 
 namespace Bolt\Tests\Twig;
 
+use Bolt\Application;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Handler\UtilsHandler;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * Class to test Bolt\Twig\Handler\UtilsHandler
@@ -14,18 +14,14 @@ use Symfony\Component\VarDumper\VarDumper;
  */
 class UtilsHandlerTest extends BoltUnitTest
 {
-    protected function tearDown()
-    {
-        parent::tearDown();
-        VarDumper::setHandler(null);
-    }
-
     /**
      * Override Symfony's default handler to get the output
+     *
+     * @param Application $app
      */
-    protected function stubVarDumper()
+    protected function stubVarDumper(Application $app)
     {
-        VarDumper::setHandler(
+        $app['dump'] = $app->protect(
             function ($var) {
                 return $var;
             }
@@ -53,6 +49,7 @@ class UtilsHandlerTest extends BoltUnitTest
     public function testPrintBacktraceSafeDebugOn()
     {
         $app = $this->getApp();
+        $this->stubVarDumper($app);
         $app['debug'] = true;
         $handler = new UtilsHandler($app);
 
@@ -63,6 +60,7 @@ class UtilsHandlerTest extends BoltUnitTest
     public function testPrintBacktraceNoSafeDebugOff()
     {
         $app = $this->getApp();
+        $this->stubVarDumper($app);
         $app['debug'] = false;
         $handler = new UtilsHandler($app);
 
@@ -74,6 +72,7 @@ class UtilsHandlerTest extends BoltUnitTest
     public function testPrintBacktraceNoSafeDebugOffLoggedoff()
     {
         $app = $this->getApp();
+        $this->stubVarDumper($app);
         $app['debug'] = true;
         $app['config']->set('general/debug_show_loggedoff', false);
         $handler = new UtilsHandler($app);
@@ -85,9 +84,8 @@ class UtilsHandlerTest extends BoltUnitTest
 
     public function testPrintBacktraceNoSafeDebugOn()
     {
-        $this->stubVarDumper();
-
         $app = $this->getApp();
+        $this->stubVarDumper($app);
         $app['debug'] = true;
         $app['config']->set('general/debug_show_loggedoff', true);
 
@@ -134,9 +132,8 @@ class UtilsHandlerTest extends BoltUnitTest
 
     public function testPrintFirebugNoSafeDebugOnArrayString()
     {
-        $this->stubVarDumper();
-
         $app = $this->getApp();
+        $this->stubVarDumper($app);
         $app['debug'] = true;
         $app['config']->set('general/debug_show_loggedoff', true);
 
@@ -152,9 +149,8 @@ class UtilsHandlerTest extends BoltUnitTest
 
     public function testPrintFirebugNoSafeDebugOnStringArray()
     {
-        $this->stubVarDumper();
-
         $app = $this->getApp();
+        $this->stubVarDumper($app);
         $app['debug'] = true;
         $app['config']->set('general/debug_show_loggedoff', true);
 
@@ -170,9 +166,8 @@ class UtilsHandlerTest extends BoltUnitTest
 
     public function testPrintFirebugNoSafeDebugOnArrayArray()
     {
-        $this->stubVarDumper();
-
         $app = $this->getApp();
+        $this->stubVarDumper($app);
         $app['debug'] = true;
 
         $logger = $this->getMock('\Monolog\Logger', ['info'], ['testlogger']);


### PR DESCRIPTION
The idea here is to not assume Bolt is configuring the system, but that it is a part of something bigger. So instead of applying defaults from our config, we don't set them if they aren't provided.

These config values are:
- debug
- error_level
- timezone
- locale
- twig's strict_variables

Tweaked `dump()` (PHP function, not Twigs) so it won't dump anything if debug is false.

Changed most of our event listeners to check if they are set before subscribing them. This way they can be disabled by unsetting them.

If debug was disabled we had a hardcoded error_level we set: https://github.com/CarsonF/bolt/commit/d116895fdfcbd5ebde336e862be997a8e9507359. I made this configurable with a new config key, `production_error_level`. It's disabled by default though, since we want to assume the system is configured correctly.

---

I would also like to comment out `strict_variables` in config by default. Twig internally sets this based on app's debug flag: app debug = strict_variables. This is logical to me because you want to see these errors while you are deving/playing, but don't want production to see them where debug is disabled. Having it commented out by default let's it operate as an override if someone wants to force it one way or the other. 
Thoughts @bolt/backend-developers @bobdenotter?