### PR TITLE
Fixes and Tweaks to exception page.

### DIFF
--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -8,7 +8,7 @@
     <tr>
         <th>{{ value }}</th>
         <td>
-            {% set value = attribute(app.request, value)|default() %}
+            {% set value = attribute(request, value)|default() %}
             {% if value is iterable %}
                 {% for k, v in value %}
                     {% if k is not same as(loop.index0) %} {{ k }} =&gt; {% endif %}
@@ -25,9 +25,9 @@
 
 {% for bag in bags %}
 
-    {% if (attribute(app.request, bag) is defined) and (attribute(app.request, bag).all is not empty) %}
+    {% if (attribute(request, bag) is defined) and (attribute(request, bag).all is not empty) %}
 
-        {% set values = attribute(app.request, bag).all %}
+        {% set values = attribute(request, bag).all %}
 
         <h2>{{ bag|ucfirst }}</h2>
 

--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -1,59 +1,54 @@
+{% macro printvalue(value) %}
+    {% if value is iterable and value is not empty %}
+        {% for k, v in value %}
+            {% if k is not same as(loop.index0) %} {{ k }} =&gt; {% endif %}
+            {% if v is iterable %}
+                <em>(object / array)</em>
+            {% else %}
+                {{ v|excerpt(200)|default('<em>(empty)</em>')|raw }}
+            {% endif %}
+            {% if not loop.last %}<br>{% endif %}
+        {% endfor %}
+    {% else %}
+        {{ value|excerpt(200)|default('<em>(empty)</em>')|raw }}
+    {% endif %}
+{% endmacro %}
+
+{% macro printrow(key, value) %}
+    {% import _self as macros %}
+    <tr>
+        <th>{{ key }}</th>
+        <td>
+            {{ macros.printvalue(value) }}
+        </td>
+    </tr>
+{% endmacro %}
+
+{% import _self as macros %}
+
 <h1>Request data</h1>
 
 {% set bags = [ 'attributes', 'query', 'server', 'files', 'cookies', 'headers', 'session'] %}
 {% set values = [ 'content', 'languages', 'charsets', 'encodings' , 'acceptableContentTypes', 'pathInfo', 'requestUri', 'baseUrl', 'basePath', 'method'] %}
 
 <table class="table table-striped table-hover table-condensed">
-{% for value in values %}
-    <tr>
-        <th>{{ value }}</th>
-        <td>
-            {% set value = attribute(request, value)|default() %}
-            {% if value is iterable %}
-                {% for k, v in value %}
-                    {% if k is not same as(loop.index0) %} {{ k }} =&gt; {% endif %}
-                    {{ v|default('<em>(empty)</em>')|raw }}{% if not loop.last %}<br>{% endif %}
-                {% endfor %}
-            {% else %}
-                {{ value|default('<em>(empty)</em>')|raw }}
-            {% endif %}
-        </td>
-    </tr>
+{% for key in values %}
+    {% set value = attribute(request, key)|default() %}
+    {{ macros.printrow(key, value) }}
 {% endfor %}
 </table>
 
 
-{% for bag in bags %}
+{% for bag in bags if (attribute(request, bag) is defined) and (attribute(request, bag).all is not empty)%}
 
-    {% if (attribute(request, bag) is defined) and (attribute(request, bag).all is not empty) %}
+    {% set values = attribute(request, bag).all %}
 
-        {% set values = attribute(request, bag).all %}
+    <h2>{{ bag|ucfirst }}</h2>
 
-        <h2>{{ bag|ucfirst }}</h2>
-
-        <table class="table table-striped table-hover table-condensed">
-            {% for key, value in values %}
-                <tr>
-                    <th>{{ key }}</th>
-                    <td>
-                        {% if value is iterable and value is not empty %}
-                            {% for k, v in value %}
-                                {% if k is not same as(loop.index0) %} {{ k }} =&gt; {% endif %}
-                                {% if v is iterable %}
-                                    <em>(object / array)</em>
-                                {% else %}
-                                    {{ v|excerpt(200)|default('<em>(empty)</em>')|raw }}
-                                {% endif %}
-                                {% if not loop.last %}<br>{% endif %}
-                            {% endfor %}
-                        {% else %}
-                            {{ value|default('<em>(empty)</em>')|raw }}
-                        {% endif %}
-                    </td>
-                </tr>
-            {% endfor %}
-        </table>
-
-    {% endif %}
+    <table class="table table-striped table-hover table-condensed">
+        {% for key, value in values %}
+            {{ macros.printrow(key, value) }}
+        {% endfor %}
+    </table>
 
 {% endfor %}

