### PR TITLE
Fix for maintaining key association in `{{ unique() }}`

### DIFF
--- a/src/Twig/Extension/ArrayExtension.php
+++ b/src/Twig/Extension/ArrayExtension.php
@@ -165,12 +165,7 @@ class ArrayExtension extends Extension
     public function unique($arr1, $arr2)
     {
         $merged = array_unique(array_merge($arr1, $arr2), SORT_REGULAR);
-        $compiled = [];
 
-        foreach ($merged as $val) {
-            $compiled[$val[0]] = $val;
-        }
-
-        return $compiled;
+        return $merged;
     }
 }


### PR DESCRIPTION
Fixes this quirk: 

![screen shot 2017-02-04 at 15 24 08](https://cloud.githubusercontent.com/assets/1833361/22619238/d182381e-eaf0-11e6-8952-f875220c2546.png)
