### PR TITLE
Fix for setups using different database prefix

### DIFF
--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -119,6 +119,11 @@ class MetadataDriver implements MappingDriver
      */
     public function initializeDefaultAliases()
     {
+        foreach ($this->defaultAliases as $def => $entityClass) {
+            $table = $this->namingStrategy->classToTableName($entityClass);
+            $this->defaultAliases[$table] = $entityClass;
+        }
+
         foreach ($this->aliases as $prefixed) {
             $entity = isset($this->defaultAliases[$prefixed]) ? $this->defaultAliases[$prefixed] : null;
             if ($entity !== null) {

--- a/tests/phpunit/unit/Mapping/MetadataDriverTest.php
+++ b/tests/phpunit/unit/Mapping/MetadataDriverTest.php
@@ -21,7 +21,7 @@ class MetadataDriverTest extends BoltUnitTest
     public function testInitialize()
     {
         $app = $this->getApp();
-        $map = new MetadataDriver($app['schema'], $app['storage.config.contenttypes'], $app['storage.config.taxonomy'], $app['storage.typemap']);
+        $map = new MetadataDriver($app['schema'], $app['storage.config.contenttypes'], $app['storage.config.taxonomy'], $app['storage.typemap'], $app['storage.namingstrategy']);
         $map->initialize();
         $metadata = $map->loadMetadataForClass('Bolt\Storage\Entity\Users');
         $this->assertNotNull($metadata);


### PR DESCRIPTION
Fixes #5385

Adds the table -> entity mapping for setups where the prefix is different than `bolt_`