### PR TITLE
Fix twig in live editor

### DIFF
--- a/app/src/js/modules/ckeditor.js
+++ b/app/src/js/modules/ckeditor.js
@@ -158,6 +158,8 @@
             config.autoGrow_bottomSpace = 24;
             config.removePlugins = 'elementspath';
             config.resize_dir = 'vertical';
+            config.protectedSource.push(/\{\{[\s\S]*?\}\}/g);
+            config.protectedSource.push(/\{\%[\s\S]*?%\}/g);
 
             if (set.filebrowser) {
                 if (set.filebrowser.browseUrl) {

--- a/app/src/js/modules/ckeditor.js
+++ b/app/src/js/modules/ckeditor.js
@@ -190,7 +190,7 @@
                 autoCloseBrackets: true,
                 enableSearchTools: true,
                 enableCodeFolding: true,
-                enableCodeFormatting: false,
+                enableCodeFormatting: true,
                 autoFormatOnStart: false,
                 autoFormatOnUncomment: false,
                 autoFormatOnModeChange: false,

--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -119,9 +119,14 @@
                     $(this).attr('contenteditable', true);
 
                     if (fieldType === 'html') {
-                        cke.inline(this, {
+                        var editor = cke.inline(this, {
                             allowedContent: ''
                         });
+                        var saveData = bolt.utils.debounce(function () {
+                            editor.element.data('src', editor.getData());
+                        }, 500);
+                        editor.on('instanceReady', saveData);
+                        editor.on('change', saveData);
                     } else {
                         $(this).on('paste', function(e) {
                             var content;
@@ -194,21 +199,17 @@
             // Find form field
             var fieldName = $(this).data('bolt-field'),
                 field = $('#editcontent [name=' + liveEditor.escapejQuery(fieldName) + ']'),
-                fieldType = field.closest('[data-bolt-fieldset]').data('bolt-fieldset'),
-                fieldValue = '';
+                fieldType = field.closest('[data-bolt-fieldset]').data('bolt-fieldset');
 
             if (fieldType === 'html') {
-                fieldValue = $(this).html();
-
                 var fieldId = field.attr('id');
 
                 if (ckeditor.instances.hasOwnProperty(fieldId)) {
-                    ckeditor.instances[fieldId].setData(fieldValue);
+                    ckeditor.instances[fieldId].setData($(this).data('src'));
                 }
             } else {
-                fieldValue = liveEditor.cleanText($(this), fieldType);
+                field.val(liveEditor.cleanText($(this), fieldType));
             }
-            field.val(fieldValue);
         });
 
         $(iframe).attr('src', '');

--- a/app/src/js/modules/utils.js
+++ b/app/src/js/modules/utils.js
@@ -61,6 +61,37 @@
         return /^(\-|\+)?([0-9]+|Infinity)$/.test(value) ? Number(value) : defaultInt || NaN;
     };
 
+    /**
+     * Returns a function, that, as long as it continues to be invoked, will not
+     * be triggered. The function will be called after it stops being called for
+     * N milliseconds. If `immediate` is passed, trigger the function on the
+     * leading edge, instead of the trailing.
+     *
+     * @static
+     * @function debounce
+     * @memberOf Bolt.utils
+     *
+     * @param {Function} func
+     * @param {number} wait milliseconds
+     * @param {boolean} [immediate=false]
+     * @returns {Function}
+     */
+    utils.debounce = function (func, wait, immediate) {
+        var timeout;
+        return function () {
+            var context = this,
+                args = arguments;
+            var later = function () {
+                timeout = null;
+                if (!immediate) func.apply(context, args);
+            };
+            var callNow = immediate && !timeout;
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+            if (callNow) func.apply(context, args);
+        };
+    };
+
     // Apply mixin container
     bolt.utils = utils;
 


### PR DESCRIPTION
- Don't parse Twig for live editor as it saves the compiled HTML.
- Set Twig syntax as protected source for CKEditor.
- Handle protected source in live editor.
- Fix JS error when switching CKEditor to source view. Credit to @dadaxr.