### PR TITLE
Only render Live editor save button when content type is set

### DIFF
--- a/app/view/twig/_nav/_primary.twig
+++ b/app/view/twig/_nav/_primary.twig
@@ -29,12 +29,14 @@
         </a>
     </li>
 
+    {% if context.contenttype is defined %}
     <li id="liveeditorsavecontinuebutton" class="save-live-editor">
         <a>
             <i class="fa fa-fw fa-flag"></i>
             {{ __('contenttypes.generic.save', {'%contenttype%': context.contenttype.slug}) }}
         </a>
     </li>
+    {% endif %}
 
     <li class="close-live-editor">
         <a>

--- a/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
+++ b/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
@@ -82,7 +82,7 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->fillField('#teaser', 'Woop woop woop! Crazy nice stuff inside!');
         $I->fillField('#body',   'Take it, take it! I have three more of these!');
 
-        $I->click('Save Page');
+        $I->click('Save Page', "#savecontinuebutton");
         $I->see('The new Page has been saved.');
 
         $I->see('A page I made');
@@ -232,7 +232,7 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->see('Template', 'a[data-toggle=tab]');
 
         $I->fillField('#templatefields-section_1', 'This is the contact text');
-        $I->click('Save Page');
+        $I->click('Save Page', "#savecontinuebutton");
 
         $I->click('CONTACT PAGE');
         /*


### PR DESCRIPTION
This PR is a follow up on #6178. Instead of trying to render the save button on every page in the back-end, only try when we're actually editing content. Otherwise Bolt will break since no contenttype is set.