--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -8,7 +8,7 @@
     <tr>
         <th>{{ value }}</th>
         <td>
-            {% set value = attribute(app.request, value) %}
+            {% set value = attribute(app.request, value)|default() %}
             {% if value is iterable %}
                 {% for k, v in value %}
                     {% if k is not same as(loop.index0) %} {{ k }} =&gt; {% endif %}
@@ -25,9 +25,10 @@
 
 {% for bag in bags %}
 
-    {% set values = attribute(app.request, bag).all %}
+    {% if (attribute(app.request, bag) is defined) and (attribute(app.request, bag).all is not empty) %}
 
-    {% if values is not empty %}
+        {% set values = attribute(app.request, bag).all %}
+
         <h2>{{ bag|ucfirst }}</h2>
 
         <table class="table table-striped table-hover table-condensed">

--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -42,7 +42,7 @@
                                 {% if v is iterable %}
                                     <em>(object / array)</em>
                                 {% else %}
-                                    {{ v|default('<em>(empty)</em>')|raw }}
+                                    {{ v|excerpt(200)|default('<em>(empty)</em>')|raw }}
                                 {% endif %}
                                 {% if not loop.last %}<br>{% endif %}
                             {% endfor %}

--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -36,10 +36,15 @@
                 <tr>
                     <th>{{ key }}</th>
                     <td>
-                        {% if value is iterable %}
+                        {% if value is iterable and value is not empty %}
                             {% for k, v in value %}
                                 {% if k is not same as(loop.index0) %} {{ k }} =&gt; {% endif %}
-                                {{ v|default('<em>(empty)</em>')|raw }}{% if not loop.last %}<br>{% endif %}
+                                {% if v is iterable %}
+                                    <em>(object / array)</em>
+                                {% else %}
+                                    {{ v|default('<em>(empty)</em>')|raw }}
+                                {% endif %}
+                                {% if not loop.last %}<br>{% endif %}
                             {% endfor %}
                         {% else %}
                             {{ value|default('<em>(empty)</em>')|raw }}

