### PR TITLE
Modded core's select field to accommodate for multiple contenttypes v2

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -30,7 +30,7 @@
     {% set wherefilter = field.filter|default({}) %}
     {% setcontent lookups = lookuptype where wherefilter order sortingorder nohydrate limit querylimit %}
     {% set valuefield = lookupfieldlist|default(lookupfield)|default('id') %}
-    {% set values = lookups|selectfield(valuefield, option.multiple, field.keys|default('id')) %}
+    {% set values = lookups|selectfield(valuefield, option.multiple, field.keys|default('id'), lookuptype) %}
 {% endif %}
 
 {# Get the current selection. Either a single value, or an array. #}

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -255,14 +255,15 @@ class RecordRuntime
     /**
      * Return a selected field from a contentset.
      *
-     * @param array        $content    A Bolt record array
-     * @param array|string $fieldName  Name of a field, or array of field names to return from each record
-     * @param boolean      $startempty Whether or not the array should start with an empty element
-     * @param string       $keyName    Name of the key in the array
+     * @param array        $content     A Bolt record array
+     * @param array|string $fieldName   Name of a field, or array of field names to return from each record
+     * @param boolean      $startempty  Whether or not the array should start with an empty element
+     * @param string       $keyName     Name of the key in the array
+     * @param string|null  $contentType ContentType string used by the select field
      *
      * @return array
      */
-    public function selectField($content, $fieldName, $startempty = false, $keyName = 'id')
+    public function selectField($content, $fieldName, $startempty = false, $keyName = 'id', $contentType = null)
     {
         $retval = $startempty ? [] : ['' => ''];
 
@@ -271,13 +272,21 @@ class RecordRuntime
         }
 
         foreach ($content as $c) {
-            $element = $c->values[$keyName];
+            if (is_string($contentType) && $contentType !== '') {
+                $contentType = explode(',', $contentType);
+            }
+
+            if (is_array($contentType) && count($contentType) > 1) {
+                $element = $c->contenttype['slug'] . '/' . $c->values[$keyName];
+            } else {
+                $element = $c->values[$keyName];
+            }
+
             if (is_array($fieldName)) {
                 $row = [];
                 foreach ($fieldName as $fn) {
                     if ($fn === 'contenttype') {
-                        $element = $c->contenttype['slug'] . '/' . $element;
-                        $row[]   = $c->contenttype['singular_name'];
+                        $row[] = $c->contenttype['singular_name'];
                     } else {
                         $row[] = isset($c->values[$fn]) ? $c->values[$fn] : null;
                     }


### PR DESCRIPTION
Continuing on from #6270 and the discussion had with @SahAssar I've modified the original implementation of this slightly so instead of determining the return value based on the existence of `contenttype` it instead does it based on whether multiple contenttypes have been defined. This separates the left hand side of the values string from the right more distinctly and allows more refined choice for the developer.

```yml
featured_items:
    label: "Event/Event series"
    autocomplete: true
    type: select
    values: (event,eventseries)/title
```

Would create a select option with `<option value="event/1">Title</option>`.

While

```yml
featured_items:
    label: "Event/Event series"
    autocomplete: true
    type: select
    values: event/contenttype,title
```

Would create a select option with `<option value="1">Event / Title</option>`

I know that it's already been merged in as is - happy for this to be closed without being pulled if everyone is more happy with the first implementation. I'm also always looking for feedback :smile: 