### PR TITLE
fix context for isallowed permissions check

### DIFF
--- a/app/view/twig/editcontent/_aside.twig
+++ b/app/view/twig/editcontent/_aside.twig
@@ -12,7 +12,7 @@
         {{ include('@bolt/editcontent/_aside-live-editor.twig') }}
         {{ include('@bolt/editcontent/_aside-preview.twig') }}
         {{ include('@bolt/editcontent/_aside-status.twig') }}
-        {% if isallowed('delete', context.content) and context.content.id is not empty %}
+        {% if isallowed('delete', context.contenttype) and context.content.id is not empty %}
             {{ include('@bolt/editcontent/_aside-delete.twig') }}
         {% endif %}
     </div>


### PR DESCRIPTION
Fixes the display of the aside delete button on editcontent views for 'editor' user roles. `isAllowed` is checking for a slug, legacy Content, or a string.