### PR TITLE
Fix Save Errors When Deleting Repeaters

### DIFF
--- a/src/Storage/ContentRequest/Save.php
+++ b/src/Storage/ContentRequest/Save.php
@@ -319,6 +319,8 @@ class Save
                     $formValues[$key] = [];
                 } elseif ($values['type'] === 'checkbox') {
                     $formValues[$key] = 0;
+                } elseif ($values['type'] === 'repeater' || $values['type'] === 'block') {
+                    $formValues[$key] = [];
                 }
             }
         }


### PR DESCRIPTION
When no repeater values are posted, make sure that the field is set to an empty value and not skipped.

Closes #6305