### PR TITLE
Add environment support to config variable lookups

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -270,6 +270,12 @@ class Config
         if (is_string($value)) {
             $serviceName = substr($value, 1, strlen($value) - 2);
 
+            // First we pass the raw variable name to getenv to see if an environment variable is set
+            $env = getenv($serviceName);
+            if ($env !== false) {
+                return $env;
+            }
+
             if (strpos($serviceName, ':') !== false) {
                 list($serviceName, $params) = explode(':', $serviceName);
             } else {
@@ -277,7 +283,7 @@ class Config
             }
 
             if (!isset($this->app[$serviceName])) {
-                return;
+                return null;
             }
 
             $service = $this->app[$serviceName];


### PR DESCRIPTION
Just a small addition to the functionality of dynamic variable lookups, this PR adds support for looking up environment variables in config files. It's ideal if you want to inject configuration into a staging/production server rather than having it in the configuration files.

Syntax:

```
#config.yml

database:
    host: %APP_DB_HOST%
    driver: mysql
    databasename: %APP_DB_DATABASE%
    username: %APP_DB_USERNAME%
    password: %APP_DB_PASSWORD%

```

The values will be swapped out at runtime for the value at `getenv('APP_DB_HOST');` etc.