### PR TITLE
Fix json parse inconsistency

### DIFF
--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -224,6 +224,12 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
         if (!is_string($value)) {
             return false;
         }
+        
+        // This handles an inconsistency in the result from the JSON parser across 5.x and 7.x of PHP
+        if ($value === '') {
+            return false;
+        }
+        
         json_decode($value);
 
         return json_last_error() === JSON_ERROR_NONE;


### PR DESCRIPTION
Handles an inconsistency in the result from the JSON parser across 5.x and 7.x of PHP whereby empty strings give different results.