### PR TITLE
Modded core's select field to accommodate for multiple contenttypes.

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -21,6 +21,11 @@
         {% set lookupfieldlist = lookupfield|split(',') %}
     {% endif %}
     {% set sortingorder = field.sort|default(lookupfieldlist|default([])|first)|default(lookupfield)|default('id') %}
+
+    {% if sortingorder == 'contenttype' %}
+        {% set sortingorder = field.sort|default(lookupfieldlist[1]|default([]))|default(lookupfield)|default('id') %}
+    {% endif %}
+
     {% set querylimit = field.limit|default(500) %}
     {% set wherefilter = field.filter|default({}) %}
     {% setcontent lookups = lookuptype where wherefilter order sortingorder nohydrate limit querylimit %}

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -275,14 +275,20 @@ class RecordRuntime
             if (is_array($fieldName)) {
                 $row = [];
                 foreach ($fieldName as $fn) {
-                    $row[] = isset($c->values[$fn]) ? $c->values[$fn] : null;
+                    if ($fn === 'contenttype') {
+                        $element = $c->contenttype['slug'] . '/' . $element;
+                        $row[]   = $c->contenttype['singular_name'];
+                    } else {
+                        $row[] = isset($c->values[$fn]) ? $c->values[$fn] : null;
+                    }
                 }
                 $retval[$element] = $row;
+            } else if ($fieldName === 'contenttype') {
+                $retval[$element] = $c->contenttype['singular_name'];
             } elseif (isset($c->values[$fieldName])) {
                 $retval[$element] = $c->values[$fieldName];
             }
         }
-
         return $retval;
     }
 }


### PR DESCRIPTION
This modification allows core's select fields to handle multiple content types. This is already possible within the codebase because `value` is applied directly to the `setcontent` call in the `_select.twig` template. Therefore the first part of `value` could have any valid `setcontent` input. It just didn't work because the existing select field combined all the ID's.

This small change works by checking for the existence of `contenttype` and if it exists, prepending it to the output text and also prepending it to the output values. This will work for singular or multiple content type combinations and has no effect on existing select fields as before declaring `contenttype` would have returned an exception.

An example of the output with `contenttype` declared:
![image](https://cloud.githubusercontent.com/assets/6642498/22065566/bd6e5240-dd80-11e6-840c-b642123755a8.png)

An example of the value/text pairs generated:
![image](https://cloud.githubusercontent.com/assets/6642498/22065754/8bc24d86-dd81-11e6-8b42-e3cf644268ca.png)

The `contenttypes.yml` example:
```yaml
featured_items:
    label: "Event/Event series"
    autocomplete: true
    type: select
    values: (event,eventseries)/contenttype,title
```
(The two `contenttypes` being shown are `event` and `eventseries`)

Of course the output style could be changed if anyone would prefer a different format!

Target branch
------------------------
 * `release/3.2` — "stable" branch
