### PR TITLE
Extension Nut command registration

### DIFF
--- a/app/nut
+++ b/app/nut
@@ -12,6 +12,7 @@ if (version_compare(PHP_VERSION, $minVersion, '<')) {
 
 /** @var \Silex\Application $app */
 $app = require __DIR__ . '/bootstrap.php';
+$app->boot();
 
 /** @var \Symfony\Component\Console\Application $nut Nut Console Application */
 $nut = $app['nut'];

--- a/src/Nut/BaseCommand.php
+++ b/src/Nut/BaseCommand.php
@@ -4,8 +4,6 @@ namespace Bolt\Nut;
 
 use Silex\Application;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -24,14 +22,6 @@ abstract class BaseCommand extends Command
     {
         parent::__construct();
         $this->app = $app;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function initialize(InputInterface $input, OutputInterface $output)
-    {
-        $this->app->boot();
     }
 
     /**


### PR DESCRIPTION
Recent changes to loading mean that Nut commands registered by extensions will never be registered … Same story at #6157

@CarsonF Yes, I know … Let's get it properly on v4 refactor?