### PR TITLE
Allow services in .bolt bootstrap config

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -145,11 +145,18 @@ return call_user_func(function () {
     $app = new $appClass(['resources' => $resources]);
 
     foreach ((array) $config['services'] as $service) {
+        $params = [];
+        if (is_array($service)) {
+            $key = key($service);
+            $params = $service[$key];
+            $service = $key;
+        }
+
         if (is_string($service) && is_a($service, Silex\ServiceProviderInterface::class, true)) {
             $service = new $service();
         }
         if ($service instanceof Silex\ServiceProviderInterface) {
-            $app->register($service);
+            $app->register($service, $params);
         } else {
             // throw error
         }

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -157,8 +157,6 @@ return call_user_func(function () {
         }
         if ($service instanceof Silex\ServiceProviderInterface) {
             $app->register($service, $params);
-        } else {
-            // throw error
         }
     }
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -79,6 +79,7 @@ return call_user_func(function () {
         'application' => null,
         'resources'   => null,
         'paths'       => [],
+        'services'    => [],
     ];
 
     if (file_exists($rootPath . '/.bolt.yml')) {
@@ -140,7 +141,19 @@ return call_user_func(function () {
     if ($config['application'] !== null && is_a($config['application'], Silex\Application::class, true)) {
         $appClass = $config['application'];
     }
+    /** @var Silex\Application $app */
     $app = new $appClass(['resources' => $resources]);
+
+    foreach ((array) $config['services'] as $service) {
+        if (is_string($service) && is_a($service, Silex\ServiceProviderInterface::class, true)) {
+            $service = new $service();
+        }
+        if ($service instanceof Silex\ServiceProviderInterface) {
+            $app->register($service);
+        } else {
+            // throw error
+        }
+    }
 
     return $app;
 });


### PR DESCRIPTION
This allows customization of Bolt at a more advanced level, that still doesn't require you to change the way you bootstrap your app. 

I feel like this is common as any customization that isn't provided in the config needs to subclass `Bolt\Application` or add a `ServiceProvider`. Now that #6133 is in, no services are invoked / loaded as `Bolt\Application` is created, so there's no need to subclass anymore.

One concrete example is configuring S3. There's no way to configure S3 from Config, and maybe there shouldn't ever be. Now you just do your configuration for S3 in a ServiceProvider class and hook it in:
```yaml
# .bolt.yml
services:
  - My\Bolt\S3ServiceProvider:
      aws.key: 1234
      aws.secret: ***
  - My\Bolt\AnotherServiceProvider # No params
```
