### PR TITLE
Codeception fixes backport

### DIFF
--- a/src/Storage/ContentRequest/Save.php
+++ b/src/Storage/ContentRequest/Save.php
@@ -168,6 +168,8 @@ class Save
             $content->setOwnerid($user['id']);
         }
 
+        // Hack … remove soon
+        $formValues += ['status' => 'draft'];
         // Make sure we have a proper status.
         if (!in_array($formValues['status'], ['published', 'timed', 'held', 'draft'])) {
             if ($status = $content->getStatus()) {

--- a/src/Storage/Field/Type/TemplateFieldsType.php
+++ b/src/Storage/Field/Type/TemplateFieldsType.php
@@ -86,6 +86,10 @@ class TemplateFieldsType extends FieldTypeBase
             $type = $fieldobj->getStorageType();
             $key = $field['fieldname'];
 
+            // Hack … remove soon
+            if (!isset($input[$key])) {
+                continue;
+            }
             if ($this->isJson($input[$key])) {
                 $input[$key] = json_decode($input[$key], true);
             }

--- a/src/Twig/Handler/HtmlHandler.php
+++ b/src/Twig/Handler/HtmlHandler.php
@@ -7,6 +7,7 @@ use Bolt\Helpers\Str;
 use Bolt\Legacy\Content;
 use Maid\Maid;
 use Silex;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Bolt specific Twig functions and filters for HTML
@@ -89,9 +90,10 @@ class HtmlHandler
      */
     public function isMobileClient()
     {
+        $request = Request::createFromGlobals();
         if (preg_match(
             '/(android|blackberry|htc|iemobile|iphone|ipad|ipaq|ipod|nokia|playbook|smartphone)/i',
-            $_SERVER['HTTP_USER_AGENT']
+            $request->server->get('HTTP_USER_AGENT')
         )) {
             return true;
         } else {

--- a/tests/codeception/_support/AcceptanceHelper.php
+++ b/tests/codeception/_support/AcceptanceHelper.php
@@ -4,6 +4,8 @@ namespace Codeception\Module;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
+use Codeception\Lib\InnerBrowser;
+
 class AcceptanceHelper extends \Codeception\Module
 {
     /**
@@ -13,11 +15,7 @@ class AcceptanceHelper extends \Codeception\Module
      */
     public function loginAs($user)
     {
-        $web = $this->getModule('PhpBrowser');
-        $web->amOnPage('/bolt/login');
-        $web->fillField('username', $user['username']);
-        $web->fillField('password', $user['password']);
-        $web->click('Log on');
+        $this->doLogin($user['username'], $user['password']);
     }
 
     /**
@@ -27,10 +25,20 @@ class AcceptanceHelper extends \Codeception\Module
      */
     public function loginWithEmailAs($user)
     {
-        $web = $this->getModule('PhpBrowser');
+        $this->doLogin($user['email'], $user['password']);
+    }
+
+    protected function doLogin($usernameOrEmail, $password)
+    {
+        /** @var InnerBrowser $web */
+        $web = $this->moduleContainer->moduleForAction('amOnPage');
+
+        // Clear cookies so bolt let's us login as someone else.
+        $web->client->getCookieJar()->clear();
+
         $web->amOnPage('/bolt/login');
-        $web->fillField('username', $user['email']);
-        $web->fillField('password', $user['password']);
+        $web->fillField('username', $usernameOrEmail);
+        $web->fillField('password', $password);
         $web->click('Log on');
     }
 }

--- a/tests/codeception/_support/AcceptanceHelper.php
+++ b/tests/codeception/_support/AcceptanceHelper.php
@@ -41,4 +41,14 @@ class AcceptanceHelper extends \Codeception\Module
         $web->fillField('password', $password);
         $web->click('Log on');
     }
+
+    /**
+     * Reload app so configuration changes take affect.
+     */
+    public function reloadApp()
+    {
+        /** @var WorkingSilex $silex */
+        $silex = $this->moduleContainer->getModule('WorkingSilex');
+        $silex->reloadApp();
+    }
 }

--- a/tests/codeception/_support/WorkingSilex.php
+++ b/tests/codeception/_support/WorkingSilex.php
@@ -26,6 +26,16 @@ class WorkingSilex extends Silex
     public function _before(TestInterface $test)
     {
         $this->reloadApp();
+
+        $this->app->finish(function () {
+            if ($this->app['mailer.initialized'] && $this->app['swiftmailer.use_spool'] && $this->app['swiftmailer.spooltransport'] instanceof \Swift_Transport_SpoolTransport) {
+                $spool = $this->app['swiftmailer.spooltransport']->getSpool();
+                $r = new \ReflectionClass($spool);
+                $p = $r->getProperty('messages');
+                $p->setAccessible(true);
+                $p->setValue($spool, []);
+            }
+        }, 512);
     }
 
     public function reloadApp()

--- a/tests/codeception/_support/WorkingSilex.php
+++ b/tests/codeception/_support/WorkingSilex.php
@@ -25,6 +25,11 @@ class WorkingSilex extends Silex
 
     public function _before(TestInterface $test)
     {
+        $this->reloadApp();
+    }
+
+    public function reloadApp()
+    {
         $this->loadApp();
         $this->client = new Client($this->app, [], null, $this->cookieJar);
         $this->client->followRedirects();

--- a/tests/codeception/_support/WorkingSilex.php
+++ b/tests/codeception/_support/WorkingSilex.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Codeception\Module;
+
+use Codeception\TestInterface;
+use Symfony\Component\BrowserKit\CookieJar;
+use Symfony\Component\HttpKernel\Client;
+
+/**
+ * Change client to follow redirects and keep cookie jar between tests.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class WorkingSilex extends Silex
+{
+    /** @var CookieJar */
+    protected $cookieJar;
+
+    public function _initialize()
+    {
+        $this->cookieJar = new CookieJar();
+
+        parent::_initialize();
+    }
+
+    public function _before(TestInterface $test)
+    {
+        $this->loadApp();
+        $this->client = new Client($this->app, [], null, $this->cookieJar);
+        $this->client->followRedirects();
+    }
+}

--- a/tests/codeception/acceptance.suite.yml
+++ b/tests/codeception/acceptance.suite.yml
@@ -7,13 +7,12 @@
 class_name: AcceptanceTester
 modules:
     enabled:
-        - PhpBrowser
+        - WorkingSilex:
+            app: app/bootstrap.php
         - AcceptanceHelper
         - YamlHelper
         - Db
     config:
-        PhpBrowser:
-            url: 'http://localhost:8123/'
         Db:
             populate: true
             cleanup: true

--- a/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
+++ b/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
@@ -569,10 +569,8 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->see('Dashboard');
         $I->click('Logout');
 
-        // Removed as we now unset the session cookie at logout
-        //$I->see('You have been logged out');
-
         $I->amOnPage('/bolt');
-        $I->see('Please log on');
+
+        $I->seeInCurrentUrl('/bolt/login');
     }
 }

