### PR TITLE
Set a default as request will not exists on CLI

### DIFF
--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -43,7 +43,7 @@
 </table>
 
 
-{% for bag in bags if (attribute(request, bag) is defined) and (attribute(request, bag).all is not empty)%}
+{% for bag in bags if (attribute(request, bag)|default()) and (attribute(request, bag).all is not empty)%}
 
     {% set values = attribute(request, bag).all %}
 


### PR DESCRIPTION
Prevents this in Nut:

```
  [Twig_Error_Runtime]                                                                                         
  Impossible to access an attribute ("all") on a null variable in "@bolt/exception/_request.twig" at line 46.  
```