### PR TITLE
Adapted searchSingleContentType() to allow status = ... to be passed as a filter

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -694,6 +694,9 @@ class Storage
      */
     private function searchSingleContentType($query, $contenttype, $fields, array $filter = null, $implode = false)
     {
+        // Add status to fields
+        $fields['status'] = true;
+
         // This could be even more configurable
         // (see also Content->getFieldWeights)
         $searchableTypes = ['text', 'textarea', 'html', 'markdown'];
@@ -745,7 +748,14 @@ class Storage
 
         // Build actual where
         $where = [];
-        $where[] = sprintf("%s.status = 'published'", $table);
+
+        $request    = $this->app['request_stack']->getCurrentRequest();
+        $isFrontend = $request ? Zone::isFrontend($request) : true;
+
+        if ($isFrontend && empty($filter['status'])) {
+            $where[] = sprintf("%s.status = 'published'", $table);
+        }
+
         $where[] = '(( ' . implode(' OR ', $fieldsWhere) . ' ) ' . $tagsQuery . ' )';
         $where = array_merge($where, $filterWhere);
 

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -695,7 +695,7 @@ class Storage
     private function searchSingleContentType($query, $contenttype, $fields, array $filter = null, $implode = false)
     {
         // Add status to fields
-        $fields['status'] = true;
+        $fields['status'] = ['type' => 'status'];
 
         // This could be even more configurable
         // (see also Content->getFieldWeights)

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -749,10 +749,7 @@ class Storage
         // Build actual where
         $where = [];
 
-        $request    = $this->app['request_stack']->getCurrentRequest();
-        $isFrontend = $request ? Zone::isFrontend($request) : true;
-
-        if ($isFrontend && empty($filter['status'])) {
+        if (empty($filter['status'])) {
             $where[] = sprintf("%s.status = 'published'", $table);
         }
 


### PR DESCRIPTION
Trying to use the searchContent() function in the backend to allow for content selection regardless of status (in an extension - in my particular instance this in the RelationList extension). E.g. if I set two things to be timed, the status=published where clause doesn't allow me to select them. 

'status' as a filter has been added to the searchSingleContentType() function with a fallback to `'published'` if a specific filter has not been defined. (Works the same as already handled in Core at [`src/Legacy/Storage.php`](https://github.com/bolt/bolt/blob/v3.2.3/src/Legacy/Storage.php#L1282-L1284))