### PR TITLE
readded missing alias config and default sizes

### DIFF
--- a/src/Provider/ThumbnailsServiceProvider.php
+++ b/src/Provider/ThumbnailsServiceProvider.php
@@ -66,11 +66,15 @@ class ThumbnailsServiceProvider implements ServiceProviderInterface
             return $finder->find($app['config']->get('general/thumbnails/error_image'));
         });
 
+        $app['thumbnails.default_imagesize'] = $app['config']->get('general/thumbnails/default_image');
+
         $app['thumbnails.cache_time'] = $app['config']->get('general/thumbnails/browser_cache_time');
 
         $app['thumbnails.limit_upscaling'] = !$app['config']->get('general/thumbnails/allow_upscale', false);
 
         $app['thumbnails.only_aliases'] = $app['config']->get('general/thumbnails/only_aliases', false);
+
+        $app['thumbnails.aliases'] = $app['config']->get('theme/thumbnails/aliases', []);
 
         ImageResource::setNormalizeJpegOrientation($app['config']->get('general/thumbnails/exif_orientation', true));
         ImageResource::setQuality($app['config']->get('general/thumbnails/quality', 80));


### PR DESCRIPTION
Readded two missing config values for the thumb-aliases change already integrated into 3.2.
These got "lost" somewhere down the git train, no clue why.