### PR TITLE
Local Extension Replacement

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -160,14 +160,27 @@ return call_user_func(function () {
         if ($service instanceof Silex\ServiceProviderInterface) {
             $app->register($service, $params);
         }
+
     }
 
+    $extensionArray = [];
     foreach ((array) $config['extensions'] as $extensionClass) {
-        if (is_string($extensionClass)) {
-            $app['extensions']->add(new $extensionClass());
-        } else {
-            $app['extensions']->add($extensionClass);
+        if (is_string($extensionClass) && is_a($extensionClass, ExtensionInterface::class, true)) {
+            $extensionClass = new $extensionClass();
         }
+        if ($extensionClass instanceof ExtensionInterface) {
+            $extensionArray[] = $extensionClass;
+        }
+    }
+
+    if (count($extensionArray)) {
+        $app['extensions'] = $app->share(
+            $app->extend('extensions', function ($extensions) use ($extensionArray) {
+                foreach ($extensionArray as $ext) {
+                    $extensions->add($ext);
+                }
+            })
+        );
     }
 
     return $app;

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -7,6 +7,7 @@ use Bolt\Configuration\ResourceManager;
 use Bolt\Configuration\Standard;
 use Bolt\Debug\ShutdownHandler;
 use Bolt\Exception\BootException;
+use Bolt\Extension\ExtensionInterface;
 use Silex;
 use Symfony\Component\Yaml\Yaml;
 
@@ -80,6 +81,7 @@ return call_user_func(function () {
         'resources'   => null,
         'paths'       => [],
         'services'    => [],
+        'extensions'  => [],
     ];
 
     if (file_exists($rootPath . '/.bolt.yml')) {
@@ -157,6 +159,14 @@ return call_user_func(function () {
         }
         if ($service instanceof Silex\ServiceProviderInterface) {
             $app->register($service, $params);
+        }
+    }
+
+    foreach ((array) $config['extensions'] as $extensionClass) {
+        if (is_string($extensionClass)) {
+            $app['extensions']->add(new $extensionClass());
+        } else {
+            $app['extensions']->add($extensionClass);
         }
     }
 

--- a/src/Composer/JsonManager.php
+++ b/src/Composer/JsonManager.php
@@ -138,6 +138,7 @@ class JsonManager
             'autoload' => [
                 'psr-4' => [
                     'Bolt\\Composer\\EventListener\\' => $eventPath,
+                    '' => 'local',
                 ],
             ],
             'scripts' => [

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -124,9 +124,13 @@ class Manager
         // Set paths in the extension
         if ($baseDir !== null) {
             $extension->setBaseDirectory($baseDir);
+        } else {
+            $extension->setBaseDirectory($this->extFs->getDir($extension->getId()));
         }
         if ($webDir !== null) {
             $extension->setWebDirectory($webDir);
+        } else {
+            $extension->setWebDirectory($this->webFs->getDir($extension->getId()));
         }
 
         // Determine if enabled
@@ -174,7 +178,6 @@ class Manager
             $this->addManagedExtension($descriptor);
         }
 
-        $this->loaded = true;
     }
 
     /**
@@ -229,6 +232,7 @@ class Manager
                 $provider->boot($app);
             }
         }
+        $this->loaded = true;
         $this->booted = true;
     }
 

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -121,7 +121,6 @@ class Manager
             throw new \RuntimeException('Can not add extensions after they are registered.');
         }
 
-
         // Set paths in the extension
         if ($baseDir === null) {
             $baseDir = $this->extFs->getDir($extension->getId());

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -121,17 +121,17 @@ class Manager
             throw new \RuntimeException('Can not add extensions after they are registered.');
         }
 
+
         // Set paths in the extension
-        if ($baseDir !== null) {
-            $extension->setBaseDirectory($baseDir);
-        } else {
-            $extension->setBaseDirectory($this->extFs->getDir($extension->getId()));
+        if ($baseDir === null) {
+            $baseDir = $this->extFs->getDir($extension->getId());
         }
-        if ($webDir !== null) {
-            $extension->setWebDirectory($webDir);
-        } else {
-            $extension->setWebDirectory($this->webFs->getDir($extension->getId()));
+        $extension->setBaseDirectory($baseDir);
+
+        if ($webDir === null) {
+            $webDir = $this->webFs->getDir($extension->getId());
         }
+        $extension->setWebDirectory($webDir);
 
         // Determine if enabled
         $enabled = $this->config->get('extensions/' . $extension->getId(), true);

--- a/src/Provider/ExtensionServiceProvider.php
+++ b/src/Provider/ExtensionServiceProvider.php
@@ -7,8 +7,10 @@ use Bolt\Composer\EventListener\BufferIOListener;
 use Bolt\Composer\JsonManager;
 use Bolt\Composer\PackageManager;
 use Bolt\Composer\Satis;
+use Bolt\Extension\ExtensionQueue;
 use Bolt\Extension\Manager;
 use Composer\IO\BufferIO;
+use Doctrine\Common\Collections\ArrayCollection;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -24,10 +26,13 @@ class ExtensionServiceProvider implements ServiceProviderInterface
                     $app['logger.flash'],
                     $app['config']
                 );
+                $loader->addManagedExtensions();
 
                 return $loader;
             }
         );
+
+
 
         $app['extensions.stats'] = $app->share(
             function ($app) {
@@ -126,7 +131,6 @@ class ExtensionServiceProvider implements ServiceProviderInterface
     {
         /** @var Manager $extensionService */
         $extensionService = $app['extensions'];
-        $extensionService->addManagedExtensions();
         $extensionService->register($app);
         $extensionService->boot($app);
     }

--- a/tests/phpunit/unit/Extension/ExtensionAddTest.php
+++ b/tests/phpunit/unit/Extension/ExtensionAddTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Bolt\Tests\Extension;
+
+use Bolt\Tests\Extension\Mock\NormalExtension;
+use Bolt\Tests\Extensions\AbstractExtensionsUnitTest;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class to test adding of application and local extensions
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class ExtensionAddTest extends AbstractExtensionsUnitTest
+{
+    public function testBasicExtensionRegisters()
+    {
+        $app = $this->makeApp();
+        $ext = new NormalExtension();
+        $app['extensions']->add($ext);
+        $app->initialize();
+        $app->handle(Request::createFromGlobals());
+        $this->assertArrayHasKey('Bolt/Normal', $app['extensions']->all());
+    }
+
+    public function testLocalExtensionRegisters()
+    {
+        $this->localExtensionInstall();
+        $app = $this->makeApp();
+        $app['extend.manager.json']->update();
+        $app['extend.manager']->dumpAutoload();
+
+        // Now init the local extension
+        $app = $this->makeApp();
+        $app['extensions']->add(new \TestLocalExtension\Extension());
+        $app->initialize();
+        $app->handle(Request::createFromGlobals());
+        $this->assertArrayHasKey('TestLocalExtension/TestLocalExtension', $app['extensions']->all());
+    }
+}

--- a/tests/phpunit/unit/resources/extensions/local/TestLocalExtension/Extension.php
+++ b/tests/phpunit/unit/resources/extensions/local/TestLocalExtension/Extension.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace TestLocalExtension;
+
+use Bolt\Extension\SimpleExtension;
+
+class Extension extends SimpleExtension
+{
+}


### PR DESCRIPTION
OK, sorry this took longer than I wanted, had to do some rejigging after the recent extension boot changes.

This adds two new ways to use extensions. Firstly you can register extensions at an application level, that is ones that can be autoloaded via your root composer.json. To do this in your bootstrap, or anywhere else prior to the `$app->initialize()` call:

```
$app['extension']->register(new MyApp\Extensions\CleverExtension());
```

We also add a new root namespace for extensions that are found at `extensions/local`, these can't be instantiated until the extension boot process so these must be registered by class name. If you use a php bootstrap this works like:

```
#bolt.php
...
// This will load a class that is found at extensions/local/MyLocalExtension/ImageProcessExtension.php
$app['extension']->register('MyLocalExtension\ImageProcessExtension');
...
```

More normally for those using the `yml` bootstrap config we add support for an extensions array

```
#bolt.yml

paths:
    web: public
    themebase: public/theme
    files: public/files
    view: public/bolt-public/view
extensions:
    - MyextOne\LocalExtensionOne
    - MyextTwo\LocalExtensionTwo
    - MyextThree\LocalExtensionThree
```

The above example will load classes found at `extensions/local/MyextOne/LocalExtensionOne.php`, `extensions/local/MyextTwo/LocalExtensionTwo.php` and `extensions/local/MyextThree/LocalExtensionThree.php` respectively.

After this happens then the extensions will load normally and can have identical functionality to traditionally loaded extensions with two important distinctions.

1. They do not appear in the extensions UI
2. There's no magic for asset copying, local extensions are responsible for putting their assets in the right place, by default this will be at `public/extensions/<response of ->getId()>`

## Edited With Updated Syntax

Internally everything now uses the extension add method so the above bolt.php code is replaced with this:

```
#bolt.php
...
// This will load a class that is found at extensions/local/MyLocalExtension/ImageProcessExtension.php
$app['extensions']->add(new MyLocalExtension\ImageProcessExtension());
...
```

The extension will also be instantiable since the autoload for extensions is now included in the constructor.
