### PR TITLE
Output the log.message as raw as the logs contain HTML.

### DIFF
--- a/app/view/twig/components/panel-activity-system.twig
+++ b/app/view/twig/components/panel-activity-system.twig
@@ -27,7 +27,7 @@
                 {% elseif log.route == 'logout' %}
                     <em>{{ macro.userlink(log.ownerid|default('')) }}</em> {{ __('panel.latest-activity.logged-out') }}
                 {% else %}
-                    <em>{{ log.message }}</em>
+                    <em>{{ log.message|raw }}</em>
                 {% endif %}
                 <small>({{ buic_moment(log.date) }})</small>
             </li>


### PR DESCRIPTION
Fix for issue #6069 

There is HTML in the logs that gets displayed.