### PR TITLE
Fix theme.yml cache

### DIFF
--- a/src/EventListener/ConfigListener.php
+++ b/src/EventListener/ConfigListener.php
@@ -81,9 +81,8 @@ class ConfigListener implements EventSubscriberInterface
             return null;
         }
 
-        $cacheFs = $this->app['filesystem']->getFilesystem('cache');
         try {
-            $this->app['config']->cacheConfig($cacheFs, false);
+            $this->app['config']->cacheConfig();
         } catch (IOException $e) {
             $response = $this->app['controller.exception']->genericException($e);
             $event->setResponse($response);


### PR DESCRIPTION
If theme file is not valid with the cache, the cache is invalidated but the file isn't loaded to cache new data. After that the cache file is rewritten with the old data. So the new data in theme file is never picked up. This fixes that.

/ping @GawainLynch