### PR TITLE
adjust alias resolve logic to be able to use a custom repository with  a custom entity using contenttype.yml to define fields

### DIFF
--- a/src/Extension/StorageTrait.php
+++ b/src/Extension/StorageTrait.php
@@ -49,6 +49,7 @@ trait StorageTrait
                         $app['storage.repositories'] += $map;
                         $app['storage.metadata']->setDefaultAlias($app['schema.prefix'] . $alias, key($map));
                         $entityManager->setRepository(key($map), current($map));
+                        $entityManager->addEntityAlias($alias, key($map));
                     }
 
                     return $entityManager;

--- a/src/Storage/EntityManager.php
+++ b/src/Storage/EntityManager.php
@@ -259,8 +259,8 @@ class EntityManager implements EntityManagerInterface
             throw new InvalidRepositoryException("Attempted to load repository for invalid class or alias: $className. Check that the class, alias or contenttype definition is correct.");
         }
 
-        if (array_key_exists($className, $this->repositories)) {
-            $repoClass = $this->repositories[$className];
+        if (array_key_exists($classMetadata->getName(), $this->repositories)) {
+            $repoClass = $this->repositories[$classMetadata->getName()];
             if (is_callable($repoClass)) {
                 return call_user_func_array($repoClass, [$this, $classMetadata]);
             }

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -150,6 +150,11 @@ class MetadataDriver implements MappingDriver
             $class = $this->aliases[$alias];
             if (class_exists($class)) {
                 return $class;
+            } elseif (array_key_exists($class, $this->defaultAliases)) {
+                $class = $this->defaultAliases[$class];
+                if (class_exists($class)) {
+                    return $class;
+                }
             }
         }
 
@@ -212,6 +217,11 @@ class MetadataDriver implements MappingDriver
         foreach ($this->getAliases() as $alias => $table) {
             if (array_key_exists($table, $this->metadata)) {
                 $this->metadata[$alias] = $this->metadata[$table];
+            } elseif(
+                array_key_exists($table, $this->defaultAliases) &&
+                array_key_exists($this->defaultAliases[$table], $this->metadata)
+            ) {
+                $this->metadata[$alias] = $this->metadata[$this->defaultAliases[$table]];
             }
         }
     }

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -217,7 +217,7 @@ class MetadataDriver implements MappingDriver
         foreach ($this->getAliases() as $alias => $table) {
             if (array_key_exists($table, $this->metadata)) {
                 $this->metadata[$alias] = $this->metadata[$table];
-            } elseif(
+            } elseif (
                 array_key_exists($table, $this->defaultAliases) &&
                 array_key_exists($this->defaultAliases[$table], $this->metadata)
             ) {

--- a/src/Storage/Repository/ContentRepository.php
+++ b/src/Storage/Repository/ContentRepository.php
@@ -92,7 +92,7 @@ class ContentRepository extends Repository
     public function hydrateLegacyHandler(HydrationEvent $event)
     {
         $entity = $event->getArgument('entity');
-        if (get_class($entity) === 'Bolt\Storage\Entity\Content') {
+        if (is_a($entity, 'Bolt\Storage\Entity\Content')) {
             $entity->setLegacyService($this->legacy);
         }
     }


### PR DESCRIPTION
Please look this PR carefully because it allows great things :)

I'll try to explain my best ( even if it's quite long ) what I tried to do and how I came to that PR

What was I trying to achieve without success before this PR : 

I wanted to be able to use contenttype.yml to define a content type, for example "races"
and defined many fields in it... 
Using contenttype.yml is a "must have" because we can then use the existing backend controllers to do all the CRUD stuff.

Then I wanted to be able in my own extension to define a custom repository to manage advanced operations ( custom select / update queries ) on "Race" entities which was extending Bolt\Storage\Entity\Content.

Details
-------

The normal way to define a repository mapping in our own extension is using : 
```
protected function registerRepositoryMappings()
    {
        return [
            RaceMemberRegistrationTable::TABLE_NAME => [
                RaceMemberRegistration::class => RaceMemberRegistrationRepository::class
            ]
        ];
    }
```

This is okay when the custom entity (RaceMemberRegistration) is tied to a custom table (RaceMemberRegistrationTable) 

but it's not working for an entity without "custom table" ( because defined in the contenttype.yml )
I will explain why : 

For instance I tried something like : 

```
// in My Extension ... 

protected function registerRepositoryMappings()
    {
        return [
            RaceMemberRegistrationTable::TABLE_NAME => [
                RaceMemberRegistration::class => RaceMemberRegistrationRepository::class
            ], 
            'races' => [
                Race::class => RaceRepository::class
            ],
        ];
    }
```

And then, somewhere in my extension files I tried to retrieve the repository tied to the 'races' table with 2 notations  : 

```
//using the entity FQDN class 
$raceRepo = $storage->getRepository(Race::class);
// then $raceRepo is indeed of type RaceRepository::class

//using the (unprefixed) table name
$raceRepo = $storage->getRepository('races');
// then $raceRepo is of type Bolt\Storage\Repository\ContentRepository
```

( I precise that my RaceRepository class is extending the Bolt\Storage\Repository\ContentRepository
 and my Race entity class is extending Bolt\Storage\Entity\Content 
 )

So I stick with the first approach... ( $storage->getRepository(Race::class); )

But when doing that ... it was no longer possible to edit my races content with the bolt backend. 
My first error was in the vendor/bolt/bolt/src/Storage/Entity/ContentRouteTrait.php link() method. line 75.

the code part of the link() method causing problem is : 

```
$link = $this->app['url_generator']->generate(
            $binding,
            array_filter(
                array_merge(
                    $route['defaults'] ?: [],
                    $this->getRouteRequirementParams($route),
                    [
                        'contenttypeslug' => $this->contenttype['singular_slug'],
                        'id'              => $this->id,
                        'slug'            => $slug,
                    ]
                )
            )
        );
```

the expression ` $this->contenttype['singular_slug'],` failed because ... in my case ... $this->contenttype is a string not an array ...

So I try to debug to understand why it was not an array as expected ... and found the explanation in the src/Storage/Repository/ContentRepository.php file : 

```
public function hydrateLegacyHandler(HydrationEvent $event)
{
    $entity = $event->getArgument('entity');
    if (get_class($entity) === 'Bolt\Storage\Entity\Content') {
        $entity->setLegacyService($this->legacy);
    }
}
```

the legacyHandler is loaded only if the entity is of type 'Bolt\Storage\Entity\Content' but ... even if mine is extending it, the get_class($entity) is returning 'my/namespace/RaceRepository' so the (strict) check failed.

That's why I updated that file to use ` if (is_a($entity, 'Bolt\Storage\Entity\Content')) `. This way, if the entity is extending the 'Bolt\Storage\Entity\Content' it's ok...

So my link() method problem was fixed.

Then a weird error appeared when I tried to edit (a previously created) or add a new 'race' content type in the back ... before seeing the "form view" I was redirected to the dasboard with a message "contenttypes.generic.not-existing" ( I paste the string key but it was translated of course )

After debugging a little bit more ... I found in the vendor/bolt/bolt/src/Controller/Backend/Records.php file :

```
try {
            // Get the record
            $repo = $this->getRepository($contenttypeslug); //where content $contenttypeslug is 'races'
        } catch (InvalidRepositoryException $e) {
            $this->flashes()->error(Trans::__('contenttypes.generic.not-existing', ['%contenttype%' => $contenttypeslug]));

            return $this->redirectToRoute('dashboard');
        }
```

and then debugging the vendor/bolt/bolt/src/Storage/EntityManager.php getRepository($className) method.

the first part of the method is : 
```
 public function getRepository($className)
    {
        //here as I said above in my case the $className value is 'races'  
        $className = (string) $className;
        //and there is no default alias tiying 'races' and 'Races::class'
        if (array_key_exists($className, $this->aliases)) {
            $className = $this->aliases[$className];
        }
        // so we dont pass here ... unless we add the modification I propose in StorageTrait.php file
      ....
```

Then the code is ...

```
try {
            $classMetadata = $this->getMapper()->loadMetadataForClass($className);
        } catch (StorageException $e) {
            throw new InvalidRepositoryException("Attempted to load repository for invalid class or alias: $className. Check that the class, alias or contenttype definition is correct.");
        }

```

And in my case the InvalidRepositoryException was thrown because we could not found any valid ClassMetadata. In the vendor/bolt/bolt/src/Storage/Mapping/MetadataDriver.php file where we try to resolve metadata from a classname (checking into alias) ... no one were found .. so it returns the fallbackEntity ( Bolt\Storage\Entity\Content ) But cannot found any metadata tied to it so ... it failed and throw a  `StorageException("Attempted` to load mapping data for unmapped class $className");`
leading to the previously mentioned `InvalidRepositoryException`.

So to be more concise : The MetadataDriver.php cannot resolve well because it does not look in the good place... it looks into $this->aliases only and not in $this->defaultAliases ... So I fixed that and you know what ....it's working like a charm :)

I can use Custom Repo, tied to a Custom Entity class which is defined in contentType ( but I can add my own getter / setter to customize some stuff ) so ... without having to define a custom Table Class ( it is already handled by the contenttype  ). So flexibility + power fullness :)

Just one more thing : 
If we want to achieve that, we must NOT use a custom "class" attribute in the contenttype... because it's was used for bolt 2.X but it's not working anymore in 3.X. Like you can see in vendor/bolt/bolt/src/Legacy/Storage.php

```
public function getContentObject($contenttype, $values = [])
    {
        // Make sure $contenttype is an array, and not just the slug.
        if (!is_array($contenttype)) {
            $contenttype = $this->getContentType($contenttype);
        }

        // If the contenttype has a 'class' specified, and the class exists,
        // Initialize the content as an object of that class.
        if (!empty($contenttype['class']) && class_exists($contenttype['class'])) {
            $content = new $contenttype['class']($this->app, $contenttype, $values);

            // Check if the class actually extends \Bolt\Legacy\Content.
            if (!($content instanceof Content)) {
                throw new \Exception($contenttype['class'] . ' does not extend \\Bolt\\Legacy\\Content.');
            }
        } else {
            $content = new Content($this->app, $contenttype, $values);
        }

        return $content;
    }
```

Thanks for reading & Hope this PR will pass all tests and be merged soon :)
