### PR TITLE
Remove record taxonomy based routes from example

### DIFF
--- a/app/config/routing.yml.dist
+++ b/app/config/routing.yml.dist
@@ -102,34 +102,6 @@ contentlisting:
 #     recordslug: page/about
 
 
-
-# Example: Use the following to add a route for contenttypes in your URL scheme. In this example we
-# add routing for the 'chapter' taxonomy, so we can link to /meta/lorum-ipsum or /main/foo-bar.
-# note that the 'showcase' in the defaults and requirements determine the fallback, for when
-# no option is specified in a specifid record. Basically, this makes the route respond to the
-# default route /showcase/foo-bar as well.
-
-# chapterbinding:
-#     path: /{chapters}/{slug}
-#     defaults:
-#         _controller: controller.frontend:record
-#         contenttypeslug: showcases
-#         chapters: showcase
-#     requirements:
-#         chapters: [ controller.requirement:singleTaxonomy, [chapters, showcase] ]
-#     contenttype: showcases
-
-# categorybinding:
-#     path: /{categories}/{slug}
-#     defaults:
-#         _controller: controller.frontend:record
-#         contenttypeslug: showcases
-#         categories: none
-#     requirements:
-#         categories: [ controller.requirement:singleTaxonomy, [categories] ]
-#     contenttype: showcases
-
-
 # Supported internal defaults are:
 #  _controller   the controller class::method to be called
 #  _before       the before to call, if non-existent the 'before()' of the controller will be called


### PR DESCRIPTION
Removes the routing examples that do not work since a while back. fixes #5211 and see #5593 for context.