### PR TITLE
Fix adjustSidebarHeight so it's longer than content for admin menus

### DIFF
--- a/app/src/js/modules/secmenu.js
+++ b/app/src/js/modules/secmenu.js
@@ -63,12 +63,14 @@
         var contentHeight = $('#navpage-content').outerHeight(),
             sidebarObj = $('#navpage-secondary'),
             sidebarHeight = sidebarObj.outerHeight(),
+            docHeight = $(document).height() - sidebarObj.position().top,
+            newHeight = Math.max(contentHeight, docHeight),
             next = 5000;
 
         // If the sidebar height doesn't match the content's height, then adjust it.  And check back sooner so we can
         // adjust again if necessary (the content might still be changing).
-        if (sidebarHeight !== contentHeight) {
-            sidebarObj.outerHeight(contentHeight);
+        if (sidebarHeight !== newHeight) {
+            sidebarObj.outerHeight(newHeight);
             next = 500;
         }
 


### PR DESCRIPTION
Remember that fix I submitted for the secondary (black) menu on the left last week? I found a small issue with it.

It works great as long as the content is longer than the menu, but when the reverse is true, as it is on some of the admin menus, I saw menu items that weren't in the black anymore. I hardly ever use those menus anymore, which is why I forgot to check them.

This small adjustment to the original change fixes that, and hopefully it's perfect now.

Sorry for the extra churn!