### PR TITLE
Make repeater fields live editable

### DIFF
--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -36,7 +36,7 @@
                     'can':      context.can,
                 }
             } %}
-            <div class="repeater-field">
+            <div class="repeater-field" data-bolt-fieldset="{{ rfield.type }}">
                 {# Prefix #}
                 {% if rcontext.field.prefix is defined and rcontext.field.prefix is not empty %}
                     <div class="prefix">


### PR DESCRIPTION
This is a simple fix to make it possible to live edit repeater fields. In the template you can link the fields like this:

    {% for company in record.companies %}
        <h2 data-bolt-field="companies[{{ loop.index0 }}][companyname]">{{ company.companyname }}</h2>
    {% endfor %}

I'm not sure which branch to pull it to, but it should probably be implemented in several (at least 3.3, 3.4, 4.x and maybe more)