### PR TITLE
Add limit to trace, show less data when not logged in.

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -266,6 +266,7 @@ debug_permission_audit_mode: false
 # debug_error_level: 8181           # equivalent to E_ALL &~ E_NOTICE &~ E_DEPRECATED &~ E_USER_DEPRECATED &~ E_WARNING
 debug_error_level: -1               # equivalent to E_ALL
 debug_error_use_symfony: false      # When set to true, Symfony Profiler will be used for exception display when possible
+debug_trace_argument_limit: 4       # Determine how many steps in the backtrace will show (dump) arguments.
 
 # error level when debug is disabled
 #production_error_level: 8181 # = E_ALL &~ E_NOTICE &~ E_WARNING &~ E_DEPRECATED &~ E_USER_DEPRECATED

--- a/app/view/twig/exception/_tracedumps.twig
+++ b/app/view/twig/exception/_tracedumps.twig
@@ -1,11 +1,12 @@
 <div style="display: none;">
 {% for t in exception.trace %}
-
-    {% if t.args_safe is not empty %}
     <div id='arguments-{{loop.index}}' class='trace-arguments-placeholder'>
+    {% if t.args_safe is not empty and loop.index0 < exception.trace_limit %}
         Arguments:
         {{ dump(t.args) }}
-    </div>
+    {% else %}
+        <em>(Arguments not available. Raise <tt>debug_trace_argument_limit</tt> to see them)</em>
     {% endif %}
+    </div>
 {% endfor %}
 </div>

