### PR TITLE
Deprecate Render

### DIFF
--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -2,6 +2,7 @@
 namespace Bolt\Controller;
 
 use Bolt\AccessControl\Token\Token;
+use Bolt\Response\TemplateResponse;
 use Bolt\Routing\DefaultControllerClassAwareInterface;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Repository;
@@ -66,14 +67,26 @@ abstract class Base implements ControllerProviderInterface
      * Renders a template
      *
      * @param string|string[] $template Template name(s)
-     * @param array  $context  Context variables
-     * @param array  $globals  Global variables
+     * @param array           $context  Context variables
+     * @param array           $globals  Global variables
      *
      * @return \Bolt\Response\TemplateResponse
      */
     protected function render($template, array $context = [], array $globals = [])
     {
-        return $this->app['render']->render($template, $context, $globals);
+        $twig = $this->app['twig'];
+
+        $template = $twig->resolveTemplate($template);
+
+        foreach ($globals as $name => $value) {
+            $twig->addGlobal($name, $value);
+        }
+        $globals = $twig->getGlobals();
+
+        $response = new TemplateResponse($template->getTemplateName(), $context, $globals);
+        $response->setContent($template->render($context));
+
+        return $response;
     }
 
     /**

--- a/src/Render.php
+++ b/src/Render.php
@@ -53,7 +53,7 @@ class Render
 
         $html = twig_include($this->app['twig'], $context, $template, [], true, false, $this->safe);
 
-        $response = new TemplateResponse($template, $context, $globals);
+        $response = new TemplateResponse($template->getTemplateName(), $context, $globals);
         $response->setContent($html);
 
         return $response;

--- a/src/Render.php
+++ b/src/Render.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Response;
  * - Fetches pages or template (partials) from cache
  *
  * @author Bob den Otter, bob@twokings.nl
+ *
+ * @deprecated Since 3.3, will be removed in 4.0.
  */
 class Render
 {
@@ -42,6 +44,8 @@ class Render
      * @param array           $globals      Global variables
      *
      * @return TemplateResponse
+     *
+     * @deprecated Since 3.3, will be removed in 4.0.
      */
     public function render($templateName, $context = [], $globals = [])
     {

--- a/src/Render.php
+++ b/src/Render.php
@@ -50,6 +50,7 @@ class Render
         foreach ($globals as $name => $value) {
             $this->app['twig']->addGlobal($name, $value);
         }
+        $globals = $this->app['twig']->getGlobals();
 
         $html = twig_include($this->app['twig'], $context, $template, [], true, false, $this->safe);
 

--- a/src/Response/TemplateResponse.php
+++ b/src/Response/TemplateResponse.php
@@ -3,7 +3,6 @@
 namespace Bolt\Response;
 
 use Symfony\Component\HttpFoundation\Response;
-use Twig_Template as Template;
 
 /**
  * Template based response.
@@ -12,8 +11,8 @@ use Twig_Template as Template;
  */
 class TemplateResponse extends Response
 {
-    /** @var Template */
-    protected $template;
+    /** @var string */
+    protected $templateName;
     /** @var array */
     protected $context = [];
     /** @var array */
@@ -22,24 +21,24 @@ class TemplateResponse extends Response
     /**
      * Constructor.
      *
-     * @param Template $template
-     * @param array    $context
-     * @param array    $globals
+     * @param string $templateName
+     * @param array  $context
+     * @param array  $globals
      */
-    public function __construct(Template $template, array $context = [], array $globals = [])
+    public function __construct($templateName, array $context = [], array $globals = [])
     {
         parent::__construct();
-        $this->template = $template;
+        $this->templateName = $templateName;
         $this->context = $context;
         $this->globals = $globals;
     }
 
     /**
-     * @return Template
+     * @return string
      */
-    public function getTemplate()
+    public function getTemplateName()
     {
-        return $this->template;
+        return $this->templateName;
     }
 
     /**

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -147,28 +147,6 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
         $app['users']->users = [];
     }
 
-    protected function getRenderMock(Application $app)
-    {
-        $render = $this->getMock(Render::class, ['render', 'fetchCachedRequest'], [$app]);
-        $render->expects($this->any())
-            ->method('fetchCachedRequest')
-            ->will($this->returnValue(false));
-
-        return $render;
-    }
-
-    protected function checkTwigForTemplate(Application $app, $testTemplate)
-    {
-        $render = $this->getRenderMock($app);
-
-        $render->expects($this->atLeastOnce())
-            ->method('render')
-            ->with($this->equalTo($testTemplate))
-            ->will($this->returnValue(new Response()));
-
-        $app['render'] = $render;
-    }
-
     protected function allowLogin($app)
     {
         $this->addDefaultUser($app);

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -61,7 +61,7 @@ class FilesystemManagerTest extends ControllerUnitTest
 
         $this->assertInstanceOf(TemplateResponse::class, $response);
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals('@bolt/async/browse.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('@bolt/async/browse.twig', $response->getTemplateName());
     }
 
     public function testCreateFolder()
@@ -276,7 +276,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $response = $this->controller()->recordBrowser();
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/recordbrowser/recordbrowser.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('@bolt/recordbrowser/recordbrowser.twig', $response->getTemplateName());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 

--- a/tests/phpunit/unit/Controller/Async/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Async/GeneralTest.php
@@ -58,7 +58,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->changeLogRecord('pages', 1);
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/panel-change-record.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('@bolt/components/panel-change-record.twig', $response->getTemplateName());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
@@ -144,7 +144,7 @@ class GeneralTest extends ControllerUnitTest
 
         $response = $this->controller()->dashboardNews($this->getRequest());
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/panel-news.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('@bolt/components/panel-news.twig', $response->getTemplateName());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
@@ -155,7 +155,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->lastModified('page', 1);
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/panel-lastmodified.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('@bolt/components/panel-lastmodified.twig', $response->getTemplateName());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
@@ -166,7 +166,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->latestActivity();
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/panel-activity.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('@bolt/components/panel-activity.twig', $response->getTemplateName());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 

--- a/tests/phpunit/unit/Controller/Async/StackTest.php
+++ b/tests/phpunit/unit/Controller/Async/StackTest.php
@@ -53,7 +53,7 @@ class StackTest extends ControllerUnitTest
         $response = $this->controller()->show(Request::create('/async/stack/show'));
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/stack/panel.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('@bolt/components/stack/panel.twig', $response->getTemplateName());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 

--- a/tests/phpunit/unit/Controller/Backend/AuthenticationTest.php
+++ b/tests/phpunit/unit/Controller/Backend/AuthenticationTest.php
@@ -2,6 +2,7 @@
 namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Logger\FlashLogger;
+use Bolt\Response\TemplateResponse;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\Request;
@@ -76,8 +77,9 @@ class AuthenticationTest extends ControllerUnitTest
             ->will($this->returnValue(false));
         $this->setService('access_control.login', $loginMock);
 
-        $this->checkTwigForTemplate($this->getApp(), '@bolt/login/login.twig');
-        $this->controller()->postLogin($this->getRequest());
+        /** @var TemplateResponse $response */
+        $response = $this->controller()->postLogin($this->getRequest());
+        $this->assertEquals('@bolt/login/login.twig', $response->getTemplateName());
 
         // Test missing data fails
         $this->setRequest(Request::create('/bolt/login', 'POST', ['action' => 'fake']));
@@ -85,8 +87,8 @@ class AuthenticationTest extends ControllerUnitTest
         $this->controller()->postLogin($this->getRequest());
 
         $this->setRequest(Request::create('/bolt/login', 'POST', []));
-        $this->checkTwigForTemplate($this->getApp(), 'error.twig');
-        $this->controller()->postLogin($this->getRequest());
+        $response = $this->controller()->postLogin($this->getRequest());
+        $this->assertEquals('error.twig', $response->getTemplateName());
     }
 
     public function testLoginSuccess()

--- a/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
+++ b/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
@@ -29,9 +29,9 @@ class DatabaseTest extends ControllerUnitTest
 
         $this->setService('schema', $check);
         $this->setRequest(Request::create('/bolt/dbcheck'));
-        $this->checkTwigForTemplate($this->getApp(), '@bolt/dbcheck/dbcheck.twig');
 
-        $this->controller()->check($this->getRequest());
+        $response = $this->controller()->check($this->getRequest());
+        $this->assertEquals('@bolt/dbcheck/dbcheck.twig', $response->getTemplateName());
     }
 
     public function testUpdate()
@@ -59,9 +59,9 @@ class DatabaseTest extends ControllerUnitTest
         $this->allowLogin($this->getApp());
 
         $this->setRequest(Request::create('/bolt/dbupdate_result'));
-        $this->checkTwigForTemplate($this->getApp(), '@bolt/dbcheck/dbcheck.twig');
 
-        $this->controller()->updateResult($this->getRequest());
+        $response = $this->controller()->updateResult();
+        $this->assertEquals('@bolt/dbcheck/dbcheck.twig', $response->getTemplateName());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Backend/ExtendTest.php
+++ b/tests/phpunit/unit/Controller/Backend/ExtendTest.php
@@ -33,10 +33,10 @@ class ExtendTest extends ControllerUnitTest
 
         $this->setRequest(Request::create('/bolt/extend'));
         $response = $this->controller()->overview();
-        $this->assertEquals('@bolt/extend/extend.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('@bolt/extend/extend.twig', $response->getTemplateName());
 
         $response = $this->controller()->installPackage();
-        $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplateName());
 
         $this->setRequest(Request::create('/', 'GET', ['package' => 'bolt/theme-2014']));
         /** @var \Bolt\Controller\Backend\Extend|\PHPUnit_Framework_MockObject_MockObject $controller */

--- a/tests/phpunit/unit/Controller/Backend/ExtendTest.php
+++ b/tests/phpunit/unit/Controller/Backend/ExtendTest.php
@@ -72,11 +72,11 @@ class ExtendTest extends ControllerUnitTest
         $this->getApp()->flush();
         $this->allowLogin($this->getApp());
         $this->setRequest(Request::create('/bolt/extend'));
-        $this->checkTwigForTemplate($this->getApp(), '@bolt/extend/extend.twig');
 
         $response = $this->controller()->overview();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertEquals('@bolt/extend/extend.twig', $response->getTemplateName());
     }
 
     public function testInstallPackage()
