### PR TITLE
Fixed: Optional `order` in relationship shouldn't throw an exception.

### DIFF
--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -187,8 +187,9 @@ class Edit
             $repo = $this->em->getRepository($relationName);
             $relationConfig = $this->config->get('contenttypes/' . $relationName, []);
             $neededFields = $this->neededFields($relationValues, $relationConfig);
+            $order = isset($relationValues['order']) ? $relationValues['order'] : null;
 
-            $list[$relationName] = $repo->getSelectList($relationConfig, $relationValues['order'], $neededFields);
+            $list[$relationName] = $repo->getSelectList($relationConfig, $order, $neededFields);
         }
 
         return $list;


### PR DESCRIPTION
Fixes #5954