### PR TITLE
Fix Config parsing lists

### DIFF
--- a/src/Composer/JsonManager.php
+++ b/src/Composer/JsonManager.php
@@ -147,7 +147,7 @@ class JsonManager
                 'post-package-update'  => 'Bolt\\Composer\\EventListener\\PackageEventListener::handle',
             ],
         ];
-        $json = Arr::mergeRecursiveDistinct($json, $defaults);
+        $json = Arr::replaceRecursive($json, $defaults);
         ksort($json);
 
         return $json;
@@ -183,7 +183,7 @@ class JsonManager
                 'wikimedia/composer-merge-plugin' => '^1.3',
             ],
         ];
-        $composerJson = Arr::mergeRecursiveDistinct($composerJson, $defaults);
+        $composerJson = Arr::replaceRecursive($composerJson, $defaults);
         ksort($composerJson);
 
         return $composerJson;

--- a/src/Config.php
+++ b/src/Config.php
@@ -658,7 +658,7 @@ class Config
 
             // Make indexed arrays into associative for select fields
             // e.g.: [ 'yes', 'no' ] => { 'yes': 'yes', 'no': 'no' }
-            if ($field['type'] === 'select' && isset($field['values']) && is_array($field['values']) && Arr::isIndexedArray($field['values'])) {
+            if ($field['type'] === 'select' && isset($field['values']) && Arr::isIndexed($field['values'])) {
                 $field['values'] = array_combine($field['values'], $field['values']);
             }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -322,7 +322,7 @@ class Config
         // "Only variables should be passed by reference")
         $tempconfig = $this->parseConfigYaml('config.yml');
         $tempconfiglocal = $this->parseConfigYaml('config_local.yml');
-        $general = Arr::mergeRecursiveDistinct($tempconfig, $tempconfiglocal);
+        $general = Arr::replaceRecursive($tempconfig, $tempconfiglocal);
 
         // Make sure old settings for 'accept_file_types' are not still picked up. Before 1.5.4 we used to store them
         // as a regex-like string, and we switched to an array. If we find the old style, fall back to the defaults.
@@ -331,7 +331,7 @@ class Config
         }
 
         // Merge the array with the defaults. Setting the required values that aren't already set.
-        $general = Arr::mergeRecursiveDistinct($this->defaultConfig, $general);
+        $general = Arr::replaceRecursive($this->defaultConfig, $general);
 
         // Make sure the cookie_domain for the sessions is set properly.
         if (empty($general['cookies_domain'])) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -324,13 +324,6 @@ class Config
         $tempconfiglocal = $this->parseConfigYaml('config_local.yml');
         $general = Arr::mergeRecursiveDistinct($tempconfig, $tempconfiglocal);
 
