### PR TITLE
Deprecation and associated clean ups

### DIFF
--- a/app/view/twig/_base/_fieldset.twig
+++ b/app/view/twig/_base/_fieldset.twig
@@ -2,7 +2,7 @@
 
 {#=== INIT ===========================================================================================================#}
 
-{% set widget_name = block('fieldset_widget') %}
+{% set widget_name = block('fieldset_widget') is defined ? block('fieldset_widget') : '' %}
 
 {% if not widget_name %}
     {% set data_bolt_widget = '' %}

--- a/app/view/twig/_base/_page-nav.twig
+++ b/app/view/twig/_base/_page-nav.twig
@@ -13,7 +13,7 @@
 
 {% set page_hasnav = true %}
 
-{% set page_nav = block('page_nav')|default('NO NAV') %}
+{% set page_nav = block('page_nav') is defined ? block('page_nav') : 'NO NAV' %}
 
 {% block page_plain %}
     {{ data('omnisearch.placeholder', __('general.phrase.find')) }}
@@ -33,11 +33,11 @@
             <div class="row">
                 <div class="col-xs-12">
                     <h1 class="page-header">
-                        {% if block('page_subtitle') is empty %}
-                            <strong>{{ block('page_title') }}</strong>
-                        {% else %}
+                        {% if block('page_subtitle') is defined %}
                             <strong>{{ block('page_title') }} »</strong>
                             <i style="font-style: normal;">{{ block('page_subtitle') }}</i>
+                        {% else %}
+                            <strong>{{ block('page_title') }}</strong>
                         {% endif %}
 
                         {# optional "showing 1-X of Y" for overview pages. #}

--- a/app/view/twig/_base/_page.twig
+++ b/app/view/twig/_base/_page.twig
@@ -15,10 +15,10 @@
 {% set page_locale_short = page_locale_long|slice(0, 2) %}
 {% set page_timezone_offset = app.timezone_offset %}
 
-{% if block('page_subtitle') is empty %}
-    {% set page_title = block('page_title') %}
-{% else %}
+{% if block('page_subtitle') is defined %}
     {% set page_title = block('page_title') ~ ' » ' ~ block('page_subtitle') %}
+{% else %}
+    {% set page_title = block('page_title') %}
 {% endif %}
 
 {# TODO: Refactor this out. Too much business logic in the template. #}

--- a/app/view/twig/editfile/editfile.twig
+++ b/app/view/twig/editfile/editfile.twig
@@ -33,11 +33,20 @@
 
             {{ widgets('editfile_below_header', 'backend') }}
 
-            <form method="post" class="form-inline" id="editfile" autocomplete="off">
+            {# Ths "editfile" ID is being used by JavaScript … somewhere #}
+            {{ form_start(context.form, {'attr': {'id': 'editfile', 'class': 'form-inline', 'autocomplete': 'off'}}) }}
                 {{ form_widget(context.form._token) }}
 
                 <div>
-                    <textarea{{ macro.attr(attr_text) }}>{{ context.form.vars.value.contents }}</textarea>
+                    {{ form_widget(context.form.contents,
+                        {
+                            'class': 'CodeMirror-scroll',
+                            'attr': {
+                                'data-bind': {'bind': 'editfile', readonly: context.write_allowed ? false : true}|json_encode,
+                                'style': 'width: 98%; min-height: 350px; white-space: pre; word-wrap: normal; overflow-x: scroll;'
+                            }
+                        })
+                    }}
                 </div>
 
                 <div>
@@ -67,7 +76,7 @@
                 ({{ buic_moment(context.datechanged) }})
             </p>
 
-            </form>
+            {{ form_end(context.form) }}
 
             {{ widgets('editfile_bottom', 'backend') }}
 

--- a/app/view/twig/editlocale/editlocale.twig
+++ b/app/view/twig/editlocale/editlocale.twig
@@ -12,27 +12,27 @@
 
     {% import '@bolt/_macro/_macro.twig' as macro %}
 
-    {% set attr_text = {
-        _bind:     ismobileclient() ? '' : ['editlocale', {readonly: context.write_allowed ? false : true}],
-        class:     'CodeMirror-scroll',
-        id:        'form_contents',
-        name:      'form[contents]',
-        required:  true,
-        style:     'width: 98%;',
-    } %}
-
     <div class="row">
         <div class="col-xs-12">
-            <form method="post" class="form-inline" autocomplete="off">
+            {{ form_start(context.form, {'attr': {'class': 'form-inline', 'autocomplete': 'off'}}) }}
                 <div>
-                    <textarea{{ macro.attr(attr_text) }}>{{ context.form.vars.value.contents }}</textarea>
+                    {% set bind = ismobileclient() ? '' : {'bind': 'editlocale', 'readonly': context.write_allowed ? false : true} %}
+                    {{ form_widget(context.form.contents,
+                        {
+                            'class': 'CodeMirror-scroll',
+                            'attr': {
+                                'data-bind': bind|json_encode
+                            }
+                        })
+                    }}
                 </div>
+                <br>
+                {# Let's play "Hide the button" … #}
                 {% if context.write_allowed %}
                     {{ form_widget(context.form._token) }}
-                    <br>
-                    <input type="submit" id="saveeditlocale" name="submit" value="{{ __('page.edit-locale.button.save') }}" class="btn btn-primary" {% if not context.write_allowed %}disabled{% endif %} />
+                    {{ form_widget(context.form.submit, { 'attr': { 'class': 'btn btn-primary' } }) }}
                 {% endif %}
-            </form>
+            {{ form_end(context.form, { 'render_rest': false }) }}
         </div>
     </div>
 

--- a/app/view/twig/edituser/edituser.twig
+++ b/app/view/twig/edituser/edituser.twig
@@ -39,7 +39,7 @@
                 </p>
             {% endif %}
 
-            <form method="post" class="form-horizontal" autocomplete="off">
+            {{ form_start(context.form, {'attr': {'class': 'form-horizontal', 'autocomplete': 'off'}}) }}
                 {# Google Chrome, Firefox, MS Edge all require this trick to prevent password fields from auto-filling.
                    @see http://stackoverflow.com/questions/15738259/disabling-chrome-autofill #}
                 <input type="text" style="display:none;" />
@@ -48,7 +48,8 @@
                 {{ form_widget(context.form) }}
 
                 <input type="submit" value="{{ __('page.edit-users.button.save') }}" name="submit" class="btn btn-primary">
-            </form>
+
+            {{ form_end(context.form) }}
 
             {{ widgets('edituser_bottom', 'backend') }}
 

--- a/app/view/twig/firstuser/firstuser.twig
+++ b/app/view/twig/firstuser/firstuser.twig
@@ -12,7 +12,7 @@
         {{ __('general.phrase.users-none-create-first-extended') }}
     </p>
 
-    <form method="post" class="form-horizontal submitspinner" autocomplete="off">
+    {{ form_start(context.form, {'attr': {'class': 'form-horizontal submitspinner', 'autocomplete': "off"}}) }}
         {# Google Chrome, Firefox, MS edge all require this trick to prevent password fields from auto-filling.
            @see http://stackoverflow.com/questions/15738259/disabling-chrome-autofill #}
         <input type="text" style="display:none;" />
@@ -23,7 +23,7 @@
         <button type="submit" class="btn btn-primary" name="submit" value="login">
             <i class="fa fa-sign-in fa-fw"></i> {{ __('general.phrase.create-user-first') }}
         </button>
-    </form>
+    {{ form_end(context.form, { 'render_rest': false }) }}
 
     {% if context.note is not empty %}
         <p class="alert alert-info" style="max-width: 550px; margin-top:10px;">

--- a/app/view/twig/prefill/prefill.twig
+++ b/app/view/twig/prefill/prefill.twig
@@ -11,7 +11,7 @@
 
     <div class="row">
         <div class="col-xs-12">
-            <form method="post" id="prefill" class="form-horizontal"{{ macro.attr({_bind: ['prefill']}) }}>
+            {{ form_start(context.form, {'attr': {'class': 'form-horizontal'}}) }}
                 <div id="form">
                     <div class="control-group">
                         <div class="info">
@@ -19,14 +19,9 @@
                         </div>
 
                         <div id="form_contenttypes" style="border-bottom: 1px solid #eee; margin-bottom: 10px; width: 50%">
-                            {% for key,ctype in context.contenttypes %}
+                            {% for field in context.form.contenttypes %}
                                 <div>
-                                    <label>
-                                        <input type="checkbox"
-                                               id="form_contenttypes_{{ loop.index0 }}"
-                                               name="form[contenttypes][]"
-                                               value="{{ key }}">{{ ctype }}
-                                    </label>
+                                    <label>{{ form_widget(field) }}{{ field.vars.label }}</label>
                                 </div>
                             {% endfor %}
                         </div>
@@ -43,7 +38,7 @@
                     <button type="submit" class="btn btn-primary"><i class="fa fa-wrench"></i> {{ __('general.phrase.database-prefill') }}</button>
                 </div>
 
-            </form>
+            {{ form_end(context.form) }}
 
         </div>
     </div>

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -11,6 +11,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -220,6 +221,14 @@ class General extends BackendBase
                         new Assert\NotBlank(),
                         new Assert\Length(['min' => 10]),
                     ],
+                ]
+            )
+            ->add(
+                'submit',
+                SubmitType::class,
+                [
+                    'label'    => Trans::__('page.edit-locale.button.save'),
+                    'disabled' => !$tr['writeallowed']
                 ]
             )
             ->getForm();

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -153,7 +153,12 @@ class General extends BackendBase
         }
 
         // Create the form
-        $form = $this->createFormBuilder(FormType::class)
+        $options = [
+            'attr' => [
+                'data-bind' => json_encode(['bind' => 'prefill']),
+            ]
+        ];
+        $form = $this->createFormBuilder(FormType::class, [], $options)
             ->add('contenttypes', ChoiceType::class, [
                 'choices_as_values' => true, // Can be removed when symfony/form:^3.0 is the minimum
                 'choices'  => $choices,

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -555,7 +555,8 @@ class Users extends BackendBase
                     'disabled' => true,
                     'label'    => Trans::__('page.edit-users.label.last-ip'),
                 ]
-            );
+            )
+        ;
 
         return $form;
     }


### PR DESCRIPTION
First off the block is, erm, `block()` … So in Twig 2 (as of current) expects the only valid test to is `block() is defined`, as (apparently) defined [here](http://twig.sensiolabs.org/doc/functions/block.html)

Second just ended up being implementing `form_start` & `form_end` where `form_widget` was being used.

I started toying with the idea of the buttons too, but put that in the "bigger work" category.