### PR TITLE
Show custom fields in "Relationships" tab

### DIFF
--- a/app/view/twig/editcontent/_relations.twig
+++ b/app/view/twig/editcontent/_relations.twig
@@ -43,7 +43,7 @@
 {% endif %}
 
 {% if context.has.tabs and 'relations' in context.contenttype.groups %}
-    {{ include('@bolt/editcontent/_fields.twig') }}{
+    {{ include('@bolt/editcontent/_field.twig') }}
 {% endif %}
 
 {% if not context.has.tabs %}


### PR DESCRIPTION
This fixes a problem where the custom fields cannot be displayed when setting the group of a field to `relationships`.

``` yaml
my:
    fields:
        foobar:
            label: Foo Bar
            type: checkbox
            group: relations
```