### PR TITLE
HTTP cache options

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -183,7 +183,7 @@ class Application extends Silex\Application
             ->register(new Silex\Provider\HttpCacheServiceProvider(),
                 [
                     'http_cache.cache_dir' => $this['resources']->getPath('cache/' . $this['environment'] . '/http'),
-                    'http_cache.options'   => $this['config']->get('general/performance/http_cache/options'),
+                    'http_cache.options'   => $this['config']->get('general/performance/http_cache/options', []),
                 ]
             );
     }


### PR DESCRIPTION
The parameters passed to http_cache.options must always be an array, cached config can cause an exception to be thrown