### PR TITLE
[3.2][RFC] Switch profiler target option to Symfony's target

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -262,9 +262,9 @@ accept_file_types: [ twig, html, js, css, scss, gif, jpg, jpeg, png, ico, zip, t
 debug: true
 debug_show_loggedoff: false
 debug_permission_audit_mode: false
-# debug_error_level: 8181 # equivalent to E_ALL &~ E_NOTICE &~ E_DEPRECATED &~ E_USER_DEPRECATED &~ E_WARNING
-debug_error_level: -1 # equivalent to E_ALL
-debug_error_use_profiler: false # When set to true, Symfony Profiler will be used for exception display when possible
+# debug_error_level: 8181           # equivalent to E_ALL &~ E_NOTICE &~ E_DEPRECATED &~ E_USER_DEPRECATED &~ E_WARNING
+debug_error_level: -1               # equivalent to E_ALL
+debug_error_use_symfony: false      # When set to true, Symfony Profiler will be used for exception display when possible
 
 # error level when debug is disabled
 #production_error_level: 8181 # = E_ALL &~ E_NOTICE &~ E_WARNING &~ E_DEPRECATED &~ E_USER_DEPRECATED

--- a/src/Config.php
+++ b/src/Config.php
@@ -1126,7 +1126,7 @@ class Config
             'debug_error_level'           => null,
             'production_error_level'      => null,
             'debug_enable_whoops'         => false, /** @deprecated. Deprecated since 3.2, to be removed in 4.0 */
-            'debug_error_use_profiler'    => false,
+            'debug_error_use_symfony'     => false,
             'debug_permission_audit_mode' => false,
             'strict_variables'            => null,
             'theme'                       => 'base-2016',

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\EventListener;
 
+use Bolt\Config;
 use Bolt\Controller;
 use Bolt\Exception\BootException;
 use Bolt\Request\ProfilerAwareTrait;
@@ -28,17 +29,21 @@ class ExceptionListener implements EventSubscriberInterface, LoggerAwareInterfac
     use LoggerAwareTrait;
     use ProfilerAwareTrait;
 
+    /** @var Config */
+    private $config;
     /** @var Controller\Exception */
     protected $exceptionController;
 
     /**
      * Constructor.
      *
+     * @param Config               $config
      * @param Controller\Exception $exceptionController
      * @param LoggerInterface      $logger
      */
-    public function __construct(Controller\Exception $exceptionController, LoggerInterface $logger)
+    public function __construct(Config $config, Controller\Exception $exceptionController, LoggerInterface $logger)
     {
+        $this->config = $config;
         $this->exceptionController = $exceptionController;
         $this->setLogger($logger);
     }
@@ -97,6 +102,8 @@ class ExceptionListener implements EventSubscriberInterface, LoggerAwareInterfac
                     'message'   => $message,
                 ]
             );
+        } elseif ($this->config->get('general/debug_error_use_symfony')) {
+            return null;
         } else {
             $response = $this->exceptionController->kernelException($event);
         }

--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -30,6 +30,7 @@ class EventListenerServiceProvider implements ServiceProviderInterface
         $app['listener.exception'] = $app->share(
             function ($app) {
                 return new Listener\ExceptionListener(
+                    $app['config'],
                     $app['controller.exception'],
                     $app['logger.system']
                 );


### PR DESCRIPTION
The profiler page was a nice idea, but it remove the ability to just refresh the page and attempt next step debugging.

Also, for a number of us, having the stack trace at the bottom of the page means we have to modify the bootstrap to disable Bolt's exception handler as it is just too much scrolling every few page refresh and not suitable for the BEs.

So this give the "pretty" crowd what they needs, and the rest of us can just fallback to Symfony.

Also, I don't want to go into RC and lock in BC on this.

Ping @CarsonF