--- a/app/view/twig/exception/exception.twig
+++ b/app/view/twig/exception/exception.twig
@@ -32,30 +32,36 @@
                             {# Note: Do not translate / localise this, because people _will_ google for this. #}
 
                             {% block title %}
-                                <h1>Uncaught Exception: {{ exception.class_name|default('unknown') }}</h1>
+                                <h1>Uncaught Exception
+                                    {%- if debug -%}
+                                        : {{ exception.class_name|default('unknown') }}
+                                    {% endif %}.
+                                </h1>
                             {% endblock title %}
 
                             {% block exception %}
                             {% endblock exception %}
 
-                            <p class='exception'>
-                                <tt><abbr title="{{ exception.class_fqn|default('unknown') }}">{{ exception.class_name|default('unknown') }}</abbr></tt> in <tt>{% if debug %}<abbr title="{{ exception.file_path|default('unknown') }}">{% endif %}
-                                {{- exception.file_name|default('unknown') }}{% if debug %}</abbr>{% endif %}</tt> line <tt>
-                                {{- exception.object.line|default('unknown') }}</tt>: <br>
-                                <em><strong>{{ exception.object.message|default('unknown')|nl2br }}</strong></em>
-                            </p>
+                            {% if debug %}
+                                <p class='exception'>
+                                    <tt><abbr title="{{ exception.class_fqn|default('unknown') }}">{{ exception.class_name|default('unknown') }}</abbr></tt> in <tt><abbr title="{{ exception.file_path|default('unknown') }}">
+                                    {{- exception.file_name|default('unknown') }}</abbr></tt> line <tt>
+                                    {{- exception.object.line|default('unknown') }}</tt>: <br>
+                                    <em><strong>{{ exception.object.message|default('unknown')|nl2br }}</strong></em>
+                                </p>
 
-                            {% if debug and exception.snippet -%}
-<pre class='line-numbers' data-start='{{ max(exception.object.line - 5, 1) }}' data-line='6'><code class='language-php'>
-{{- exception.snippet -}}
-</code></pre>
-                            {%- endif %}
+                                {% if exception.snippet -%}
+    <pre class='line-numbers' data-start='{{ max(exception.object.line - 5, 1) }}' data-line='6'><code class='language-php'>
+    {{- exception.snippet -}}
+    </code></pre>
+                                {%- endif %}
 
-                            <p class='exception'>
-                                {# Based on this classic tweet: https://twitter.com/divineomega/status/695744177557106688 #}
-                                {% set query = 'Bolt ' ~ exception.class_name|default('unknown') ~ ' in ' ~ exception.file_name|default('unknown') ~ ' line ' ~ exception.object.line|default('unknown') ~ ': ' ~ exception.object.message|default('unknown') %}
-                                <a class='btn btn-default' href='https://www.google.com/search?q={{ query|url_encode }}' target='_blank'>Google this Exception</a>
-                            </p>
+                                <p class='exception'>
+                                    {# Based on this classic tweet: https://twitter.com/divineomega/status/695744177557106688 #}
+                                    {% set query = 'Bolt ' ~ exception.class_name|default('unknown') ~ ' in ' ~ exception.file_name|default('unknown') ~ ' line ' ~ exception.object.line|default('unknown') ~ ': ' ~ exception.object.message|default('unknown') %}
+                                    <a class='btn btn-default' href='https://www.google.com/search?q={{ query|url_encode }}' target='_blank'>Google this Exception</a>
+                                </p>
+                            {% endif %}
 
                             {% block trace %}
                                 {% if debug %}

--- a/src/Config.php
+++ b/src/Config.php
@@ -1128,6 +1128,7 @@ class Config
             'debug_enable_whoops'         => false, /** @deprecated. Deprecated since 3.2, to be removed in 4.0 */
             'debug_error_use_symfony'     => false,
             'debug_permission_audit_mode' => false,
+            'debug_trace_argument_limit'  => 4,
             'strict_variables'            => null,
             'theme'                       => 'base-2016',
             'listing_template'            => 'listing.twig',

--- a/src/Controller/Exception.php
+++ b/src/Controller/Exception.php
@@ -201,6 +201,10 @@ class Exception extends Base implements ExceptionControllerInterface
         $loggedOnUser = (bool) $this->app['users']->getCurrentUser() ?: false;
         $showLoggedOff = (bool) $this->app['config']->get('general/debug_show_loggedoff', false);
 
+        // Note: We set this to a high value deliberately. If 'config' is not yet available, the
+        // user can't influence this, so it shouldn't be too low.
+        $traceLimit = (int) $this->app['config']->get('general/debug_trace_argument_limit', 40);
+
         // Grab a section of the file that threw the exception, so we can show it.
         $filePath = $exception ? $exception->getFile() : null;
         $lineNumber = $exception ? $exception->getLine() : null;
@@ -220,13 +224,14 @@ class Exception extends Base implements ExceptionControllerInterface
             'debug'     => ($this->app['debug'] && ($loggedOnUser || $showLoggedOff)),
             'request'   => $request,
             'exception' => [
-                'object'     => $exception,
-                'class_name' => $exception ? (new \ReflectionClass($exception))->getShortName() : null,
-                'class_fqn'  => $exception ? get_class($exception) : null,
-                'file_path'  => $filePath,
-                'file_name'  => basename($filePath),
-                'trace'      => $exception ? $this->getSafeTrace($exception) : null,
-                'snippet'    => $snippet,
+                'object'      => $exception,
+                'class_name'  => $exception ? (new \ReflectionClass($exception))->getShortName() : null,
+                'class_fqn'   => $exception ? get_class($exception) : null,
+                'file_path'   => $filePath,
+                'file_name'   => basename($filePath),
+                'trace'       => $exception ? $this->getSafeTrace($exception) : null,
+                'snippet'     => $snippet,
+                'trace_limit' => $traceLimit,
             ],
         ];
     }


### PR DESCRIPTION
This PR fixes two things: 

 - It makes the amont of 'dumped' trace data configurable. 
 - It makes the exception page show less sensitive data, when people aren't logged in. 

![screen shot 2016-12-04 at 15 11 01](https://cloud.githubusercontent.com/assets/1833361/20866766/f5f82e16-ba34-11e6-9bed-fbd064aa32ff.png)
