### PR TITLE
Handle user entity pre-save events very early to mitigate passwords not being hashed if another event stop propagation

### DIFF
--- a/src/EventListener/StorageEventListener.php
+++ b/src/EventListener/StorageEventListener.php
@@ -14,6 +14,7 @@ use Bolt\Storage\EventProcessor;
 use Bolt\Translation\Translator as Trans;
 use PasswordLib\Password\Factory as PasswordFactory;
 use PasswordLib\Password\Implementation as Password;
+use Silex\Application;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -63,11 +64,11 @@ class StorageEventListener implements EventSubscriberInterface
     }
 
     /**
-     * Pre-save storage event.
+     * Pre-save storage event for user entities.
      *
      * @param StorageEvent $event
      */
-    public function onPreSave(StorageEvent $event)
+    public function onUserEntityPreSave(StorageEvent $event)
     {
         /** @var Entity\Users $entityRecord */
         $entityRecord = $event->getContent();
@@ -189,7 +190,7 @@ class StorageEventListener implements EventSubscriberInterface
     {
         return [
             KernelEvents::REQUEST       => ['onKernelRequest', 31],
-            StorageEvents::PRE_SAVE     => 'onPreSave',
+            StorageEvents::PRE_SAVE     => ['onUserEntityPreSave', Application::EARLY_EVENT],
             StorageEvents::POST_HYDRATE => 'onPostHydrate',
         ];
     }

--- a/tests/phpunit/unit/EventListener/StorageEventListenerTest.php
+++ b/tests/phpunit/unit/EventListener/StorageEventListenerTest.php
@@ -66,7 +66,7 @@ class StorageEventListenerTest extends \PHPUnit_Framework_TestCase
         $this->user->getPassword()->willReturn('pass');
         $this->storageEvent->getContent()->willReturn($this->user->reveal());
 
-        $this->listener->onPreSave($this->storageEvent->reveal());
+        $this->listener->onUserEntityPreSave($this->storageEvent->reveal());
     }
 
     /**
@@ -79,7 +79,7 @@ class StorageEventListenerTest extends \PHPUnit_Framework_TestCase
         $this->passwordFactory->createHash('password', Argument::type('string'))->willReturn('hashedpassword');
         $this->user->setPassword('hashedpassword')->shouldBeCalled();
 
-        $this->listener->onPreSave($this->storageEvent->reveal());
+        $this->listener->onUserEntityPreSave($this->storageEvent->reveal());
     }
 
     /**
@@ -94,7 +94,7 @@ class StorageEventListenerTest extends \PHPUnit_Framework_TestCase
         $this->passwordFactory->createHash(Argument::cetera())->shouldNotBeCalled();
         $this->user->setPassword($hash)->shouldBeCalled();
 
-        $this->listener->onPreSave($this->storageEvent->reveal());
+        $this->listener->onUserEntityPreSave($this->storageEvent->reveal());
     }
 
     public function providePreSaveAlreadyHashed()


### PR DESCRIPTION
Handle user entity pre-save events very early to mitigate passwords not being hashed if another event stop propagation

Fixes #5947