### PR TITLE
Upstream deprecations

### DIFF
--- a/src/Asset/Widget/Queue.php
+++ b/src/Asset/Widget/Queue.php
@@ -12,6 +12,8 @@ use Bolt\Render;
 use Doctrine\Common\Cache\CacheProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Twig_Environment as TwigEnvironment;
+use Twig_Markup as TwigMarkup;
 
 /**
  * Widget queue processor.
@@ -29,7 +31,7 @@ class Queue implements QueueInterface
     protected $injector;
     /** @var \Doctrine\Common\Cache\CacheProvider */
     protected $cache;
-    /** @var \Bolt\Render */
+    /** @var TwigEnvironment */
     protected $render;
 
     /** @var boolean */
@@ -38,15 +40,21 @@ class Queue implements QueueInterface
     /**
      * Constructor.
      *
-     * @param Injector      $injector
-     * @param CacheProvider $cache
-     * @param Render        $render
+     * NOTE: Constructor type hint for TwigEnvironment omitted for BC, add in v4
+     *
+     * @param Injector        $injector
+     * @param CacheProvider   $cache
+     * @param TwigEnvironment $render
      */
-    public function __construct(Injector $injector, CacheProvider $cache, Render $render)
+    public function __construct(Injector $injector, CacheProvider $cache, $render)
     {
         $this->injector = $injector;
         $this->cache = $cache;
         $this->render = $render;
+
+        if ($render instanceof Render) {
+            @trigger_error('Passing Bolt\Render to the widget queue constructor is deprecated since 3.3, use Twig_Environment instead.', E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -77,7 +85,7 @@ class Queue implements QueueInterface
      *
      * @param string $key
      *
-     * @return \Twig_Markup|string
+     * @return TwigMarkup|string
      */
     public function getRendered($key)
     {

--- a/src/Configuration/Check/EmailSetup.php
+++ b/src/Configuration/Check/EmailSetup.php
@@ -83,14 +83,14 @@ class EmailSetup extends BaseCheck implements ConfigurationCheckInterface
      */
     private function getEmailHtml()
     {
-        return $this->app['render']->render(
+        return $this->app['twig']->render(
             'email/pingtest.twig',
             [
                 'sitename' => $this->app['config']->get('general/sitename'),
                 'user'     => $this->options['user']['displayname'],
                 'ip'       => $this->options['ip'],
             ]
-        )->getContent();
+        );
     }
 
     /**

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -145,15 +145,17 @@ class General extends BackendBase
     {
         // Determine the Contenttypes that we're doing the prefill for
         $choices = [];
-        foreach ($this->getOption('contenttypes') as $key => $cttype) {
-            $namekey = 'contenttypes.' . $key . '.name.plural';
-            $name = Trans::__($namekey, [], 'contenttypes');
-            $choices[$key] = ($name == $namekey) ? $cttype['name'] : $name;
+        foreach ($this->getOption('contenttypes') as $key => $contentType) {
+            $nameKey = 'contenttypes.' . $key . '.name.plural';
+            $nameTrans = Trans::__($nameKey, [], 'contenttypes');
+            $name = ($nameTrans === $nameKey) ? $contentType['name'] : $nameTrans;
+            $choices[$name] = $key;
         }
 
         // Create the form
         $form = $this->createFormBuilder(FormType::class)
             ->add('contenttypes', ChoiceType::class, [
+                'choices_as_values' => true, // Can be removed when symfony/form:^3.0 is the minimum
                 'choices'  => $choices,
                 'multiple' => true,
                 'expanded' => true,

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -498,17 +498,17 @@ class Users extends BackendBase
      */
     private function getUserEditFields(FormBuilder $form, $id)
     {
-        $enabledoptions = [
-            1 => Trans::__('page.edit-users.activated.yes'),
-            0 => Trans::__('page.edit-users.activated.no'),
+        $enabledOptions = [
+            Trans::__('page.edit-users.activated.yes') => 1,
+            Trans::__('page.edit-users.activated.no')  => 0,
         ];
 
-        $roles = array_map(
+        $roles = array_flip(array_map(
             function ($role) {
                 return $role['label'];
             },
             $this->app['permissions']->getDefinedRoles()
-        );
+        ));
 
         // New users and the current users don't need to disable themselves
         $currentUser = $this->getUser();
@@ -517,9 +517,10 @@ class Users extends BackendBase
                 'enabled',
                 ChoiceType::class,
                 [
-                    'choices'     => $enabledoptions,
+                    'choices_as_values' => true, // Can be removed when symfony/form:^3.0 is the minimum
+                    'choices'     => $enabledOptions,
                     'expanded'    => false,
-                    'constraints' => new Assert\Choice(array_keys($enabledoptions)),
+                    'constraints' => new Assert\Choice(array_values($enabledOptions)),
                     'label'       => Trans::__('page.edit-users.label.user-enabled'),
                 ]
             );
@@ -530,6 +531,7 @@ class Users extends BackendBase
                 'roles',
                 ChoiceType::class,
                 [
+                    'choices_as_values' => true, // Can be removed when symfony/form:^3.0 is the minimum
                     'choices'  => $roles,
                     'expanded' => true,
                     'multiple' => true,

--- a/src/Debug/ShutdownHandler.php
+++ b/src/Debug/ShutdownHandler.php
@@ -27,9 +27,9 @@ class ShutdownHandler
             $errorLevels |= E_RECOVERABLE_ERROR | E_USER_ERROR | E_DEPRECATED | E_USER_DEPRECATED;
             Debug\DebugClassLoader::enable();
         }
-        Debug\ErrorHandler::register()->throwAt($errorLevels, true);
 
         if (PHP_SAPI !== 'cli') {
+            Debug\ErrorHandler::register()->throwAt($errorLevels, true);
             Debug\ExceptionHandler::register($debug);
         } else {
             $consoleHandler = function (\Exception $e) {

--- a/src/Nut/Extensions.php
+++ b/src/Nut/Extensions.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Nut;
 
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -43,10 +44,11 @@ class Extensions extends BaseCommand
             $rows[] = [$package->getPrettyName(), $package->getPrettyVersion(), $package->getType(), $package->getDescription()];
         }
 
-        $table = $this->getHelper('table');
+        $table = new Table($output);
         $table
             ->setHeaders(['Name', 'Version', 'Type',  'Description'])
-            ->setRows($rows);
-        $table->render($output);
+            ->setRows($rows)
+            ->render()
+        ;
     }
 }

--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -139,7 +139,7 @@ class AssetServiceProvider implements ServiceProviderInterface
                 $queue = new Asset\Widget\Queue(
                     $app['asset.injector'],
                     $app['cache'],
-                    $app['render']
+                    $app['twig']
                 );
 
                 return $queue;

--- a/src/Twig/SetcontentNode.php
+++ b/src/Twig/SetcontentNode.php
@@ -2,18 +2,39 @@
 
 namespace Bolt\Twig;
 
-class SetcontentNode extends \Twig_Node
+use Twig_Node as Node;
+use Twig_Node_Expression_Array as NodeExpressionArray;
+
+/**
+ * Twig setcontent node.
+ *
+ * @author Bob den Otter <bob@twokings.nl>
+ */
+class SetcontentNode extends Node
 {
-    public function __construct($name, $contenttype, \Twig_Node_Expression_Array $arguments, $wherearguments, $lineno, $tag = null)
+    /**
+     * Constructor.
+     *
+     * @param string              $name
+     * @param Node                $contentType
+     * @param NodeExpressionArray $arguments
+     * @param array               $whereArguments
+     * @param int                 $lineNo
+     * @param null                $tag
+     */
+    public function __construct($name, Node $contentType, NodeExpressionArray $arguments, array $whereArguments, $lineNo, $tag = null)
     {
         parent::__construct(
-            ['wherearguments' => $wherearguments],
-            ['name'           => $name, 'contenttype' => $contenttype, 'arguments' => $arguments],
-            $lineno,
+            $whereArguments,
+            ['name' => $name, 'contenttype' => $contentType, 'arguments' => $arguments],
+            $lineNo,
             $tag
         );
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function compile(\Twig_Compiler $compiler)
     {
         $arguments = $this->getAttribute('arguments');
@@ -25,12 +46,14 @@ class SetcontentNode extends \Twig_Node
             ->write('$template_storage->getContent(')
             ->subcompile($this->getAttribute('contenttype'))
             ->raw(', ')
-            ->subcompile($arguments);
+            ->subcompile($arguments)
+        ;
 
-        if (!is_null($this->getNode('wherearguments'))) {
+        if ($this->hasNode('wherearguments')) {
             $compiler
                 ->raw(', $pager, ')
-                ->subcompile($this->getNode('wherearguments'));
+                ->subcompile($this->getNode('wherearguments'))
+            ;
         }
 
         $compiler->raw(" );\n");

--- a/src/Twig/SetcontentTokenParser.php
+++ b/src/Twig/SetcontentTokenParser.php
@@ -2,21 +2,29 @@
 
 namespace Bolt\Twig;
 
+/**
+ * TWig setcontent token parser.
+ *
+ * @author Bob den Otter <bob@twokings.nl>
+ */
 class SetcontentTokenParser extends \Twig_TokenParser
 {
+    /**
+     * {@inheritdoc}
+     */
     public function parse(\Twig_Token $token)
     {
         $lineno = $token->getLine();
 
         $arguments = new \Twig_Node_Expression_Array([], $lineno);
-        $wherearguments = null;
+        $whereArguments = [];
 
         // name - the new variable with the results
         $name = $this->parser->getStream()->expect(\Twig_Token::NAME_TYPE)->getValue();
         $this->parser->getStream()->expect(\Twig_Token::OPERATOR_TYPE, '=');
 
-        // contenttype, or simple expression to content.
-        $contenttype = $this->parser->getExpressionParser()->parseExpression();
+        // ContentType, or simple expression to content.
+        $contentType = $this->parser->getExpressionParser()->parseExpression();
 
         $counter = 0;
 
@@ -24,7 +32,7 @@ class SetcontentTokenParser extends \Twig_TokenParser
             // where parameter
             if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'where')) {
                 $this->parser->getStream()->next();
-                $wherearguments = $this->parser->getExpressionParser()->parseExpression();
+                $whereArguments = ['wherearguments' => $this->parser->getExpressionParser()->parseExpression()];
             }
 
             // limit parameter
@@ -85,9 +93,12 @@ class SetcontentTokenParser extends \Twig_TokenParser
 
         $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        return new SetcontentNode($name, $contenttype, $arguments, $wherearguments, $lineno, $this->getTag());
+        return new SetcontentNode($name, $contentType, $arguments, $whereArguments, $lineno, $this->getTag());
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getTag()
     {
         return 'setcontent';

--- a/src/Twig/SwitchNode.php
+++ b/src/Twig/SwitchNode.php
@@ -2,27 +2,34 @@
 
 namespace Bolt\Twig;
 
+use Twig_Node as Node;
+
 /**
  * Represents a switch node.
  *
- * @package    twig
+ * @author Dsls
+ * @author maxgalbu
  *
- * @author     Dsls
- * @author     maxgalbu
- *
- * @see        https://gist.github.com/maxgalbu/9409182
+ * @see https://gist.github.com/maxgalbu/9409182
  */
-class SwitchNode extends \Twig_Node
+class SwitchNode extends Node
 {
-    public function __construct(\Twig_NodeInterface $value, \Twig_NodeInterface $cases, \Twig_NodeInterface $default = null, $lineno = 0, $tag = null)
+    /**
+     * Constructor.
+     *
+     * @param Node      $value
+     * @param Node      $cases
+     * @param Node|null $default
+     * @param int       $lineNo
+     * @param null      $tag
+     */
+    public function __construct(Node $value, Node $cases, Node $default = null, $lineNo = 0, $tag = null)
     {
-        parent::__construct(['value' => $value, 'cases' => $cases, 'default' => $default], [], $lineno, $tag);
+        parent::__construct(['value' => $value, 'cases' => $cases, 'default' => $default], [], $lineNo, $tag);
     }
 
     /**
-     * Compiles the node to PHP.
-     *
-     * @param Twig_Compiler A Twig_Compiler instance
+     * {@inheritdoc}
      */
     public function compile(\Twig_Compiler $compiler)
     {
@@ -31,7 +38,7 @@ class SwitchNode extends \Twig_Node
             ->write('switch (')
             ->subcompile($this->getNode('value'))
             ->raw(") {\n")
-            ->indent
+            ->indent()
         ;
         for ($i = 0; $i < count($this->getNode('cases')); $i += 2) {
             $compiler
@@ -40,7 +47,7 @@ class SwitchNode extends \Twig_Node
                 ->raw(":\n")
                 ->indent()
                 ->subcompile($this->getNode('cases')->getNode($i + 1))
-                ->addIndentation()
+                ->write('')
                 ->raw("break;\n")
             ;
         }
@@ -50,7 +57,7 @@ class SwitchNode extends \Twig_Node
                 ->write("default:\n")
                 ->indent()
                 ->subcompile($this->getNode('default'))
-                ->addIndentation()
+                ->write('')
                 ->raw("break;\n")
             ;
         }


### PR DESCRIPTION
* Switch choices key/values around and set choices_as_values to true
  * When upgrading to Symfony 3, we'll need to remove choices_as_values
* Don't catch **errors** (still catching exceptions) on CLI
* Update Nut extensions command
* Remove use of `Bolt\Render` where a `BoltResponse` is neither needed nor appropriate
* Only use `Twig_Node`s for `setcontent` where parameters
* Remove deprecation from `SwitchNode` and fix a bug