### PR TITLE
[3.3] Replacing RandomLib

### DIFF
--- a/src/AccessControl/AccessChecker.php
+++ b/src/AccessControl/AccessChecker.php
@@ -1,17 +1,18 @@
 <?php
+
 namespace Bolt\AccessControl;
 
 use Bolt\Events\AccessControlEvent;
 use Bolt\Events\AccessControlEvents;
 use Bolt\Exception\AccessControlException;
 use Bolt\Logger\FlashLoggerInterface;
+use Bolt\Security\Random\Generator;
 use Bolt\Storage\Entity;
 use Bolt\Storage\EntityManagerInterface;
 use Bolt\Storage\Repository;
 use Bolt\Translation\Translator as Trans;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Psr\Log\LoggerInterface;
-use RandomLib\Generator;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -36,7 +37,7 @@ class AccessChecker
     protected $systemLogger;
     /** @var \Bolt\AccessControl\Permissions */
     protected $permissions;
-    /** @var \RandomLib\Generator */
+    /** @var Generator */
     protected $randomGenerator;
     /** @var EventDispatcherInterface */
     protected $dispatcher;

--- a/src/AccessControl/Login.php
+++ b/src/AccessControl/Login.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\AccessControl;
 
 use Bolt\AccessControl\Token\Token;

--- a/src/AccessControl/Login.php
+++ b/src/AccessControl/Login.php
@@ -10,6 +10,7 @@ use Bolt\Storage\Entity;
 use Bolt\Translation\Translator as Trans;
 use Carbon\Carbon;
 use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use PasswordLib\Password\Factory;
 use PasswordLib\Password\Implementation\Blowfish;
 use Silex\Application;
 
@@ -20,8 +21,10 @@ use Silex\Application;
  */
 class Login extends AccessChecker
 {
-    /** @var \Silex\Application $app */
-    protected $app;
+    /** @var Factory */
+    protected $passwordFactory;
+    /** @var string */
+    protected $authTokenName;
 
     /**
      * Constructor.
@@ -30,11 +33,6 @@ class Login extends AccessChecker
      */
     public function __construct(Application $app)
     {
-        /** @var \Bolt\Storage\Repository\AuthtokenRepository $repoAuth */
-        $repoAuth = $app['storage']->getRepository('Bolt\Storage\Entity\Authtoken');
-        /** @var \Bolt\Storage\Repository\UsersRepository $repoUsers */
-        $repoUsers = $app['storage']->getRepository('Bolt\Storage\Entity\Users');
-
         parent::__construct(
             $app['storage.lazy'],
             $app['request_stack'],
@@ -46,8 +44,8 @@ class Login extends AccessChecker
             $app['randomgenerator'],
             $app['access_control.cookie.options']
         );
-
-        $this->app = $app;
+        $this->passwordFactory = $app['password_factory'];
+        $this->authTokenName = $app['token.authentication.name'];
     }
 
     /**
@@ -64,7 +62,7 @@ class Login extends AccessChecker
      */
     public function login($userName, $password, AccessControlEvent $event)
     {
-        $authCookie = $this->requestStack->getCurrentRequest()->cookies->get($this->app['token.authentication.name']);
+        $authCookie = $this->requestStack->getCurrentRequest()->cookies->get($this->authTokenName);
 
         // Remove expired tokens
         $this->getRepositoryAuthtoken()->deleteExpiredTokens();
@@ -91,7 +89,7 @@ class Login extends AccessChecker
     protected function loginCheckPassword($userName, $password, AccessControlEvent $event)
     {
         if (!$userEntity = $this->getUserEntity($userName)) {
-            $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_INVALID));
+            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_INVALID));
 
             return false;
         }
@@ -100,7 +98,7 @@ class Login extends AccessChecker
         if ($userAuth->getPassword() === null || $userAuth->getPassword() === '') {
             $this->systemLogger->alert("Attempt to login to an account with empty password field: '$userName'", ['event' => 'security']);
             $this->flashLogger->error(Trans::__('general.phrase.login-account-disabled'));
-            $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_DISABLED));
+            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_DISABLED));
 
             return $this->loginFailed($userEntity);
         }
@@ -108,21 +106,21 @@ class Login extends AccessChecker
         if ((bool) $userEntity->getEnabled() === false) {
             $this->systemLogger->alert("Attempt to login to a disabled account: '$userName'", ['event' => 'security']);
             $this->flashLogger->error(Trans::__('general.phrase.login-account-disabled'));
-            $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_DISABLED));
+            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_DISABLED));
 
             return $this->loginFailed($userEntity);
         }
 
-        $isValid = $this->app['password_factory']->verifyHash($password, $userAuth->getPassword());
+        $isValid = $this->passwordFactory->verifyHash($password, $userAuth->getPassword());
         if (!$isValid) {
-            $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_PASSWORD));
+            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_PASSWORD));
 
             return $this->loginFailed($userEntity);
         }
 
         // Rehash password if not using Blowfish algorithm
         if (!Blowfish::detect($userAuth->getPassword())) {
-            $userEntity->setPassword($this->app['password_factory']->createHash($password, '$2y$'));
+            $userEntity->setPassword($this->passwordFactory->createHash($password, '$2y$'));
             try {
                 $this->getRepositoryUsers()->update($userEntity);
             } catch (NotNullConstraintViolationException $e) {
@@ -130,7 +128,7 @@ class Login extends AccessChecker
             }
         }
 
