### PR TITLE
Twig Sandbox

### DIFF
--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -164,10 +164,10 @@ class General extends BackendBase
 
         if ($request->isMethod('POST') || $request->get('force') == 1) {
             $form->handleRequest($request);
-            $contenttypes = $form->get('contenttypes')->getData();
+            $contentTypes = (array) $form->get('contenttypes')->getData();
 
             try {
-                $content = $this->storage()->preFill($contenttypes);
+                $content = $this->storage()->preFill($contentTypes);
                 $this->flashes()->success($content);
             } catch (RequestException $e) {
                 $msg = "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.";

--- a/src/Debug/Caster/TransparentProxyTrait.php
+++ b/src/Debug/Caster/TransparentProxyTrait.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Bolt\Debug\Caster;
+
+use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\VarDumper\Cloner\AbstractCloner;
+use Symfony\Component\VarDumper\Cloner\Stub;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+
+/**
+ * Helper to make proxy classes transparent to VarDumper.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+trait TransparentProxyTrait
+{
+    /** @var bool */
+    protected $transparent;
+
+    /**
+     * @return string
+     */
+    abstract protected function getProxiedClass();
+
+    /**
+     * @return object|array
+     */
+    abstract protected function getProxiedObject();
+
+    /**
+     * Enable or disable transparency to dumper.
+     *
+     * @param bool $bool
+     */
+    public function setTransparent($bool = true)
+    {
+        $this->transparent = (bool) $bool;
+    }
+
+    /**
+     * Registers caster for this class.
+     *
+     * This allows VarDumper to make this proxy transparent when dumping.
+     *
+     * @param AbstractCloner $cloner
+     */
+    public static function registerCaster(AbstractCloner $cloner)
+    {
+        /**
+         * Don't want this to be publicly accessible ;)
+         *
+         * @param TransparentProxyTrait $obj
+         * @param array                 $a
+         * @param Stub                  $stub
+         * @param bool                  $isNested
+         * @param int                   $filter
+         *
+         * @return array
+         */
+        $caster = static function ($obj, array $a, Stub $stub, $isNested, $filter) {
+            if (!$obj->transparent) {
+                return $a;
+            }
+
+            // Fake the class name
+            $stub->class = $obj->getProxiedClass();
+
+            $object = $obj->getProxiedObject();
+            if (is_array($object)) {
+                // Fake to look like array
+                $a = $object;
+                $stub->type = Stub::TYPE_ARRAY;
+                $stub->class = Stub::ARRAY_ASSOC;
+                $stub->value = count($a);
+                $stub->handle = 0;
+            } else {
+                // Fake to look like inner object
+                $refCls = new \ReflectionClass($object);
+                $a = Caster::castObject($object, $refCls);
+
+                // Fake handle to inner object handle
+                (new VarCloner([
+                    $refCls->getName() => function ($obj, $a, Stub $innerStub) use ($stub) {
+                        $stub->handle = $innerStub->handle;
+                    },
+                ]))->cloneVar($object);
+            }
+
+            return $a;
+        };
+
+        $cloner->addCasters([
+            get_called_class() => $caster
+        ]);
+    }
+}

--- a/src/EventListener/ConfigListener.php
+++ b/src/EventListener/ConfigListener.php
@@ -6,6 +6,7 @@ use Bolt;
 use Bolt\Controller\Zone;
 use Bolt\Filesystem\Exception\IOException;
 use Bolt\Translation\Translator as Trans;
+use Bolt\Twig\ArrayAccessSecurityProxy;
 use Bolt\Version;
 use Silex\Application;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -67,8 +68,7 @@ class ConfigListener implements EventSubscriberInterface
         }
 
         // Twig globals
-        $this->setGlobals(false);
-        $this->setGlobals(true);
+        $this->setGlobals();
 
         // Only cache if the config passes checks
         if ($this->app['config']->checkConfig() === false) {
@@ -129,18 +129,13 @@ class ConfigListener implements EventSubscriberInterface
      * globals.
      *
      * This is here as a transitory measure.
-     *
-     * @param bool $safe
-     *
-     * @return array
      */
-    private function setGlobals($safe)
+    private function setGlobals()
     {
         /** @var \Twig_Environment $twig */
-        $twig = $safe ? $this->app['safe_twig'] : $this->app['twig'];
+        $twig = $this->app['twig'];
         /** @var \Bolt\Config $config */
         $config = $this->app['config'];
-        $configVal = $safe ? null : $config;
         /** @var \Bolt\Users $users */
         $users = $this->app['users'];
         /** @var \Bolt\Configuration\ResourceManager $resources */
@@ -155,8 +150,14 @@ class ConfigListener implements EventSubscriberInterface
         // User calls can cause exceptions that block the exception handler
         try {
             /** @deprecated Deprecated since 3.0, to be removed in 4.0. */
-            $usersVal = $safe ? null : $users->getUsers();
+            $usersVal = $users->getUsers();
             $usersCur = $users->getCurrentUser();
+
+            $sandbox = $this->app['twig.extension.sandbox'];
+            $usersVal = array_map(function ($user) use ($sandbox) {
+                return new ArrayAccessSecurityProxy($user, $sandbox, 'User');
+            }, $usersVal);
+            $usersCur = new ArrayAccessSecurityProxy($usersCur, $sandbox, 'User');
         } catch (\Exception $e) {
             $usersVal = null;
             $usersCur = null;
@@ -172,6 +173,6 @@ class ConfigListener implements EventSubscriberInterface
         $twig->addGlobal('theme', $config->get('theme'));
         $twig->addGlobal('user', $usersCur);
         $twig->addGlobal('users', $usersVal);
-        $twig->addGlobal('config', $configVal);
+        $twig->addGlobal('config', $config);
     }
 }

--- a/src/EventListener/ConfigListener.php
+++ b/src/EventListener/ConfigListener.php
@@ -138,8 +138,6 @@ class ConfigListener implements EventSubscriberInterface
         $config = $this->app['config'];
         /** @var \Bolt\Users $users */
         $users = $this->app['users'];
-        /** @var \Bolt\Configuration\ResourceManager $resources */
-        $resources = $this->app['resources'];
         $zone = null;
         /** @var RequestStack $requestStack */
         $requestStack = $this->app['request_stack'];
@@ -163,16 +161,11 @@ class ConfigListener implements EventSubscriberInterface
             $usersCur = null;
         }
 
