### PR TITLE
dot dev is an actual TLD, so use dot test for testing instead

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
          syntaxCheck="false"
         >
     <php>
-        <server name="HTTP_HOST" value="bolt.dev" />
+        <server name="HTTP_HOST" value="bolt.test" />
         <server name="REQUEST_URI" value="/bolt" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     </php>

--- a/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
+++ b/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
@@ -135,7 +135,7 @@ class AccessCheckerTest extends BoltUnitTest
         $userName = 'koala';
         $salt = 'vinagre';
         $ipAddress = '8.8.8.8';
-//         $hostName = 'bolt.dev';
+//         $hostName = 'bolt.test';
         $userAgent = 'Bolt PHPUnit tests';
 //         $cookieOptions = [
 //             'remoteaddr'   => true,

--- a/tests/phpunit/unit/AccessControl/LoginTest.php
+++ b/tests/phpunit/unit/AccessControl/LoginTest.php
@@ -274,7 +274,7 @@ class LoginTest extends BoltUnitTest
         $userName = 'admin';
         $salt = 'vinagre';
         $ipAddress = '1.2.3.4';
-        $hostName = 'bolt.dev';
+        $hostName = 'bolt.test';
         $userAgent = 'Bolt PHPUnit tests';
         $cookieOptions = [
             'remoteaddr'   => true,

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -92,7 +92,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $bolt['config']->set('general/canonical', 'bolt.dev');
+        $bolt['config']->set('general/canonical', 'bolt.test');
         $bolt['slugify'] = Slugify::create();
 
         $this->setAppPaths($bolt['resources']);

--- a/tests/phpunit/unit/Canonical/CanonicalTest.php
+++ b/tests/phpunit/unit/Canonical/CanonicalTest.php
@@ -16,7 +16,7 @@ class CanonicalTest extends BoltUnitTest
     public function provider()
     {
         return [
-            'default'                  => [null, '/drop/bear', 'http://bolt.dev/drop/bear'],
+            'default'                  => [null, '/drop/bear', 'http://bolt.test/drop/bear'],
             'override host'            => ['koala.org.au', '/drop/bear', 'http://koala.org.au/drop/bear'],
             'override host and https'  => ['https://koala.org.au', '/drop/bear', 'https://koala.org.au/drop/bear'],
             'https does not downgrade' => ['koala.org.au', 'https://koala.org.au/drop/bear', 'https://koala.org.au/drop/bear'],

--- a/tests/phpunit/unit/Configuration/ResourceManagerTest.php
+++ b/tests/phpunit/unit/Configuration/ResourceManagerTest.php
@@ -177,10 +177,10 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
         );
         $app = new Application(['resources' => $config]);
         $this->assertEquals('http', $config->getRequest('protocol'));
-        $this->assertEquals('bolt.dev', $config->getRequest('hostname'));
-        $this->assertEquals('http://bolt.dev/bolt', $config->getUrl('canonical'));
-        $this->assertEquals('http://bolt.dev', $config->getUrl('host'));
-        $this->assertEquals('http://bolt.dev/', $config->getUrl('rooturl'));
+        $this->assertEquals('bolt.test', $config->getRequest('hostname'));
+        $this->assertEquals('http://bolt.test/bolt', $config->getUrl('canonical'));
+        $this->assertEquals('http://bolt.test', $config->getUrl('host'));
+        $this->assertEquals('http://bolt.test/', $config->getUrl('rooturl'));
     }
 
     /**
@@ -217,7 +217,7 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'HTTP_HOST'       => 'test.dev',
+                'HTTP_HOST'       => 'test.test',
                 'SERVER_PROTOCOL' => 'https',
             ]
         );
@@ -232,7 +232,7 @@ class ResourceManagerTest extends \PHPUnit_Framework_TestCase
         );
         new Application(['resources' => $config]);
         $this->assertEquals('https', $config->getRequest('protocol'));
-        $this->assertEquals('test.dev', $config->getRequest('hostname'));
+        $this->assertEquals('test.test', $config->getRequest('hostname'));
     }
 
     public function testNonRootDirectory()

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -144,12 +144,12 @@ class FrontendTest extends ControllerUnitTest
     public function testCanonicalUrlProvider()
     {
         return [
-            ['http://bolt.dev/', null, false],
-            ['http://bolt.dev/', null, true],
-            ['https://foo.dev/', 'https://foo.dev/', false],
-            ['https://foo.dev/', 'https://foo.dev/', true],
-            ['http://bar.dev/', 'http://bar.dev/', false],
-            ['http://bar.dev/', 'http://bar.dev/', true],
+            ['http://bolt.test/', null, false],
+            ['http://bolt.test/', null, true],
+            ['https://foo.test/', 'https://foo.test/', false],
+            ['https://foo.test/', 'https://foo.test/', true],
+            ['http://bar.test/', 'http://bar.test/', false],
+            ['http://bar.test/', 'http://bar.test/', true],
         ];
     }
 


### PR DESCRIPTION
Since .dev is an actual tld we should use a tld reserved for testing, like .test