### PR TITLE
[Deprecations] Have {{ setcontent }} use FQCN of Bolt's Twig extension

### DIFF
--- a/src/Twig/SetcontentNode.php
+++ b/src/Twig/SetcontentNode.php
@@ -44,7 +44,7 @@ class SetcontentNode extends Node
             ->write("\$context['")
             ->raw($this->getAttribute('name'))
             ->raw("'] = ")
-            ->raw("\$this->env->getExtension('Bolt')->getStorage()->getContent(")
+            ->raw("\$this->env->getExtension('\\Bolt\\Twig\\Extension\\BoltExtension')->getStorage()->getContent(")
             ->subcompile($this->getAttribute('contenttype'))
             ->raw(', ')
             ->subcompile($arguments)


### PR DESCRIPTION
Just a few deprecated calls …
```
Referencing the "Bolt" extension by its name (defined by getName()) is 
deprecated since 1.26 and will be removed in Twig 2.0. Use the Fully 
Qualified Extension Class Name instead: 472x
    472x in Application::run from Codeception
```