### PR TITLE
Fixes empty multiple & sortable select fields to have blank item, by preventing bogus items in array.

### DIFF
--- a/app/src/sass/modules/custom/_select2.scss
+++ b/app/src/sass/modules/custom/_select2.scss
@@ -48,11 +48,8 @@
  */
 .sortable-select2-container {
 
-    .select2-container-multi .select2-choices .select2-search-choice {
-        cursor: move;
-    }
-
     .select2-selection__choice {
+        cursor: move !important;
         border-color: #d0d0d0;
         padding: 0px;
         display: block;
@@ -60,9 +57,7 @@
         border-radius: 0px;
         border-color: #d0d0d0;
     }
-    .select2-selection__choice.ui-sortable-helper {
-        cursor:move;
-    }
+
     .select2-drop {
         border-radius: 0px;
     }

--- a/app/src/sass/modules/custom/_select2.scss
+++ b/app/src/sass/modules/custom/_select2.scss
@@ -26,6 +26,8 @@
         background-color: #f4f4f4;
         border: 1px solid #ddd;
         padding: 2px 5px;
+        display: block;
+        width: 100%;
     }
 
     // Push the input line of a multi select into a new line.
@@ -45,11 +47,6 @@
  * Styles for Sortable Select2 Fields
  */
 .sortable-select2-container {
-
-    .select2-container {
-        display: block;
-        width: 100%;
-    }
 
     .select2-container-multi .select2-choices .select2-search-choice {
         cursor: move;

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -35,14 +35,10 @@
 
 
 {% if field.sortable|default(false) %}
-    {% set oldclass = option.class %}
-    {% set option = option|merge({ class: oldclass~' select2-sortable wide'}) %}
-
-    {% set newvals = [] %}
+    {% set option = option|merge({ class: option.class ~ ' select2-sortable wide'}) %}
     {% for key, sel in selection %}
-        {% set newvals = newvals|merge({ (key):values[sel]})%}
+        {% set values = unique({ (key) : values[sel] }, values)%}
     {% endfor %}
-    {% set values = unique(newvals, values)%}
 {% endif %}
 
 {# If the current selection contains an existing id, we must use _only_ the id, and not accept a fallback. #}

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -4,6 +4,7 @@
     info:      field.info|default(''),
     label:     field.label,
     multiple:  (field.multiple is defined and field.multiple),
+    sortable:  (field.sortable is defined and field.sortable),
     required:  field.required|default(false),
     values:    field.values|default([]),
     default:   field.default|default(null),
@@ -31,14 +32,6 @@
 {% set selection = context.content.get(contentkey)|default(option.default) %}
 {% if selection is not iterable %}
     {% set selection = [ selection ] %}
-{% endif %}
-
-
-{% if field.sortable|default(false) %}
-    {% set option = option|merge({ class: option.class ~ ' select2-sortable wide'}) %}
-    {% for key, sel in selection %}
-        {% set values = unique({ (key) : values[sel] }, values)%}
-    {% endfor %}
 {% endif %}
 
 {# If the current selection contains an existing id, we must use _only_ the id, and not accept a fallback. #}
@@ -83,7 +76,7 @@
 {% block fieldset_label_for   key %}
 
 {% block fieldset_controls %}
-    {% if field.sortable|default(false) %}
+    {% if option.sortable %}
         <script>
             $(function() {
                 $(function(){
@@ -94,7 +87,7 @@
     {% endif %}
     {% from '@bolt/_buic/_select.twig' import buic_select %}
 
-    <div class="col-sm-9{{ (field.sortable|default(false)) ? ' sortable-select2-container' }}">
+    <div class="col-sm-9{{ option.sortable ? ' sortable-select2-container' }}">
         {{ buic_select(buic_opt_select) }}
     </div>
 {% endblock fieldset_controls %}


### PR DESCRIPTION
Fixes #6094 