### PR TITLE
Set LegacyService for all Repo extending ContentRepository

### DIFF
--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -54,6 +54,7 @@ class StorageServiceProvider implements ServiceProviderInterface
                     $app['storage.metadata'],
                     $app['logger.system']
                 );
+                $storage->setLegacyService($app['storage.legacy_service']);
                 $storage->setLegacyStorage($app['storage.legacy']);
                 $storage->setEntityBuilder($app['storage.entity_builder']);
                 $storage->setFieldManager($app['storage.field_manager']);
@@ -74,7 +75,6 @@ class StorageServiceProvider implements ServiceProviderInterface
                 $repoClass = $app['storage.repository.default'];
                 /** @var Repository\ContentRepository $repo */
                 $repo = new $repoClass($app['storage'], $classMetadata);
-                $repo->setLegacyService($app['storage.legacy_service']);
 
                 return $repo;
             }

--- a/src/Storage/EntityManager.php
+++ b/src/Storage/EntityManager.php
@@ -269,12 +269,12 @@ class EntityManager implements EntityManagerInterface
             $repoClass = $this->repositories[$classMetadata->getName()];
             if (is_callable($repoClass)) {
                 $repo = call_user_func_array($repoClass, [$this, $classMetadata]);
+            } else {
+                $repo = new $repoClass($this, $classMetadata);
             }
-
-            $repo = $repoClass($this, $classMetadata);
         }
 
-        if (is_null($repo)) {
+        if ($repo === null) {
             foreach ($this->aliases as $alias => $namespace) {
                 $full = str_replace($alias, $namespace, $className);
 
@@ -294,7 +294,7 @@ class EntityManager implements EntityManagerInterface
          * the content repository, but in time this should be a metadata level
          * configuration.
          */
-        if (is_null($repo) && $this->getMapper()->resolveClassName($className) === 'Bolt\Storage\Entity\Content') {
+        if ($repo === null && $this->getMapper()->resolveClassName($className) === 'Bolt\Storage\Entity\Content') {
             $repo = $this->getDefaultRepositoryFactory($classMetadata);
         }
 
@@ -302,15 +302,15 @@ class EntityManager implements EntityManagerInterface
          * If the fetched metadata isn't mapped to a specific entity then we treat
          * it as a generic Content repo
          */
-        if (is_null($repo) && in_array($className, $this->getMapper()->getUnmapped())) {
+        if ($repo === null  && in_array($className, $this->getMapper()->getUnmapped())) {
             $repo = $this->getDefaultRepositoryFactory($classMetadata);
         }
 
-        if (is_null($repo)) {
+        if ($repo === null) {
             $repo = new Repository($this, $classMetadata);
         }
 
-        if (is_a($repo, Repository\ContentRepository::class)) {
+        if ($repo instanceof Repository\ContentRepository) {
             /** @var ContentRepository $repo */
             $repo->setLegacyService($this->legacyService);
         }

--- a/src/Storage/Repository/ContentRepository.php
+++ b/src/Storage/Repository/ContentRepository.php
@@ -5,6 +5,7 @@ namespace Bolt\Storage\Repository;
 use Bolt\Events\HydrationEvent;
 use Bolt\Events\StorageEvents;
 use Bolt\Storage\ContentLegacyService;
+use Bolt\Storage\Entity\Content;
 use Bolt\Storage\Mapping\ContentTypeTitleTrait;
 use Bolt\Storage\Repository;
 use Doctrine\DBAL\Query\QueryBuilder;
@@ -92,7 +93,7 @@ class ContentRepository extends Repository
     public function hydrateLegacyHandler(HydrationEvent $event)
     {
         $entity = $event->getArgument('entity');
-        if (is_a($entity, 'Bolt\Storage\Entity\Content')) {
+        if ($entity instanceof Content) {
             $entity->setLegacyService($this->legacy);
         }
     }


### PR DESCRIPTION
Fix a bug introduced with : [PR 5862](https://github.com/bolt/bolt/pull/5862)

All the Repositories extending the ContentRepository must have (for now) a "LegacyService" configured to handle correctly "Content Entities" ( content entities defined with the contenttype.yml file )

The previous PR was not always  setting that legacy service and it could (not always) end up with a bolt exception page when editing a content with the default backend UI.

This PR just ensure that the legacy service is set when retrieving a repository.
