### PR TITLE
Fix queries on multiple content types

### DIFF
--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -25,6 +25,17 @@ class SelectQueryHandler
             $query->setQueryBuilder($repo->createQueryBuilder($contenttype));
             $query->setContentType($contenttype);
 
+            /** This block is added to deal with the possibility that a requested filter is not an allowable option on the
+             * database table. If the requested field filter is not a valid field on this table then we completely skip
+             * the query because no results will be expected if the field does not exist.
+             */
+            $metadata = $repo->getClassMetadata();
+            $allowedParams = array_keys($metadata->getFieldMappings());
+            $queryParams = array_keys($contentQuery->getParameters());
+            if(array_diff($queryParams, $allowedParams)) {
+                continue;
+            }
+
             $query->setParameters($contentQuery->getParameters());
             $contentQuery->runDirectives($query);
 

--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -32,7 +32,7 @@ class SelectQueryHandler
             $metadata = $repo->getClassMetadata();
             $allowedParams = array_keys($metadata->getFieldMappings());
             $queryParams = array_keys($contentQuery->getParameters());
-            if(array_diff($queryParams, $allowedParams)) {
+            if (array_diff($queryParams, $allowedParams)) {
                 continue;
             }
 

--- a/src/Storage/Query/SelectQuery.php
+++ b/src/Storage/Query/SelectQuery.php
@@ -214,6 +214,7 @@ class SelectQuery implements QueryInterface
      */
     protected function processFilters()
     {
+        $this->filters = [];
         foreach ($this->params as $key => $value) {
             $this->parser->setAlias($this->contenttype);
             $this->addFilter($this->parser->getFilter($key, $value));


### PR DESCRIPTION
Fixes #6050

This adds a fix for this kind of getContent query: `$app['query']->getContent(('pages','events','reports'), ['tags' => 'soapbox']);` to handle the fact that one or more of the contenttypes may not have a tags field, if that is the case, the contenttype returns zero results rather than carrying on and performing a query.