### PR TITLE
Lock Twig at < 1.26 to preserve BC break on extension driven Twig fun…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "symfony/web-profiler-bundle" : "^2.8",
         "symfony/yaml" : "^2.8",
         "tdammers/htmlmaid" : "~0.7",
-        "twig/twig" : "^1.18",
+        "twig/twig" : "<1.26",
         "ua-parser/uap-php" : "~3.4"
     },
     "require-dev" : {


### PR DESCRIPTION
Fixes #5868