### PR TITLE
Add BC binding to extend overview page

### DIFF
--- a/src/Controller/Backend/Extend.php
+++ b/src/Controller/Backend/Extend.php
@@ -28,6 +28,10 @@ class Extend extends BackendBase
     {
         $c->get('', 'overview')
             ->bind('extensions');
+        
+        // Allows BC with 3.2 and earlier, to be removed in 4.0
+        $c->get('', 'overview')
+            ->bind('extend');
 
         $c->get('/check', 'check')
             ->bind('check');


### PR DESCRIPTION
This allows a BC method to get a base url for extensions since the change from `/extend` to `/extensions` means there isn't a standard call for multiple versions.

Accessing with `$app['url_generator']->generate('extend')` will return the correct url on all 3.x versions of Bolt.