### PR TITLE
Boot extension registered service providers

### DIFF
--- a/src/Provider/ExtensionServiceProvider.php
+++ b/src/Provider/ExtensionServiceProvider.php
@@ -124,7 +124,10 @@ class ExtensionServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
-        $app['extensions']->addManagedExtensions();
-        $app['extensions']->register($app);
+        /** @var Manager $extensionService */
+        $extensionService = $app['extensions'];
+        $extensionService->addManagedExtensions();
+        $extensionService->register($app);
+        $extensionService->boot($app);
     }
 }


### PR DESCRIPTION
Fixes #6151

tl;dr #6133 gone b0rked 'setnshun muntin', :koala: bru!

Early in Application we [register](https://github.com/bolt/bolt/blob/release/3.3/src/Application.php#L51) the extension service provider so that it will be the (closest to) first to boot.

When the extension service provider [boots](https://github.com/bolt/bolt/blob/release/3.3/src/Provider/ExtensionServiceProvider.php#L125-L130) we are now registering the extensions, which in the case of anything based on `\Bolt\Extension\SimpleExtension` will implement `ServiceProviderInterface` therefore requiring both `register()` and `boot()` to be called …

Now for the O.C.D. in the room …

[calling `$app->register()`](https://github.com/silexphp/Silex/blob/1.3/src/Silex/Application.php#L176) during `$app->boot()` will add providers to the `$this->providers` in Application, but the iterrator that is [used in `$app->boot()`](
https://github.com/silexphp/Silex/blob/1.3/src/Silex/Application.php#L196-L198) won't have it … so if we're adding that late, we need some way of cleanly invoking those boots.

…and yeah, adding a `boot()` method is killing my OCD too, @CarsonF, but happy to hear better ideas just got work that is D.O.A. right now as a result.