-        $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_SUCCESS, $event->setDispatched());
+        $this->dispatcher->dispatch(AccessControlEvents::LOGIN_SUCCESS, $event->setDispatched());
 
         return $this->loginFinish($userEntity);
     }
@@ -147,7 +145,7 @@ class Login extends AccessChecker
     {
         if (!$userTokenEntity = $this->getRepositoryAuthtoken()->getToken($authCookie, $this->getClientIp(), $this->getClientUserAgent())) {
             $this->flashLogger->error(Trans::__('general.phrase.error-login-invalid-parameters'));
-            $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_INVALID));
+            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_INVALID));
 
             return false;
         }
@@ -155,7 +153,7 @@ class Login extends AccessChecker
         $checksalt = $this->getAuthToken($userTokenEntity->getUsername(), $userTokenEntity->getSalt());
         if ($checksalt === $userTokenEntity->getToken()) {
             if (!$userEntity = $this->getUserEntity($userTokenEntity->getUsername())) {
-                $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_INVALID));
+                $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_INVALID));
 
                 return false;
             }
@@ -165,12 +163,12 @@ class Login extends AccessChecker
             $userTokenEntity->setLastseen(Carbon::now());
             $this->getRepositoryAuthtoken()->save($userTokenEntity);
             $this->flashLogger->success(Trans::__('general.phrase.session-resumed-colon'));
-            $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_SUCCESS, $event->setDispatched());
+            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_SUCCESS, $event->setDispatched());
 
             return $this->loginFinish($userEntity);
         }
 
-        $this->app['dispatcher']->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_INVALID));
+        $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_INVALID));
         $this->systemLogger->alert(sprintf('Attempt to login with an invalid token from %s', $this->getClientIp()), ['event' => 'security']);
 
         return false;

--- a/src/AccessControl/Token/Generator.php
+++ b/src/AccessControl/Token/Generator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\AccessControl\Token;
 
 /**

--- a/src/AccessControl/Token/Generator.php
+++ b/src/AccessControl/Token/Generator.php
@@ -12,7 +12,18 @@ class Generator
     /** @var string */
     protected $token;
 
-    public function __construct($username, $salt, $remoteIP, $hostName, $userAgent, array $cookieOptions)
+    /**
+     * Constructor.
+     *
+     * @param string $username
+     * @param string $salt
+     * @param string $remoteIP
+     * @param string $hostName
+     * @param string $userAgent
+     * @param array  $cookieOptions
+     * @param string $algorithm
+     */
+    public function __construct($username, $salt, $remoteIP, $hostName, $userAgent, array $cookieOptions, $algorithm = 'sha256')
     {
         if ($remoteIP === null) {
             throw new \InvalidArgumentException('Token generator requires an IP address to be provided');
@@ -28,7 +39,7 @@ class Generator
         $hostName = $cookieOptions['browseragent'] ? $userAgent : '';
         $userAgent = $cookieOptions['httphost'] ? $hostName : '';
 
-        $this->token = md5($username . $salt . $remoteIP . $hostName . $userAgent);
+        $this->token = hash($algorithm, $username . $salt . $remoteIP . $hostName . $userAgent);
     }
 
     public function __toString()

--- a/src/AccessControl/Token/Token.php
+++ b/src/AccessControl/Token/Token.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\AccessControl\Token;
 
 use Bolt\Storage\Entity;

--- a/src/Provider/RandomGeneratorServiceProvider.php
+++ b/src/Provider/RandomGeneratorServiceProvider.php
@@ -2,8 +2,7 @@
 
 namespace Bolt\Provider;
 
-use RandomLib;
-use SecurityLib\Strength;
+use Bolt\Security\Random\Generator;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -13,9 +12,7 @@ class RandomGeneratorServiceProvider implements ServiceProviderInterface
     {
         $app['randomgenerator'] = $app->share(
             function () {
-                $factory = new RandomLib\Factory();
-
-                return $factory->getGenerator(new Strength(Strength::MEDIUM));
+                return new Generator();
             }
         );
     }

--- a/src/Security/Random/Generator.php
+++ b/src/Security/Random/Generator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Bolt\Security\Random;
+
+/**
+ * Random generator.
+ *
+ * NOTE: PHP 5 polyfill for random_bytes() and random_int() provided by
+ * paragonie/random_compat Composer library.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class Generator
+{
+    /**
+     * Generate a random byte string.
+     *
+     * @param int $length
+     *
+     * @return mixed
+     */
+    public function generate($length)
+    {
+
+        return random_bytes($length);
+    }
+
+    /**
+     * Generate a random integer.
+     *
+     * @param int $min Lower bound of the range to generate
+     * @param int $max Upper bound of the range to generate
+     *
+     * @return int
+     */
+    public function generateInt($min = 0, $max = PHP_INT_MAX)
+    {
+        return random_int($min, $max);
+    }
+
+    /**
+     * Generate a random string.
+     *
+     * @param int $length
+     *
+     * @return string
+     */
+    public function generateString($length)
+    {
+        return substr(bin2hex(random_bytes($length)), 1, $length);
+    }
+}

