### PR TITLE
switch checkbox field storage type from "string" to "boolean"

### DIFF
--- a/src/Storage/Field/Type/CheckboxType.php
+++ b/src/Storage/Field/Type/CheckboxType.php
@@ -24,6 +24,6 @@ class CheckboxType extends FieldTypeBase
      */
     public function getStorageType()
     {
-        return Type::getType('string');
+        return Type::getType('boolean');
     }
 }


### PR DESCRIPTION
The current CheckboxType Field was under the hood using the "String" Storage Type ... but the (Mysql) database column tied is 'tinyint (1)' ( ie : boolean )... If we use 0 / 1 as value it's working but ... if we use true or false it's not working because it tries to convert 't' or 'f' to tiny int ... 

Moreover, according to doctrine doc, [the boolean field type seems supported by all DB engines](http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#mapping-matrix) 

( please dont ask me why i'm using true or false instead of 0 or 1 :) )

I tried to persist a new content type with a checkbox type field using the boolean storage type it's working ... but I did not try with sqlite. 

