### PR TITLE
Add labels to translations for repeaters / new block fields

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -177,6 +177,7 @@ contenttypes.generic.wrong-use-field: "In the ContentType for '%contenttype%', t
 
 contenttypes.record.comment-add-colon: "Add a comment:"
 
+field.block.label.add-new: "Add new..."
 field.block.label.add-set: "Add new %label% set"
 
 field.general.allowed-filetypes: "Allowed file types are:"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -177,6 +177,8 @@ contenttypes.generic.wrong-use-field: "In the ContentType for '%contenttype%', t
 
 contenttypes.record.comment-add-colon: "Add a comment:"
 
+field.block.label.add-set: "Add new %label% set"
+
 field.general.allowed-filetypes: "Allowed file types are:"
 field.general.select-from-server: "Select from server"
 field.general.stack: "Stack"
@@ -193,6 +195,8 @@ field.image.label.alt: "Alt"
 
 field.markdown.label.markedview: "Markdown"
 field.markdown.label.preview: "Preview"
+
+field.repeater.label.add-set: "Add new %label% set"
 
 field.slug.button.edit: "Edit"
 field.slug.button.generate: "Generate from:"

--- a/app/view/twig/editcontent/fields/_block.twig
+++ b/app/view/twig/editcontent/fields/_block.twig
@@ -36,7 +36,7 @@
     <div class="col-xs-12">
         <div class="block-add">
             <div class="btn-group">
-                <button type="button" class="btn btn-default">Add New...</button>
+                <button type="button" class="btn btn-default">{{ __('field.block.label.add-new') }}</button>
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                     <span class="caret"></span>
                 </button>

--- a/app/view/twig/editcontent/fields/_block.twig
+++ b/app/view/twig/editcontent/fields/_block.twig
@@ -43,7 +43,7 @@
                 <ul class="dropdown-menu" role="menu">
                     {% for blockname, block in field.fields %}
                         <li>
-                            <a class="add-button" data-block-type="{{ blockname }}"><i class="fa fa-plus"></i> Add new {{ block.label }} set</a>
+                            <a class="add-button" data-block-type="{{ blockname }}"><i class="fa fa-plus"></i> __('field.block.label.add-set', {'%label%': block.label})</a>
                         </li>
                     {% endfor %}
                 </ul>

--- a/app/view/twig/editcontent/fields/_block.twig
+++ b/app/view/twig/editcontent/fields/_block.twig
@@ -43,7 +43,9 @@
                 <ul class="dropdown-menu" role="menu">
                     {% for blockname, block in field.fields %}
                         <li>
-                            <a class="add-button" data-block-type="{{ blockname }}"><i class="fa fa-plus"></i> __('field.block.label.add-set', {'%label%': block.label})</a>
+                            <a class="add-button" data-block-type="{{ blockname }}">
+                                <i class="fa fa-plus"></i> {{  __('field.block.label.add-set', {'%label%': block.label}) }}
+                            </a>
                         </li>
                     {% endfor %}
                 </ul>

--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -36,7 +36,7 @@
 
     <div class="repeater-add">
         <button type="button" class="btn btn-default add-button">
-            <i class="fa fa-plus"></i> __('field.repeater.label.add-set', {'%label%': labelkey})
+            <i class="fa fa-plus"></i> {{ __('field.repeater.label.add-set', {'%label%': labelkey}) }}
         </button>
     </div>
 </fieldset>

--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -36,7 +36,7 @@
 
     <div class="repeater-add">
         <button type="button" class="btn btn-default add-button">
-            <i class="fa fa-plus"></i> Add new {{ labelkey }} set
+            <i class="fa fa-plus"></i> __('field.repeater.label.add-set', {'%label%': labelkey})
         </button>
     </div>
 </fieldset>


### PR DESCRIPTION
Fixes #5972
Also adds the fix to the new named repeaters/blocks functionality