### PR TITLE
[3.3] Profiler deprecation notices

### DIFF
--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -367,7 +367,7 @@ class General extends AsyncBase
         // Iterate over the items, pick the first news-item that
         // applies and the first alert we need to show
         foreach ($fetchedNewsItems as $item) {
-            $type = ($item->type === 'alert') ? 'alert' : 'information';
+            $type = isset($item->type) ? $item->type : 'information';
             if (!isset($news[$type])
                 && (empty($item->target_version) || Bolt\Version::compare($item->target_version, '>'))
             ) {

--- a/src/Controller/Backend/Log.php
+++ b/src/Controller/Backend/Log.php
@@ -128,6 +128,7 @@ class Log extends BackendBase
                 'title'   => Trans::__('logs.change-log.contenttypes.all'),
                 'entries' => $this->changeLogRepository()->getChangeLog($queryOptions),
                 'count'   => $this->changeLogRepository()->countChangeLog(),
+                'content' => null,
             ];
         } else {
             $contenttype = $this->getContentType($contenttype);

--- a/src/Debug/ShutdownHandler.php
+++ b/src/Debug/ShutdownHandler.php
@@ -15,23 +15,22 @@ use Symfony\Component\Debug;
  */
 class ShutdownHandler
 {
+    public static $errorLevels;
+
     /**
      * Set the handlers.
+     *
+     * NOTE:
+     * CLI uses a custom output handler & must NOT call Debug::enable() as this
+     * breaks Codeception redirect handling under some circumstances.
      *
      * @param bool $debug
      */
     public static function register($debug = true)
     {
-        $errorLevels = error_reporting();
-        if ($debug) {
-            $errorLevels |= E_RECOVERABLE_ERROR | E_USER_ERROR | E_DEPRECATED | E_USER_DEPRECATED;
-            Debug\DebugClassLoader::enable();
-        }
+        self::$errorLevels = error_reporting();
 
-        if (PHP_SAPI !== 'cli') {
-            Debug\ErrorHandler::register()->throwAt($errorLevels, true);
-            Debug\ExceptionHandler::register($debug);
-        } else {
+        if (PHP_SAPI === 'cli') {
             $consoleHandler = function (\Exception $e) {
                 $app = new Application('Bolt CLI', Version::VERSION);
                 $output = new ConsoleOutput(OutputInterface::VERBOSITY_DEBUG);
@@ -39,6 +38,14 @@ class ShutdownHandler
                 ob_clean();
             };
             Debug\ExceptionHandler::register($debug)->setHandler($consoleHandler);
+
+            return;
         }
+
+        if ($debug) {
+            self::$errorLevels |= E_RECOVERABLE_ERROR | E_USER_ERROR | E_DEPRECATED | E_USER_DEPRECATED;
+        }
+        Debug\Debug::enable(self::$errorLevels, true);
+        Debug\ExceptionHandler::register($debug);
     }
 }

--- a/src/Debug/ShutdownHandler.php
+++ b/src/Debug/ShutdownHandler.php
@@ -15,8 +15,6 @@ use Symfony\Component\Debug;
  */
 class ShutdownHandler
 {
-    public static $errorLevels;
-
     /**
      * Set the handlers.
      *
@@ -28,8 +26,6 @@ class ShutdownHandler
      */
     public static function register($debug = true)
     {
-        self::$errorLevels = error_reporting();
-
         if (PHP_SAPI === 'cli') {
             $consoleHandler = function (\Exception $e) {
                 $app = new Application('Bolt CLI', Version::VERSION);
@@ -42,10 +38,7 @@ class ShutdownHandler
             return;
         }
 
-        if ($debug) {
-            self::$errorLevels |= E_RECOVERABLE_ERROR | E_USER_ERROR | E_DEPRECATED | E_USER_DEPRECATED;
-        }
-        Debug\Debug::enable(self::$errorLevels, true);
+        Debug\Debug::enable();
         Debug\ExceptionHandler::register($debug);
     }
 }

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -113,7 +113,7 @@ class Html
         }
 
         // If we forgot the second element in the array, substitute the first for it.
-        if (empty(strip_tags($providedby[1]))) {
+        if (empty($providedby[1]) || empty(strip_tags($providedby[1]))) {
             $providedby[1] = $providedby[0];
         }
 

--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -271,9 +271,10 @@ class Content implements \ArrayAccess
 
         $operator = $asc ? '<' : '>';
         $order = $asc ? ' DESC' : ' ASC';
+        $value = isset($this->values[$field]) ? $this->values[$field] : null;
 
         $params = [
-            $field         => $operator . $this->values[$field],
+            $field         => $operator . $value,
             'limit'        => 1,
             'order'        => $field . $order,
             'returnsingle' => true,
@@ -302,9 +303,10 @@ class Content implements \ArrayAccess
 
         $operator = $asc ? '>' : '<';
         $order = $asc ? ' ASC' : ' DESC';
+        $value = isset($this->values[$field]) ? $this->values[$field] : null;
 
         $params = [
-            $field         => $operator . $this->values[$field],
+            $field         => $operator . $value,
             'limit'        => 1,
             'order'        => $field . $order,
             'returnsingle' => true,

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1263,7 +1263,7 @@ class Storage
             // like 'page/random/4'
             $decoded['contenttypes'] = $this->decodeContentTypesFromText($match[1]);
             $dboptions = $this->app['config']->get('general/database');
-            $metaParameters['order'] = $dboptions['randomfunction']; // 'RAND()' or 'RANDOM()'
+            $metaParameters['order'] = isset($dboptions['randomfunction']) ? $dboptions['randomfunction'] : null; // 'RAND()' or 'RANDOM()'
             if (!isset($metaParameters['limit'])) {
                 $metaParameters['limit'] = $match[2];
             }

--- a/src/Provider/DebugServiceProvider.php
+++ b/src/Provider/DebugServiceProvider.php
@@ -5,6 +5,7 @@ namespace Bolt\Provider;
 use Bolt\Debug\ShutdownHandler;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Symfony\Component\HttpKernel\EventListener\DebugHandlersListener;
 
 class DebugServiceProvider implements ServiceProviderInterface
 {
@@ -30,6 +31,21 @@ class DebugServiceProvider implements ServiceProviderInterface
 
         // Register PHP shutdown functions to catch fatal errors & exceptions
         ShutdownHandler::register();
+
+        $app['debug.debug_handlers_listener'] = $app->share(
+            function ($app) {
+                return new DebugHandlersListener(
+                    null,
+                    $app['logger'],
+                    ShutdownHandler::$errorLevels, // Levels
+                    ShutdownHandler::$errorLevels, // Throw at
+                    true, // Scream
+                    $app['debug.file_link_formatter']
+                );
+            }
+        );
+
+        $app['debug.file_link_formatter'] = null;
     }
 
     /**
@@ -39,6 +55,8 @@ class DebugServiceProvider implements ServiceProviderInterface
     {
         if (!$app['debug']) {
             ShutdownHandler::register(false);
+        } else {
+            $app['dispatcher']->addSubscriber($app['debug.debug_handlers_listener']);
         }
 
         $errorLevel = $app['config']->get($app['debug'] ? 'general/debug_error_level' : 'production_error_level');

--- a/src/Provider/DebugServiceProvider.php
+++ b/src/Provider/DebugServiceProvider.php
@@ -34,11 +34,17 @@ class DebugServiceProvider implements ServiceProviderInterface
 
         $app['debug.debug_handlers_listener'] = $app->share(
             function ($app) {
+                $errorLevels = $app['config']->get(
+                    $app['debug'] ?
+                    'general/debug_error_level' :
+                    'general/production_error_level'
+                );
+
                 return new DebugHandlersListener(
                     null,
                     $app['logger'],
-                    ShutdownHandler::$errorLevels, // Levels
-                    ShutdownHandler::$errorLevels, // Throw at
+                    $errorLevels, // Levels
+                    $errorLevels, // Throw at
                     true, // Scream
                     $app['debug.file_link_formatter']
                 );
@@ -57,11 +63,6 @@ class DebugServiceProvider implements ServiceProviderInterface
             ShutdownHandler::register(false);
         } else {
             $app['dispatcher']->addSubscriber($app['debug.debug_handlers_listener']);
-        }
-
-        $errorLevel = $app['config']->get($app['debug'] ? 'general/debug_error_level' : 'production_error_level');
-        if ($errorLevel !== null) {
-            error_reporting($errorLevel);
         }
     }
 }

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -22,6 +22,8 @@ class NutServiceProvider implements ServiceProviderInterface
 
                 $console->addCommands($app['nut.commands']);
 
+                $console->setDispatcher($app['dispatcher']);
+
                 return $console;
             }
         );

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -23,6 +23,14 @@ class TwigServiceProvider implements ServiceProviderInterface
             $app->register(new \Silex\Provider\TwigServiceProvider());
         }
 
+        // Set authentication providers before security extension is invoked.
+        $factory = $app->raw('twig');
+        $app['twig'] = $app->share(function ($app) use ($factory) {
+            $app['security.firewall'];
+
+            return $factory($app);
+        });
+
         // Twig runtime handlers
         $app['twig.runtime.bolt_admin'] = function ($app) {
             return new Twig\Runtime\AdminRuntime($app['config'], $app['stack'], $app['url_generator'], $app);

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -258,7 +258,7 @@ class Stack implements \Countable, \IteratorAggregate
                 // Guess it doesn't exist anymore or we can't find it, remove from list.
                 return null;
             }
-        }, $paths));
+        }, (array) $paths));
 
         $files = array_slice($files, 0, self::MAX_ITEMS);
 

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -125,6 +125,9 @@ trait ContentValuesTrait
         // add the fields for this contenttype,
         if (is_array($contenttype)) {
             foreach ($contenttype['fields'] as $field => $property) {
+                if (!isset($this->values[$field])) {
+                    continue;
+                }
                 switch ($property['type']) {
                     // Set the slug, while we're at it
                     case 'slug':

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -449,6 +449,7 @@ trait ContentValuesTrait
     public function setFromPost($values, $contenttype)
     {
         $values = Input::cleanPostedData($values);
+        $values += ['status' => 'draft'];
 
         if (!$this->id) {
             // this is a new record: current user becomes the owner.

--- a/src/Storage/Repository/LogChangeRepository.php
+++ b/src/Storage/Repository/LogChangeRepository.php
@@ -228,7 +228,7 @@ class LogChangeRepository extends BaseLogRepository
     protected function setLimitOrder(QueryBuilder $query, array $options)
     {
         if (isset($options['order'])) {
-            $query->orderBy($options['order'], $options['direction']);
+            $query->orderBy($options['order'], isset($options['direction']) ? $options['direction'] : null);
         }
         if (isset($options['limit'])) {
             $query->setMaxResults(intval($options['limit']));

--- a/src/Twig/Runtime/AdminRuntime.php
+++ b/src/Twig/Runtime/AdminRuntime.php
@@ -107,7 +107,8 @@ class AdminRuntime
     public function stack($types = [])
     {
         if (is_string($types)) {
-            $types = array_filter(array_map('trim', explode(',', $types)));
+            $types = explode(',', $types) ?: [];
+            $types = array_filter(array_map('trim', $types));
         }
 
         $files = $this->stack->getList($types);

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -161,7 +161,8 @@ class RecordRuntime
         }
 
         if (!is_array($exclude)) {
-            $exclude = array_map('trim', explode(',', $exclude));
+            $exclude = explode(',', $exclude) ?: [];
+            $exclude = array_map('trim', $exclude);
         }
 
         $context = [

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -67,8 +67,8 @@ class RecordRuntime
             return true;
         }
 
-        if (is_array($content) && isset($content['link'])) {
-            $linkToCheck = $content['link'];
+        if (is_array($content)) {
+            $linkToCheck = isset($content['link']) ? $content['link'] : null;
         } elseif ($content instanceof \Bolt\Legacy\Content) {
             $linkToCheck = $content->link();
         } else {

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -30,8 +30,8 @@ class BoltListener implements \PHPUnit_Framework_TestListener
     protected $timer;
     /** @var array */
     protected $tracker = [];
-    /** @var string */
-    protected $currentSuite;
+    /** @var string[] */
+    protected $currentSuite = [];
     /** @var boolean */
     protected $reset;
 
@@ -234,7 +234,8 @@ class BoltListener implements \PHPUnit_Framework_TestListener
     {
         /** @var \PHPUnit_Framework_TestCase $test */
         $name = $test->getName();
-        $this->tracker[$this->currentSuite . '::' . $name] = $time;
+        $suite = end($this->currentSuite);
+        $this->tracker[$suite . '::' . $name] = $time;
     }
 
     /**
@@ -246,7 +247,7 @@ class BoltListener implements \PHPUnit_Framework_TestListener
      */
     public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
     {
-        $this->currentSuite = $suite->getName();
+        array_push($this->currentSuite, $suite->getName());
     }
 
     /**
@@ -258,7 +259,7 @@ class BoltListener implements \PHPUnit_Framework_TestListener
      */
     public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
     {
-        unset($this->currentSuite);
+        array_pop($this->currentSuite);
     }
 
     /**

--- a/tests/phpunit/unit/Menu/MenuBuilderTest.php
+++ b/tests/phpunit/unit/Menu/MenuBuilderTest.php
@@ -189,6 +189,7 @@ class MenuBuilderTest extends BoltUnitTest
         $app = $this->getApp();
         $app['request'] = Request::createFromGlobals();
 
+        $contentMock = null;
         if (false !== $content) {
             $contentMock = $this->getMock('Bolt\Legacy\Content', ['getContent', 'link'], [$app], '', false);
             $contentMock->expects($this->once())

--- a/tests/phpunit/unit/Storage/RepositoryTest.php
+++ b/tests/phpunit/unit/Storage/RepositoryTest.php
@@ -177,6 +177,7 @@ class RepositoryTest extends BoltUnitTest
     {
         $this->eventCount[$event] = 0;
         $phpunit = $this;
+        $count = 0;
         $app['dispatcher']->addListener($event, function () use ($count, $phpunit, $event) {
             $count ++;
             $phpunit->eventCount[$event] = $count;


### PR DESCRIPTION
[New in Symfony 2.2: Logging of deprecated calls](http://symfony.com/blog/new-in-symfony-2-2-logging-of-deprecated-calls) …

… and now [***new in Bolt 3.3***](.) :tada: :balloon: 

![profiler-bar](https://cloud.githubusercontent.com/assets/1427081/21936871/0b389e08-d9b3-11e6-89d2-2ce0b2178362.png)

![profiler-deprecations-page](https://cloud.githubusercontent.com/assets/1427081/21936874/0f479a4e-d9b3-11e6-8ddc-4c918088bf0f.png)

@CarsonF just thought it was easier to throw it up on `bolt/bolt` and PR it, we can work from there.