-        // Make sure old settings for 'contentsCss' are still picked up correctly
-        if (isset($general['wysiwyg']['ck']['contentsCss'])) {
-            $general['wysiwyg']['ck']['contentsCss'] = [
-                1 => $general['wysiwyg']['ck']['contentsCss'],
-            ];
-        }
-
         // Make sure old settings for 'accept_file_types' are not still picked up. Before 1.5.4 we used to store them
         // as a regex-like string, and we switched to an array. If we find the old style, fall back to the defaults.
         if (isset($general['accept_file_types']) && !is_array($general['accept_file_types'])) {

--- a/src/Extension/ConfigTrait.php
+++ b/src/Extension/ConfigTrait.php
@@ -117,7 +117,7 @@ trait ConfigTrait
         }
 
         if (is_array($newConfig)) {
-            $this->config = Arr::mergeRecursiveDistinct($this->config, $newConfig);
+            $this->config = Arr::replaceRecursive($this->config, $newConfig);
         }
     }
 

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -5,6 +5,72 @@ namespace Bolt\Helpers;
 class Arr
 {
     /**
+     * Replaces values from second array into first array recursively.
+     *
+     * This differs from {@see array_replace_recursive} in a couple ways:
+     *  - Lists (indexed arrays) from second array completely replace list in first array.
+     *  - Null values from second array do not replace lists or associative arrays in first
+     *    (they do still replace scalar values).
+     *
+     * @param array $array1
+     * @param array $array2
+     *
+     * @return array The combined array
+     */
+    public static function replaceRecursive(array $array1, array $array2)
+    {
+        $merged = $array1;
+
+        foreach ($array2 as $key => $value) {
+            if (is_array($value) && static::isAssociative($value) && isset($merged[$key]) && is_array($merged[$key])) {
+                $merged[$key] = static::replaceRecursive($merged[$key], $value);
+            } elseif ($value === null && isset($merged[$key]) && is_array($merged[$key])) {
+                continue;
+            } else {
+                $merged[$key] = $value;
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Returns whether the given item is an indexed array - zero indexed and sequential.
+     *
+     * Note: Empty arrays are.
+     *
+     * @param array $array
+     *
+     * @return bool
+     */
+    public static function isIndexed($array)
+    {
+        if (!is_array($array)) {
+            return false;
+        }
+
+        return !static::isAssociative($array);
+    }
+
+    /**
+     * Returns whether the given item is an associative array.
+     *
+     * Note: Empty arrays are not.
+     *
+     * @param array $array
+     *
+     * @return bool
+     */
+    public static function isAssociative($array)
+    {
+        if (!is_array($array) || $array === []) {
+            return false;
+        }
+
+        return array_keys($array) !== range(0, count($array) - 1);
+    }
+
+    /**
      * Make a simple array consisting of key=>value pairs, that can be used
      * in select-boxes in forms.
      *
@@ -32,32 +98,15 @@ class Arr
     }
 
     /**
-     * array_merge_recursive does indeed merge arrays, but it converts values with duplicate
-     * keys to arrays rather than overwriting the value in the first array with the duplicate
-     * value in the second array, as array_merge does. I.e., with array_merge_recursive,
-     * this happens (documented behavior):
-     *
-     * array_merge_recursive(array('key' => 'org value'), array('key' => 'new value'));
-     *     => array('key' => array('org value', 'new value'));
-     *
-     * array_merge_recursive_distinct does not change the datatypes of the values in the arrays.
-     * Matching keys' values in the second array overwrite those in the first array, as is the
-     * case with array_merge, i.e.:
-     *
-     * array_merge_recursive_distinct(array('key' => 'org value'), array('key' => 'new value'));
-     *     => array('key' => array('new value'));
-     *
-     * Parameters are passed by reference, though only for performance reasons. They're not
-     * altered by this function.
+     * This is the same as {@see array_replace_recursive}.
+     * Use that instead or the smarter {@see replaceRecursive}.
      *
      * @param array $array1
      * @param array $array2
      *
      * @return array
      *
-     * @author Daniel <daniel (at) danielsmedegaardbuus (dot) dk>
-     * @author Gabriel Sobrinho <gabriel (dot) sobrinho (at) gmail (dot) com>
-     * @author Bob den Otter for Bolt-specific excludes
+     * @deprecated since 3.3, to be removed in 4.0.
      */
     public static function mergeRecursiveDistinct(array &$array1, array &$array2)
     {
@@ -81,11 +130,16 @@ class Arr
     }
 
     /**
-     * Check if an array is indexed or associative.
+     * Use {@see isIndexed} or {@see isAssociative} instead.
+     *
+     * This is the same as isIndexed but it does not check if
+     * array is zero-indexed and has sequential keys.
      *
      * @param array $arr
      *
      * @return boolean True if indexed, false if associative
+     *
+     * @deprecated since 3.3, to be removed in 4.0.
      */
     public static function isIndexedArray(array $arr)
     {

--- a/src/Storage/Migration/Import.php
+++ b/src/Storage/Migration/Import.php
@@ -185,7 +185,7 @@ class Import extends AbstractMigration
             'ownerid'     => 1,
         ];
 
-        $values = Arr::mergeRecursiveDistinct($values, $meta);
+        $values = Arr::replaceRecursive($values, $meta);
 
         $record = $this->app['storage']->getEmptyContent($contenttypeslug);
         $record->setValues($values);


### PR DESCRIPTION
- Added `Arr::replaceRecursive` which handles lists smarter than `array_replace_recursive`
- Added `Arr::isAssociative` and `Arr::isIndexed` - this one catches a couple edge cases.
- Deprecated `Arr::mergeRecursiveDistinct` and `Arr::isIndexedArray`
