### PR TITLE
Nicer listing overview for System Log.

### DIFF
--- a/app/view/twig/activity/systemlog.twig
+++ b/app/view/twig/activity/systemlog.twig
@@ -71,11 +71,8 @@
                         <th>Type</th>
                         <th>Context</th>
                         <th>Route</th>
-                        <th>URI</th>
-                        <th>Details</th>
-                        <th>User</th>
-                        <th>IP</th>
-                        <th>Date</th>
+                        <th>URI / Details</th>
+                        <th>User / IP / Date</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -94,27 +91,20 @@
                             {{ entry.route }}
                         </td>
                         <td>
-                            {{ entry.requesturi }}
-                        </td>
-                        <td>
-                            {% spaceless %}
-                            <b>{{ entry.message|raw }}</b>
-                            {% if entry.source %}
-                            <span class="info-pop pull-right" style="background-color: inherit !important;"
-                                  data-content="{{ _self.trace_info_html(entry.source) }}"
-                                  data-html="true" >
-                                  <i class="fa fa-bug"></i>
-                            </span>
+
+                            {{ entry.message|raw }} <a onclick="$(this).hide(); $('#trace-source-{{ entry.id }}').removeClass('hide');" class="btn btn-default btn-xs"><i class="fa fa-bug"></i> Source</a> <br>
+
+                            <span id="trace-source-{{ entry.id }}" class="hide">
+                            {% if entry.requesturi %}
+                               <span class="dim"><strong>URI:</strong> <code>{{ entry.requesturi }}</code></span><br>
                             {% endif %}
-                            {% endspaceless %}
+                            {% if entry.source %}
+                               <span class="dim"><strong>Source:</strong> <code>{{ entry.source.file }} :: {{ entry.source.line }} </code></span>
+                            {% endif %}
+                            </span>
                         </td>
-                        <td>
-                            <em>{{ macro.userlink(entry.ownerid) }}</em>
-                        </td>
-                        <td>
-                            {{ entry.ip }}
-                        </td>
-                        <td>
+                        <td class="username">
+                            {{ macro.userlink(entry.ownerid) }} / {{ entry.ip }} <br>
                             {{ buic_moment(entry.date) }}
                         </td>
                     </tr>
@@ -128,11 +118,3 @@
     </div>
 
 {% endblock page_main %}
-
-{% macro trace_info_html(source) %}
-    {% if source %}
-        {% for key,value in source %}
-            {{ key }}: {{ value }}<br>
-        {% endfor %}
-    {% endif %}
-{% endmacro %}


### PR DESCRIPTION
Before: 

![screen shot 2016-11-30 at 16 50 15](https://cloud.githubusercontent.com/assets/1833361/20760868/75ba320a-b721-11e6-96d5-60b4976bceb9.png)

After: 

![screen shot 2016-11-30 at 17 18 56](https://cloud.githubusercontent.com/assets/1833361/20760899/8eaa0196-b721-11e6-91a2-5a6db7f65859.png)


Fixes: #6107 