### PR TITLE
fix accessing slug property from Entity\Content class

### DIFF
--- a/src/Storage/Entity/ContentRouteTrait.php
+++ b/src/Storage/Entity/ContentRouteTrait.php
@@ -96,7 +96,8 @@ trait ContentRouteTrait
             return null;
         }
 
-        $slug = $this->values['slug'];
+        // slug is either stored in $this->values['slug'] or in $this->slug
+        $slug = $this->values['slug'] ?: $this->slug;
         if (empty($slug)) {
             $slug = $this->id;
         }


### PR DESCRIPTION
Fixes #6066 

When accessed from the Entity\Content class, this trait cannot access its slug property, resulting in an incorrect link. 