--- a/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
+++ b/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
@@ -109,8 +109,10 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         // Save it
         $token = $I->grabValueFrom('#form__token');
         $I->sendAjaxPostRequest('/bolt/file/edit/themes/base-2016/partials/_footer.twig', [
-            'form[_token]'   => $token,
-            'form[contents]' => $twig,
+            'form' => [
+                '_token'   => $token,
+                'contents' => $twig,
+            ],
         ]);
 
         $I->amOnPage('/bolt/file/edit/themes/base-2016/partials/_footer.twig');
@@ -139,11 +141,7 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         $I->fillField('#form_contents', $twig);
 
         // Save it
-        $token = $I->grabValueFrom('#form__token');
-        $I->sendAjaxPostRequest('/bolt/tr', [
-            'form[_token]'   => $token,
-            'form[contents]' => $twig,
-        ]);
+        $I->click('Save', '#saveeditlocale');
 
         $I->amOnPage('/bolt/tr');
         $I->see('Built with Bolt, tested with Codeception', '#form_contents');
@@ -169,11 +167,7 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         $I->fillField('#form_contents', $twig);
 
         // Save it
-        $token = $I->grabValueFrom('#form__token');
-        $I->sendAjaxPostRequest('/bolt/tr/infos', [
-            'form[_token]'   => $token,
-            'form[contents]' => $twig,
-        ]);
+        $I->click('Save', '#saveeditlocale');
 
         $I->amOnPage('/bolt/tr/infos');
         $I->see('Use this field to upload a photo of a kitten', 'textarea');
