### PR TITLE
If `name:` or `singular_name:` isn't set in 'contenttype.yml', generate something semi logical from the slug.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -562,8 +562,14 @@ class Config
         if (!isset($contentType['slug'])) {
             $contentType['slug'] = Slugify::create()->slugify($contentType['name']);
         }
+        if (!isset($contentType['name'])) {
+            $contentType['name'] = ucwords(preg_replace('/[^a-z0-9]/', ' ', $contentType['slug']));
+        }
         if (!isset($contentType['singular_slug'])) {
             $contentType['singular_slug'] = Slugify::create()->slugify($contentType['singular_name']);
+        }
+        if (!isset($contentType['singular_name'])) {
+            $contentType['singular_name'] = ucwords(preg_replace('/[^a-z0-9]/i', ' ', $contentType['singular_slug']));
         }
         if (!isset($contentType['show_on_dashboard'])) {
             $contentType['show_on_dashboard'] = true;

--- a/src/Config.php
+++ b/src/Config.php
@@ -563,7 +563,7 @@ class Config
             $contentType['slug'] = Slugify::create()->slugify($contentType['name']);
         }
         if (!isset($contentType['name'])) {
-            $contentType['name'] = ucwords(preg_replace('/[^a-z0-9]/', ' ', $contentType['slug']));
+            $contentType['name'] = ucwords(preg_replace('/[^a-z0-9]/i', ' ', $contentType['slug']));
         }
         if (!isset($contentType['singular_slug'])) {
             $contentType['singular_slug'] = Slugify::create()->slugify($contentType['singular_name']);


### PR DESCRIPTION
Fixes #5961 

Note: We don't have to check for the case where _both_ `name` and `slug` aren't set. That's already handled here: 

https://github.com/bolt/bolt/blob/hotfix/set-name-from-slug-if-not-defined/src/Config.php#L545-L554

