### PR TITLE
Fix hyphen warnings when underscores are used

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -453,7 +453,6 @@ class Config
         foreach ($tempContentTypes as $key => $contentType) {
             try {
                 $contentType = $this->parseContentType($key, $contentType, $generalConfig);
-                $key = $contentType['slug'];
                 $contentTypes[$key] = $contentType;
             } catch (InvalidArgumentException $e) {
                 $this->exceptions[] = $e->getMessage();


### PR DESCRIPTION
This should fix #5926

I can't think of any really bad side effects of doing this, but the problem was that we always wrote the value of `slug` back to be the key which is incorrect in this case because we want the key to be `submitted_website` but the slug `submitted-website`

So this stops doing that and leaves the key as-is. The place where BC could break here is if someone depended on slugify fixing a key, eg they called their contenttype `submitted%$&website` and expected it to be fixed to `submittedwebsite` via a slugify. I don't think we have ever or should ever have supported this but it might be worth everyone sanity checking this.