### PR TITLE
Fix relation collection hydration

### DIFF
--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -248,7 +248,7 @@ class Content extends Entity
             $this->relation = new Collection\Relations();
         }
 
-        if ($contenttype !== null) {
+        if ($contentType !== null) {
             return $this->relation[$contentType];
         }
 

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -239,12 +239,17 @@ class Content extends Entity
     }
 
     /**
+     * @param string|null $contentType
      * @return Collection\Relations
      */
-    public function getRelation()
+    public function getRelation($contentType = null)
     {
         if (!$this->relation instanceof Collection\Relations) {
             $this->relation = new Collection\Relations();
+        }
+
+        if ($contenttype !== null) {
+            return $this->relation[$contentType];
         }
 
         return $this->relation;

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -109,7 +109,7 @@ class RelationType extends FieldTypeBase
             $entity->getRelation()->add($relEntity);
             $fieldRels->add($relEntity);
         }
-        $this->set($entity, $fieldRels);
+        $this->set($entity, $fieldRels[$field]);
     }
 
     /**


### PR DESCRIPTION
This fixes an inconsistency with how the relation collection is hydrated.

At the moment if you call `$entity->getRelation()['entries']` you get pointers to the actual entry entity whereas if you call `$entity->getRelation('entries')` which is the preferred method you get a collection of the actual `bolt_relation` entities which is not expected behaviour.

This PR standardises these cases and also does the same for the shorthand access of `$entity->getEntries()`