### PR TITLE
Minor feature: Contenttype singletons

### DIFF
--- a/app/view/twig/_nav/_secondary-content.twig
+++ b/app/view/twig/_nav/_secondary-content.twig
@@ -1,7 +1,17 @@
 {% set definedSubs = [] %}
 
 {% for slug, contenttype in app.config.get('contenttypes')  %}
-    {% if isallowed('contenttype:' ~ slug) %}
+    {% setcontent records = slug limit 4 nohydrate orderby '-datechanged' %}
+    {% if not isallowed('contenttype:' ~ slug ~ ':create') and isallowed('contenttype:' ~ slug) and records|length == 1 and contenttype.show_in_menu == "true" %}
+        <li>
+            <a href="{{ path('editcontent', {contenttypeslug: slug, id: records|first.id}) }}">
+                {{ nav.label(
+                    contenttype.icon_one|default(''),
+                    __(['contenttypes', contenttype.slug, 'name', 'plural'], {DEFAULT: contenttype.name})
+                ) }}
+            </a>
+        </li>
+    {% elseif isallowed('contenttype:' ~ slug) %}
         {% set sub_view = {
             icon: contenttype.icon_many|default(contenttype.show_in_menu ? 'fa:files-o' : 'fa:th-list'),
             label: __('contenttypes.generic.view', {'%contenttypes%': contenttype.slug}),
@@ -18,7 +28,6 @@
         {# ContentTypes, where show_in_menu is set true #}
         {% if contenttype.show_in_menu == "true" %}
 
-            {% setcontent records = slug limit 4 nohydrate orderby '-datechanged' %}
             {% for record in records %}
                 {% set sub = sub|merge([
                     {
@@ -40,8 +49,13 @@
             {% set sub_view = {
                 icon: contenttype.icon_many|default(contenttype.show_in_menu ? 'fa:files-o' : 'fa:th-list'),
                 label: __(['contenttypes', contenttype.slug, 'name', 'plural'], {DEFAULT: contenttype.name}),
-                link: path('overview', {'contenttypeslug': slug})
             } %}
+
+            {% if not isallowed('contenttype:' ~ slug ~ ':create') and isallowed('contenttype:' ~ slug) and records|length == 1 %}
+                {% set sub_view = sub_view|merge({link: path('editcontent', {contenttypeslug: slug, id: records|first.id})}) %}
+            {% else %}
+                {% set sub_view = sub_view|merge({link: path('overview', {'contenttypeslug': slug})}) %}
+            {% endif %}
 
             {% set key = contenttype.show_in_menu ?: __('general.phrase.other-content') %}
             {% if definedSubs[key] is defined %}

--- a/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
+++ b/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
@@ -43,7 +43,9 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->dontSee('View Entries');
         $I->dontSee('New Entry');
 
-        $I->see('View Showcases');
+        // Showcases is a singleton, so we should only see the single top-menu item
+        $I->see('Showcases');
+        $I->dontSee('View Showcases');
         $I->dontSee('New Showcase');
 
         $I->dontSee('Configuration', Locator::href('/bolt/users'));


### PR DESCRIPTION
This is the "singleton contenttype" feature that @bobdenotter, me and a few others have talked about in slack.

It checks if there is only one record and the current user has no permissions to create new records and will then consider that contenttype a "singleton" that we link directly to the only record, skipping the submenu.