### PR TITLE
Fix installAssets Failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "symfony/http-foundation": "^2.8",
         "symfony/http-kernel": "^2.8",
         "symfony/intl" : "^2.8",
+        "symfony/monolog-bridge": "^2.8",
         "symfony/options-resolver": "^2.8",
         "symfony/process": "^2.8",
         "symfony/property-access": "^2.8",


### PR DESCRIPTION
A lot of xdebugging Composer later … Credit to @CarsonF for the SP changes

This was the error:
```
> Bolt\Composer\ScriptHandler::installAssets
                                                           
  [Symfony\Component\Debug\Exception\FatalThrowableError]  
  Call to a member function findFile() on string           

Exception trace:
 () at [snip]/vendor/symfony/debug/DebugClassLoader.php:168
 Symfony\Component\Debug\DebugClassLoader->loadClass() at n/a:n/a
 spl_autoload_call() at n/a:n/a
 class_exists() at [snip]/vendor/silex/silex/src/Silex/Provider/MonologServiceProvider.php:34
 Silex\Provider\MonologServiceProvider->register() at [snip]/vendor/silex/silex/src/Silex/Application.php:178
 Silex\Application->register() at [snip]/vendor/bolt/bolt/src/Provider/LoggerServiceProvider.php:82
 Bolt\Provider\LoggerServiceProvider->register() at [snip]/vendor/silex/silex/src/Silex/Application.php:178
 Silex\Application->register() at [snip]/vendor/bolt/bolt/src/Application.php:157
 Bolt\Application->initLogger() at [snip]/vendor/bolt/bolt/src/Application.php:59
 Bolt\Application->__construct() at [snip]/vendor/bolt/bolt/app/bootstrap.php:132
 Bolt\Composer\ScriptHandler::Bolt\{closure}() at n/a:n/a
 call_user_func() at [snip]/vendor/bolt/bolt/app/bootstrap.php:140
 require() at [snip]/vendor/bolt/bolt/src/Composer/ScriptHandler.php:274
 Bolt\Composer\ScriptHandler::getApp() at [snip]/vendor/bolt/bolt/src/Composer/ScriptHandler.php:249
 Bolt\Composer\ScriptHandler::getDir() at [snip]/vendor/bolt/bolt/src/Composer/ScriptHandler.php:225
 Bolt\Composer\ScriptHandler::getWebDir() at [snip]/vendor/bolt/bolt/src/Composer/ScriptHandler.php:37
 Bolt\Composer\ScriptHandler::installAssets() at /usr/share/php/Composer/EventDispatcher/EventDispatcher.php:255
 Composer\EventDispatcher\EventDispatcher->executeEventPhpScript() at /usr/share/php/Composer/EventDispatcher/EventDispatcher.php:209
 Composer\EventDispatcher\EventDispatcher->doDispatch() at /usr/share/php/Composer/EventDispatcher/EventDispatcher.php:95
 Composer\EventDispatcher\EventDispatcher->dispatchScript() at /usr/share/php/Composer/Installer.php:297
 Composer\Installer->run() at /usr/share/php/Composer/Command/RemoveCommand.php:128
 Composer\Command\RemoveCommand->execute() at /usr/share/php/Symfony/Component/Console/Command/Command.php:259
 Symfony\Component\Console\Command\Command->run() at /usr/share/php/Symfony/Component/Console/Application.php:849
 Symfony\Component\Console\Application->doRunCommand() at /usr/share/php/Symfony/Component/Console/Application.php:193
 Symfony\Component\Console\Application->doRun() at /usr/share/php/Composer/Console/Application.php:231
 Composer\Console\Application->doRun() at /usr/share/php/Symfony/Component/Console/Application.php:124
 Symfony\Component\Console\Application->run() at /usr/share/php/Composer/Console/Application.php:104
 Composer\Console\Application->run() at /usr/bin/composer:44
```