@@ -84,11 +84,11 @@ class ExtendTest extends ControllerUnitTest
         $this->getApp()->flush();
         $this->allowLogin($this->getApp());
         $this->setRequest(Request::create('/bolt/extend/installPackage'));
-        $this->checkTwigForTemplate($this->getApp(), '@bolt/extend/_action-modal.twig');
 
         $response = $this->controller()->installPackage();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplateName());
     }
 
     public function testInstallInfo()

--- a/tests/phpunit/unit/Controller/Backend/FileManagerTest.php
+++ b/tests/phpunit/unit/Controller/Backend/FileManagerTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Filesystem\Handler\DirectoryInterface;
+use Bolt\Response\TemplateResponse;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,9 +20,10 @@ class FileManagerTest extends ControllerUnitTest
     {
         $this->setRequest(Request::create('/bolt/file/edit/config/config.yml'));
 
+        /** @var TemplateResponse $response */
         $response = $this->controller()->edit($this->getRequest(), 'config', 'config.yml');
 
-        $this->assertEquals('@bolt/editfile/editfile.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('@bolt/editfile/editfile.twig', $response->getTemplateName());
     }
 
     public function testManage()

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -45,7 +45,7 @@ class GeneralTest extends ControllerUnitTest
 
         $response = $this->controller()->about();
 
-        $this->assertEquals('@bolt/about/about.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('@bolt/about/about.twig', $response->getTemplateName());
     }
 
     public function testClearCache()
@@ -157,7 +157,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->translation($this->getRequest(), 'contenttypes', 'en_CY');
 
         $this->assertTrue($response instanceof TemplateResponse, 'Response is not instance of TemplateResponse');
-        $this->assertEquals('@bolt/editlocale/editlocale.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('@bolt/editlocale/editlocale.twig', $response->getTemplateName());
         $context = $response->getContext();
         $this->assertEquals('contenttypes.en_CY.yml', $context['context']['basename']);
 

--- a/tests/phpunit/unit/Controller/Backend/LogTest.php
+++ b/tests/phpunit/unit/Controller/Backend/LogTest.php
@@ -50,8 +50,8 @@ class LogTest extends ControllerUnitTest
         $this->assertEquals('/bolt/changelog', $response->getTargetUrl());
 
         $this->setRequest(Request::create('/bolt/changelog'));
-        $this->checkTwigForTemplate($this->getApp(), '@bolt/activity/changelog.twig');
-        $this->controller()->changeOverview($this->getRequest());
+        $response = $this->controller()->changeOverview($this->getRequest());
+        $this->assertEquals('@bolt/activity/changelog.twig', $response->getTemplateName());
     }
 
     public function testChangeRecord()
@@ -183,8 +183,8 @@ class LogTest extends ControllerUnitTest
         $this->assertEquals('/bolt/systemlog', $response->getTargetUrl());
 
         $this->setRequest(Request::create('/bolt/systemlog'));
-        $this->checkTwigForTemplate($this->getApp(), '@bolt/activity/systemlog.twig');
-        $this->controller()->systemOverview($this->getRequest());
+        $response = $this->controller()->systemOverview($this->getRequest());
+        $this->assertEquals('@bolt/activity/systemlog.twig', $response->getTemplateName());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Backend/UsersTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UsersTest.php
@@ -282,7 +282,7 @@ class UsersTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/profile'));
         $response = $this->controller()->profile($this->getRequest());
         $context = $response->getContext();
-        $this->assertEquals('@bolt/edituser/edituser.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('@bolt/edituser/edituser.twig', $response->getTemplateName());
         $this->assertEquals('profile', $context['context']['kind']);
 
         // Now try a POST to update the profile
@@ -342,7 +342,7 @@ class UsersTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/roles'));
         $response = $this->controller()->viewRoles();
         $context = $response->getContext();
-        $this->assertEquals('@bolt/roles/roles.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('@bolt/roles/roles.twig', $response->getTemplateName());
         $this->assertNotEmpty($context['context']['global_permissions']);
         $this->assertNotEmpty($context['context']['effective_permissions']);
     }

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -48,7 +48,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->homepage($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('index.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('index.twig', $response->getTemplateName());
     }
 
     public function testConfiguredConfigHomepageTemplate()
@@ -59,7 +59,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->homepage($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('index.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('index.twig', $response->getTemplateName());
     }
 
     public function testConfiguredThemeHomepageTemplate()
@@ -71,7 +71,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->homepage($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('custom-home.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('custom-home.twig', $response->getTemplateName());
     }
 
     public function testHomepageContent()
@@ -109,7 +109,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->record($request, 'pages', 'test');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('page.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('page.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -207,7 +207,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->record($this->getRequest(), 'pages', 5);
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('page.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('page.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -241,7 +241,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->record($this->getRequest(), 'pages');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('record.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('record.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -260,7 +260,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->record($this->getRequest(), 'pages');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('record.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('record.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -282,7 +282,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->record($this->getRequest(), 'pages', 'test');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('record.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('record.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -304,7 +304,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->preview($this->getRequest(), 'pages');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('record.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('record.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -313,7 +313,7 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/pages'));
         $response = $this->controller()->listing($this->getRequest(), 'pages');
 
-        $this->assertSame('listing.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('listing.twig', $response->getTemplateName());
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertNotEmpty($response->getGlobals());
     }
@@ -368,7 +368,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->taxonomy($this->getRequest(), 'categories', 'news');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('listing.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('listing.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -379,7 +379,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->template('index');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('index.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('index.twig', $response->getTemplateName());
 //$this->assertNotEmpty($response->getGlobals());
     }
 
@@ -399,7 +399,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->search($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('search.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('search.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -415,7 +415,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->search($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('search.twig', $response->getTemplate()->getTemplateName());
+        $this->assertSame('search.twig', $response->getTemplateName());
         $this->assertNotEmpty($response->getGlobals());
     }
 

--- a/tests/phpunit/unit/Response/TemplateResponseTest.php
+++ b/tests/phpunit/unit/Response/TemplateResponseTest.php
@@ -23,7 +23,7 @@ class TemplateResponseTest extends BoltUnitTest
 
         $this->assertInstanceOf(TemplateResponse::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('error.twig', $response->getTemplate()->getTemplateName());
+        $this->assertEquals('error.twig', $response->getTemplateName());
         $this->assertEquals($context, $response->getContext());
         $this->assertEquals($globals, $response->getGlobals());
     }


### PR DESCRIPTION
# Deprecate `Render`

`Render::render` is the last non-deprecated method in the class, and it is now just a shortcut to render template to `TemplateResponse`. As a shortcut, it makes more sense to do the logic in the Base Controller with the other shortcut methods.

It also gets simpler once the globals go away (to be deprecated later in 3.x).

---

I also changed `TemplateResponse` to take template name instead of template object.
Name is really the only thing useful from the object since it's already rendered.
Not to mention `Twig_Template` is marked as internal.