### PR TITLE
Fix array_column for PHP 5.x

### DIFF
--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -71,6 +71,65 @@ class Arr
     }
 
     /**
+     * Return the values from a single column in the input array, identified by the $columnKey.
+     *
+     * Optionally, an $indexKey may be provided to index the values in the returned array by the
+     * values from the $indexKey column in the input array.
+     *
+     * This supports objects which was added in PHP 7.0. This method can be dropped when support for PHP 5.x is dropped.
+     *
+     * @param array           $input A list of arrays or objects from which to pull a column of values.
+     * @param string|int      $columnKey The column of values to return.
+     * @param string|int|null $indexKey The column to use as the index/keys for the returned array.
+     *
+     * @return array
+     */
+    public static function column(array $input, $columnKey, $indexKey = null)
+    {
+        if (PHP_MAJOR_VERSION > 5) {
+            return array_column($input, $columnKey, $indexKey);
+        }
+
+        $output = [];
+
+        foreach ($input as $row) {
+            $key = $value = null;
+            $keySet = $valueSet = false;
+
+            if ($indexKey !== null) {
+                if (is_array($row) && array_key_exists($indexKey, $row)) {
+                    $keySet = true;
+                    $key = (string) $row[$indexKey];
+                } elseif (is_object($row) && isset($row->{$indexKey})) {
+                    $keySet = true;
+                    $key = (string) $row->{$indexKey};
+                }
+            }
+
+            if ($columnKey === null) {
+                $valueSet = true;
+                $value = $row;
+            } elseif (is_array($row) && array_key_exists($columnKey, $row)) {
+                $valueSet = true;
+                $value = $row[$columnKey];
+            } elseif (is_object($row) && isset($row->{$columnKey})) {
+                $valueSet = true;
+                $value = $row->{$columnKey};
+            }
+
+            if ($valueSet) {
+                if ($keySet) {
+                    $output[$key] = $value;
+                } else {
+                    $output[] = $value;
+                }
+            }
+        }
+
+        return $output;
+    }
+
+    /**
      * Make a simple array consisting of key=>value pairs, that can be used
      * in select-boxes in forms.
      *

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -138,22 +138,16 @@ class Arr
      * @param string $value
      *
      * @return array
+     *
+     * @deprecated since 3.3, to be removed in 4.0. Use {@see array_column} or {@see Arr::column} instead.
      */
     public static function makeValuePairs($array, $key, $value)
     {
-        $tempArray = [];
-
-        if (is_array($array)) {
-            foreach ($array as $item) {
-                if (empty($key)) {
-                    $tempArray[] = $item[$value];
-                } else {
-                    $tempArray[$item[$key]] = $item[$value];
-                }
-            }
+        if (!is_array($array)) {
+            return [];
         }
 
-        return $tempArray;
+        return Arr::column($array, $value, $key);
     }
 
     /**

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2455,7 +2455,7 @@ class Storage
 
             if (!empty($currentvalues)) {
                 $currentsortorder = $currentvalues[0]['sortorder'];
-                $currentvalues = Arr::makeValuePairs($currentvalues, 'id', 'slug');
+                $currentvalues = Arr::column($currentvalues, 'slug', 'id');
             } else {
                 $currentsortorder = 0;
                 $currentvalues = [];

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -766,7 +766,7 @@ class Storage
         $results = $this->app['db']->fetchAll($select);
 
         if (!empty($results)) {
-            $ids = implode(' || ', array_column($results, 'id'));
+            $ids = implode(' || ', Arr::column($results, 'id'));
 
             $results = $this->getContent($contenttype, ['id' => $ids, 'returnsingle' => false]);
 
@@ -2374,7 +2374,7 @@ class Storage
     {
         $tablename = $this->getTablename("taxonomy");
 
-        $ids = array_column($content, 'id');
+        $ids = Arr::column($content, 'id');
 
         if (empty($ids)) {
             return;
@@ -2551,7 +2551,7 @@ class Storage
     {
         $tablename = $this->getTablename("relations");
 
-        $ids = array_column($content, 'id');
+        $ids = Arr::column($content, 'id');
 
         if (empty($ids)) {
             return;
@@ -2590,7 +2590,7 @@ class Storage
     public function getRepeaters($content)
     {
 
-        $ids = array_column($content, 'id');
+        $ids = Arr::column($content, 'id');
 
         if (empty($ids)) {
             return;

--- a/tests/phpunit/unit/Helper/ArrTest.php
+++ b/tests/phpunit/unit/Helper/ArrTest.php
@@ -12,7 +12,7 @@ use Bolt\Tests\BoltUnitTest;
  */
 class ArrTest extends BoltUnitTest
 {
-    public function testMakeValuePairs()
+    public function testLegacyMakeValuePairs()
     {
         $test = [
             ['id' => 1, 'value' => 1],

--- a/tests/phpunit/unit/Helper/ArrTest.php
+++ b/tests/phpunit/unit/Helper/ArrTest.php
@@ -133,4 +133,46 @@ class ArrTest extends BoltUnitTest
         $this->assertFalse(Arr::isIndexed('derp'));
         $this->assertFalse(Arr::isAssociative('derp'));
     }
+
+    public function testColumn()
+    {
+        $data = [
+            new TestColumn('foo', 'bar'),
+            new TestColumn('hello', 'world'),
+            ['id' => '5', 'value' => 'asdf'],
+        ];
+
+        $result = Arr::column($data, 'id');
+        $this->assertEquals(['foo', 'hello', '5'], $result);
+
+        $result = Arr::column($data, 'value', 'id');
+        $expected = [
+            'foo'   => 'bar',
+            'hello' => 'world',
+            '5'     => 'asdf',
+        ];
+        $this->assertEquals($expected, $result);
+    }
+}
+
+class TestColumn
+{
+    public $id;
+    private $value;
+
+    public function __construct($id, $value)
+    {
+        $this->id = $id;
+        $this->value = $value;
+    }
+
+    public function __isset($name)
+    {
+        return $name === 'value';
+    }
+
+    public function __get($name)
+    {
+        return $this->value;
+    }
 }


### PR DESCRIPTION
Fixes #6278

- Implemented `Arr::column`
- Deprecated `Arr::makeValuePairs`