### PR TITLE
Backport PathsProxy to 3.2

### DIFF
--- a/src/Configuration/PathsProxy.php
+++ b/src/Configuration/PathsProxy.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Bolt\Configuration;
+
+/**
+ * Bolt\Configuration\ResourceManager::getPaths() is proxied here, which used to return a simple array.
+ *
+ * This allows us to still use getPath, getUrl, and getRequest methods which have custom logic in them to maintain BC.
+ *
+ * @deprecated since 3.0, to be removed in 4.0.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class PathsProxy implements \ArrayAccess
+{
+    /** @var ResourceManager */
+    protected $resources;
+
+    /**
+     * Constructor.
+     *
+     * @param ResourceManager $resources
+     */
+    public function __construct(ResourceManager $resources)
+    {
+        $this->resources = $resources;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return $this->offsetGet($offset) !== null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        try {
+            return $this->resources->getRequest($offset);
+        } catch (\InvalidArgumentException $e) {
+        }
+
+        try {
+            return $this->resources->getUrl($offset);
+        } catch (\InvalidArgumentException $e) {
+        }
+
+        try {
+            return $this->resources->getPath($offset);
+        } catch (\InvalidArgumentException $e) {
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value)
+    {
+        throw new \LogicException('Use Bolt\Configuration\ResourceManager::setUrl() or setPath() instead.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        throw new \LogicException('You cannot remove urls or paths.');
+    }
+}

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -53,6 +53,12 @@ class ResourceManager
     protected $pathManager;
 
     /**
+     * @deprecated since 3.0, to be removed in 4.0.
+     * @var PathsProxy
+     */
+    private $pathsProxy;
+
+    /**
      * Constructor initialises on the app root path.
      *
      * @param \ArrayAccess $container ArrayAccess compatible DI container that must contain one of:
@@ -305,18 +311,19 @@ class ResourceManager
     }
 
     /**
-     * Returns merged array of Urls, Paths and current request.
+     * Just don't use this.
      *
-     * However $this->paths can be either mixed array elements of String or Path
-     * getPaths() will convert them string to provide homogeneous type result.
+     * @deprecated since 3.0, to be removed in 4.0.
      *
-     * @return string[] array of merged strings
+     * @return PathsProxy
      */
     public function getPaths()
     {
-        $paths = array_map('strval', $this->paths);
+        if ($this->pathsProxy === null) {
+            $this->pathsProxy = new PathsProxy($this);
+        }
 
-        return array_merge($paths, $this->urls, $this->request);
+        return $this->pathsProxy;
     }
 
     /**


### PR DESCRIPTION
This fixes `urlPrefix` (base path) not being used in paths array.