### PR TITLE
Fix adjustSidebarHeight so it's not adjusting when it shouldn't

### DIFF
--- a/app/src/js/modules/secmenu.js
+++ b/app/src/js/modules/secmenu.js
@@ -53,22 +53,25 @@
     var timeout = 0;
 
     /**
-     * Make sure the sidebar is as long as the document height.
+     * Make sure the sidebar is as long as the content height.
      *
      * @private
      * @function adjustSidebarHeight
      * @memberof Bolt.secmenu
      */
     function adjustSidebarHeight() {
-        $('#navpage-secondary').outerHeight(0);
+        var contentHeight = $('#navpage-content').outerHeight(),
+            sidebarObj = $('#navpage-secondary'),
+            sidebarHeight = sidebarObj.outerHeight(),
+            next = 5000;
 
-        var newHeight = $(document).height() - $('#navpage-secondary').position().top,
-            next = 3000;
-
-        if (newHeight !== $('#navpage-secondary').outerHeight()) {
-            $('#navpage-secondary').outerHeight(newHeight);
-            next = 300;
+        // If the sidebar height doesn't match the content's height, then adjust it.  And check back sooner so we can
+        // adjust again if necessary (the content might still be changing).
+        if (sidebarHeight !== contentHeight) {
+            sidebarObj.outerHeight(contentHeight);
+            next = 500;
         }
+
         window.setTimeout(adjustSidebarHeight, next);
     }
 


### PR DESCRIPTION
This is a fix for a problem that we saw with our nested content and very long templates here at Curriculum Associates.  It's probably not a pressing problem for users of more "average" sites, but still the performance improvement is there in case you need it.

The problem stems from the first line of the function.  It sets the sidebar height to zero (actually goes to 16), which means that the "old" height and the "new" height will never match.  So it's always adjusting the sidebar every 300ms.  Over the summer I saw a tab peg out at around 80-90% usage of the CPU for that tab.  More recently it's been better behaved, but under the old code I still got it to peg out at about 30% (and stay there) just yesterday.

Under the new code, the steady state usage is about 3%.  That's because it uses the content height rather then the document height as the measuring stick, so it's only adjusting when absolutely necessary.

If it works for our extreme templates, I'm sure it'll be fine for the rest of the world.  :-)
