### PR TITLE
Fix label translate in 'Extend' template

### DIFF
--- a/app/resources/translations/cs_CZ/messages.cs_CZ.yml
+++ b/app/resources/translations/cs_CZ/messages.cs_CZ.yml
@@ -128,6 +128,7 @@
 "page.extend.message.updating": # "Searching for available updates …"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
+"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 "permissions.roles.label.anonymous": # "Anonymous"
 

--- a/app/resources/translations/de_DE/messages.de_DE.yml
+++ b/app/resources/translations/de_DE/messages.de_DE.yml
@@ -114,6 +114,7 @@
 "page.extend.message.shows-updates": # "This won't install anything, just show you available updates"
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
+"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 76 translations ----------------------------------------------------------

--- a/app/resources/translations/el/messages.el.yml
+++ b/app/resources/translations/el/messages.el.yml
@@ -412,6 +412,7 @@
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.label.create-folder": # "Create folder"
 "page.file-management.message.create-file": # "Please enter a new file name!"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -649,6 +649,7 @@ page.extend.pagetitle: "Extend %BOLTNAME%"
 page.extend.theme.generation.failure: "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 page.extend.theme.generation.missing.name: "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: "Theme successfully generated. You can now edit it directly from your theme folder."
+page.extend.options: "Extension Options"
 
 page.file-management.label.create-file: "Create File"
 page.file-management.label.create-folder: "Create folder"

--- a/app/resources/translations/es_ES/messages.es_ES.yml
+++ b/app/resources/translations/es_ES/messages.es_ES.yml
@@ -21,6 +21,7 @@
 "general.phrase.status-explanation": # "The status defines whether or not this record is published. Select 'Timed publish' to automatically publish on the set Publication Date."
 "nut.greeting": # "Welcome to Bolt!"
 "nut.version": # "version"
+"page.extend.options": #
 
 #--- 92 translations ----------------------------------------------------------
 

--- a/app/resources/translations/fi/messages.fi.yml
+++ b/app/resources/translations/fi/messages.fi.yml
@@ -193,6 +193,7 @@
 "page.extend.message.updating": # "Searching for available updates …"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 

--- a/app/resources/translations/fr/messages.fr.yml
+++ b/app/resources/translations/fr/messages.fr.yml
@@ -46,6 +46,7 @@
 "field.slug.button.generate": # "Generate from:"
 "nut.greeting": # "Welcome to Bolt!"
 "nut.version": # "version"
+"page.extend.options": #
 
 #--- 88 translations ----------------------------------------------------------
 

--- a/app/resources/translations/hu/messages.hu.yml
+++ b/app/resources/translations/hu/messages.hu.yml
@@ -643,6 +643,7 @@ page.extend.pagetitle: "A %BOLTNAME% kibővítése"
 page.extend.theme.generation.failure: "Nem tudjuk előállítani a témát. Olyan mint ha a téma mappa nem lenne írható. Ellenőrizd a jogokat és próbáld újra!"
 page.extend.theme.generation.missing.name: "Nincs a témának neve. Így a téma nem állítható elő."
 page.extend.theme.generation.success: "A téma rendben elkészült. Mostantól közvetlenül szerkesztheted a téma mappában."
+page.extend.options: "Bővítmény opciók"
 
 page.file-management.label.create-file: "Fájl létrehozása"
 page.file-management.label.create-folder: "Könyvtár létrehozása"

--- a/app/resources/translations/id/messages.id.yml
+++ b/app/resources/translations/id/messages.id.yml
@@ -454,6 +454,7 @@
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.label.create-folder": # "Create folder"
 "page.file-management.message.create-file": # "Please enter a new file name!"

--- a/app/resources/translations/it/messages.it.yml
+++ b/app/resources/translations/it/messages.it.yml
@@ -400,6 +400,7 @@
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.label.create-folder": # "Create folder"
 "page.file-management.message.create-file": # "Please enter a new file name!"

--- a/app/resources/translations/ja/messages.ja.yml
+++ b/app/resources/translations/ja/messages.ja.yml
@@ -325,6 +325,7 @@
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.create-file": # "Please enter a new file name!"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."

--- a/app/resources/translations/nb/messages.nb.yml
+++ b/app/resources/translations/nb/messages.nb.yml
@@ -412,6 +412,7 @@
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.label.create-folder": # "Create folder"
 "page.file-management.message.create-file": # "Please enter a new file name!"

--- a/app/resources/translations/nl_NL/messages.nl_NL.yml
+++ b/app/resources/translations/nl_NL/messages.nl_NL.yml
@@ -63,6 +63,7 @@
 "page.extend.message.invalid-theme-source-dir": # "Invalid theme source directory: %SOURCE%"
 "page.extend.message.package-dependencies": # "Packages that depend on this"
 "page.extend.message.running-update-all": # "Running updates"
+"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 80 translations ----------------------------------------------------------

--- a/app/resources/translations/pl_PL/messages.pl_PL.yml
+++ b/app/resources/translations/pl_PL/messages.pl_PL.yml
@@ -197,6 +197,7 @@
 "page.extend.message.updating": # "Searching for available updates …"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
+"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 64 translations ----------------------------------------------------------

--- a/app/resources/translations/pt/messages.pt.yml
+++ b/app/resources/translations/pt/messages.pt.yml
@@ -68,6 +68,7 @@
 "page.extend.message.package-dependencies": # "Packages that depend on this"
 "page.extend.message.running-update-all": # "Running updates"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
+"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 84 translations ----------------------------------------------------------

--- a/app/resources/translations/pt_BR/messages.pt_BR.yml
+++ b/app/resources/translations/pt_BR/messages.pt_BR.yml
@@ -279,6 +279,7 @@
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"

--- a/app/resources/translations/ru/messages.ru.yml
+++ b/app/resources/translations/ru/messages.ru.yml
@@ -1,10 +1,10 @@
 # app/resources/translations/ru/messages.ru.yml – generated on 2017-01-02 07:50:25 Europe/Amsterdam
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
@@ -199,6 +199,7 @@
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
 "panel.latest-activity.by": # "by"

--- a/app/resources/translations/sv_SE/messages.sv_SE.yml
+++ b/app/resources/translations/sv_SE/messages.sv_SE.yml
@@ -89,6 +89,7 @@
 "page.extend.message.package-dependencies": # "Packages that depend on this"
 "page.extend.message.package-install-info-fail": # "Unable to get installation information for %PACKAGE% %VERSION%."
 "page.extend.message.running-update-all": # "Running updates"
+"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 76 translations ----------------------------------------------------------

--- a/app/resources/translations/zh_CN/messages.zh_CN.yml
+++ b/app/resources/translations/zh_CN/messages.zh_CN.yml
@@ -254,6 +254,7 @@
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"

--- a/app/resources/translations/zh_TW/messages.zh_TW.yml
+++ b/app/resources/translations/zh_TW/messages.zh_TW.yml
@@ -242,6 +242,7 @@
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
+"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -100,7 +100,7 @@
 
         <aside class="col-md-3">
             <div class="panel panel-default">
-                <div class="panel-heading"><i class="fa fa-cog fa-fw"></i>Extensions Options</div>
+                <div class="panel-heading"><i class="fa fa-cog fa-fw"></i>{{ __('page.extend.options') }}</div>
                 <div class="panel-body">
                         <p><strong>{{ __('page.extend.message.check-for-updates') }}</strong></p>
                         <div class="btn-group">


### PR DESCRIPTION
1555 like PR for a missing translation template entry for ``Extend`` -> ``Extension Options`` box title.
