### PR TITLE
use the contenttype name, not the tablename

### DIFF
--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -104,7 +104,7 @@ class MetadataDriver implements MappingDriver
     {
         foreach ($this->schemaManager->getSchemaTables() as $table) {
             if ($tableName = $table->getName()) {
-                $this->aliases[$table->getOption('alias')] = $tableName;
+                $this->aliases[$this->getContentTypeFromAlias($table->getOption('alias'))] = $tableName;
             }
         }
     }


### PR DESCRIPTION
Use the contenttype name not the tablename to register an alias.

Fixes #5960