### PR TITLE
Fixes #6109 - Make content search case insensitive on every platform

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -708,7 +708,8 @@ class Storage
         foreach ($fields as $field => $fieldconfig) {
             if (in_array($fieldconfig['type'], $searchableTypes)) {
                 foreach ($query['words'] as $word) {
-                    $fieldsWhere[] = sprintf('%s.%s LIKE %s', $table, $field, $this->app['db']->quote('%' . $word . '%'));
+                    // Build the LIKE, lowering the searched field to cover case-sensitive database systems
+                    $fieldsWhere[] = sprintf('LOWER(%s.%s) LIKE LOWER(%s)', $table, $field, $this->app['db']->quote('%' . $word . '%'));
                 }
             }
         }


### PR DESCRIPTION
This PR fixes #6109 

I put the searched fields and the input in a _LOWER()_ sql function. That way, the search is now case insensitive on every platform.

Lowering the input string might be seen as double job because the string is already lowered in PHP. I see it more like a double security. I let you to remove one the php or sql part if you think it'd be better.

Note that I worked in the Legacy Storage class, not sure if the non-legacy search is yet in use and how to fix it too.