-        $twig->addGlobal('bolt_name', Bolt\Version::name());
-        $twig->addGlobal('bolt_version', Bolt\Version::VERSION);
-        $twig->addGlobal('bolt_stable', Bolt\Version::isStable());
         $twig->addGlobal('frontend', $zone === Zone::FRONTEND);
         $twig->addGlobal('backend', $zone === Zone::BACKEND);
         $twig->addGlobal('async', $zone === Zone::ASYNC);
-        $twig->addGlobal('paths', $resources->getPaths());
         $twig->addGlobal('theme', $config->get('theme'));
         $twig->addGlobal('user', $usersCur);
         $twig->addGlobal('users', $usersVal);
-        $twig->addGlobal('config', $config);
     }
 }

--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -216,7 +216,9 @@ class Content implements \ArrayAccess
         $snippet = html_entity_decode($snippet, ENT_QUOTES, 'UTF-8');
 
         try {
-            return $this->app['safe_render']->render($snippet, $this->getTemplateContext());
+            $template = $this->app['twig']->createTemplate((string) $snippet);
+
+            return twig_include($this->app['twig'], $this->getTemplateContext(), $template, [], true, false, true);
         } catch (\Twig_Error $e) {
             $message = sprintf('Rendering a record Twig snippet failed: %s', $e->getRawMessage());
             $this->app['logger.system']->critical($message, ['event' => 'exception', 'exception' => $e]);

--- a/src/Provider/DumperServiceProvider.php
+++ b/src/Provider/DumperServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Bolt\Provider;
 
 use Bolt\Debug\Caster;
+use Bolt\Twig\ArrayAccessSecurityProxy;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
@@ -64,6 +65,8 @@ class DumperServiceProvider implements ServiceProviderInterface
             function () {
                 $cloner = new VarCloner();
                 $cloner->addCasters(Caster\FilesystemCasters::getCasters());
+
+                ArrayAccessSecurityProxy::registerCaster($cloner);
 
                 return $cloner;
             }

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -82,12 +82,7 @@ class TwigServiceProvider implements ServiceProviderInterface
                     $twig->addExtension($app['twig.extension.http_foundation']);
 
                     if (isset($app['dump'])) {
-                        $twig->addExtension(new DumpExtension(
-                            $app['dumper.cloner'],
-                            $app['dumper.html'],
-                            $app['users'],
-                            $app['config']->get('general/debug_show_loggedoff', false)
-                        ));
+                        $twig->addExtension($app['twig.extension.dump']);
                     }
 
                     return $twig;
@@ -104,6 +99,17 @@ class TwigServiceProvider implements ServiceProviderInterface
         $app['twig.extension.http_foundation'] = $app->share(
             function ($app) {
                 return new HttpFoundationExtension($app['request_stack'], $app['request_context']);
+            }
+        );
+
+        $app['twig.extension.dump'] = $app->share(
+            function ($app) {
+                return new DumpExtension(
+                    $app['dumper.cloner'],
+                    $app['dumper.html'],
+                    $app['users'],
+                    $app['config']->get('general/debug_show_loggedoff', false)
+                );
             }
         );
 

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Provider;
 
+use Bolt\Twig\ArrayAccessSecurityProxy;
 use Bolt\Twig\DumpExtension;
 use Bolt\Twig\FilesystemLoader;
 use Bolt\Twig\Handler;
@@ -88,7 +89,9 @@ class TwigServiceProvider implements ServiceProviderInterface
                         $twig->addExtension($app['twig.extension.dump']);
                     }
 
-                    $twig->addExtension($app['twig.extension.sandbox']);
+                    $sandbox = $app['twig.extension.sandbox'];
+                    $twig->addExtension($sandbox);
+                    $twig->addGlobal('app', new ArrayAccessSecurityProxy($app, $sandbox));
 
                     return $twig;
                 }

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -85,6 +85,7 @@ class TwigServiceProvider implements ServiceProviderInterface
                     $twig->addExtension(new TwigExtension($app, $app['twig.handlers'], false));
                     $twig->addExtension($app['twig.extension.asset']);
                     $twig->addExtension($app['twig.extension.http_foundation']);
+                    $twig->addExtension($app['twig.extension.string_loader']);
 
                     if (isset($app['dump'])) {
                         $twig->addExtension($app['twig.extension.dump']);
@@ -119,6 +120,12 @@ class TwigServiceProvider implements ServiceProviderInterface
                     $app['users'],
                     $app['config']->get('general/debug_show_loggedoff', false)
                 );
