### PR TITLE
Fixed bug in Storage::saveContent() (slug)

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -401,10 +401,10 @@ class Storage
         }
 
         // Test to see if this is a new record, or an update
-        if (empty($fieldvalues['id'])) {
-            $create = true;
-        } else {
-            $create = false;
+        $create = empty($fieldvalues['id']);
+
+        if (!isset($fieldvalues['slug'])) {
+            $fieldvalues['slug'] = ''; // Prevent 'slug may not be NULL'
         }
 
         // We need to verify if the slug is unique. If not, we update it.


### PR DESCRIPTION
In `Storage:saveContent` the slug is used to create the uri, but
`$fieldValues['slug']` is not always present.
Added the check for missing slug to the class again because `getUri()`
is able to handle an empty slug.

I changed the simple if statement above because it's shorter and faster now. And I don't think it's worse readable. I can put it in an own commit, but there is no change at all. A revert would do no change there.

I can only find this commit e7516d643a1f879aa56c68f33a06e30291860513 which first introduced the **fix**, but I can't find the one which removes these required lines of code with blame.

Hope you can follow my explanations and thank you for reading and checking 👍 

Fixes #6295 
