### PR TITLE
[BUG] Do not escape markdown content in backend

### DIFF
--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -48,6 +48,6 @@
 
 {% block fieldset_controls %}
     <div class="col-xs-12">
-        <textarea{{ macro.attr(attributes.text) }}>{{ context.content.get(contentkey)|default('') }}</textarea>
+        <textarea{{ macro.attr(attributes.text) }}>{{ context.content.get(contentkey)|default('')|raw }}</textarea>
     </div>
 {% endblock fieldset_controls %}


### PR DESCRIPTION
Details
---------

When using the markdown field to write code examples some characters would be escaped, for example:

```
test(x => y)
```
is being converted to

```
test(x =&gt; y)
```

Reproduce
--------------

1. Make a new post which contains a markdown field
2. Add a code snippet, like the example given above
3. Save the blog post
4. Press F5
5. The code is now escaped

This PR adds the `raw` filter to the markdown field so HTML tags are no longer being escaped by twig