--- a/app/view/twig/exception/_trace.twig
+++ b/app/view/twig/exception/_trace.twig
@@ -10,9 +10,9 @@
             {%- endif -%}
             {{ t.function|default() }}(
 
-            {%- if t.simpleargs is not empty -%}
+            {%- if t.args_safe is not empty -%}
                 {% set index = loop.index %}
-                {%- for arg in t.simpleargs -%}
+                {%- for arg in t.args_safe -%}
                     <tt><a href="#trace-arguments-{{index}}" onclick="javascript:$('#trace-arguments-{{index}}').slideDown('fast'); return false;">{{ arg|raw }}</a></tt>{% if not loop.last %}, {% endif %}
                 {%- endfor -%}
             {%- endif -%}
@@ -23,7 +23,7 @@
                 <em class='dim'>{{ t.file|default() }} # line <strong>{{ t.line|default() }}</strong></em>
             {% endif %}
 
-            {% if t.simpleargs is not empty %}
+            {% if t.args_safe is not empty %}
             <div id='trace-arguments-{{loop.index}}' style="display: none;">
                 Arguments:
                 {{ dump(t.args) }}

--- a/app/view/twig/exception/exception.twig
+++ b/app/view/twig/exception/exception.twig
@@ -60,7 +60,7 @@
                             <p class='exception'>
                                 {# Based on this classic tweet: https://twitter.com/divineomega/status/695744177557106688 #}
                                 {% set query = 'Bolt ' ~ exception.classbase|default('unknown') ~ ' in ' ~ exception.filebasename|default('unknown') ~ ' line ' ~ exception.object.line|default('unknown') ~ ': ' ~ exception.object.message|default('unknown') %}
-                                <a class='btn btn-default' href='https://www.google.nl/search?q={{ query|url_encode }}' target='_blank'>Google this Exception</a>
+                                <a class='btn btn-default' href='https://www.google.com/search?q={{ query|url_encode }}' target='_blank'>Google this Exception</a>
                             </p>
 
                             {% block request %}

--- a/app/view/twig/exception/exception.twig
+++ b/app/view/twig/exception/exception.twig
@@ -44,8 +44,8 @@
                             {% endblock exception %}
 
                             <p class='exception'>
-                                <tt><abbr title="{{ exception.class|default('unknown') }}">{{ exception.classbase|default('unknown') }}</abbr></tt> in <tt>{% if debug %}<abbr title="{{ exception.filename|default('unknown') }}">{% endif %}
-                                {{- exception.filebasename|default('unknown') }}{% if debug %}</abbr>{% endif %}</tt> line <tt>
+                                <tt><abbr title="{{ exception.class_fqn|default('unknown') }}">{{ exception.class_name|default('unknown') }}</abbr></tt> in <tt>{% if debug %}<abbr title="{{ exception.file_path|default('unknown') }}">{% endif %}
+                                {{- exception.file_name|default('unknown') }}{% if debug %}</abbr>{% endif %}</tt> line <tt>
                                 {{- exception.object.line|default('unknown') }}</tt>: <br>
                                 <em><strong>{{ exception.object.message|default('unknown')|nl2br }}</strong></em>
 
@@ -59,7 +59,7 @@
 
                             <p class='exception'>
                                 {# Based on this classic tweet: https://twitter.com/divineomega/status/695744177557106688 #}
-                                {% set query = 'Bolt ' ~ exception.classbase|default('unknown') ~ ' in ' ~ exception.filebasename|default('unknown') ~ ' line ' ~ exception.object.line|default('unknown') ~ ': ' ~ exception.object.message|default('unknown') %}
+                                {% set query = 'Bolt ' ~ exception.class_name|default('unknown') ~ ' in ' ~ exception.file_name|default('unknown') ~ ' line ' ~ exception.object.line|default('unknown') ~ ': ' ~ exception.object.message|default('unknown') %}
                                 <a class='btn btn-default' href='https://www.google.com/search?q={{ query|url_encode }}' target='_blank'>Google this Exception</a>
                             </p>
 

--- a/app/view/twig/exception/exception.twig
+++ b/app/view/twig/exception/exception.twig
@@ -9,11 +9,11 @@
 
     <link rel="stylesheet" href="{{ asset('css/bolt.css', 'bolt') }}">
     {% if debug and exception.snippet %}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/prism.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/components/prism-php.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/plugins/line-numbers/prism-line-numbers.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/plugins/line-highlight/prism-line-highlight.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js" async></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/prism.min.js" defer></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/components/prism-php.min.js" defer></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/plugins/line-numbers/prism-line-numbers.min.js" defer></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/plugins/line-highlight/prism-line-highlight.min.js" defer></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/themes/prism.min.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/plugins/line-numbers/prism-line-numbers.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/plugins/line-highlight/prism-line-highlight.min.css">

--- a/app/view/twig/exception/exception.twig
+++ b/app/view/twig/exception/exception.twig
@@ -43,30 +43,28 @@
                             {% block exception %}
                             {% endblock exception %}
 
-                            {% if debug %}
-                                <p class='exception'>
-                                    <tt>{{ exception.class|default('unknown') }}</tt> in <tt><abbr title="{{ exception.filename|default('unknown') }}">
-                                    {{- exception.filebasename|default('unknown') }}</abbr></tt> line <tt>
-                                    {{- exception.object.line|default('unknown') }}</tt>. <br>
-                                    <em><strong>{{ exception.object.message|default('unknown')|nl2br }}</strong></em>
-                                </p>
-                            {% else %}
-                              <p class='exception'>
-                                    <tt>{{ exception.class|default('unknown') }}</tt> in <tt>
-                                    {{- exception.filebasename|default('unknown') }}</tt> line <tt>
-                                    {{- exception.object.line|default('unknown') }}</tt>. <br>
-                                    <em><strong>{{ exception.object.message|default('unknown')|nl2br }}</strong></em>
-                                </p>
-                            {% endif %}
+                            <p class='exception'>
+                                <tt><abbr title="{{ exception.class|default('unknown') }}">{{ exception.classbase|default('unknown') }}</abbr></tt> in <tt>{% if debug %}<abbr title="{{ exception.filename|default('unknown') }}">{% endif %}
+                                {{- exception.filebasename|default('unknown') }}{% if debug %}</abbr>{% endif %}</tt> line <tt>
+                                {{- exception.object.line|default('unknown') }}</tt>: <br>
+                                <em><strong>{{ exception.object.message|default('unknown')|nl2br }}</strong></em>
+
+                            </p>
 
                             {% if debug and exception.snippet -%}
-<pre class='line-numbers' data-start='{{ exception.object.line|default(1) }}' data-line='6'><code class='language-php'>
+<pre class='line-numbers' data-start='{{ max(exception.object.line - 5, 1) }}' data-line='6'><code class='language-php'>
 {{- exception.snippet -}}
 </code></pre>
                             {%- endif %}
 
+                            <p class='exception'>
+                                {# Based on this classic tweet: https://twitter.com/divineomega/status/695744177557106688 #}
+                                {% set query = 'Bolt ' ~ exception.classbase|default('unknown') ~ ' in ' ~ exception.filebasename|default('unknown') ~ ' line ' ~ exception.object.line|default('unknown') ~ ': ' ~ exception.object.message|default('unknown') %}
+                                <a class='btn btn-default' href='https://www.google.nl/search?q={{ query|url_encode }}' target='_blank'>Google this Exception</a>
+                            </p>
+
                             {% block request %}
-                                {% if debug %}
+                                {% if debug and app.request is defined %}
                                     <hr>
                                     {{ include('@bolt/exception/_request.twig') }}
                                 {% endif %}

--- a/app/view/twig/exception/exception.twig
+++ b/app/view/twig/exception/exception.twig
@@ -64,7 +64,7 @@
                             </p>
 
                             {% block request %}
-                                {% if debug and app.request is defined %}
+                                {% if debug and request is defined %}
                                     <hr>
                                     {{ include('@bolt/exception/_request.twig') }}
                                 {% endif %}

--- a/src/Controller/Exception.php
+++ b/src/Controller/Exception.php
@@ -236,6 +236,7 @@ class Exception extends Base implements ExceptionControllerInterface
         $loggedOnUser = (bool) $this->app['users']->getCurrentUser() ?: false;
         $showLoggedOff = (bool) $this->app['config']->get('general/debug_show_loggedoff', false);
 
+        // Grab a section of the file that threw the exception, so we can show it.
         $filename = $exception ? $exception->getFile() : null;
         $linenumber = $exception ? $exception->getLine() : null;
 
@@ -245,8 +246,17 @@ class Exception extends Base implements ExceptionControllerInterface
             $snippet = false;
         }
 
+        // We might or might not have $this->app['request'] yet, which is used in the
+        // template to show the request variables. Use it, or grab what we can get.
+        if ($this->app['request'] instanceof Request) {
+            $request = $this->app['request'];
+        } else {
+            $request = Request::createFromGlobals();
+        }
+
         return [
             'debug'     => ($this->app['debug'] && ($loggedOnUser || $showLoggedOff)),
+            'request'   => $request,
             'exception' => [
                 'object'       => $exception,
                 'class'        => $exception ? get_class($exception) : null,

--- a/src/Controller/Exception.php
+++ b/src/Controller/Exception.php
@@ -250,6 +250,7 @@ class Exception extends Base implements ExceptionControllerInterface
             'exception' => [
                 'object'       => $exception,
                 'class'        => $exception ? get_class($exception) : null,
+                'classbase'    => $exception ? (new \ReflectionClass($exception))->getShortName() : null,
                 'filename'     => $filename,
                 'filebasename' => basename($filename),
                 'trace'        => $exception ? $this->getSafeTrace($exception) : null,

--- a/src/Controller/Exception.php
+++ b/src/Controller/Exception.php
@@ -237,40 +237,37 @@ class Exception extends Base implements ExceptionControllerInterface
         $showLoggedOff = (bool) $this->app['config']->get('general/debug_show_loggedoff', false);
 
         // Grab a section of the file that threw the exception, so we can show it.
-        $filename = $exception ? $exception->getFile() : null;
-        $linenumber = $exception ? $exception->getLine() : null;
+        $filePath = $exception ? $exception->getFile() : null;
+        $lineNumber = $exception ? $exception->getLine() : null;
 
-        if ($filename && $linenumber) {
-            $snippet = implode('', array_slice(file($filename), max(0, $linenumber - 6), 11));
+        if ($filePath && $lineNumber) {
+            $phpFile = file($filePath) ?: [];
+            $snippet = implode('', array_slice($phpFile, max(0, $lineNumber - 6), 11));
         } else {
             $snippet = false;
         }
 
         // We might or might not have $this->app['request'] yet, which is used in the
         // template to show the request variables. Use it, or grab what we can get.
-        if ($this->app['request_stack']->getCurrentRequest() instanceof Request) {
-            $request = $this->app['request_stack']->getCurrentRequest();
-        } else {
-            $request = Request::createFromGlobals();
-        }
+        $request = $this->app['request_stack']->getCurrentRequest() ?: Request::createFromGlobals();
 
         return [
             'debug'     => ($this->app['debug'] && ($loggedOnUser || $showLoggedOff)),
             'request'   => $request,
             'exception' => [
-                'object'       => $exception,
-                'class'        => $exception ? get_class($exception) : null,
-                'classbase'    => $exception ? (new \ReflectionClass($exception))->getShortName() : null,
-                'filename'     => $filename,
-                'filebasename' => basename($filename),
-                'trace'        => $exception ? $this->getSafeTrace($exception) : null,
-                'snippet'      => $snippet,
+                'object'     => $exception,
+                'class_name' => $exception ? (new \ReflectionClass($exception))->getShortName() : null,
+                'class_fqn'  => $exception ? get_class($exception) : null,
+                'file_path'  => $filePath,
+                'file_name'  => basename($filePath),
+                'trace'      => $exception ? $this->getSafeTrace($exception) : null,
+                'snippet'    => $snippet,
             ],
         ];
     }
 
     /**
-     * Get the exception trace that is safe to display publicly.
+     * Get an exception trace that is safe to display publicly.
      *
      * @param \Exception  $exception
      *
@@ -285,37 +282,9 @@ class Exception extends Base implements ExceptionControllerInterface
         $rootPath = $this->app['resources']->getPath('root');
         $trace = $exception->getTrace();
         foreach ($trace as $key => $value) {
-            $simpleargs = [];
-            foreach ($trace[$key]['args'] as $arg) {
-                $type = gettype($arg);
-                switch ($type) {
-                    case 'string':
-                        $simpleargs[] = sprintf('<span>"%s"</span>', Html::trimText($arg, 30));
-                        break;
+            $trace[$key]['args_safe'] = $this->getSafeArguments($trace[$key]['args']);
 
-                    case 'integer':
-                    case 'float':
-                        $simpleargs[] = sprintf('<span>%s</span>', $arg);
-                        break;
-
-                    case 'object':
-                        $classname = get_class($arg);
-                        $shortname = (new \ReflectionClass($arg))->getShortName();
-                        $simpleargs[] = sprintf('<abbr title="%s">%s</abbr>', $classname, $shortname);
-                        break;
-
-                    case 'boolean':
-                        $simpleargs[] = $arg ? '[true]' : '[false]';
-                        break;
-
-                    default:
-                        $simpleargs[] = '[' . $type . ']';
-                }
-            }
-
-            $trace[$key]['simpleargs'] = $simpleargs;
-
-            // Don't display the full path, trim 64-char hexadecimal filenames.
+            // Don't display the full path, trim 64-char hexadecimal file names.
             if (isset($trace[$key]['file'])) {
                 $trace[$key]['file'] = str_replace($rootPath, '[root]', $trace[$key]['file']);
                 $trace[$key]['file'] = preg_replace('/([0-9a-f]{16})[0-9a-f]{48}/i', '\1…', $trace[$key]['file']);
@@ -323,6 +292,46 @@ class Exception extends Base implements ExceptionControllerInterface
         }
 
         return $trace;
+    }
+
+    /**
+     * Get an array of safe (sanitised) function arguments from a trace entry.
+     *
+     * @param array $args
+     *
+     * @return array
+     */
+    protected function getSafeArguments(array $args)
+    {
+        $argsSafe = [];
+        foreach ($args as $arg) {
+            $type = gettype($arg);
+            switch ($type) {
+                case 'string':
+                    $argsSafe[] = sprintf('<span>"%s"</span>', Html::trimText($arg, 30));
+                    break;
+
+                case 'integer':
+                case 'float':
+                    $argsSafe[] = sprintf('<span>%s</span>', $arg);
+                    break;
+
+                case 'object':
+                    $className = get_class($arg);
+                    $shortName = (new \ReflectionClass($arg))->getShortName();
+                    $argsSafe[] = sprintf('<abbr title="%s">%s</abbr>', $className, $shortName);
+                    break;
+
+                case 'boolean':
+                    $argsSafe[] = $arg ? '[true]' : '[false]';
+                    break;
+
+                default:
+                    $argsSafe[] = '[' . $type . ']';
+            }
+        }
+
+        return $argsSafe;
     }
 
     /**

--- a/src/Controller/Exception.php
+++ b/src/Controller/Exception.php
@@ -248,8 +248,8 @@ class Exception extends Base implements ExceptionControllerInterface
 
         // We might or might not have $this->app['request'] yet, which is used in the
         // template to show the request variables. Use it, or grab what we can get.
-        if ($this->app['request'] instanceof Request) {
-            $request = $this->app['request'];
+        if ($this->app['request_stack']->getCurrentRequest() instanceof Request) {
+            $request = $this->app['request_stack']->getCurrentRequest();
         } else {
             $request = Request::createFromGlobals();
         }


### PR DESCRIPTION
 - Add a 'Google this exception' button. 
 - Shows correct line numbers in snippet
 - Abbreviates the classname of the Exception that was thrown
 - Should fix the failure if `Request` doesn't exist (yet), as reported by @CarsonF (see #5891) 

![screen shot 2016-10-10 at 20 57 34](https://cloud.githubusercontent.com/assets/1833361/19247999/d7f82c04-8f2d-11e6-8d7f-22e79c808337.png)
