### PR TITLE
Fix Issues Caused By Slug/Key inconsistencies

### DIFF
--- a/src/Configuration/ConfigurationValueProxy.php
+++ b/src/Configuration/ConfigurationValueProxy.php
@@ -52,6 +52,18 @@ class ConfigurationValueProxy implements ArrayAccess, EventSubscriberInterface
         ];
     }
 
+
+    /**
+     * Get the data of the loaded config
+     * @return array
+     */
+    public function getData()
+    {
+        $this->initialize();
+
+        return $this->data;
+    }
+
     /**
      *{@inheritdoc}
      */

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -172,7 +172,7 @@ class MetadataDriver implements MappingDriver
             $this->unmapped[] = $tblName;
         }
 
-        $contentKey = $table->getOption('alias');
+        $contentKey = $this->getContenttypeFromAlias($table->getOption('alias'));
         $this->metadata[$className] = [];
         $this->metadata[$className]['identifier'] = $table->getPrimaryKey();
         $this->metadata[$className]['table'] = $table->getName();
@@ -586,5 +586,24 @@ class MetadataDriver implements MappingDriver
     public function getTaxonomyConfig()
     {
         return $this->taxonomies;
+    }
+
+    /**
+     * Given a tablename or slug get the correct Bolt keyname from the config
+     * @param $alias
+     * @return string $key
+     */
+    public function getContentTypeFromAlias($alias)
+    {
+
+        foreach ($this->contenttypes->getData() as $key => $contenttype) {
+            if (isset($contenttype['tablename']) && $contenttype['tablename'] == $alias) {
+                return $key;
+            }
+
+            if (isset($contenttype['slug']) && $contenttype['slug'] == $alias) {
+                return $key;
+            }
+        }
     }
 }

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -605,5 +605,7 @@ class MetadataDriver implements MappingDriver
                 return $key;
             }
         }
+
+        return $alias;
     }
 }

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -182,7 +182,7 @@ class MetadataDriver implements MappingDriver
                 'fieldname'        => $column->getName(),
                 'attribute'        => $this->camelize($column->getName()),
                 'type'             => $column->getType()->getName(),
-                'fieldtype'        => $this->getFieldTypeFor($table->getOption('alias'), $column),
+                'fieldtype'        => $this->getFieldTypeFor($contentKey, $column),
                 'length'           => $column->getLength(),
                 'nullable'         => $column->getNotnull(),
                 'platformOptions'  => $column->getPlatformOptions(),


### PR DESCRIPTION
This is a problem that was papered over by the fact we always used to write the slug back to the contenttype key. This behaviour was removed in #5939 and so this nasty little bug revealed itself.

We were using the table alias, rather than the original contenttype name to load in the contenttype structure to the entity, so in cases where they differ this was incorrect.

The main difference here is that we consult the original `contenttypes.yml` data to find the key for a given table alias, no longer assuming they are the same.

Fixes #5965