### PR TITLE
Check file_uploads ini directive for allowed uploads

### DIFF
--- a/src/Exception/FilesystemException.php
+++ b/src/Exception/FilesystemException.php
@@ -7,10 +7,9 @@ namespace Bolt\Exception;
  */
 class FilesystemException extends \Exception
 {
-    const FILE_NOT_READABLE            = 1;
-    const FILE_NOT_WRITEABLE           = 2;
-    const FILE_NOT_REMOVEABLE          = 4;
-    const FILE_UPLOADS_ARE_NOT_ALLOWED = 5;
+    const FILE_NOT_READABLE   = 1;
+    const FILE_NOT_WRITEABLE  = 2;
+    const FILE_NOT_REMOVEABLE = 4;
 
     protected $code = 0;
 

--- a/src/Exception/FilesystemException.php
+++ b/src/Exception/FilesystemException.php
@@ -7,9 +7,10 @@ namespace Bolt\Exception;
  */
 class FilesystemException extends \Exception
 {
-    const FILE_NOT_READABLE   = 1;
-    const FILE_NOT_WRITEABLE  = 2;
-    const FILE_NOT_REMOVEABLE = 4;
+    const FILE_NOT_READABLE            = 1;
+    const FILE_NOT_WRITEABLE           = 2;
+    const FILE_NOT_REMOVEABLE          = 4;
+    const FILE_UPLOADS_ARE_NOT_ALLOWED = 5;
 
     protected $code = 0;
 

--- a/src/Filesystem/FilePermissions.php
+++ b/src/Filesystem/FilePermissions.php
@@ -3,7 +3,7 @@
 namespace Bolt\Filesystem;
 
 use Bolt\Config;
-use Bolt\Exception\FilesystemException;
+use Bolt\Filesystem\Exception\IOException;
 use Bolt\Library as Lib;
 
 /**
@@ -93,7 +93,7 @@ class FilePermissions
     {
         // Check if file_uploads ini directive is true
         if (ini_get('file_uploads') != 1) {
-            throw new FilesystemException('File uploads are not allowed, check the file_uploads ini directive.', 5);
+            throw new IOException('File uploads are not allowed, check the file_uploads ini directive.');
         }
         // no UNIX-hidden files
         if ($originalFilename[0] === '.') {

--- a/src/Filesystem/FilePermissions.php
+++ b/src/Filesystem/FilePermissions.php
@@ -3,6 +3,7 @@
 namespace Bolt\Filesystem;
 
 use Bolt\Config;
+use Bolt\Exception\FilesystemException;
 use Bolt\Library as Lib;
 
 /**
@@ -86,9 +87,14 @@ class FilePermissions
      * @param string $originalFilename
      *
      * @return bool
+     * @throws \Bolt\Exception\FilesystemException
      */
     public function allowedUpload($originalFilename)
     {
+        // Check if file_uploads ini directive is true
+        if (ini_get('file_uploads') != 1) {
+            throw new FilesystemException('File uploads are not allowed, check the file_uploads ini directive.', 5);
+        }
         // no UNIX-hidden files
         if ($originalFilename[0] === '.') {
             return false;

--- a/tests/phpunit/unit/FilePermissions/FilePermissionsTest.php
+++ b/tests/phpunit/unit/FilePermissions/FilePermissionsTest.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace Bolt\Tests\FilePermissions;
 
+use Bolt\Exception\FilesystemException;
 use Bolt\Filesystem\FilePermissions;
 use Bolt\Tests\BoltUnitTest;
 
@@ -31,6 +33,17 @@ class FilePermissionsTest extends BoltUnitTest
         $this->assertFalse($fp->allowedUpload($badExtension));
 
         $okFile = 'mycoolimage.jpg';
+
+        if (ini_set('file_uploads', '0') !== false) {
+            try {
+                $fp->allowedUpload($okFile);
+            } catch (FilesystemException $e) {
+                $this->assertEquals($e->getCode(), 5);
+                $this->assertEquals($e->getMessage(), 'File uploads are not allowed, check the file_uploads ini directive.');
+            }
+            ini_set('file_uploads', '1');
+        }
+
         $this->assertTrue($fp->allowedUpload($okFile));
     }
 }

--- a/tests/phpunit/unit/FilePermissions/FilePermissionsTest.php
+++ b/tests/phpunit/unit/FilePermissions/FilePermissionsTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\FilePermissions;
 
-use Bolt\Exception\FilesystemException;
+use Bolt\Filesystem\Exception\IOException;
 use Bolt\Filesystem\FilePermissions;
 use Bolt\Tests\BoltUnitTest;
 
@@ -37,8 +37,7 @@ class FilePermissionsTest extends BoltUnitTest
         if (ini_set('file_uploads', '0') !== false) {
             try {
                 $fp->allowedUpload($okFile);
-            } catch (FilesystemException $e) {
-                $this->assertEquals($e->getCode(), 5);
+            } catch (IOException $e) {
                 $this->assertEquals($e->getMessage(), 'File uploads are not allowed, check the file_uploads ini directive.');
             }
             ini_set('file_uploads', '1');


### PR DESCRIPTION
Hoping that it fixes the issue #5963. 

There may be one possible issue with testing where the user is not allowed to change the `file_uploads` ini directive. 

That's why added the code block below to the tests.

``` php
if (ini_set('file_uploads', '0') !== false) {
    ...
}
```
