### PR TITLE
Prevent encoding of entities "On save" in text fields.

### DIFF
--- a/src/Storage/Field/Sanitiser/Sanitiser.php
+++ b/src/Storage/Field/Sanitiser/Sanitiser.php
@@ -41,6 +41,10 @@ class Sanitiser implements SanitiserInterface
             ? $this->getWyswigAllowedTags()
             : $this->getAllowedTags();
 
+        // If the input does not contain encoded HTML entities, we'll need to
+        // decode the output later, because the sanitiser will insert entities.
+        $needsDecodeEntities = ($value === html_entity_decode($value, ENT_NOQUOTES));
+
         $maid = new Maid(
             [
                 'output-format'   => 'html',
@@ -49,7 +53,13 @@ class Sanitiser implements SanitiserInterface
             ]
         );
 
-        return $maid->clean($value);
+        $output = $maid->clean($value);
+
+        if ($needsDecodeEntities) {
+            $output = html_entity_decode($output, ENT_NOQUOTES);
+        }
+
+        return $output;
     }
 
     /**

--- a/src/Storage/Field/Sanitiser/Sanitiser.php
+++ b/src/Storage/Field/Sanitiser/Sanitiser.php
@@ -41,12 +41,12 @@ class Sanitiser implements SanitiserInterface
             ? $this->getWyswigAllowedTags()
             : $this->getAllowedTags();
         
-        // Check if the input containts encoded HTML entities. If it does, we'll 
-        // need to decode the output later. This is because the sanitiser will 
-        // convert entities in the cleaned HTML, if they aren't present yet. 
-        // Ideally we'd fix this upstream by using \DomDocument::substituteEntities, 
-        // but that setting is disregarded in PHP's implementation at least. 
-        // This leaves us no choice but to implement this crude, albeit contained 
+        // Check if the input containts encoded HTML entities. If it does, we'll
+        // need to decode the output later. This is because the sanitiser will
+        // convert entities in the cleaned HTML, if they aren't present yet.
+        // Ideally we'd fix this upstream by using \DomDocument::substituteEntities,
+        // but that setting is disregarded in PHP's implementation at least.
+        // This leaves us no choice but to implement this crude, albeit contained
         // fix in this location.
         $needsDecodeEntities = ($value === html_entity_decode($value, ENT_NOQUOTES));
 

--- a/src/Storage/Field/Sanitiser/Sanitiser.php
+++ b/src/Storage/Field/Sanitiser/Sanitiser.php
@@ -40,9 +40,14 @@ class Sanitiser implements SanitiserInterface
         $allowedTags = $isWysiwyg
             ? $this->getWyswigAllowedTags()
             : $this->getAllowedTags();
-
-        // If the input does not contain encoded HTML entities, we'll need to
-        // decode the output later, because the sanitiser will insert entities.
+        
+        // Check if the input containts encoded HTML entities. If it does, we'll 
+        // need to decode the output later. This is because the sanitiser will 
+        // convert entities in the cleaned HTML, if they aren't present yet. 
+        // Ideally we'd fix this upstream by using \DomDocument::substituteEntities, 
+        // but that setting is disregarded in PHP's implementation at least. 
+        // This leaves us no choice but to implement this crude, albeit contained 
+        // fix in this location.
         $needsDecodeEntities = ($value === html_entity_decode($value, ENT_NOQUOTES));
 
         $maid = new Maid(


### PR DESCRIPTION
Fixes: #6005

Details
-------

Our sanitiser inserts HTML entities for non-correctly used ones when saving user input to the database. For example, `Foo & Bar` becomes `Foo &amp; Bar`.

With this fix: 

`Foo & Bar` stays `Foo & Bar`.
`<b>Foo &amp; Bar</b>` stays `<b>Foo &amp; Bar</b>`.
`<b>Foo &amp; Bar & Baz</b>` becomes `<b>Foo &amp; Bar &amp; Baz</b>`.

This fix checks if the input contains improperly encoded `<`, `&`, etc., and reverts the cleanup on these. This just applies to sanitising just before fields of type `text`, `html`, `textarea` and `markdown` get inserted into the DB only.

@CarsonF I've gone over this with @GawainLynch. If you have a better solution, i'm all ears. For now, this seems to fix it, and it's pretty much contained. 