+            }
+        );
+
+        $app['twig.extension.string_loader'] = $app->share(
+            function () {
+                return new \Twig_Extension_StringLoader();
             }
         );
 

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -5,6 +5,7 @@ use Bolt\Twig\ArrayAccessSecurityProxy;
 use Bolt\Twig\DumpExtension;
 use Bolt\Twig\FilesystemLoader;
 use Bolt\Twig\Handler;
+use Bolt\Twig\SafeEnvironment;
 use Bolt\Twig\SecurityPolicy;
 use Bolt\Twig\TwigExtension;
 use Silex\Application;
@@ -138,17 +139,9 @@ class TwigServiceProvider implements ServiceProviderInterface
             return $options;
         };
 
-        $app['safe_twig.bolt_extension'] = function () use ($app) {
-            return new TwigExtension($app, $app['twig.handlers'], true);
-        };
-
         $app['safe_twig'] = $app->share(
             function ($app) {
-                $loader = new \Twig_Loader_String();
-                $twig = new \Twig_Environment($loader);
-                $twig->addExtension($app['safe_twig.bolt_extension']);
-
-                return $twig;
+                return new SafeEnvironment($app['twig'], $app['twig.extension.sandbox']);
             }
         );
     }

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -4,6 +4,7 @@ namespace Bolt\Provider;
 use Bolt\Twig\DumpExtension;
 use Bolt\Twig\FilesystemLoader;
 use Bolt\Twig\Handler;
+use Bolt\Twig\SecurityPolicy;
 use Bolt\Twig\TwigExtension;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -72,6 +73,8 @@ class TwigServiceProvider implements ServiceProviderInterface
             }
         );
 
+        $this->registerSandbox($app);
+
         // Add the Bolt Twig Extension.
         $app['twig'] = $app->share(
             $app->extend(
@@ -84,6 +87,8 @@ class TwigServiceProvider implements ServiceProviderInterface
                     if (isset($app['dump'])) {
                         $twig->addExtension($app['twig.extension.dump']);
                     }
+
+                    $twig->addExtension($app['twig.extension.sandbox']);
 
                     return $twig;
                 }
@@ -150,5 +155,194 @@ class TwigServiceProvider implements ServiceProviderInterface
      */
     public function boot(Application $app)
     {
+    }
+
+    protected function registerSandbox(Application $app)
+    {
+        $app['twig.extension.sandbox'] = $app->share(
+            function ($app) {
+                return new \Twig_Extension_Sandbox($app['twig.sandbox.policy']);
+            }
+        );
+
+        $app['twig.sandbox.policy'] = $app->share(
+            function ($app) {
+                return new SecurityPolicy(
+                    $app['twig.sandbox.policy.tags'],
+                    $app['twig.sandbox.policy.filters'],
+                    $app['twig.sandbox.policy.methods'],
+                    $app['twig.sandbox.policy.properties'],
+                    $app['twig.sandbox.policy.functions']
+                );
+            }
+        );
+
+        $app['twig.sandbox.policy.tags'] = $app->share(
+            function () {
+                return [
+                    // Core
+                    'for',
+                    'if',
+                    'block',
+                    'filter',
+                    'macro',
+                    'set',
+                    'spaceless',
+                    'do',
+
+                    // Translation Extension
+                    'trans',
+                    'transchoice',
+                    'trans_default_domain',
+                ];
+            }
+        );
+
+        $app['twig.sandbox.policy.functions'] = $app->share(
+            function () {
+                return [
+                    // Core
+                    'max',
+                    'min',
+                    'range',
+                    'constant',
+                    'cycle',
+                    'random',
+                    'date',
+
+                    // Asset Extension
+                    'asset',
+                    'asset_version',
+
+                    // Bolt Extension
+                    '__',
+                    'backtrace',
+                    'buid',
+                    'canonical',
+                    'countwidgets',
+                    'current',
+                    'data',
+                    'dump',
+                    'excerpt',
+                    'fancybox',
+                    'fields',
+                    //'file_exists',
+                    'firebug',
+                    'first',
+                    'getuser',
+                    'getuserid',
+                    'getwidgets',
+                    'haswidgets',
+                    'hattr',
+                    'hclass',
+                    'htmllang',
+                    'image',
+                    //'imageinfo',
+                    'isallowed',
+                    'ischangelogenabled',
+                    'ismobileclient',
+                    'last',
+                    'link',
+                    //'listtemplates',
+                    'markdown',
+                    //'menu',
+                    'pager',
+                    'popup',
+                    'print',
+                    'randomquote',
+                    //'redirect',
+                    //'request',
+                    'showimage',
+                    'stack',
+                    'thumbnail',
+                    'token',
+                    'trimtext',
+                    'unique',
+                    'widgets',
+
+                    // Routing Extension
+                    'url',
+                    'path',
+                ];
+            }
+        );
+
+        $app['twig.sandbox.policy.filters'] = $app->share(
+            function () {
+                return [
+                    // Core
+                    'date',
+                    'date_modify',
+                    'format',
+                    'replace',
+                    'number_format',
+                    'abs',
+                    'round',
+                    'url_encode',
+                    'json_encode',
+                    'convert_encoding',
+                    'title',
+                    'capitalize',
+                    'upper',
+                    'lower',
+                    'striptags',
+                    'trim',
+                    'nl2br',
+                    'join',
+                    'split',
+                    'sort',
+                    'merge',
+                    'batch',
+                    'reverse',
+                    'length',
+                    'slice',
+                    'first',
+                    'last',
+                    'default',
+                    'keys',
+                    'escape',
+                    'e',
+
+                    // Bolt Extension
+                    '__',
+                    'current',
+                    //'editable',
+                    'excerpt',
+                    'fancybox',
+                    'image',
+                    //'imageinfo',
+                    'json_decode',
+                    'localdate',
+                    'localedatetime',
+                    'loglevel',
+                    'markdown',
+                    'order',
+                    'popup',
+                    'preg_replace',
+                    'safestring',
+                    'selectfield',
+                    'showimage',
+                    'shuffle',
+                    'shy',
+                    'slug',
+                    'thumbnail',
+                    'trimtext',
+                    'tt',
+                    'twig',
+                    'ucfirst',
+                    //'ymllink',
+
+                    // Form Extension
+                    'humanize',
+
+                    // Translation Extension
+                    'trans',
+                    'transchoice',
+                ];
+            }
+        );
+
+        $app['twig.sandbox.policy.methods'] = [];
+        $app['twig.sandbox.policy.properties'] = [];
     }
 }

