### PR TITLE
fix order of content repeater fields in frontend

### DIFF
--- a/src/Storage/Repository/FieldValueRepository.php
+++ b/src/Storage/Repository/FieldValueRepository.php
@@ -19,6 +19,7 @@ class FieldValueRepository extends Repository
             ->where('content_id = :id')
             ->andWhere('contenttype = :contenttype')
             ->andWhere('name = :name')
+            ->orderBy('grouping', 'ASC')
             ->setParameters([
                 'id'          => $id,
                 'contenttype' => $contenttype,


### PR DESCRIPTION
Related to PR #5976, but for frontend.

In this case repeater fields were ordered by some id, which is subject to change on repeater field update.
Ordering by grouping ensures everything is displayed properly.