### PR TITLE
Fixed: Don't stretch tags to full width

### DIFF
--- a/app/src/sass/modules/custom/_select2.scss
+++ b/app/src/sass/modules/custom/_select2.scss
@@ -30,6 +30,12 @@
         width: 100%;
     }
 
+    // Except tags: Don't fill the entire width with tag selects.
+    .tags-select2 .select2-container--default .select2-selection--multiple .select2-selection__choice {
+        display: inline;
+        width: auto;
+    }
+
     // Push the input line of a multi select into a new line.
     .select2-container--open .select2-search--inline {
         clear: both;

--- a/app/view/twig/editcontent/fields/_tags.twig
+++ b/app/view/twig/editcontent/fields/_tags.twig
@@ -17,6 +17,7 @@
     'multiple':  true,
     'name':      'taxonomy[' ~ taxonomy.slug ~ '][]',
     'options':   options,
+    'class':     'tags-select2'
 } %}
 
 {#=== FIELDSET =======================================================================================================#}


### PR DESCRIPTION
Before: 

![screen shot 2016-11-30 at 16 29 34](https://cloud.githubusercontent.com/assets/1833361/20759096/36fc8054-b71c-11e6-88c7-65be09e21c6f.png)


After: 

![screen shot 2016-11-30 at 16 37 30](https://cloud.githubusercontent.com/assets/1833361/20759098/39ea1eb6-b71c-11e6-9f29-c14491f83c05.png)