--- a/src/Twig/ArrayAccessSecurityProxy.php
+++ b/src/Twig/ArrayAccessSecurityProxy.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Bolt\Twig;
+
+use ArrayAccess;
+use ArrayIterator;
+use BadMethodCallException;
+use Bolt\Debug\Caster\TransparentProxyTrait;
+use Countable;
+use InvalidArgumentException;
+use IteratorAggregate;
+use IteratorIterator;
+use Traversable;
+use Twig_Extension_Sandbox as Sandbox;
+
+/**
+ * This is a proxy for arrays and ArrayAccess objects that verifies access with a Twig Sandbox.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class ArrayAccessSecurityProxy implements ArrayAccess, Countable, IteratorAggregate, SecurityProxyInterface
+{
+    use TransparentProxyTrait;
+
+    /** @var array|ArrayAccess */
+    protected $object;
+    /** @var Sandbox */
+    protected $sandbox;
+    /** @var string */
+    protected $class;
+
+    /**
+     * Constructor.
+     *
+     * @param array|ArrayAccess $array       The object or array to proxy to
+     * @param Sandbox           $sandbox     The Sandbox to verify with
+     * @param string            $fakeClass   A class name to use for checking with Sandbox and dumper (if object)
+     * @param bool              $transparent Whether this proxy should be transparent to the VarDumper
+     */
+    public function __construct($array, Sandbox $sandbox, $fakeClass = null, $transparent = true)
+    {
+        if (!is_array($array) && !$array instanceof ArrayAccess) {
+            throw new InvalidArgumentException('Must be given an array, or an object implementing ArrayAccess');
+        }
+
+        $this->object = $array;
+        $this->sandbox = $sandbox;
+        $this->class = $fakeClass ?: (is_object($array) ? get_class($array) : 'Array');
+        $this->transparent = $transparent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProxiedClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->object[$offset]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        $this->sandbox->checkPropertyAllowed($this, $offset);
+
+        return $this->object[$offset];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->object[$offset] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->object[$offset]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        if (!is_array($this->object) && !$this->object instanceof Traversable) {
+            throw new BadMethodCallException('Object is not an array, or does not implement Traversable');
+        }
+
+        $this->sandbox->checkPropertyAllowed($this, 'iterator');
+
+        if ($this->object instanceof Traversable) {
+            return new IteratorIterator($this->object);
+        }
+        return new ArrayIterator($this->object);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        if (!is_array($this->object) && !$this->object instanceof Countable) {
+            throw new BadMethodCallException('Object is not an array, or does not implement Countable');
+        }
+
+        $this->sandbox->checkPropertyAllowed($this, 'count');
+
+        return count($this->object);
+    }
+
+    /**
+     * @return array|ArrayAccess
+     */
+    protected function getProxiedObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/Twig/DumpExtension.php
+++ b/src/Twig/DumpExtension.php
@@ -5,7 +5,7 @@ namespace Bolt\Twig;
 use Bolt\Users;
 use Symfony\Bridge\Twig\Extension\DumpExtension as BaseDumpExtension;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
-use Symfony\Component\VarDumper\Dumper\DataDumperInterface;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 /**
  * Extended to allow dumper to be passed in.
@@ -16,7 +16,7 @@ class DumpExtension extends BaseDumpExtension
 {
     /** @var ClonerInterface */
     private $cloner;
-    /** @var DataDumperInterface */
+    /** @var HtmlDumper */
     private $dumper;
     /** @var Users */
     private $users;
@@ -26,12 +26,12 @@ class DumpExtension extends BaseDumpExtension
     /**
      * Constructor.
      *
-     * @param ClonerInterface     $cloner
-     * @param DataDumperInterface $dumper
-     * @param Users               $users
-     * @param boolean             $debugShowLoggedoff
+     * @param ClonerInterface $cloner
+     * @param HtmlDumper      $dumper
+     * @param Users           $users
+     * @param boolean         $debugShowLoggedoff
      */
-    public function __construct(ClonerInterface $cloner, DataDumperInterface $dumper, Users $users, $debugShowLoggedoff)
+    public function __construct(ClonerInterface $cloner, HtmlDumper $dumper, Users $users, $debugShowLoggedoff)
     {
         parent::__construct($cloner);
         $this->cloner = $cloner;
@@ -66,16 +66,12 @@ class DumpExtension extends BaseDumpExtension
         }
 
         $output = fopen('php://memory', 'r+b');
-        $prevOutput = $this->dumper->setOutput($output);
+        $this->dumper->setCharset($env->getCharset());
 
         foreach ($vars as $value) {
-            $this->dumper->dump($this->cloner->cloneVar($value));
+            $this->dumper->dump($this->cloner->cloneVar($value), $output);
         }
 