@@ -198,13 +192,10 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
 
         $twig = $I->grabTextFrom('#form_contents', 'textarea');
         $twig = str_replace('The Entry you were looking for does not exist.', 'These are not the Entries you are looking for.', $twig);
+        $I->fillField('#form_contents', $twig);
 
         // Save it
-        $token = $I->grabValueFrom('#form__token');
-        $I->sendAjaxPostRequest('/bolt/tr/contenttypes', [
-            'form[_token]'   => $token,
-            'form[contents]' => $twig,
-        ]);
+        $I->click('Save', '#saveeditlocale');
 
         $I->amOnPage('/bolt/tr/contenttypes');
         $I->see('These are not the Entries you are looking for.', 'textarea');
@@ -258,8 +249,10 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
 
         $token = $I->grabValueFrom('#form__token');
         $I->sendAjaxPostRequest('/bolt/file/edit/config/extensions/testerevents.bolt.yml', [
-            'form[_token]'   => $token,
-            'form[contents]' => $twig,
+            'form' => [
+                '_token' => $token,
+                'contents' => $twig,
+            ],
         ]);
         $I->amOnPage('/bolt/file/edit/config/extensions/testerevents.bolt.yml');
 

--- a/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
+++ b/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
@@ -141,7 +141,7 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         $I->fillField('#form_contents', $twig);
 
         // Save it
-        $I->click('Save', '#saveeditlocale');
+        $I->click('Save');
 
         $I->amOnPage('/bolt/tr');
         $I->see('Built with Bolt, tested with Codeception', '#form_contents');
@@ -167,7 +167,7 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         $I->fillField('#form_contents', $twig);
 
         // Save it
-        $I->click('Save', '#saveeditlocale');
+        $I->click('Save');
 
         $I->amOnPage('/bolt/tr/infos');
         $I->see('Use this field to upload a photo of a kitten', 'textarea');
@@ -195,7 +195,7 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         $I->fillField('#form_contents', $twig);
 
         // Save it
-        $I->click('Save', '#saveeditlocale');
+        $I->click('Save');
 
         $I->amOnPage('/bolt/tr/contenttypes');
         $I->see('These are not the Entries you are looking for.', 'textarea');

--- a/tests/codeception/acceptance/105-BackendLemmings/BackendLemmingsCest.php
+++ b/tests/codeception/acceptance/105-BackendLemmings/BackendLemmingsCest.php
@@ -48,8 +48,10 @@ class BackendLemmingsCest extends AbstractAcceptanceTest
 
         $token = $I->grabValueFrom('#form__token');
         $I->sendAjaxPostRequest('/bolt/file/edit/config/permissions.yml', [
-            'form[_token]'   => $token,
-            'form[contents]' => $yaml,
+            'form' => [
+                '_token'   => $token,
+                'contents' => $yaml,
+            ],
         ]);
 
         // Verify we go to the dashboard and end up on the homepage

--- a/tests/codeception/acceptance/105-BackendLemmings/BackendLemmingsCest.php
+++ b/tests/codeception/acceptance/105-BackendLemmings/BackendLemmingsCest.php
@@ -48,6 +48,8 @@ class BackendLemmingsCest extends AbstractAcceptanceTest
 
         $I->click('Save');
 
+        $I->reloadApp();
+
         // Verify we go to the dashboard and end up on the homepage
         $I->amOnPage('/bolt');
 

--- a/tests/codeception/acceptance/105-BackendLemmings/BackendLemmingsCest.php
+++ b/tests/codeception/acceptance/105-BackendLemmings/BackendLemmingsCest.php
@@ -46,13 +46,7 @@ class BackendLemmingsCest extends AbstractAcceptanceTest
 
         $I->fillField('#form_contents', $yaml);
 
