### PR TITLE
Fix HTTPS detection for canonical url

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1175,7 +1175,7 @@ class Config
                 ],
             ],
             'liveeditor'                  => true,
-            'canonical'                   => !empty($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '',
+            'canonical'                   => null,
             'cookies_use_remoteaddr'      => true,
             'cookies_use_browseragent'    => false,
             'cookies_use_httphost'        => true,

--- a/tests/phpunit/unit/Configuration/ResourceManagerTest.php
+++ b/tests/phpunit/unit/Configuration/ResourceManagerTest.php
@@ -176,10 +176,10 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $app = new Application(['resources' => $config]);
-        $this->assertEquals('cli', $config->getRequest('protocol'));
+        $this->assertEquals('http', $config->getRequest('protocol'));
         $this->assertEquals('bolt.dev', $config->getRequest('hostname'));
         $this->assertEquals('http://bolt.dev/bolt', $config->getUrl('canonical'));
-        $this->assertEquals('cli://bolt.dev', $config->getUrl('host'));
+        $this->assertEquals('http://bolt.dev', $config->getUrl('host'));
         $this->assertEquals('http://bolt.dev/', $config->getUrl('rooturl'));
     }
 


### PR DESCRIPTION
Also don't include canonical in cached configs if it isn't set, since it can vary per request.

If one has host requirements in the routing.yml one doesn't want to set a canonical for the whole site (because it needs to be autodetected from the request since there are multiple valid hostnames for one site).

This fixes so that:

1. The canonical is only cached if it is set in the config.yml
2. HTTPS detection happens before the canonical is built, so that HTTPS detection for the canonical works.