### PR TITLE
Handle empty repeaters in Templatefields

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -82,6 +82,17 @@ class RepeaterType extends FieldTypeBase
     public function hydrate($data, $entity)
     {
         $key = $this->mapping['fieldname'];
+        $collection = new RepeatingFieldCollection($this->em, $this->mapping);
+        $collection->setName($key);
+
+        // If there isn't anything set yet then we just return an empty collection
+        if (!isset($data[$key])) {
+            $this->set($entity, $collection);
+
+            return;
+        }
+
+        // This block separately handles JSON content for Templatefields
         if (isset($data[$key]) && $this->isJson($data[$key])) {
             $originalMapping[$key]['fields'] = $this->mapping['fields'];
             $originalMapping[$key]['type'] = 'repeater';
@@ -102,6 +113,7 @@ class RepeaterType extends FieldTypeBase
             return;
         }
 
+        // Final block handles values stored in the DB and creates a lazy collection
         $vals = array_filter(explode(',', $data[$key]));
         $values = [];
         foreach ($vals as $fieldKey) {
@@ -111,9 +123,6 @@ class RepeaterType extends FieldTypeBase
             $field = join('_', $split);
             $values[$field][$group][] = $id;
         }
-
-        $collection = new RepeatingFieldCollection($this->em, $this->mapping);
-        $collection->setName($key);
 
         if (isset($values[$key]) && count($values[$key])) {
             foreach ($values[$key] as $group => $refs) {


### PR DESCRIPTION
Adds an extra check to repeaters to return an empty collection if they are used in Templatefields and are empty.

Fixes #6323