### PR TITLE
Fix magic attribute parsing to avoid removing parts of field

### DIFF
--- a/src/Storage/Entity/MagicAttributeTrait.php
+++ b/src/Storage/Entity/MagicAttributeTrait.php
@@ -51,7 +51,7 @@ trait MagicAttributeTrait
 
     public function __call($method, $arguments)
     {
-        $var = lcfirst(preg_replace('/^(get|set|serialize)/i','', $method));
+        $var = lcfirst(preg_replace('/^(get|set|serialize)/i', '', $method));
         $underscored = $this->underscore($var);
         $camelized = $this->camelize($var);
         $numericCamel = $this->underscore(preg_replace('/([a-z])([\d])/', '$1_$2', $var));

--- a/src/Storage/Entity/MagicAttributeTrait.php
+++ b/src/Storage/Entity/MagicAttributeTrait.php
@@ -51,7 +51,7 @@ trait MagicAttributeTrait
 
     public function __call($method, $arguments)
     {
-        $var = lcfirst(str_replace(['get', 'set', 'serialize'], '', $method));
+        $var = lcfirst(preg_replace('/^(get|set|serialize)/i','', $method));
         $underscored = $this->underscore($var);
         $camelized = $this->camelize($var);
         $numericCamel = $this->underscore(preg_replace('/([a-z])([\d])/', '$1_$2', $var));


### PR DESCRIPTION
Fixes #6242 

The current code wasn't limited to the start of a string, switching to a regex fixes that.