### PR TITLE
Fixes: #5974

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -330,7 +330,7 @@ class Config
 
         // Make sure old settings for 'contentsCss' are still picked up correctly
         if (isset($general['wysiwyg']['ck']['contentsCss'])) {
-            if(is_array($general['wysiwyg']['ck']['contentsCss'])) {
+            if (is_array($general['wysiwyg']['ck']['contentsCss'])) {
                 array_unshift($general['wysiwyg']['ck']['contentsCss'], '', '');
                 unset($general['wysiwyg']['ck']['contentsCss'][0], $general['wysiwyg']['ck']['contentsCss'][1]);
             } else {

--- a/src/Config.php
+++ b/src/Config.php
@@ -330,9 +330,14 @@ class Config
 
         // Make sure old settings for 'contentsCss' are still picked up correctly
         if (isset($general['wysiwyg']['ck']['contentsCss'])) {
-            $general['wysiwyg']['ck']['contentsCss'] = [
-                1 => $general['wysiwyg']['ck']['contentsCss'],
-            ];
+            if(is_array($general['wysiwyg']['ck']['contentsCss'])) {
+                array_unshift($general['wysiwyg']['ck']['contentsCss'], '', '');
+                unset($general['wysiwyg']['ck']['contentsCss'][0], $general['wysiwyg']['ck']['contentsCss'][1]);
+            } else {
+                $general['wysiwyg']['ck']['contentsCss'] = [
+                    2 => $general['wysiwyg']['ck']['contentsCss'],
+                ];
+            }
         }
 
         // Make sure old settings for 'accept_file_types' are not still picked up. Before 1.5.4 we used to store them
@@ -1251,15 +1256,6 @@ class Config
     public function setCKPath()
     {
         $app = $this->app['resources']->getUrl('app');
-
-        // Make sure the paths for CKeditor config are always set correctly.
-        $this->set(
-            'general/wysiwyg/ck/contentsCss',
-            [
-                $app . 'view/css/ckeditor-contents.css',
-                $app . 'view/css/ckeditor.css',
-            ]
-        );
         $this->set('general/wysiwyg/filebrowser/browseUrl', $this->app['resources']->getUrl('async') . 'recordbrowser/');
         $this->set(
             'general/wysiwyg/filebrowser/imageBrowseUrl',


### PR DESCRIPTION
Prevents defaults from overriding user supplied values for ContentsCss field and appends user supplied ones to the defaults - Fixes: #5974

**What I did:**
Removed code from setCKPath function that was overriding user supplied
config values with defaults again and altered parseGeneral function so
that it appends the user supplied value(s) for the contentsCss field in
a way that will maintain the defaults when the mergeRecursiveDistinct
function runs.

**Explanation**
It's a bit strange as the recursive merge that occurs will override the default values if I didn't index everything from two onwards (as there are two default css files in the default config settings). I think the array_unshift and unset is the quickest way to do this if the user supplies an array of strings in their config.yml file for the contentsCss field, but feel free to correct me if there's a better way.

Tested it locally with no user supplied contentsCss field in config.yml, a single string and an array of strings (in case the user wishes to supply more than one css file).