### PR TITLE
Re-add extension:setup command

### DIFF
--- a/src/Nut/ExtensionsSetup.php
+++ b/src/Nut/ExtensionsSetup.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut command to set up extension directories.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ExtensionsSetup extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('extensions:setup')
+            ->setDescription('Set up extension directories, and create/update composer.json.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->setupJson($output);
+        $this->setupAutoloader($output);
+    }
+
+    /**
+     * Create or update the extensions/composer.json file.
+     *
+     * @param OutputInterface $output
+     */
+    private function setupJson(OutputInterface $output)
+    {
+        $output->write("\n<info>Creating/updating composer.json… </info>");
+        $this->app['extend.manager.json']->update();
+        $output->write("<info>[DONE]</info>\n");
+    }
+
+    /**
+     * Set up the Composer autoloader.
+     *
+     * @param OutputInterface $output
+     *
+     * @throws \Bolt\Exception\PackageManagerException
+     */
+    private function setupAutoloader(OutputInterface $output)
+    {
+        $output->write("\n<info>Updating autoloaders… </info>");
+        $result = $this->app['extend.action']['autoload']->execute();
+        $this->outputResult($output, $result);
+    }
+
+    /**
+     * Output the relevant result.
+     *
+     * @param OutputInterface $output
+     * @param int             $result
+     */
+    private function outputResult(OutputInterface $output, $result)
+    {
+        if ($result === 0) {
+            $output->write("<info>[DONE]</info>\n");
+        } else {
+            $output->write("<error>[FAILED]</error>\n");
+        }
+
+        $output->writeln(sprintf('<comment>%s</comment>', $this->app['extend.action.io']->getOutput()), OutputInterface::OUTPUT_PLAIN);
+    }
+}

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -41,6 +41,7 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\Extensions($app),
                     new Nut\ExtensionsDumpAutoload($app),
                     new Nut\ExtensionsInstall($app),
+                    new Nut\ExtensionsSetup($app),
                     new Nut\ExtensionsUninstall($app),
                     new Nut\ExtensionsUpdate($app),
                     new Nut\Info($app),

--- a/tests/phpunit/unit/Nut/ExtensionsSetupTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsSetupTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Bolt\Tests\Nut;
+
+use Bolt\Nut\ExtensionsSetup;
+use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class to test Bolt\Nut\ExtensionsSetup class.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ExtensionsSetupTest extends BoltUnitTest
+{
+    public function testRun()
+    {
+        $app = $this->getApp();
+        $app['extend.action.options']->set('optimize-autoloader', true);
+
+        $command = new ExtensionsSetup($app);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+        $result = $tester->getDisplay();
+
+        $this->assertRegExp('/Creating\/updating composer.json… \[DONE\]/', $result);
+
+        $this->assertRegExp('/Updating autoloaders… \[DONE\]/', $result);
+        $this->assertRegExp('/Generating optimized autoload files/', $result);
+        $this->assertRegExp('/PackageEventListener::dump/', $result);
+    }
+
+    public function testRunWithLocal()
+    {
+        $app = $this->getApp();
+        $app['extend.action.options']->set('optimize-autoloader', true);
+        $app['filesystem']->createDir('extensions://local');
+
+        $command = new ExtensionsSetup($app);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+        $result = $tester->getDisplay();
+
+        $app['filesystem']->deleteDir('extensions://local');
+
+        $this->assertRegExp('/Creating\/updating composer.json… \[DONE\]/', $result);
+
+        $this->assertRegExp('/Updating autoloaders… \[DONE\]/', $result);
+        $this->assertRegExp('/Generating optimized autoload files/', $result);
+        $this->assertRegExp('/PackageEventListener::dump/', $result);
+    }
+}


### PR DESCRIPTION
This re-adds Nut's extension:setup command, minus the local extension ~~mess~~ functionality