--- a/src/Session/Generator/RandomGenerator.php
+++ b/src/Session/Generator/RandomGenerator.php
@@ -2,10 +2,10 @@
 
 namespace Bolt\Session\Generator;
 
-use RandomLib\Generator;
+use Bolt\Security\Random\Generator;
 
 /**
- * Generates session IDs with RandomLib
+ * Generates session IDs.
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
@@ -15,21 +15,17 @@ class RandomGenerator implements GeneratorInterface
     protected $generator;
     /** @var integer */
     protected $length;
-    /** @var integer */
-    protected $characters;
 
     /**
      * Constructor.
      *
      * @param Generator $generator
      * @param integer   $length
-     * @param integer   $characters
      */
-    public function __construct(Generator $generator, $length = 32, $characters = Generator::CHAR_ALNUM)
+    public function __construct(Generator $generator, $length = 32)
     {
         $this->generator = $generator;
         $this->length = $length;
-        $this->characters = $characters;
     }
 
     /**
@@ -37,6 +33,6 @@ class RandomGenerator implements GeneratorInterface
      */
     public function generateId()
     {
-        return $this->generator->generateString($this->length, $this->characters);
+        return $this->generator->generateString($this->length);
     }
 }

--- a/tests/phpunit/unit/AccessControl/TokenGeneratorTest.php
+++ b/tests/phpunit/unit/AccessControl/TokenGeneratorTest.php
@@ -25,7 +25,7 @@ class TokenGeneratorTest extends BoltUnitTest
 
         $generator = new Generator($username, $salt, $remoteIP, $hostName, $userAgent, $cookieOptions);
 
-        $this->assertSame('a186bd81a42ade8d9db20d67f3e3dedb', (string) $generator);
+        $this->assertSame('9b5573929c64c32c04f194e803397b5b2331c0e37710f18880919c7821012b00', (string) $generator);
     }
 
     public function testGenerateNoRemoteAddress()
@@ -43,7 +43,7 @@ class TokenGeneratorTest extends BoltUnitTest
 
         $generator = new Generator($username, $salt, $remoteIP, $hostName, $userAgent, $cookieOptions);
 
-        $this->assertSame('fab8d7c5234c667135c6272593801cde', (string) $generator);
+        $this->assertSame('4821a933b29911764493b2c094481de4053386ed406e978ef57c9199eae4238f', (string) $generator);
     }
 
     public function testGenerateNoHttpHost()
@@ -61,7 +61,7 @@ class TokenGeneratorTest extends BoltUnitTest
 
         $generator = new Generator($username, $salt, $remoteIP, $hostName, $userAgent, $cookieOptions);
 
-        $this->assertSame('adf79fb05150a89782c040901b62e364', (string) $generator);
+        $this->assertSame('3e242930d5d3f507d7b6e2b3b342b2d3b7af0dbbdd5687524cec3a1301dab91d', (string) $generator);
     }
 
     public function testGenerateNoBrowserAgent()
@@ -79,7 +79,7 @@ class TokenGeneratorTest extends BoltUnitTest
 
         $generator = new Generator($username, $salt, $remoteIP, $hostName, $userAgent, $cookieOptions);
 
-        $this->assertSame('87089069215f0b7f2a066c3ad132a5c2', (string) $generator);
+        $this->assertSame('183b1f0a3f665b4f2f5c0da5583559b5852ddd6106e3dcb4ed7b6ba563dd2a4d', (string) $generator);
     }
 
     /**

--- a/tests/phpunit/unit/Session/RandomGeneratorTest.php
+++ b/tests/phpunit/unit/Session/RandomGeneratorTest.php
@@ -18,7 +18,6 @@ class RandomGeneratorTest extends BoltUnitTest
 
         $this->assertObjectHasAttribute('generator',  $fooFighters);
         $this->assertObjectHasAttribute('length',     $fooFighters);
-        $this->assertObjectHasAttribute('characters', $fooFighters);
     }
 
     public function testGenerateId()


### PR DESCRIPTION
In an effort to get PHP 7.1 a happening thing, and per RFC #5893 … removal of `RandomLib` use in core.

This PR maintains a service under `$app['randomgenerator']` for BC. 

There is a corner-case BC break with this PR, where someone is type hinting on the service itself, which would be pretty rare. 

### Imports

```
use RandomLib\Generator;
```
to:
```
use Bolt\Security\Random\Generator;
```

### Function signatures

In the case of a fully namespaced function hint:

```
function foo(\RandomLib\Generator $generator)
{
}
```
to
```
use Bolt\Security\Random\Generator;

// …

function foo(Generator $generator)
{
}
```

Would generally suffice.