### PR TITLE
Add missing HttpFoundationExtension Twig extension

### DIFF
--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -8,6 +8,7 @@ use Bolt\Twig\TwigExtension;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Bridge\Twig\Extension\AssetExtension;
+use Symfony\Bridge\Twig\Extension\HttpFoundationExtension;
 
 class TwigServiceProvider implements ServiceProviderInterface
 {
@@ -75,6 +76,7 @@ class TwigServiceProvider implements ServiceProviderInterface
                 function (\Twig_Environment $twig, $app) {
                     $twig->addExtension(new TwigExtension($app, $app['twig.handlers'], false));
                     $twig->addExtension($app['twig.extension.asset']);
+                    $twig->addExtension($app['twig.extension.http_foundation']);
 
                     if (isset($app['dump'])) {
                         $twig->addExtension(new DumpExtension(
@@ -92,7 +94,13 @@ class TwigServiceProvider implements ServiceProviderInterface
 
         $app['twig.extension.asset'] = $app->share(
             function ($app) {
-                return new AssetExtension($app['asset.packages']);
+                return new AssetExtension($app['asset.packages'], $app['twig.extension.http_foundation']);
+            }
+        );
+
+        $app['twig.extension.http_foundation'] = $app->share(
+            function ($app) {
+                return new HttpFoundationExtension($app['request_stack'], $app['request_context']);
             }
         );
 


### PR DESCRIPTION
Fixes #6090

Add the missing Twig functions `{{ absolute_url() }}` and `{{ relative_path() }}` in the process.

Aiming at 3.2 as this is definitely a bug due to oversight on the `\Symfony\Bridge\Twig\Extension\AssetExtension` constructor.

c.f. http://symfony.com/blog/new-in-symfony-2-7-the-new-asset-component#template-function-changes