-        $token = $I->grabValueFrom('#form__token');
-        $I->sendAjaxPostRequest('/bolt/file/edit/config/permissions.yml', [
-            'form' => [
-                '_token'   => $token,
-                'contents' => $yaml,
-            ],
-        ]);
+        $I->click('Save');
 
         // Verify we go to the dashboard and end up on the homepage
         $I->amOnPage('/bolt');

--- a/tests/codeception/acceptance/AbstractAcceptanceTest.php
+++ b/tests/codeception/acceptance/AbstractAcceptanceTest.php
@@ -6,10 +6,6 @@ abstract class AbstractAcceptanceTest
 {
     /** @var string[] */
     protected $user;
-    /** @var string[] */
-    protected $tokenNames;
-    /** @var string[] */
-    protected $cookies = [];
 
     /**
      * @param \AcceptanceTester $I
@@ -17,7 +13,6 @@ abstract class AbstractAcceptanceTest
     public function _before(\AcceptanceTester $I)
     {
         $this->user = Fixtures::get('users');
-        $this->tokenNames = Fixtures::get('tokenNames');
     }
 
     /**
@@ -28,26 +23,20 @@ abstract class AbstractAcceptanceTest
     }
 
     /**
+     * @deprecated
+     *
      * @param AcceptanceTester $I
      */
     protected function saveLogin(\AcceptanceTester $I)
     {
-        $authTokenName = (string) $this->tokenNames['authtoken'];
-        $sessionTokenName = (string) $this->tokenNames['session'];
-
-        $this->cookies[$authTokenName] = $I->grabCookie($this->tokenNames['authtoken']);
-        $this->cookies[$sessionTokenName] = $I->grabCookie($this->tokenNames['session']);
     }
 
     /**
+     * @deprecated
+     *
      * @param AcceptanceTester $I
      */
     protected function setLoginCookies(\AcceptanceTester $I)
     {
-        $authTokenName = (string) $this->tokenNames['authtoken'];
-        $sessionTokenName = (string) $this->tokenNames['session'];
-
-        $I->setCookie($this->tokenNames['authtoken'], $this->cookies[$authTokenName]);
-        $I->setCookie($this->tokenNames['session'], $this->cookies[$sessionTokenName]);
     }
 }

--- a/tests/codeception/extensions/CodeceptionEventsExtension.php
+++ b/tests/codeception/extensions/CodeceptionEventsExtension.php
@@ -1,10 +1,7 @@
 <?php
 
-use Codeception\Event\FailEvent;
-use Codeception\Event\PrintResultEvent;
-use Codeception\Event\StepEvent;
 use Codeception\Event\SuiteEvent;
-use Codeception\Event\TestEvent;
+use Codeception\Events;
 use Codeception\Util\Fixtures;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Filesystem\Filesystem;
