### PR TITLE
Remove bolt.render stopwatch event

### DIFF
--- a/src/Render.php
+++ b/src/Render.php
@@ -45,8 +45,6 @@ class Render
      */
     public function render($templateName, $context = [], $globals = [])
     {
-        $this->app['stopwatch']->start('bolt.render', 'template');
-
         $template = $this->app['twig']->resolveTemplate($templateName);
 
         foreach ($globals as $name => $value) {
@@ -57,8 +55,6 @@ class Render
 
         $response = new TemplateResponse($template, $context, $globals);
         $response->setContent($html);
-
-        $this->app['stopwatch']->stop('bolt.render');
 
         return $response;
     }


### PR DESCRIPTION
It is redundant now that Twig events are in the profiler.

![screen shot 2017-01-26 at 11 19 19 am](https://cloud.githubusercontent.com/assets/932566/22342260/5c547bbc-e3b9-11e6-92b1-e742c2c80bea.png)
