### PR TITLE
Use consistent semantics for PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "nesbot/carbon": "^1.20",
         "paragonie/random_compat": "^1.4",
         "PasswordLib/PasswordLib": "^1.0@beta",
-        "php": ">=5.5.9",
+        "php": "^5.5.9 || ^7.0",
         "silex/silex": "^1.3",
         "silex/web-profiler": "^1.0",
         "siriusphp/upload": "^1.2",


### PR DESCRIPTION
This is the same as we use for the Composer installs … and would prevent PHP 8 until we know what that is, and that we can support it :-)