### PR TITLE
Order field values by grouping in postgres (#5968)

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -198,7 +198,7 @@ class RepeaterType extends FieldTypeBase
             case 'sqlite':
                 return 'GROUP_CONCAT(DISTINCT ' . $dummy . ".name||'_'||" . $dummy . ".grouping||'_'||" . $dummy . ".id) as $alias";
             case 'postgresql':
-                return 'string_agg(DISTINCT ' . $dummy . ".name||'_'||" . $dummy . ".grouping||'_'||" . $dummy . ".id, ',') as $alias";
+                return 'string_agg(' . $dummy . ".name||'_'||" . $dummy . ".grouping||'_'||" . $dummy . ".id, ',' ORDER BY " . $dummy . ".grouping) as $alias";
         }
     }
 


### PR DESCRIPTION
Fixes: #5968

- The ordering was mangled, because record ids are casted to string.
- This should only affect postgres, because it uses string_agg instead of GROUP_CONCAT
- DISTINCT was removed, but I don't see why it was there anyways