### PR TITLE
Set a default on user display name

### DIFF
--- a/app/view/twig/_nav/_primary.twig
+++ b/app/view/twig/_nav/_primary.twig
@@ -47,7 +47,8 @@
 
     <li class="dropdown">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-            <i class="fa fa-fw fa-user"></i> <span>{{ user.displayname|excerpt(16) }}</span> <i class="fa fa-caret-down"></i>
+            {# FIXME DTO: When the session hits the check timer, the user object can be empty #}
+            <i class="fa fa-fw fa-user"></i> <span>{{ user.displayname|default()|excerpt(16) }}</span> <i class="fa fa-caret-down"></i>
         </a>
         <ul class="dropdown-menu dropdown-user" role="menu" >
             <li>


### PR DESCRIPTION
Fixes occasional "single request crashes" in the back-end with debug enabled.

![screenshot_from_2017-01-16_16-01-09](https://cloud.githubusercontent.com/assets/1427081/22011187/003ee39e-dc8e-11e6-9704-ce416dbd52ff.png)

When the session hits the check timer, the user object can be empty and the nav render still gets called during that redirect. 

We'll address properly with the DTO/REST work.