### PR TITLE
Fix bug causing missing incoming relations

### DIFF
--- a/app/view/twig/editcontent/fields/_relationship.twig
+++ b/app/view/twig/editcontent/fields/_relationship.twig
@@ -7,7 +7,7 @@
 {% set groupby = relation.groupby|default(false) %}
 
 {# Currently selected relationship values #}
-{% set values = context.content.relation.getField(relcontenttype, true, context.contenttype.slug, context.content.id)|default([]) %}
+{% set values = context.content.relation.getField(relcontenttype, true, context.contenttype.__toString(), context.content.id)|default([]) %}
 {% set relselect = [] %}
 {% for item in values %}
     {# We use item.toid instead of item.to_id here to make sure that inversed relations are picked up correctly #}


### PR DESCRIPTION
Fixes #6311

Fixes a bug where we were using the slug, not the contenttype name to decide incoming relations.