### PR TITLE
Handling of fragment in URL generator

### DIFF
--- a/src/Routing/UrlGeneratorFragmentWrapper.php
+++ b/src/Routing/UrlGeneratorFragmentWrapper.php
@@ -33,16 +33,17 @@ class UrlGeneratorFragmentWrapper implements UrlGeneratorInterface, Configurable
      */
     public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        $fragment = null;
-        if (isset($parameters['#'])) {
+        $fragment = isset($parameters['_fragment']) ? $parameters['_fragment'] : null;
+        unset($parameters['_fragment']);
+        if ($fragment === null && isset($parameters['#'])) {
             $fragment = $parameters['#'];
-            unset($parameters['#']);
         }
+        unset($parameters['#']);
 
         $url = $this->wrapped->generate($name, $parameters, $referenceType);
 
         if (!empty($fragment)) {
-            $url .= '#' . $fragment;
+            $url .= '#' . strtr(rawurlencode($fragment), ['%2F' => '/', '%3F' => '?']);
         }
 
         return $url;


### PR DESCRIPTION
* Fix fragments that have '/' & '?'
* Backport handling of fragment in URL generator @see https://github.com/symfony/symfony/pull/12979/commits/6d79a565e0e56b525134080687eba3961eab1a73