### PR TITLE
Fix for #6115: Added a check on $valueSelect to see if it is a string. 

### DIFF
--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -70,8 +70,12 @@ class SelectQueryHandler
         $allowedParams = array_keys($metadata->getFieldMappings());
         $cleanParams = [];
         foreach ($queryParams as $fieldSelect => $valueSelect) {
-            $stack = preg_split('/ *(\|\|\|) */', $fieldSelect);
-            $valueStack = preg_split('/ *(\|\|\|) */', $valueSelect);
+            $stack = [];
+
+            if (is_string($valueSelect)) {
+                $stack = preg_split('/ *(\|\|\|) */', $fieldSelect);
+                $valueStack = preg_split('/ *(\|\|\|) */', $valueSelect);
+            }
 
             if (count($stack) > 1) {
                 $allowedKeys = [];


### PR DESCRIPTION
This PR should fix #6115.

We've added a check to `$valueSelect` to make sure it is a string. If not, we set the `$stack` empty. This is to prevent calling `preg_split()` on `$valueSelect` in the situations where it is an object. 