### PR TITLE
When saving field values for repeaters, do not trigger additional events.

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -241,7 +241,7 @@ class RepeaterType extends FieldTypeBase
                 function ($query, $result, $id) use ($repo, $fieldValue) {
                     if ($result === 1 && $id) {
                         $fieldValue->setContent_id($id);
-                        $repo->save($fieldValue);
+                        $repo->save($fieldValue, $silenceEvents = true);
                     }
                 }
             );


### PR DESCRIPTION
Credit to @Maelstromeous for finding this one.