### PR TITLE
Don't persist unset fields on update

### DIFF
--- a/src/Storage/Database/Schema/Table/ContentType.php
+++ b/src/Storage/Database/Schema/Table/ContentType.php
@@ -186,7 +186,7 @@ class ContentType extends BaseTable
         if ($this->platform->getName() === 'sqlite') {
             $this->table->addColumn($fieldName, 'json_array', ['default' => '[]']);
         } else {
-            $this->table->addColumn($fieldName, 'json_array', []);
+            $this->table->addColumn($fieldName, 'json_array', ['notnull' => false]);
         }
     }
 

--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -296,7 +296,13 @@ class Repository implements ObjectRepository
         $metadata = $this->getClassMetadata();
 
         foreach ($metadata->getFieldMappings() as $field) {
-            if (in_array($field['fieldname'], $exclusions)) {
+            $fieldName = $field['fieldname'];
+            if (in_array($fieldName, $exclusions)) {
+                continue;
+            }
+            // Don't add field to the persistence query if it is not an entity
+            // property, and on UPDATE only
+            if (!isset($entity->$fieldName) && $entity->getId() !== null) {
                 continue;
             }
 

--- a/tests/phpunit/unit/Storage/EntityTest.php
+++ b/tests/phpunit/unit/Storage/EntityTest.php
@@ -24,4 +24,31 @@ class EntityTest extends BoltUnitTest
         $this->assertEquals('bolt_field_example', $entity->underscore($camel2));
 
     }
+
+    public function testEntityUpdatePartial()
+    {
+        $app = $this->getApp();
+        $repo = $app['storage']->getRepository('pages');
+
+        $entity = $repo->getEntityBuilder()->getEntity();
+        $entity->set('title', 'Kenny Koala');
+        $entity->set('status', 'published');
+        $entity->set('slug', 'kenny-koala');
+        $entity->set('image', ['file' => 'koala.png']);
+        $repo->save($entity);
+        $id = $entity->getId();
+
+        $entity = $repo->getEntityBuilder()->getEntity();
+        $entity->set('id', $id);
+        $entity->set('title', 'Kenny Koala Jr.');
+        $entity->set('status', 'draft');
+        $entity->set('slug', 'kenny-koala');
+        $repo->save($entity);
+
+        $entity = $repo->find($id);
+        $this->assertSame($entity->getTitle(), 'Kenny Koala Jr.');
+        $this->assertSame($entity->getStatus(), 'draft');
+        $this->assertSame($entity->getSlug(), 'kenny-koala');
+        $this->assertSame($entity->getImage(), ['file' => 'koala.png']);
+    }
 }


### PR DESCRIPTION
* Don't add a field to the persistence query if it is not an entity property

To reproduce the problem, the simplest ContentType:
```
koalas:
    name: Koalas
    singular_name: Koala
    fields:
        title:
            type: text
        slug:
            type: slug
            uses: title
        imagelist:
            type: imagelist
```
Test PHP code:

```
$repo = $app['storage']->getRepository('koalas');
$entity = $repo->getEntityBuilder()->getEntity();
$entity->set('title', 'Kenny Koala');
$entity->set('status', 'published');
$entity->set('slug', 'kenny-koala');
$repo->save($entity);
```

Result:

```
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'imagelist' cannot be null
```