### PR TITLE
Fix to #6293

### DIFF
--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -487,8 +487,21 @@ trait ContentValuesTrait
                     }
                 }
 
-                $this->taxonomy[$taxonomytype] = $value;
+                $taxonomyOptions = $this->app['config']->get('taxonomy/' . $taxonomytype . '/options');
+
+                if ($taxonomyOptions && is_array($value)) {
+                    foreach ($value as $k => $v) {
+                        if (isset($taxonomyOptions[$v])) {
+                            $this->setTaxonomy($taxonomytype, $v, $taxonomyOptions[$v], $k);
+                        }
+                    }
+                } else if ($taxonomyOptions && isset($taxonomyOptions[$value])) {
+                    $this->setTaxonomy($taxonomytype, $value, $taxonomyOptions[$value], 0);
+                } else {
+                    $this->setTaxonomy($taxonomytype, $value, $value, 0);
+                }
             }
+
             unset($values['taxonomy']);
             unset($values['taxonomy-order']);
         }


### PR DESCRIPTION
So I came across @graham73may 's issue while dealing with a bug myself so I thought I'd take a stab at fixing it.

My solution is to try and retrieve the taxonomy options from the config, if it exists apply the `setTaxonomy` method to each taxonomy with values obtained from the options otherwise provide the only value we have `$value` (this is for tags).

All are having the default `sortorder` set to 0 unless it's an array in which case the `sortorder` is set to the index key (is there ever an instance where the key is an associative?).

Fixes #6293 