### PR TITLE
Fix 'Notice: Undefined index: persistant' when using redis for sessions

### DIFF
--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -308,7 +308,7 @@ class SessionServiceProvider implements ServiceProviderInterface
                     $redis = new \Redis();
                     foreach ($connections as $conn) {
                         $params = [$conn['path'] ?: $conn['host'], $conn['port'], $conn['timeout'] ?: 0];
-                        call_user_func_array([$redis, $conn['persistant'] ? 'pconnect' : 'connect'], $params);
+                        call_user_func_array([$redis, $conn['persistent'] ? 'pconnect' : 'connect'], $params);
                         if (!empty($conn['password'])) {
                             $redis->auth($conn['password']);
                         }


### PR DESCRIPTION
When using redis for sessions with errors enabled, Bolt throws the following exception:

<img width="987" alt="error" src="https://cloud.githubusercontent.com/assets/3878240/21787997/2b1032f0-d6c4-11e6-9820-f922c48546df.png">

Easy fix to get it working again. This also should enable persistent connections to redis again as it would just default to `connect`