### PR TITLE
Base Directory Fixes for Local Extensions

### DIFF
--- a/src/Extension/ConfigTrait.php
+++ b/src/Extension/ConfigTrait.php
@@ -133,10 +133,10 @@ trait ConfigTrait
     private function copyDistFile(YamlFile $file)
     {
         $app = $this->getContainer();
-        $filesystem = $app['filesystem']->getFilesystem('extensions');
 
         /** @var YamlFile $distFile */
-        $distFile = $filesystem->get(sprintf('%s/config/config.yml.dist', $this->getBaseDirectory()->getPath()), new YamlFile());
+        $distFile = $this->getBaseDirectory()->get('/config/config.yml.dist', new YamlFile());
+
         if (!$distFile->exists()) {
             throw new \RuntimeException(sprintf('No config.yml.dist file found at extensions://%s', $this->getBaseDirectory()->getPath()));
         }

--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -4,12 +4,15 @@ namespace Bolt\Extension;
 
 use Bolt\Composer\EventListener\PackageDescriptor;
 use Bolt\Config;
+use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Exception\FileNotFoundException;
+use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\FilesystemInterface;
 use Bolt\Filesystem\Handler\DirectoryInterface;
 use Bolt\Filesystem\Handler\JsonFile;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Translation\LazyTranslator as Trans;
+use ReflectionClass;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Debug\Exception\ContextErrorException;
@@ -123,7 +126,11 @@ class Manager
 
         // Set paths in the extension
         if ($baseDir === null) {
-            $baseDir = $this->extFs->getDir($extension->getId());
+            // If there is no base dir we just default to the same directory as the extension class is in.
+            $reflector = new ReflectionClass($extension);
+            $fs = new Filesystem(new Local(dirname($reflector->getFileName())));
+
+            $baseDir = $fs->getDir('/');
         }
         $extension->setBaseDirectory($baseDir);
 


### PR DESCRIPTION
A couple of fixes to make local extensions behave the same as distributed ones.

These changes make sure that directories are always relative so extensions don't have to be in extensions/vendor to work correctly.