### PR TITLE
Fix to incorrect Extension Field Initialisation

### DIFF
--- a/src/Extension/ConfigTrait.php
+++ b/src/Extension/ConfigTrait.php
@@ -45,7 +45,11 @@ trait ConfigTrait
         $app = $this->getContainer();
         foreach ((array) $this->registerFields() as $fieldClass) {
             if ($fieldClass instanceof FieldInterface) {
-                $app['config']->getFields()->addField($fieldClass);
+                $app['storage.typemap'] = array_merge(
+                    $app['storage.typemap'],
+                    [$fieldClass->getName() => get_class($fieldClass)]
+                );
+                $app['storage.field_manager']->addFieldType($fieldClass->getName(), $fieldClass);
             }
         }
     }


### PR DESCRIPTION
This is to fix a bug that led to custom fields not being initialised properly since they were only registered with the legacy field manager.

This moves it over to the new system so everything should work correctly.