-        $this->dumper->setOutput($prevOutput);
-
-        rewind($output);
-
-        return stream_get_contents($output);
+        return stream_get_contents($output, -1, 0);
     }
 }

--- a/src/Twig/Handler/HtmlHandler.php
+++ b/src/Twig/Handler/HtmlHandler.php
@@ -201,23 +201,22 @@ class HtmlHandler
     }
 
     /**
+     * @deprecated since 3.3. To be removed in 4.0.
+     *
      * Formats the given string as Twig in HTML.
      *
-     * Note: this is partially duplicating the template_from_string functionality:
+     * Use template_from_string instead:
      * http://twig.sensiolabs.org/doc/functions/template_from_string.html
      *
-     * We can't use that functionality though, since it requires the Twig_Extension_StringLoader()
-     * extension. If we would use that, when instantiating Twig, it screws up the rendering: Every
-     * template that has a filename that doesn't exist will be rendered as literal string. This
-     * _really_ messes up the 'cascading rendering' of our theme templates.
-     *
-     * @param $snippet
-     * @param array $extravars
+     * @param string $snippet
+     * @param array  $extravars
      *
      * @return string Twig output
      */
     public function twig($snippet, $extravars = [])
     {
-        return $this->app['safe_render']->render($snippet, $extravars)->getContent();
+        $template = $this->app['twig']->createTemplate((string) $snippet);
+
+        return twig_include($this->app['twig'], $extravars, $template, [], true, false, true);
     }
 }

