### PR TITLE
Revert 94ecd7e as it hides twig in ckeditor view.

### DIFF
--- a/app/src/js/modules/ckeditor.js
+++ b/app/src/js/modules/ckeditor.js
@@ -158,8 +158,6 @@
             config.autoGrow_bottomSpace = 24;
             config.removePlugins = 'elementspath';
             config.resize_dir = 'vertical';
-            config.protectedSource.push(/\{\{[\s\S]*?\}\}/g);
-            config.protectedSource.push(/\{\%[\s\S]*?%\}/g);
 
             if (set.filebrowser) {
                 if (set.filebrowser.browseUrl) {


### PR DESCRIPTION
This can still be opt in, but I don't feel like it should be default.

@bobdenotter - as we discussed.