### PR TITLE
Hotfix Twig current function

### DIFF
--- a/src/Twig/Handler/RecordHandler.php
+++ b/src/Twig/Handler/RecordHandler.php
@@ -71,12 +71,12 @@ class RecordHandler
             return true;
         }
 
-        if (!isset($content['contenttype'])) {
+        if (!$content instanceof \Bolt\Legacy\Content || !property_exists($content, 'contenttype')) {
             return false;
         }
 
         // if the current requested page is for the same slug or singularslug.
-        $ct = $content['contenttype'];
+        $ct = $content->contenttype;
         if ($routeParams['contenttypeslug'] === $ct['slug'] || $routeParams['contenttypeslug'] === $ct['singular_slug']) {
             // …and the slugs should match.
             return $routeParams['slug'] === $content['slug'];

--- a/tests/phpunit/unit/Twig/Handler/RecordHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/RecordHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Twig;
 
 use Bolt\Asset\Snippet\Snippet;
+use Bolt\Legacy\Content;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Handler\RecordHandler;
 use Symfony\Component\HttpFoundation\Request;
@@ -167,11 +168,7 @@ GRINGALET;
         $app['request'] = $request;
 
         $handler = new RecordHandler($app);
-        $content = $this->getMock('\Bolt\Legacy\Content', ['link'], [$app]);
-        $content->expects($this->atLeastOnce())
-            ->method('link')
-            ->will($this->returnValue('/pages/koala'))
-        ;
+        $content = new Content($app, 'pages', ['id' => 42, 'slug' => 'koala']);
 
         $result = $handler->current($content);
         $this->assertTrue($result);
@@ -277,60 +274,6 @@ GRINGALET;
         $handler = new RecordHandler($app);
 
         $result = $handler->current('/pages/koala');
-        $this->assertTrue($result);
-    }
-
-    public function testCurrentTheFinalCountdown()
-    {
-        $app = $this->getApp();
-        $app->flush();
-        $this->addDefaultUser($app);
-        $this->addSomeContent();
-        $request = (new Request())->create('/gum-tree/koala');
-        $request->query->set('_route_params', [
-            'zone'            => 'frontend',
-            'slug'            => 'koala',
-            'contenttypeslug' => 'gum-tree',
-        ]);
-        $app['request'] = $request;
-
-        $handler = new RecordHandler($app);
-        $content = [
-            'slug'        => 'koala',
-            'contenttype' => [
-                'slug'          => 'gum-trees',
-                'singular_slug' => 'gum-tree',
-            ],
-        ];
-
-        $result = $handler->current($content);
-        $this->assertTrue($result);
-    }
-
-    public function testCurrentTheFinalCountdownRadioEdit()
-    {
-        $app = $this->getApp();
-        $app->flush();
-        $this->addDefaultUser($app);
-        $this->addSomeContent();
-        $request = (new Request())->create('/gum-trees/koala');
-        $request->query->set('_route_params', [
-            'zone'            => 'frontend',
-            'slug'            => 'koala',
-            'contenttypeslug' => 'gum-trees',
-        ]);
-        $app['request'] = $request;
-
-        $handler = new RecordHandler($app);
-        $content = [
-            'slug'        => 'koala',
-            'contenttype' => [
-                'slug'          => 'gum-trees',
-                'singular_slug' => 'gum-tree',
-            ],
-        ];
-
-        $result = $handler->current($content);
         $this->assertTrue($result);
     }
 


### PR DESCRIPTION
There is a slightly new-ish bug in the `{{ current() }}` Twig function that seems to have been introduced in d56905f9a4d79c31e390525ee315998fdf9bb45b

The short version is that [`Content::offsetExists()`](https://github.com/bolt/bolt/blob/release/3.2/src/Legacy/Content.php#L358) checks the `value` property, and the ContentType was never stored there, rather in its own named property. 

The unit test mocked the Content object therefore hiding the problem, hence the update to the test.

#1555 lives … it is real … it has found us! I warned you all of this day, now it has arrived :stuck_out_tongue_winking_eye: 