### PR TITLE
Fix incorrect alias

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -175,11 +175,11 @@ class RepeaterType extends FieldTypeBase
 
         switch ($platform) {
             case 'mysql':
-                return "GROUP_CONCAT(DISTINCT CONCAT_WS('_', f.name, f.grouping, f.id))";
+                return "GROUP_CONCAT(DISTINCT CONCAT_WS('_', f.name, f.grouping, f.content_id))";
             case 'sqlite':
-                return "GROUP_CONCAT(DISTINCT f.name||'_'||f.grouping||'_'||f.id)";
+                return "GROUP_CONCAT(DISTINCT f.name||'_'||f.grouping||'_'||f.content_id)";
             case 'postgresql':
-                return "string_agg(concat_ws('_', f.name,f.grouping,f.id), ',' ORDER BY f.grouping)";
+                return "string_agg(concat_ws('_', f.name,f.grouping,f.content_id), ',' ORDER BY f.grouping)";
         }
     }
 

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -31,6 +31,8 @@ class RepeaterType extends FieldTypeBase
         $boltname = $metadata->getBoltName();
         $table = $this->mapping['tables']['field_value'];
 
+        $from = $query->getQueryPart('from');
+
         if (isset($from[0]['alias'])) {
             $alias = $from[0]['alias'];
         } else {

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -184,11 +184,11 @@ class RepeaterType extends FieldTypeBase
 
         switch ($platform) {
             case 'mysql':
-                return "GROUP_CONCAT(DISTINCT CONCAT_WS('_', f.name, f.grouping, f.content_id))";
+                return "GROUP_CONCAT(DISTINCT CONCAT_WS('_', f.name, f.grouping, f.id))";
             case 'sqlite':
-                return "GROUP_CONCAT(DISTINCT f.name||'_'||f.grouping||'_'||f.content_id)";
+                return "GROUP_CONCAT(DISTINCT f.name||'_'||f.grouping||'_'||f.id)";
             case 'postgresql':
-                return "string_agg(concat_ws('_', f.name,f.grouping,f.content_id), ',' ORDER BY f.grouping)";
+                return "string_agg(concat_ws('_', f.name,f.grouping,f.id), ',' ORDER BY f.grouping)";
         }
     }
 

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -39,7 +39,7 @@ class RepeaterType extends FieldTypeBase
             $alias = $from[0]['table'];
         }
 
-        $subQuery = '(SELECT '.$this->getPlatformGroupConcat($query). " FROM $table f WHERE f.content_id = $alias.id AND contenttype='$boltname' AND f.name = '$field') as $field";
+        $subQuery = '(SELECT '.$this->getPlatformGroupConcat($query). " FROM $table f WHERE f.content_id = $alias.id AND f.contenttype='$boltname' AND f.name = '$field') as $field";
         $query->addSelect($subQuery);
     }
 

--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -28,9 +28,16 @@ class RepeaterType extends FieldTypeBase
     public function load(QueryBuilder $query, ClassMetadata $metadata)
     {
         $field = $this->mapping['fieldname'];
+        $boltname = $metadata->getBoltName();
         $table = $this->mapping['tables']['field_value'];
 
-        $subQuery = '(SELECT '.$this->getPlatformGroupConcat($query). ' FROM '. $table .' f) as '.$field;
+        if (isset($from[0]['alias'])) {
+            $alias = $from[0]['alias'];
+        } else {
+            $alias = $from[0]['table'];
+        }
+
+        $subQuery = '(SELECT '.$this->getPlatformGroupConcat($query). " FROM $table f WHERE f.content_id = $alias.id AND contenttype='$boltname' AND f.name = '$field') as $field";
         $query->addSelect($subQuery);
     }
 


### PR DESCRIPTION
The join aliased content_id to id but this is no longer the case in the subselect.

This updates the alias to point to content_id