### PR TITLE
Change order on exception page, and show page before dumps have loaded.

### DIFF
--- a/app/view/js/bolt_exception.js
+++ b/app/view/js/bolt_exception.js
@@ -17,4 +17,10 @@ $(document).ready(function() {
         $(this).removeClass('obfuscated').html(value);
         return false;
     });
+
+    $('.trace-arguments-placeholder').each(function(){
+        var id = $(this).attr('id');
+        trace = $('#'+id).detach();
+        $('#trace-'+id).html(trace);
+    });
 });

--- a/app/view/twig/exception/_trace.twig
+++ b/app/view/twig/exception/_trace.twig
@@ -25,8 +25,7 @@
 
             {% if t.args_safe is not empty %}
             <div id='trace-arguments-{{loop.index}}' style="display: none;">
-                Arguments:
-                {{ dump(t.args) }}
+                <em>(Arguments are loading)</em>
             </div>
             {% endif %}
         </td>

--- a/app/view/twig/exception/_tracedumps.twig
+++ b/app/view/twig/exception/_tracedumps.twig
@@ -1,0 +1,11 @@
+<div style="display: none;">
+{% for t in exception.trace %}
+
+    {% if t.args_safe is not empty %}
+    <div id='arguments-{{loop.index}}' class='trace-arguments-placeholder'>
+        Arguments:
+        {{ dump(t.args) }}
+    </div>
+    {% endif %}
+{% endfor %}
+</div>

--- a/app/view/twig/exception/exception.twig
+++ b/app/view/twig/exception/exception.twig
@@ -57,20 +57,20 @@
                                 <a class='btn btn-default' href='https://www.google.com/search?q={{ query|url_encode }}' target='_blank'>Google this Exception</a>
                             </p>
 
+                            {% block trace %}
+                                {% if debug %}
+                                    {{ include('@bolt/exception/_trace.twig') }}
+                                {% endif %}
+                            {% endblock trace %}
+
+                            <hr>
+
                             {% block request %}
                                 {% if debug and request is defined %}
                                     <hr>
                                     {{ include('@bolt/exception/_request.twig') }}
                                 {% endif %}
                             {% endblock request %}
-
-                            <hr>
-
-                            {% block trace %}
-                                {% if debug %}
-                                    {{ include('@bolt/exception/_trace.twig') }}
-                                {% endif %}
-                            {% endblock trace %}
 
                             {% if not debug %}
                                 <p>Debug is not available, and/or you are not logged on. To see a full backtrace of the
@@ -97,4 +97,8 @@
 </body>
 </html>
 
-
+{% block tracedumps %}
+    {% if debug %}
+        {{ include('@bolt/exception/_tracedumps.twig') }}
+    {% endif %}
+{% endblock tracedumps %}


### PR DESCRIPTION
I've moved the trace nearer to the top of the page (by request). The actual `dump()`s of the arguments are loaded _after_ the rest of the page, and injected into the trace after loading. The result is a page, that appears on screen much sooner. 