@@ -15,16 +12,12 @@ use Symfony\Component\Finder\Finder;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class CodeceptionEventsExtension extends \Codeception\Platform\Extension
+class CodeceptionEventsExtension extends \Codeception\Extension
 {
     /** @var array list events to listen to */
     public static $events = [
-        'suite.before'       => 'beforeSuite',
-        'suite.after'        => 'afterSuite',
-        'test.before'        => 'beforeTest',
-        'step.before'        => 'beforeStep',
-        'test.fail'          => 'testFailed',
-        'result.print.after' => 'printResult',
+        Events::SUITE_BEFORE => 'beforeSuite',
+        Events::SUITE_AFTER  => 'afterSuite',
     ];
 
     /**
@@ -34,19 +27,8 @@ class CodeceptionEventsExtension extends \Codeception\Platform\Extension
      */
     public function beforeSuite(SuiteEvent $e)
     {
-        /** @var $suite \PHPUnit_Framework_TestSuite */
-        $suite = $e->getSuite();
-
-        if ($suite->getName() === 'acceptance') {
+        if ($e->getSuite()->getName() === 'acceptance') {
             $this->beforeSuiteAcceptance($e);
-        }
-
-        if ($suite->getName() === 'functional') {
-            $this->beforeSuiteFunctional($e);
-        }
-
-        if ($suite->getName() === 'unit') {
-            $this->beforeSuiteUnit($e);
         }
     }
 
@@ -57,56 +39,9 @@ class CodeceptionEventsExtension extends \Codeception\Platform\Extension
      */
     public function afterSuite(SuiteEvent $e)
     {
-        /** @var $suite \PHPUnit_Framework_TestSuite */
-        $suite = $e->getSuite();
-
-        if ($suite->getName() === 'acceptance') {
+        if ($e->getSuite()->getName() === 'acceptance') {
             $this->afterSuiteAcceptance($e);
         }
-
-        if ($suite->getName() === 'functional') {
-            $this->afterSuiteFunctional($e);
-        }
-
-        if ($suite->getName() === 'unit') {
-            $this->afterSuiteUnit($e);
-        }
-    }
-
-    /**
-     * Before individual test callback
-     *
-     * @param \Codeception\Event\TestEvent $e
-     */
-    public function beforeTest(TestEvent $e)
-    {
-    }
-
-    /**
-     * Before test step callback
-     *
-     * @param \Codeception\Event\StepEvent $e
-     */
-    public function beforeStep(StepEvent $e)
-    {
-    }
-
-    /**
-     * Test failure callback
-     *
-     * @param \Codeception\Event\FailEvent $e
-     */
-    public function testFailed(FailEvent $e)
-    {
-    }
-
-    /**
-     * Priting the test results callback
-     *
-     * @param \Codeception\Event\PrintResultEvent $e
-     */
-    public function printResult(PrintResultEvent $e)
-    {
     }
 
     /**
@@ -148,26 +83,6 @@ class CodeceptionEventsExtension extends \Codeception\Platform\Extension
 
         // Turn up Twig's anger ratio
         $this->nut('config:set strict_variables true');
-    }
-
-    /**
-     * Set up before functional test suite run
-     *
-     * @param \Codeception\Event\SuiteEvent $e
-     */
-    private function beforeSuiteFunctional(SuiteEvent $e)
-    {
-        //
-    }
-
-    /**
-     * Set up before unit test suite run
-     *
-     * @param \Codeception\Event\SuiteEvent $e
-     */
-    private function beforeSuiteUnit(SuiteEvent $e)
-    {
-        //
     }
 
     /**
@@ -221,26 +136,6 @@ class CodeceptionEventsExtension extends \Codeception\Platform\Extension
             $fs->remove(INSTALL_ROOT . '/app/config/extensions/testerevents.bolt.yml');
         }
         $this->nut('extensions:dumpautoload');
-    }
-
-    /**
-     * Clean up after functional test suite run
-     *
-     * @param \Codeception\Event\SuiteEvent $e
-     */
-    private function afterSuiteFunctional(SuiteEvent $e)
-    {
-        //
-    }
-
-    /**
-     * Clean up after unit test suite run
-     *
-     * @param \Codeception\Event\SuiteEvent $e
-     */
-    private function afterSuiteUnit(SuiteEvent $e)
-    {
-        //
     }
 
     private function nut($args)

--- a/tests/scripts/run-codeception-tests
+++ b/tests/scripts/run-codeception-tests
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 PHP_NEW_ENOUGH=$(php -r 'echo ((PHP_VERSION_ID < 50400) ? "" : "1\n");')
-CODECEPT=./vendor/codeception/codeception/codecept
+CODECEPT=./vendor/bin/codecept
 if [ "$PHP_NEW_ENOUGH" ]
     then
-        php -S localhost:8123 -t . index.php &
-        SERVER_PID=$!
         $CODECEPT build
         $CODECEPT run "$@"
-        RC=$?
-        kill "$SERVER_PID"
     else
         PHP_VERSION=$(php -r 'echo PHP_VERSION;')
         echo "Cannot run codeception integration tests, because the installed PHP version ($PHP_VERSION) does not support the built-in web server."


### PR DESCRIPTION
This is a back port of the Codeception changes from #5836 

These changes do not affect production, only acceptance tests, with the exception of two small changes to _not_ fatal during debug/test if fields are not included in a POST.

…and one small assassination of a super global.

Obviously 99% of the work on this was @CarsonF … so props there :+1: 