### PR TITLE
[Tests] Fix acceptance test checks for session cookies front-end

### DIFF
--- a/tests/codeception/acceptance/000-FirstUser/FirstUserCest.php
+++ b/tests/codeception/acceptance/000-FirstUser/FirstUserCest.php
@@ -11,12 +11,15 @@ class FirstUserCest
 {
     /** @var array */
     protected $user;
+    /** @var array */
+    protected $tokenNames;
 
     /**
      * @param \AcceptanceTester $I
      */
     public function _before(\AcceptanceTester $I)
     {
+        $this->tokenNames = Fixtures::get('tokenNames');
         $this->user = Fixtures::get('users');
     }
 
@@ -51,5 +54,9 @@ class FirstUserCest
 
         // We should now be logged in an greeted!
         $I->see('Welcome to your new Bolt site');
+
+        // Check for nom nom
+        $I->seeCookie($this->tokenNames['session']);
+        $I->seeCookie($this->tokenNames['authtoken']);
     }
 }

--- a/tests/codeception/acceptance/200-Frontend/FrontendCest.php
+++ b/tests/codeception/acceptance/200-Frontend/FrontendCest.php
@@ -57,8 +57,12 @@ class FrontendCest
     {
         $I->wantTo('see that there are no session cookies set.');
 
-        $I->amOnPage('/');
+        $I->resetCookie($this->tokenNames['session']);
 
+        $I->amOnPage('/');
+        $I->dontSeeCookie($this->tokenNames['session']);
+
+        $I->amOnPage('/thumbs/42x42c/koala.jpg');
         $I->dontSeeCookie($this->tokenNames['session']);
     }
 

--- a/tests/codeception/acceptance/_bootstrap.php
+++ b/tests/codeception/acceptance/_bootstrap.php
@@ -69,6 +69,6 @@ Fixtures::add('backups', [
 
 // Session and authentication tokens
 Fixtures::add('tokenNames', [
-    'session'   => 'bolt_session_' . md5('localhost:8123'),
-    'authtoken' => 'bolt_authtoken_' . md5('localhost:8123'),
+    'session'   => 'bolt_session_' . md5('localhost'),
+    'authtoken' => 'bolt_authtoken_' . md5('localhost'),
 ]);


### PR DESCRIPTION
This PR fixes the test for no session cookie, e.g. #6196, that should have been shown up in our acceptance tests, but weren't.

The tests on this PR will fail until https://github.com/bolt/bolt-thumbs/pull/35 is modified & merged.