### PR TITLE
[WIP] Live editor modals

### DIFF
--- a/app/src/js/modules/liveeditor.js
+++ b/app/src/js/modules/liveeditor.js
@@ -378,7 +378,6 @@
      * @memberof Bolt.liveEditor
      */
     liveEditor.closeModal = function () {
-        console.log("closeModal: modalChanged:" + liveEditor.modalChanged);
         if (liveEditor.modalChanged === true) {
             $(".live-editor-modal-done-button").addClass("disabled");
             liveEditor.reload(liveEditor.closeModal);

--- a/app/src/sass/editcontent/_field.scss
+++ b/app/src/sass/editcontent/_field.scss
@@ -144,3 +144,7 @@ fieldset.bolt-field-imagelist {
         }
     }
 }
+
+.live-editor-modal-buttons {
+    display: none;
+}

--- a/app/src/sass/modules/_liveeditor.scss
+++ b/app/src/sass/modules/_liveeditor.scss
@@ -47,7 +47,10 @@
 
 .live-editor-active {
     #navpage-content, .navbar-toggle {
-        display: none;
+        /* Hide, but make possible to show inner elements */
+        position: absolute;
+        height: 0;
+        overflow: hidden;
     }
 
     /*#navpage-wrapper {
@@ -101,6 +104,38 @@
             &.close-live-editor, &.nav-secondary-dashboard {
                 display: block;
             }
+        }
+    }
+
+    #editcontent .live-editor-modal-active {
+        display: block;
+        position: fixed;
+        z-index: 100;
+        top: 30px;
+        left: 0;
+        right: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0,0,0,0.5);
+        padding: 50px;
+        bottom: 0;
+        div[data-bolt-fieldset] {
+            display: none;
+        }
+        div[data-bolt-fieldset].live-editor-modal {
+            display: block;
+            background: white;
+            padding: 40px;
+            margin: 0 auto;
+            overflow: auto;
+            max-height: 85%;
+            box-shadow: 0 5px 15px rgba(0,0,0,.5);
+            max-width: 700px;
+
+        }
+        .live-editor-modal-buttons {
+            display: block;
+            padding-top: 20px;
         }
     }
 }

--- a/app/src/sass/modules/_liveeditor.scss
+++ b/app/src/sass/modules/_liveeditor.scss
@@ -136,6 +136,10 @@
         .live-editor-modal-buttons {
             display: block;
             padding-top: 20px;
+            .disabled {
+                opacity: 0.65;
+                cursor: not-allowed;
+            }
         }
     }
 }

--- a/app/view/twig/editcontent/_field.twig
+++ b/app/view/twig/editcontent/_field.twig
@@ -29,6 +29,11 @@
         </div>
     {% endif %}
 
+    {# TODO: Don't hardcode message #}
+        <div class="live-editor-modal-buttons">
+            <a href="#" class="btn btn-primary pull-right live-editor-modal-done-button">Done</a>
+        </div>
+
     {# Divider #}
     {% if field.separator is defined and field.separator == true %}
         <hr>

--- a/app/view/twig/editcontent/editcontent.twig
+++ b/app/view/twig/editcontent/editcontent.twig
@@ -90,28 +90,32 @@
                     {% if context.has.tabs %}
                         <div class="tab-pane{{ group.is_active ? ' active' : '' }}" id="{{ group.id }}">
                     {% endif %}
+                    
+                    <div class="field-group">
 
-                    {% for key in group.fields %}
+                        {% for key in group.fields %}
 
-                        {% if key == '*relations' %}
-                            {{ include('@bolt/editcontent/_relations.twig') }}
+                            {% if key == '*relations' %}
+                                {{ include('@bolt/editcontent/_relations.twig') }}
 
-                        {% elseif key == '*taxonomy' %}
-                            {{ include('@bolt/editcontent/_taxonomies.twig') }}
+                            {% elseif key == '*taxonomy' %}
+                                {{ include('@bolt/editcontent/_taxonomies.twig') }}
 
-                        {% elseif key == '*meta' %}
-                            <div data-bolt-fieldset="meta">
-                                {{ include('@bolt/editcontent/fields/_meta.twig') }}
-                            </div>
+                            {% elseif key == '*meta' %}
+                                <div data-bolt-fieldset="meta">
+                                    {{ include('@bolt/editcontent/fields/_meta.twig') }}
+                                </div>
 
-                        {% elseif key == '*template' %}
-                            {{ include('@bolt/editcontent/_templatefields.twig') }}
+                            {% elseif key == '*template' %}
+                                {{ include('@bolt/editcontent/_templatefields.twig') }}
 
-                        {% else %}
-                            {{ include('@bolt/editcontent/_field.twig') }}
-                        {% endif %}
+                            {% else %}
+                                {{ include('@bolt/editcontent/_field.twig') }}
+                            {% endif %}
 
-                    {% endfor %}
+                        {% endfor %}
+
+                    </div>
 
                     {% if context.has.tabs %}
                         </div>

--- a/theme/base-2016/page.twig
+++ b/theme/base-2016/page.twig
@@ -2,13 +2,13 @@
 
 {% block main %}
 
-    <h1>{{ record.title }}</h1>
+    <h1 data-bolt-field="title">{{ record.title }}</h1>
 
     {{ record.teaser }}
 
     {% if record.image!="" %}
         <a href="{{ image(record.image) }}">
-            <img src="{{ thumbnail(record.image, 740, 560) }}">
+            <img src="{{ thumbnail(record.image, 740, 560) }}" data-bolt-field="image[file]">
         </a>
     {% endif %}
 


### PR DESCRIPTION
I've played around a little with making modal popups out of the fields that are not possible to make  contentEditable, such as images. So when clicking an image in the live editor, a modal popup with only that field would show up. The screenshot below is from the current implementation:

![image](https://cloud.githubusercontent.com/assets/2410669/21366021/57cb7bdc-c6f8-11e6-9519-90425353a9ed.png)


Right now the live editor simply reloads when the content is changed. That's the easiest way to make the content show up correctly. It increases the load time a little bit compared to just updating the affected elements, but it's a more general solution. Of course it's possible to fine tune the behavior for specific field types.

Personally I think this modal approach has several pros, since it makes it easier for editors to know which piece of content that is linked to which field, and the appearance is consistent between the regular Edit content section and the live editor, while we keep the duplication of code to a minimum.

There are several things to keep working on. For example fields that have several input areas (file, title etc) must be handled better. So far I've almost exclusively looked at the image field type, but theoretically most of the fields should work with some tweaking.

Before I continue and hack on this I'd like to know what you guys think, is this a preferred route forward? Are there better ways to implement/accomplish this kind of functionality?