--- a/src/Twig/SafeEnvironment.php
+++ b/src/Twig/SafeEnvironment.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Bolt\Twig;
+
+use Twig_Environment as Environment;
+use Twig_Extension_Sandbox as Sandbox;
+use Twig_ExtensionInterface as ExtensionInterface;
+
+/**
+ * Wraps real Twig environment:
+ * - render() and display() are called with sandbox enabled.
+ * - Adding an extension here adds the tags/functions/filters in extension to the security policy whitelist.
+ *
+ * @deprecated since 3.3, will be removed in 4.0.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class SafeEnvironment extends TwigEnvironmentWrapper
+{
+    protected $sandbox;
+
+    /**
+     * Constructor.
+     *
+     * @param Environment $env
+     * @param Sandbox     $sandbox
+     */
+    public function __construct(Environment $env, Sandbox $sandbox)
+    {
+        parent::__construct($env);
+        $this->sandbox = $sandbox;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($name, array $context = [])
+    {
+        $weSandboxed = false;
+        if (!$this->sandbox->isSandboxed()) {
+            $weSandboxed = true;
+            $this->sandbox->enableSandbox();
+        }
+
+        $result = $this->env->render($name, $context);
+
+        if ($weSandboxed) {
+            $this->sandbox->disableSandbox();
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function display($name, array $context = [])
+    {
+        $weSandboxed = false;
+        if (!$this->sandbox->isSandboxed()) {
+            $weSandboxed = true;
+            $this->sandbox->enableSandbox();
+        }
+
+        $this->env->display($name, $context);
+
+        if ($weSandboxed) {
+            $this->sandbox->disableSandbox();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addExtension(ExtensionInterface $extension)
+    {
+        $policy = $this->sandbox->getSecurityPolicy();
+
+        if (!$policy instanceof SecurityPolicy) {
+            return;
+        }
+
+        foreach ($extension->getTokenParsers() as $tokenParser) {
+            $policy->addAllowedTag($tokenParser->getTag());
+        }
+
+        foreach ($extension->getFunctions() as $function) {
+            $policy->addAllowedFunction($function->getName());
+        }
+
+        foreach ($extension->getFilters() as $filter) {
+            $policy->addAllowedFilter($filter->getName());
+        }
+    }
+}

--- a/src/Twig/SecurityPolicy.php
+++ b/src/Twig/SecurityPolicy.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Bolt\Twig;
+
+use Twig_Markup as Markup;
+use Twig_Sandbox_SecurityError as SecurityError;
+use Twig_Sandbox_SecurityNotAllowedFilterError as SecurityNotAllowedFilterError;
+use Twig_Sandbox_SecurityNotAllowedFunctionError as SecurityNotAllowedFunctionError;
+use Twig_Sandbox_SecurityNotAllowedTagError as SecurityNotAllowedTagError;
+use Twig_Sandbox_SecurityPolicy;
+use Twig_TemplateInterface as TemplateInterface;
+
+/**
+ * Security policy enforced in sandbox mode.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class SecurityPolicy extends Twig_Sandbox_SecurityPolicy
+{
+    /**
+     * Add tag allowed by this policy.
+     *
+     * @param string $tag
+     */
+    public function addAllowedTag($tag)
+    {
+        $this->allowedTags[] = $tag;
+    }
+
+    /**
+     * Add filter allowed by this policy.
+     *
+     * @param string $filter
+     */
+    public function addAllowedFilter($filter)
+    {
+        $this->allowedFilters[] = $filter;
+    }
+
+    /**
+     * Add function allowed by this policy.
+     *
+     * @param string $function
+     */
+    public function addAllowedFunction($function)
+    {
+        $this->allowedFunctions[] = $function;
+    }
+
+    /**
+     * Add class method allowed by this policy.
+     *
+     * @param string $class
+     * @param string $method
+     */
+    public function addAllowedMethod($class, $method)
+    {
+        if (!isset($this->allowedMethods[$class])) {
+            $this->allowedMethods[$class] = [];
+        }
+        $this->allowedMethods[$class][] = strtolower($method);
+    }
+
+    /**
+     * Add class property allowed by this policy.
+     *
+     * @param string $class
+     * @param string $method
+     */
+    public function addAllowedProperty($class, $property)
+    {
+        if (!isset($this->allowedProperties[$class])) {
+            $this->allowedProperties[$class] = [];
+        }
+        $this->allowedProperties[$class][] = $property;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkSecurity($tags, $filters, $functions)
+    {
+        foreach ($tags as $tag) {
+            if (!in_array($tag, $this->allowedTags)) {
+                throw new SecurityNotAllowedTagError(sprintf('Tag "%s" is not allowed.', $tag), $tag);
+            }
+        }
+
+        foreach ($filters as $filter) {
+            if (!in_array($filter, $this->allowedFilters)) {
+                throw new SecurityNotAllowedFilterError(sprintf('Filter "%s" is not allowed.', $filter), $filter);
+            }
+        }
+
+        foreach ($functions as $function) {
+            if (!in_array($function, $this->allowedFunctions)) {
+                throw new SecurityNotAllowedFunctionError(sprintf('Function "%s" is not allowed.', $function), $function);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkMethodAllowed($obj, $method)
+    {
+        if ($obj instanceof TemplateInterface || $obj instanceof Markup) {
+            return;
+        }
+
+        $allowed = false;
+        $method = strtolower($method);
+
+        foreach ($this->allowedMethods as $class => $methods) {
+            if (!$this->matchAnyClassInTree($class, $obj)) {
+                continue;
+            }
+            if ($this->globMatchAll($methods, $method)) {
+                $allowed = true;
+
+                break;
+            }
+        }
+
+        if (!$allowed) {
+            throw new SecurityError(sprintf('Calling "%s" method on a "%s" object is not allowed.', $method, get_class($obj)));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkPropertyAllowed($obj, $property)
+    {
+        $allowed = false;
+
+        foreach ($this->allowedProperties as $class => $properties) {
+            if (!$this->matchAnyClassInTree($class, $obj)) {
+                continue;
+            }
+            if ($this->globMatchAll((array) $properties, $property)) {
+                $allowed = true;
+
+                break;
+            }
+        }
+
+        if (!$allowed) {
+            throw new SecurityError(sprintf('Calling "%s" property on a "%s" object is not allowed.', $property, get_class($obj)));
+        }
+    }
+
+    protected function matchAnyClassInTree($class, $obj)
+    {
+        foreach ($this->getAllClasses(get_class($obj)) as $objClass) {
+            if ($this->globMatch($class, $objClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function getAllClasses($class)
+    {
+        return array_reverse([$class => $class] + class_parents($class) + class_implements($class));
+    }
+
+    protected function globMatchAll($patterns, $string, $ignoreCase = true)
+    {
+        foreach ($patterns as $pattern) {
+            if ($this->globMatch($pattern, $string, $ignoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function globMatch($pattern, $string, $ignoreCase = true)
+    {
+        $expr = preg_replace_callback('/[\\\\^$.[\\]|()?*+{}\\-\\/]/', function ($matches) {
+            switch ($matches[0]) {
+                case '*':
+                    return '.*';
+                case '?':
+                    return '.';
+                default:
+                    return '\\'.$matches[0];
+            }
+        }, $pattern);
+
+        $expr = '/'.$expr.'/';
+        if ($ignoreCase) {
+            $expr .= 'i';
+        }
+
+        return (bool) preg_match($expr, $string);
+    }
+}

--- a/src/Twig/SecurityProxyInterface.php
+++ b/src/Twig/SecurityProxyInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Bolt\Twig;
+
+/**
+ * {@see SecurityPolicy} will check for this interface to get the class name
+ * of the object to verify (instead of {@see get_class} by default).
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+interface SecurityProxyInterface
+{
+    /**
+     * Gets the proxied class name.
+     *
+     * @return string
+     */
+    public function getProxiedClass();
+}

--- a/src/Twig/SetcontentNode.php
+++ b/src/Twig/SetcontentNode.php
@@ -41,9 +41,10 @@ class SetcontentNode extends Node
 
         $compiler
             ->addDebugInfo($this)
-            ->write('$template_storage = $context[\'app\'][\'storage\'];' . "\n")
-            ->write('$context[\'' . $this->getAttribute('name') . '\'] = ')
-            ->write('$template_storage->getContent(')
+            ->write("\$context['")
+            ->raw($this->getAttribute('name'))
+            ->raw("'] = ")
+            ->raw("\$this->env->getExtension('Bolt')->getStorage()->getContent(")
             ->subcompile($this->getAttribute('contenttype'))
             ->raw(', ')
             ->subcompile($arguments)

--- a/src/Twig/TwigEnvironmentWrapper.php
+++ b/src/Twig/TwigEnvironmentWrapper.php
@@ -1,0 +1,597 @@
+<?php
+
+namespace Bolt\Twig;
+
+use Twig_CompilerInterface as CompilerInterface;
+use Twig_Environment as Environment;
+use Twig_ExtensionInterface as ExtensionInterface;
+use Twig_LexerInterface as LexerInterface;
+use Twig_LoaderInterface as LoaderInterface;
+use Twig_NodeInterface as NodeInterface;
+use Twig_NodeVisitorInterface as NodeVisitorInterface;
+use Twig_ParserInterface as ParserInterface;
+use Twig_RuntimeLoaderInterface as RuntimeLoaderInterface;
+use Twig_TokenParserInterface as TokenParserInterface;
+use Twig_TokenStream as TokenStream;
+
+/**
+ * Base class for wrapping twig environment.
+ *
+ * @deprecated since 3.3, will be removed in 4.0.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+abstract class TwigEnvironmentWrapper extends Environment
+{
+    protected $env;
+
+    /**
+     * Constructor.
+     *
+     * @param Environment $env
+     */
+    public function __construct(Environment $env)
+    {
+        $this->env = $env;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseTemplateClass()
+    {
+        return $this->env->getBaseTemplateClass();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setBaseTemplateClass($class)
+    {
+        $this->env->setBaseTemplateClass($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableDebug()
+    {
+        $this->env->enableDebug();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableDebug()
+    {
+        $this->env->disableDebug();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDebug()
+    {
+        return $this->env->isDebug();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableAutoReload()
+    {
+        $this->env->enableAutoReload();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableAutoReload()
+    {
+        $this->env->disableAutoReload();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAutoReload()
+    {
+        return $this->env->isAutoReload();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enableStrictVariables()
+    {
+        $this->env->enableStrictVariables();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disableStrictVariables()
+    {
+        $this->env->disableStrictVariables();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStrictVariables()
+    {
+        return $this->env->isStrictVariables();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCache($original = true)
+    {
+        return $this->env->getCache($original);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCache($cache)
+    {
+        $this->env->setCache($cache);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheFilename($name)
+    {
+        return $this->env->getCacheFilename($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateClass($name, $index = null)
+    {
+        return $this->env->getTemplateClass($name, $index);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateClassPrefix()
+    {
+        return $this->env->getTemplateClassPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($name, array $context = [])
+    {
+        return $this->env->render($name, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function display($name, array $context = [])
+    {
+        $this->env->display($name, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load($name)
+    {
+        return $this->env->load($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadTemplate($name, $index = null)
+    {
+        return $this->env->loadTemplate($name, $index);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createTemplate($template)
+    {
+        return $this->env->createTemplate($template);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTemplateFresh($name, $time)
+    {
+        return $this->env->isTemplateFresh($name, $time);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolveTemplate($names)
+    {
+        return $this->env->resolveTemplate($names);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clearTemplateCache()
+    {
+        $this->env->clearTemplateCache();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clearCacheFiles()
+    {
+        $this->env->clearCacheFiles();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLexer()
+    {
+        return $this->env->getLexer();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLexer(LexerInterface $lexer)
+    {
+        $this->env->setLexer($lexer);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tokenize($source, $name = null)
+    {
+        return $this->env->tokenize($source, $name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParser()
+    {
+        return $this->env->getParser();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParser(ParserInterface $parser)
+    {
+        $this->env->setParser($parser);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(TokenStream $stream)
+    {
+        return $this->env->parse($stream);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCompiler()
+    {
+        return $this->env->getCompiler();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCompiler(CompilerInterface $compiler)
+    {
+        $this->env->setCompiler($compiler);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile(NodeInterface $node)
+    {
+        return $this->env->compile($node);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compileSource($source, $name = null)
+    {
+        return $this->env->compileSource($source, $name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLoader(LoaderInterface $loader)
+    {
+        $this->env->setLoader($loader);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLoader()
+    {
+        return $this->env->getLoader();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCharset($charset)
+    {
+        $this->env->setCharset($charset);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCharset()
+    {
+        return $this->env->getCharset();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initRuntime()
+    {
+        $this->env->initRuntime();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasExtension($class)
+    {
+        return $this->env->hasExtension($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addRuntimeLoader(RuntimeLoaderInterface $loader)
+    {
+        $this->env->addRuntimeLoader($loader);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtension($class)
+    {
+        return $this->env->getExtension($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRuntime($class)
+    {
+        return $this->env->getRuntime($class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addExtension(ExtensionInterface $extension)
+    {
+        $this->env->addExtension($extension);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeExtension($name)
+    {
+        $this->env->removeExtension($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setExtensions(array $extensions)
+    {
+        $this->env->setExtensions($extensions);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtensions()
+    {
+        return $this->env->getExtensions();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addTokenParser(TokenParserInterface $parser)
+    {
+        $this->env->addTokenParser($parser);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTokenParsers()
+    {
+        return $this->env->getTokenParsers();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTags()
+    {
+        return $this->env->getTags();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addNodeVisitor(NodeVisitorInterface $visitor)
+    {
+        $this->env->addNodeVisitor($visitor);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeVisitors()
+    {
+        return $this->env->getNodeVisitors();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFilter($name, $filter = null)
+    {
+        $this->env->addFilter($name, $filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilter($name)
+    {
+        return $this->env->getFilter($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerUndefinedFilterCallback($callable)
+    {
+        $this->env->registerUndefinedFilterCallback($callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return $this->env->getFilters();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addTest($name, $test = null)
+    {
+        $this->env->addTest($name, $test);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTests()
+    {
+        return $this->env->getTests();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTest($name)
+    {
+        return $this->env->getTest($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFunction($name, $function = null)
+    {
+        $this->env->addFunction($name, $function);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunction($name)
+    {
+        return $this->env->getFunction($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerUndefinedFunctionCallback($callable)
+    {
+        $this->env->registerUndefinedFunctionCallback($callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return $this->env->getFunctions();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addGlobal($name, $value)
+    {
+        $this->env->addGlobal($name, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGlobals()
+    {
+        return $this->env->getGlobals();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mergeGlobals(array $context)
+    {
+        return $this->env->mergeGlobals($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUnaryOperators()
+    {
+        return $this->env->getUnaryOperators();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBinaryOperators()
+    {
+        return $this->env->getBinaryOperators();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function computeAlternatives($name, $items)
+    {
+        return $this->env->computeAlternatives($name, $items);
+    }
+}

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -36,6 +36,16 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
         return 'Bolt';
     }
 
+    /**
+     * Used by setcontent tag.
+     *
+     * @return \Bolt\Storage\EntityManager
+     */
+    public function getStorage()
+    {
+        return $this->app['storage'];
+    }
+
     public function getFunctions()
     {
         $safe = ['is_safe' => ['html']];

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -134,7 +134,7 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
             new \Twig_SimpleFilter('thumbnail',      [$this, 'thumbnail']),
             new \Twig_SimpleFilter('trimtext',       [$this, 'trim'],              $safe + $deprecated + ['alternative' => 'excerpt']),
             new \Twig_SimpleFilter('tt',             [$this, 'decorateTT'],        $safe),
-            new \Twig_SimpleFilter('twig',           [$this, 'twig'],              $safe),
+            new \Twig_SimpleFilter('twig',           [$this, 'twig'],              $safe + $deprecated + ['alternative' => 'template_from_string']),
             new \Twig_SimpleFilter('ucfirst',        'twig_capitalize_string_filter', $env + $deprecated + ['alternative' => 'capitalize']),
             new \Twig_SimpleFilter('ymllink',        [$this, 'ymllink'],           $safe),
             // @codingStandardsIgnoreEnd

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -159,17 +159,17 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
     public function getGlobals()
     {
         return [
-            'bolt_name'    => null,
-            'bolt_version' => null,
-            'bolt_stable'  => null,
+            'bolt_name'    => Bolt\Version::name(),
+            'bolt_version' => Bolt\Version::VERSION,
+            'bolt_stable'  => Bolt\Version::isStable(),
             'frontend'     => null,
             'backend'      => null,
             'async'        => null,
-            'paths'        => null,
+            'paths'        => $this->app['resources']->getPaths(),
             'theme'        => null,
             'user'         => null,
             'users'        => null,
-            'config'       => null,
+            'config'       => $this->app['config'],
         ];
     }
 

--- a/tests/codeception/acceptance/_bootstrap.php
+++ b/tests/codeception/acceptance/_bootstrap.php
@@ -72,3 +72,6 @@ Fixtures::add('tokenNames', [
     'session'   => 'bolt_session_' . md5('localhost:8123'),
     'authtoken' => 'bolt_authtoken_' . md5('localhost:8123'),
 ]);
+
+// Temporary hack
+restore_error_handler();

--- a/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
@@ -3,6 +3,7 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\TwigServiceProvider;
 use Bolt\Tests\BoltUnitTest;
+use Bolt\Twig\SafeEnvironment;
 
 /**
  * Class to test src/Provider/TwigServiceProvider.
@@ -28,8 +29,7 @@ class TwigServiceProviderTest extends BoltUnitTest
         $this->assertTrue($app['twig']->hasExtension('Bolt'), 'Bolt\Twig\TwigExtension was not added to twig environment');
         $this->assertContains('bolt', $app['twig.loader.bolt_filesystem']->getNamespaces(), 'bolt namespace was not added to filesystem loader');
 
-        $this->assertInstanceOf('\Bolt\Twig\TwigExtension', $app['safe_twig.bolt_extension']);
-        $this->assertInstanceOf('\Twig_Environment', $app['safe_twig']);
+        $this->assertInstanceOf(SafeEnvironment::class, $app['safe_twig']);
     }
 
     public function testConfigCacheDisabled()

--- a/tests/phpunit/unit/Twig/SetcontentTest.php
+++ b/tests/phpunit/unit/Twig/SetcontentTest.php
@@ -3,7 +3,6 @@ namespace Bolt\Tests\Twig;
 
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\SetcontentTokenParser;
-use Twig_Compiler;
 use Twig_Environment;
 use Twig_ExpressionParser;
 use Twig_Parser;
@@ -131,7 +130,7 @@ class SetcontentTest extends BoltUnitTest
             ->willReturnSelf()
         ;
         $compiler
-            ->expects($this->atLeast(3))
+            ->expects($this->atLeast(1))
             ->method('write')
             ->willReturnSelf()
         ;

--- a/tests/phpunit/unit/Twig/TwigExtensionTest.php
+++ b/tests/phpunit/unit/Twig/TwigExtensionTest.php
@@ -52,7 +52,6 @@ class TwigExtensionTest extends BoltUnitTest
         $this->assertArrayHasKey('users', $response);
         $this->assertArrayHasKey('config', $response);
         $this->assertNotNull($response['config']);
-        $this->assertNotNull($response['users']);
     }
 
     public function testGetGlobalsSafe()
@@ -66,7 +65,6 @@ class TwigExtensionTest extends BoltUnitTest
 
         $result = $twig->getGlobals();
         $this->assertArrayHasKey('config', $result);
-        $this->assertNull($result['config']);
         $this->assertNull($result['users']);
     }
 


### PR DESCRIPTION
This replaces `safe_twig` with Twig's Sandbox extension (BC should be maintained).

It can be used in Twig with the [`sandbox` tag](http://twig.sensiolabs.org/doc/tags/sandbox.html).
The `twig` function/filter has also been deprecated for the [`template_from_string` function](http://twig.sensiolabs.org/doc/functions/template_from_string.html).
