### PR TITLE
[3.3][RFC] Adding security service provider

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -210,6 +210,7 @@ class Application extends Silex\Application
             ->register(new Silex\Provider\ValidatorServiceProvider())
             ->register(new Provider\RoutingServiceProvider())
             ->register(new Silex\Provider\ServiceControllerServiceProvider()) // must be after Routing
+            ->register(new Provider\SecurityServiceProvider())
             ->register(new Provider\RandomGeneratorServiceProvider())
             ->register(new Provider\PermissionsServiceProvider())
             ->register(new Provider\StorageServiceProvider())

--- a/src/Provider/SecurityServiceProvider.php
+++ b/src/Provider/SecurityServiceProvider.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Bolt\Provider;
+
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Silex\Provider\SecurityServiceProvider as SilexSecurityServiceProvider;
+
+/**
+ * Bolt security service provider.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class SecurityServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function register(Application $app)
+    {
+        $app['security.firewalls'] = $app->share(
+            function ($app) {
+                $boltPath = $app['config']->get('general/branding/path');
+
+                return  [
+                    'login_path' => [
+                        'pattern'   => '^' . $boltPath . '/login$',
+                        'anonymous' => true,
+                    ],
+                    'bolt' => [
+                        'pattern'  => '^' . $boltPath,
+                        'security' => false,
+                    ],
+                    'default' => [
+                        'pattern'   => '^/.*$',
+                        'anonymous' => true,
+                        'form'      => [
+                            'login_path' => $boltPath . '/login',
+                            'check_path' => $boltPath . '/login_check',
+                        ],
+                        'logout'    => [
+                            'logout_path'        => $boltPath . '/logout',
+                            'invalidate_session' => false,
+                        ],
+                    ],
+                ];
+            }
+        );
+
+        $app['security.access_rules'] = $app->share(
+            function ($app) {
+                $boltPath = $app['config']->get('general/branding/path');
+
+                return [
+                    ['^' . $boltPath . '/login$', 'IS_AUTHENTICATED_ANONYMOUSLY'],
+                    ['^/.+$', 'ROLE_USER'],
+                ];
+            }
+        );
+
+        $app->register(new SilexSecurityServiceProvider());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot(Application $app)
+    {
+    }
+}

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -58,6 +58,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
 
             if ($boot) {
                 $this->app->boot();
+                $this->app->flush();
             }
         }
 

--- a/tests/phpunit/unit/Controller/ControllerUnitTest.php
+++ b/tests/phpunit/unit/Controller/ControllerUnitTest.php
@@ -48,6 +48,7 @@ abstract class ControllerUnitTest extends BoltUnitTest
         $verifier->checks();
 
         $app->boot();
+        $app->flush();
 
         return $app;
     }

--- a/tests/phpunit/unit/Provider/OmnisearchServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/OmnisearchServiceProviderTest.php
@@ -17,6 +17,5 @@ class OmnisearchServiceProviderTest extends BoltUnitTest
         $provider = new OmnisearchServiceProvider($app);
         $app->register($provider);
         $this->assertInstanceOf('Bolt\Omnisearch', $app['omnisearch']);
-        $app->boot();
     }
 }


### PR DESCRIPTION
If agreed upon, this PR will add the Silex provider, and a provider of our own for Symfony Security.

This changes nothing about Bolt's current route security behaviour, but makes ` $app['security.firewalls']` and ` $app['security.access_rules']` shareable services that we know will be there from 3.3.0 onward (_read_: extensions)
