### PR TITLE
[Tests] Back-port of deprecations work

### DIFF
--- a/tests/phpunit/unit/AccessControl/LoginTest.php
+++ b/tests/phpunit/unit/AccessControl/LoginTest.php
@@ -26,7 +26,7 @@ class LoginTest extends BoltUnitTest
         $app['request_stack']->push(new Request());
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Monolog\Logger', ['error'], ['testlogger']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Login function called with empty username/password combination, or no authentication token.'));
@@ -44,7 +44,7 @@ class LoginTest extends BoltUnitTest
         $app['request_stack']->push(new Request());
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Bolt\Logger\FlashLogger', ['error']);
+        $logger = $this->getMockFlashLogger();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Username or password not correct. Please check your input.'));
@@ -62,13 +62,13 @@ class LoginTest extends BoltUnitTest
         $app['request_stack']->push(new Request());
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Monolog\Logger', ['alert'], ['testlogger']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
             ->method('alert')
             ->with($this->equalTo("Attempt to login with disabled account by 'admin'"));
         $app['logger.system'] = $logger;
 
-        $logger = $this->getMock('\Bolt\Logger\FlashLogger', ['error']);
+        $logger = $this->getMockFlashLogger();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Your account is disabled. Sorry about that.'));
@@ -93,7 +93,7 @@ class LoginTest extends BoltUnitTest
         $this->addDefaultUser($app);
         $this->addNewUser($app, 'koala', 'Koala', 'editor', false);
 
-        $logger = $this->getMock('\Bolt\Logger\FlashLogger', ['error']);
+        $logger = $this->getMockFlashLogger();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Your account is disabled. Sorry about that.'));
@@ -110,13 +110,13 @@ class LoginTest extends BoltUnitTest
         $app = $this->getApp();
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Monolog\Logger', ['info'], ['testlogger']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
             ->method('info')
             ->with($this->equalTo("Failed login attempt for 'Admin'."));
         $app['logger.system'] = $logger;
 
-        $logger = $this->getMock('\Bolt\Logger\FlashLogger', ['error']);
+        $logger = $this->getMockFlashLogger();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Username or password not correct. Please check your input.'));
@@ -135,7 +135,7 @@ class LoginTest extends BoltUnitTest
         $app = $this->getApp();
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Monolog\Logger', ['debug'], ['testlogger']);
+        $logger = $this->getMockMonolog(['debug']);
         $logger->expects($this->at(0))
             ->method('debug')
             ->with($this->matchesRegularExpression('#Generating authentication cookie#'));
@@ -159,7 +159,7 @@ class LoginTest extends BoltUnitTest
         $app = $this->getApp();
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Bolt\Logger\FlashLogger', ['error']);
+        $logger = $this->getMockFlashLogger();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Invalid login parameters.'));
@@ -181,7 +181,7 @@ class LoginTest extends BoltUnitTest
         $app = $this->getApp();
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Bolt\Logger\FlashLogger', ['error']);
+        $logger = $this->getMockFlashLogger();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Invalid login parameters.'));
@@ -215,7 +215,7 @@ class LoginTest extends BoltUnitTest
         $app = $this->getApp();
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Monolog\Logger', ['alert', 'debug'], ['testlogger']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
             ->method('alert')
             ->with($this->equalTo('Attempt to login with an invalid token from 1.2.3.4'));
@@ -252,7 +252,7 @@ class LoginTest extends BoltUnitTest
         $app = $this->getApp();
         $this->addDefaultUser($app);
 
-        $logger = $this->getMock('\Monolog\Logger', ['debug'], ['testlogger']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->at(0))
             ->method('debug')
             ->with($this->matchesRegularExpression('#Generating authentication cookie#'));
@@ -261,7 +261,7 @@ class LoginTest extends BoltUnitTest
             ->with($this->matchesRegularExpression('#Saving new login token#'));
         $app['logger.system'] = $logger;
 
-        $logger = $this->getMock('\Bolt\Logger\FlashLogger', ['success']);
+        $logger = $this->getMockFlashLogger();
         $logger->expects($this->at(0))
             ->method('success')
             ->with($this->equalTo('Session resumed.'));

--- a/tests/phpunit/unit/Asset/AbstractExtensionsUnitTest.php
+++ b/tests/phpunit/unit/Asset/AbstractExtensionsUnitTest.php
@@ -1,5 +1,6 @@
 <?php
-namespace Bolt\Tests\Extensions;
+
+namespace Bolt\Tests\Asset;
 
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Filesystem\Filesystem;
@@ -23,7 +24,7 @@ abstract class AbstractExtensionsUnitTest extends BoltUnitTest
             ->mockFunction('file_get_contents')
             ->getMock();
 
-        $this->php2 = \PHPUnit_Extension_FunctionMocker::start($this, 'Bolt\Tests\Extensions\Mock')
+        $this->php2 = \PHPUnit_Extension_FunctionMocker::start($this, 'Bolt\Tests\Asset\Mock')
             ->mockFunction('file_get_contents')
             ->getMock();
     }

--- a/tests/phpunit/unit/Asset/AssetsProviderTest.php
+++ b/tests/phpunit/unit/Asset/AssetsProviderTest.php
@@ -2,11 +2,13 @@
 
 namespace Bolt\Tests\Asset;
 
+use Bolt\Asset\BoltVersionStrategy;
 use Bolt\Asset\File\JavaScript;
 use Bolt\Asset\File\Stylesheet;
 use Bolt\Asset\Snippet\Snippet;
 use Bolt\Asset\Target;
 use Bolt\Controller\Zone;
+use Bolt\Tests\Extensions\Mock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -189,7 +191,11 @@ HTML;
     protected function getApp($boot = true)
     {
         $app = parent::getApp(false);
-        $mock = $this->getMock('\Bolt\Asset\BoltVersionStrategy', ['getVersion'], [$app['filesystem']->getFilesystem('extensions')->getDir(''), $app['asset.salt']]);
+        $mock = $this->getMockBuilder(BoltVersionStrategy::class)
+            ->setMethods(['getVersion'])
+            ->setConstructorArgs([$app['filesystem']->getFilesystem('extensions')->getDir(''), $app['asset.salt']])
+            ->getMock()
+        ;
         $mock->expects($this->any())
             ->method('getVersion')
             ->will($this->returnCallback(

--- a/tests/phpunit/unit/Asset/AssetsProviderTest.php
+++ b/tests/phpunit/unit/Asset/AssetsProviderTest.php
@@ -1,5 +1,6 @@
 <?php
-namespace Bolt\Tests\Extensions;
+
+namespace Bolt\Tests\Asset;
 
 use Bolt\Asset\File\JavaScript;
 use Bolt\Asset\File\Stylesheet;
@@ -380,42 +381,6 @@ HTML;
         $app['asset.queue.snippet']->add($this->getSnippet(Target::AFTER_META, '<meta name="test-snippet" />'));
         $app['asset.queue.snippet']->process($this->getRequest(), $response);
         $this->assertEquals($this->html($this->expectedAfterMeta), $this->html($response->getContent()));
-    }
-
-    public function testSnippetsWithCallback()
-    {
-        $app = $this->getApp();
-        new Mock\SnippetCallbackExtension($app);
-        $response = new Response($this->template);
-
-        // Test snippet inserts at top of <head>
-        $app['asset.queue.snippet']->process($this->getRequest(), $response);
-        $this->assertEquals($this->html($this->expectedStartOfHead), $this->html($response->getContent()));
-    }
-
-    public function testSnippetsWithGlobalCallback()
-    {
-        $app = $this->getApp();
-        $app['asset.queue.snippet']->add($this->getSnippet(
-            Target::AFTER_META,
-            '\Bolt\Tests\Extensions\globalAssetsSnippet',
-            'core',
-            ["\n"]
-        ));
-
-        // Test snippet inserts at top of <head>
-        $response = new Response('<html></html>');
-        $app['asset.queue.snippet']->process($this->getRequest(), $response);
-        $this->assertEquals('<html></html><br />' . PHP_EOL . PHP_EOL, $response->getContent());
-    }
-
-    public function testExtensionSnippets()
-    {
-        $app = $this->getApp();
-        new Mock\Extension($app);
-        $response = new Response($this->template);
-        $app['asset.queue.snippet']->process($this->getRequest(), $response);
-        $this->assertEquals($this->html($this->expectedEndOfHead), $this->html($response->getContent()));
     }
 
     public function testAddJquery()

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -1,15 +1,28 @@
 <?php
 namespace Bolt\Tests;
 
+use Bolt\AccessControl\AccessChecker;
+use Bolt\AccessControl\Login;
+use Bolt\AccessControl\Permissions;
 use Bolt\AccessControl\Token;
 use Bolt\Application;
+use Bolt\Cache;
 use Bolt\Configuration as Config;
 use Bolt\Legacy\Storage;
+use Bolt\Logger\FlashLogger;
+use Bolt\Logger\Manager;
 use Bolt\Render;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Mocks\LoripsumMock;
-use Symfony\Component\HttpFoundation\Response;
+use Bolt\Users;
+use GuzzleHttp\Client;
+use Monolog\Logger;
+use PHPUnit_Framework_MockObject_MockObject;
+use Swift_Mailer;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
 
 /**
  * Abstract Class that other unit tests can extend, provides generic methods for Bolt tests.
@@ -150,19 +163,19 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     protected function allowLogin($app)
     {
         $this->addDefaultUser($app);
-        $users = $this->getMock('Bolt\Users', ['isEnabled'], [$app]);
+        $users = $this->getMockUsers(['isEnabled']);
         $users->expects($this->any())
             ->method('isEnabled')
             ->will($this->returnValue(true));
         $app['users'] = $users;
 
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions(['isAllowed']);
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(true));
         $this->setService('permissions', $permissions);
 
-        $auth = $this->getAccessCheckerMock($app);
+        $auth = $this->getMockAccessChecker($app);
         $auth->expects($this->any())
             ->method('isValidSession')
             ->will($this->returnValue(true));
@@ -232,7 +245,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     protected function removeCSRF($app)
     {
         // Symfony forms need a CSRF token so we have to mock this too
-        $csrf = $this->getMock(CsrfTokenManager::class, ['isTokenValid', 'getToken'], [], '', false);
+        $csrf = $this->getMockCsrfTokenManager(['isTokenValid', 'getToken']);
         $csrf->expects($this->any())
             ->method('isTokenValid')
             ->will($this->returnValue(true));
@@ -277,5 +290,230 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
         $authToken = new Token\Token($userEntity, $tokenEntity);
 
         $this->getService('session')->set('authentication', $authToken);
+    }
+
+    /*
+     * MOCKS
+     */
+
+    /**
+     * @param \Silex\Application $app
+     * @param array              $methods Defaults to ['isValidSession']
+     *
+     * @return \Bolt\AccessControl\AccessChecker|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockAccessChecker($app, $methods = ['isValidSession'])
+    {
+        $parameters = [
+            $app['storage.lazy'],
+            $app['request_stack'],
+            $app['session'],
+            $app['dispatcher'],
+            $app['logger.flash'],
+            $app['logger.system'],
+            $app['permissions'],
+            $app['randomgenerator'],
+            $app['access_control.cookie.options'],
+        ];
+        $accessCheckerMock =  $this->getMockBuilder(AccessChecker::class)
+            ->setMethods($methods)
+            ->setConstructorArgs($parameters)
+            ->getMock()
+        ;
+
+        return $accessCheckerMock;
+    }
+
+    /**
+     * @param null $path
+     *
+     * @return Cache|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockCache($path = null)
+    {
+        $app = $this->getApp();
+        if ($path === null) {
+            $path = $app['resources']->getPath('cache');
+        }
+
+        $params = [
+            $path,
+            Cache::EXTENSION,
+            0002,
+            $app['filesystem'],
+        ];
+
+        return $this->getMockBuilder(Cache::class)
+            ->setMethods(['flushAll'])
+            ->setConstructorArgs($params)
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return CsrfTokenManager|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockCsrfTokenManager($methods = ['isTokenValid'])
+    {
+        return $this->getMockBuilder(CsrfTokenManager::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([null, new SessionTokenStorage(new Session(new MockArraySessionStorage()))])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @return Client|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockGuzzleClient()
+    {
+        return $this->getMockBuilder(Client::class)
+            ->setMethods(['get'])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return FlashLogger|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockFlashLogger($methods = ['danger', 'error', 'success'])
+    {
+        return $this->getMockBuilder(FlashLogger::class)
+            ->setMethods($methods)
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods Defaults to ['login']
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject A mocked \Bolt\AccessControl\Login
+     */
+    protected function getMockLogin($methods = ['login'])
+    {
+        return $this->getMockBuilder(Login::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$this->getApp()])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return Manager|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockLoggerManager($methods = ['clear', 'error', 'info', 'trim'])
+    {
+        $app = $this->getApp();
+        $changeRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogChange');
+        $systemRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogSystem');
+
+        return $this->getMockBuilder(Manager::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$app, $changeRepository, $systemRepository])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return Logger|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockMonolog($methods = ['alert', 'clear', 'debug', 'error', 'info'])
+    {
+        return $this->getMockBuilder(Logger::class)
+            ->setMethods($methods)
+            ->setConstructorArgs(['testlogger'])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return Permissions|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockPermissions($methods = ['isAllowed', 'isAllowedToManipulate'])
+    {
+        return $this->getMockBuilder(Permissions::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$this->getApp()])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param Application $app
+     *
+     * @return Render|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockRender(Application $app)
+    {
+        return $this->getMockBuilder(Render::class)
+            ->setMethods(['render'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject|Swift_Mailer
+     */
+    protected function getMockSwiftMailer($methods = ['send'])
+    {
+        return $this->getMockBuilder(Swift_Mailer::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$this->app['swiftmailer.transport']])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return Storage|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockStorage($methods = ['getContent', 'getContentType', 'getTaxonomyType'])
+    {
+        return $this->getMockBuilder(Storage::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$this->getApp()])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return Users|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockUsers($methods = ['getUsers', 'isAllowed'])
+    {
+        return $this->getMockBuilder(Users::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$this->getApp()])
+            ->getMock()
+        ;
+    }
+
+    /**
+     * @deprecated Remove in v4 as PHPUnit 5 includes this.
+     */
+    protected function createMock($originalClassName)
+    {
+        return $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock()
+        ;
     }
 }

--- a/tests/phpunit/unit/Composer/Satis/StatServiceTest.php
+++ b/tests/phpunit/unit/Composer/Satis/StatServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Tests\Extensions;
 
+use Bolt\Composer\Satis\StatService;
 use Bolt\Tests\BoltUnitTest;
 
 /**
@@ -13,12 +14,17 @@ class StatServiceTest extends BoltUnitTest
     public function testSetup()
     {
         $app = $this->getApp();
-        $stat = $this->getMock('Bolt\Composer\Satis\StatService', ['recordInstall'], [$app['guzzle.client'], $app['logger.system'], $app['extend.site']]);
+        $stat = $this->getMockBuilder(StatService::class)
+            ->setMethods(['recordInstall'])
+            ->setConstructorArgs([$app['guzzle.client'], $app['logger.system'], $app['extend.site']])
+            ->getMock()
+        ;
         $stat->expects($this->once())
             ->method('recordInstall')
             ->with('mytest', '1.0.0');
 
-        $response = $stat->recordInstall('mytest', '1.0.0');
+        /** @var StatService $stat */
+        $stat->recordInstall('mytest', '1.0.0');
     }
 }
 

--- a/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
+++ b/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
@@ -2,6 +2,7 @@
 namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Configuration\ResourceManager;
+use Bolt\Storage\Database\Schema\Manager;
 use Bolt\Storage\Database\Schema\SchemaCheck;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,7 +23,7 @@ class DatabaseTest extends ControllerUnitTest
     {
         $this->allowLogin($this->getApp());
         $checkResponse = new SchemaCheck();
-        $check = $this->getMock('Bolt\Storage\Database\Schema\Manager', ['check'], [$this->getApp()]);
+        $check = $this->getMockSchemaManager(['check']);
         $check->expects($this->atLeastOnce())
             ->method('check')
             ->will($this->returnValue($checkResponse));
@@ -38,7 +39,7 @@ class DatabaseTest extends ControllerUnitTest
     {
         $this->allowLogin($this->getApp());
         $checkResponse = new SchemaCheck();
-        $check = $this->getMock('Bolt\Storage\Database\Schema\Manager', ['update'], [$this->getApp()]);
+        $check = $this->getMockSchemaManager(['update']);
 
         $check->expects($this->any())
             ->method('update')
@@ -70,5 +71,19 @@ class DatabaseTest extends ControllerUnitTest
     protected function controller()
     {
         return $this->getService('controller.backend.database');
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return Manager|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockSchemaManager(array $methods)
+    {
+        return $this->getMockBuilder(Manager::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$this->getApp()])
+            ->getMock()
+        ;
     }
 }

--- a/tests/phpunit/unit/Controller/Backend/ExtendTest.php
+++ b/tests/phpunit/unit/Controller/Backend/ExtendTest.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Tests\Controller\Backend;
 
+use Bolt\Composer\Satis\QueryService;
+use Bolt\Controller\Backend\Extend;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -39,8 +41,10 @@ class ExtendTest extends ControllerUnitTest
         $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplateName());
 
         $this->setRequest(Request::create('/', 'GET', ['package' => 'bolt/theme-2014']));
-        /** @var \Bolt\Controller\Backend\Extend|\PHPUnit_Framework_MockObject_MockObject $controller */
-        $controller = $this->getMock('Bolt\Controller\Backend\Extend', ['installInfo', 'packageInfo', 'check']);
+        $controller = $this->getMockBuilder(Extend::class)
+            ->setMethods(['installInfo', 'packageInfo', 'check'])
+            ->getMock()
+        ;
         $controller->expects($this->any())
             ->method('installInfo')
             ->will($this->returnValue(new Response('{"dev": [{"name": "bolt/theme-2014","version": "dev-master"}],"stable": []}')));
@@ -94,7 +98,13 @@ class ExtendTest extends ControllerUnitTest
     public function testInstallInfo()
     {
         $this->getApp()->flush();
-        $mockInfo = $this->getMock('Bolt\Composer\Satis\QueryService', ['info'], [], 'MockInfoService', false);
+        $mockInfo = $this->getMockBuilder(QueryService::class)
+            ->setMethods(['info'])
+            ->setConstructorArgs([$this->getApp()])
+            ->setMockClassName('MockInfoService')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
         $mockInfo->expects($this->once())
             ->method('info')
             ->will($this->returnValue($this->packageInfoProvider()));

--- a/tests/phpunit/unit/Controller/Backend/FileManagerTest.php
+++ b/tests/phpunit/unit/Controller/Backend/FileManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Controller\Backend;
 
+use Bolt\Filesystem\FilePermissions;
 use Bolt\Filesystem\Handler\DirectoryInterface;
 use Bolt\Response\TemplateResponse;
 use Bolt\Tests\Controller\ControllerUnitTest;
@@ -42,7 +43,11 @@ class FileManagerTest extends ControllerUnitTest
         $this->assertEquals([], $context['files']);
 
         // Try and upload a file
-        $perms = $this->getMock('Bolt\Filesystem\FilePermissions', ['allowedUpload'], [$app['config']]);
+        $perms = $this->getMockBuilder(FilePermissions::class)
+            ->setMethods(['allowedUpload'])
+            ->setConstructorArgs([$app['config']])
+            ->getMock()
+        ;
         $perms->expects($this->any())
             ->method('allowedUpload')
             ->will($this->returnValue(true));

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Application;
 use Bolt\Controller\Zone;
+use Bolt\Legacy\Storage;
 use Bolt\Logger\FlashLogger;
 use Bolt\Response\TemplateResponse;
 use Bolt\Tests\Controller\ControllerUnitTest;
@@ -121,7 +122,7 @@ class GeneralTest extends ControllerUnitTest
         $this->assertEquals('/bolt/prefill', $response->getTargetUrl());
 
         // Test for the Exception if connection fails to the prefill service
-        $store = $this->getMock('Bolt\Storage', ['preFill'], [$this->getApp()]);
+        $store = $this->getMock(Storage::class, ['preFill'], [$this->getApp()]);
 
         $app = $this->getApp();
         if ($app['guzzle.api_version'] === 5) {

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -34,7 +34,7 @@ class GeneralTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt'));
 
         $request = $this->getRequest();
-        $kernel = $this->getMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $app['dispatcher']->dispatch(KernelEvents::REQUEST, new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         $this->assertEquals('backend', Zone::get($request));
@@ -53,7 +53,7 @@ class GeneralTest extends ControllerUnitTest
     public function testClearCache()
     {
         $this->allowLogin($this->getApp());
-        $cache = $this->getCacheMock();
+        $cache = $this->getMockCache();
         $cache->expects($this->at(0))
             ->method('flushAll')
             ->will($this->returnValue(false));
@@ -122,7 +122,11 @@ class GeneralTest extends ControllerUnitTest
         $this->assertEquals('/bolt/prefill', $response->getTargetUrl());
 
         // Test for the Exception if connection fails to the prefill service
-        $store = $this->getMock(Storage::class, ['preFill'], [$this->getApp()]);
+        $store = $this->getMockBuilder(Storage::class)
+            ->setMethods(['preFill'])
+            ->setConstructorArgs([$this->getApp()])
+            ->getMock()
+        ;
 
         $app = $this->getApp();
         if ($app['guzzle.api_version'] === 5) {
@@ -138,7 +142,7 @@ class GeneralTest extends ControllerUnitTest
 
         $this->setService('storage', $store);
 
-        $logger = $this->getMock('Monolog\Logger', ['error'], ['test']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->once())
             ->method('error')
             ->with("Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.");

--- a/tests/phpunit/unit/Controller/Backend/LogTest.php
+++ b/tests/phpunit/unit/Controller/Backend/LogTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Tests\Controller\Backend;
 
+use Bolt\Logger\Manager;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -27,10 +28,7 @@ class LogTest extends ControllerUnitTest
     {
         $this->allowLogin($this->getApp());
 
-        $changeRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogChange');
-        $systemRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogSystem');
-        $log = $this->getMock('Bolt\Logger\Manager', ['clear', 'trim'], [$this->getApp(), $changeRepository, $systemRepository]);
-
+        $log = $this->getMockLoggerManager();
         $log->expects($this->once())
             ->method('clear')
             ->will($this->returnValue(true));
@@ -163,7 +161,11 @@ class LogTest extends ControllerUnitTest
 
         $changeRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogChange');
         $systemRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogSystem');
-        $log = $this->getMock('Bolt\Logger\Manager', ['clear', 'trim'], [$this->getApp(), $changeRepository, $systemRepository]);
+        $log = $this->getMockBuilder(Manager::class)
+            ->setMethods(['clear', 'trim'])
+            ->setConstructorArgs([$this->getApp(), $changeRepository, $systemRepository])
+            ->getMock()
+        ;
         $log->expects($this->once())
             ->method('clear')
             ->will($this->returnValue(true));

--- a/tests/phpunit/unit/Controller/Backend/RecordsTest.php
+++ b/tests/phpunit/unit/Controller/Backend/RecordsTest.php
@@ -29,7 +29,7 @@ class RecordsTest extends ControllerUnitTest
         $this->assertEquals('/bolt', $response->getTargetUrl());
 
         // Since we're the test user we won't automatically have permission to edit.
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(true));
@@ -58,7 +58,7 @@ class RecordsTest extends ControllerUnitTest
     public function testEditDuplicate()
     {
         // Since we're the test user we won't automatically have permission to edit.
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(true));
@@ -83,13 +83,13 @@ class RecordsTest extends ControllerUnitTest
 
     public function testEditCSRF()
     {
-        $csrf = $this->getMock(CsrfTokenManager::class, ['isTokenValid'], [null, new SessionTokenStorage(new Session(new MockArraySessionStorage()))]);
+        $csrf = $this->getMockCsrfTokenManager();
         $csrf->expects($this->any())
             ->method('isTokenValid')
             ->will($this->returnValue(false));
         $this->setService('csrf', $csrf);
 
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(true));
@@ -102,13 +102,13 @@ class RecordsTest extends ControllerUnitTest
 
     public function testEditPermissions()
     {
-        $users = $this->getMock('Bolt\Users', ['checkAntiCSRFToken'], [$this->getApp()]);
+        $users = $this->getMockUsers(['checkAntiCSRFToken']);
         $users->expects($this->any())
             ->method('checkAntiCSRFToken')
             ->will($this->returnValue(true));
         $this->setService('users', $users);
 
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(false));
@@ -122,19 +122,19 @@ class RecordsTest extends ControllerUnitTest
 
     public function testEditPost()
     {
-        $csrf = $this->getMock(CsrfTokenManager::class, ['isTokenValid'], [null, new SessionTokenStorage(new Session(new MockArraySessionStorage()))]);
+        $csrf = $this->getMockCsrfTokenManager();
         $csrf->expects($this->any())
             ->method('isTokenValid')
             ->will($this->returnValue(true));
         $this->setService('csrf', $csrf);
 
-        $users = $this->getMock('Bolt\Users', ['checkAntiCSRFToken'], [$this->getApp()]);
+        $users = $this->getMockUsers(['checkAntiCSRFToken']);
         $users->expects($this->any())
             ->method('checkAntiCSRFToken')
             ->will($this->returnValue(true));
         $this->setService('users', $users);
 
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(true));
@@ -147,20 +147,20 @@ class RecordsTest extends ControllerUnitTest
 
     public function testEditPostAjax()
     {
-        $csrf = $this->getMock(CsrfTokenManager::class, ['isTokenValid'], [null, new SessionTokenStorage(new Session(new MockArraySessionStorage()))]);
+        $csrf = $this->getMockCsrfTokenManager();
         $csrf->expects($this->any())
             ->method('isTokenValid')
             ->will($this->returnValue(true));
         $this->setService('csrf', $csrf);
 
-        $users = $this->getMock('Bolt\Users', ['checkAntiCSRFToken'], [$this->getApp()]);
+        $users = $this->getMockUsers(['checkAntiCSRFToken']);
         $users->expects($this->any())
             ->method('checkAntiCSRFToken')
             ->will($this->returnValue(true));
         $this->setService('users', $users);
 
         // Since we're the test user we won't automatically have permission to edit.
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(true));
@@ -192,7 +192,7 @@ class RecordsTest extends ControllerUnitTest
         $this->controller()->overview($this->getRequest(), 'showcases');
 
         // Test redirect when user isn't allowed.
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(false));
@@ -247,7 +247,7 @@ class RecordsTest extends ControllerUnitTest
         $this->assertNull($context['context']['relations']);
 
         // Test redirect when user isn't allowed.
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(false));

--- a/tests/phpunit/unit/Controller/Backend/UsersTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UsersTest.php
@@ -39,7 +39,7 @@ class UsersTest extends ControllerUnitTest
         $this->assertEquals('/bolt/users', $response->getTargetUrl());
 
         // Now we allow the permsission check to return true
-        $perms = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowedToManipulate'], [$this->getApp()]);
+        $perms = $this->getMockPermissions();
         $perms->expects($this->any())
             ->method('isAllowedToManipulate')
             ->will($this->returnValue(true));
@@ -63,7 +63,7 @@ class UsersTest extends ControllerUnitTest
         $user = $this->getService('users')->getUser(1);
         $this->setSessionUser(new Entity\Users($user));
 
-        $perms = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowedToManipulate'], [$this->getApp()]);
+        $perms = $this->getMockPermissions();
         $perms->expects($this->any())
             ->method('isAllowedToManipulate')
             ->will($this->returnValue(true));
@@ -134,7 +134,7 @@ class UsersTest extends ControllerUnitTest
 
     public function testModifyBadCsrf()
     {
-        $csrf = $this->getMock(CsrfTokenManager::class, ['isTokenValid'], [null, new SessionTokenStorage(new Session(new MockArraySessionStorage()))]);
+        $csrf = $this->getMockCsrfTokenManager();
         $csrf->expects($this->any())
             ->method('isTokenValid')
             ->will($this->returnValue(false));
@@ -152,7 +152,7 @@ class UsersTest extends ControllerUnitTest
     public function testModifyValidCsrf()
     {
         // Now we mock the CSRF token to validate
-        $csrf = $this->getMock(CsrfTokenManager::class, ['isTokenValid'], [null, new SessionTokenStorage(new Session(new MockArraySessionStorage()))]);
+        $csrf = $this->getMockCsrfTokenManager();
         $csrf->expects($this->any())
             ->method('isTokenValid')
             ->will($this->returnValue(true));
@@ -214,7 +214,7 @@ class UsersTest extends ControllerUnitTest
         $this->addNewUser($this->getApp(), 'editor', 'Editor', 'editor');
         $editor = $this->getService('users')->getUser('editor');
 
-        $perms = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowedToManipulate'], [$this->getApp()]);
+        $perms = $this->getMockPermissions();
         $perms->expects($this->any())
             ->method('isAllowedToManipulate')
             ->will($this->returnValue(false));
@@ -234,13 +234,13 @@ class UsersTest extends ControllerUnitTest
         $this->addNewUser($this->getApp(), 'editor', 'Editor', 'editor');
 
         // Now we mock the CSRF token to validate
-        $csrf = $this->getMock(CsrfTokenManager::class, ['isTokenValid'], [null, new SessionTokenStorage(new Session(new MockArraySessionStorage()))]);
+        $csrf = $this->getMockCsrfTokenManager();
         $csrf->expects($this->any())
             ->method('isTokenValid')
             ->will($this->returnValue(true));
         $this->setService('csrf', $csrf);
 
-        $users = $this->getMock('Bolt\Users', ['setEnabled', 'deleteUser'], [$this->getApp()]);
+        $users = $this->getMockUsers(['setEnabled', 'deleteUser']);
         $users->expects($this->any())
             ->method('setEnabled')
             ->will($this->returnValue(false));
@@ -310,7 +310,7 @@ class UsersTest extends ControllerUnitTest
         $user = $this->getService('users')->getUser(1);
         $this->setSessionUser(new Entity\Users($user));
 
-        $perms = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowedToManipulate'], [$this->getApp()]);
+        $perms = $this->getMockPermissions();
         $perms->expects($this->any())
             ->method('isAllowedToManipulate')
             ->will($this->returnValue(true));

--- a/tests/phpunit/unit/Controller/ControllerUnitTest.php
+++ b/tests/phpunit/unit/Controller/ControllerUnitTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Tests\Controller;
 
+use Bolt\AccessControl\Permissions;
 use Bolt\Configuration\Validation\Validator;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -34,7 +34,7 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/'));
 
         $request = $this->getRequest();
-        $kernel = $this->getMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
+        $kernel = $this->createMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
         $app['dispatcher']->dispatch(KernelEvents::REQUEST, new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         $this->assertEquals('frontend', Zone::get($request));
@@ -139,7 +139,11 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create($expected));
         $app['request_context']->fromRequest($this->getRequest());
 
-        $templates = $this->getMock(TemplateChooser::class, ['record'], [$app['config']]);
+        $templates = $this->getMockBuilder(TemplateChooser::class)
+            ->setMethods(['record'])
+            ->setConstructorArgs([$app['config']])
+            ->getMock()
+        ;
         $templates->expects($this->any())
             ->method('record')
             ->will($this->returnValue('index.twig'));
@@ -165,7 +169,7 @@ class FrontendTest extends ControllerUnitTest
         $content1->id = 5;
         $content1['slug'] = 'foo';
 
-        $storage = $this->getMock(Storage::class, ['getContent'], [$app]);
+        $storage = $this->getMockStorage(['getContent']);
         $app['storage'] = $storage;
 
         $storage->expects($this->at(0))
@@ -192,7 +196,7 @@ class FrontendTest extends ControllerUnitTest
         $contentType = $this->getService('storage')->getContentType('pages');
         $content1 = new Content($this->getApp(), $contentType);
 
-        $storage = $this->getMock(Storage::class, ['getContent'], [$this->getApp()]);
+        $storage = $this->getMockStorage(['getContent']);
 
         $storage->expects($this->at(0))
             ->method('getContent')
@@ -229,7 +233,7 @@ class FrontendTest extends ControllerUnitTest
     public function testNoRecord()
     {
         $this->setRequest(Request::create('/pages/', 'GET', ['id' => 5]));
-        $storage = $this->getMock(Storage::class, ['getContent'], [$this->getApp()]);
+        $storage = $this->getMockStorage();
 
         $storage->expects($this->at(0))
             ->method('getContent')
@@ -248,7 +252,7 @@ class FrontendTest extends ControllerUnitTest
     public function testRecordNoTemplate()
     {
         $this->setRequest(Request::create('/pages/', 'GET', ['id' => 5]));
-        $storage = $this->getMock(Storage::class, ['getContent'], [$this->getApp()]);
+        $storage = $this->getMockStorage();
 
         $storage->expects($this->at(0))
             ->method('getContent')
@@ -271,7 +275,7 @@ class FrontendTest extends ControllerUnitTest
         $contentType = $this->getService('storage')->getContentType('pages');
         $contentType['viewless'] = true;
 
-        $storage = $this->getMock(Storage::class, ['getContentType'], [$this->getApp()]);
+        $storage = $this->getMockStorage();
         $storage->expects($this->once())
             ->method('getContentType')
             ->will($this->returnValue($contentType));
@@ -294,11 +298,16 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/pages'));
         $this->controller()->listing($this->getRequest(), 'pages/test');
 
-        $templates = $this->getMock(TemplateChooser::class, ['record'], [$this->getApp()['config']]);
+        $templates = $this->getMockBuilder(TemplateChooser::class)
+            ->setMethods(['record'])
+            ->setConstructorArgs([$this->getApp()['config']])
+            ->getMock()
+        ;
         $templates
             ->expects($this->any())
             ->method('record')
-            ->will($this->returnValue('record.twig'));
+            ->will($this->returnValue('record.twig'))
+        ;
         $this->setService('templatechooser', $templates);
 
         $response = $this->controller()->preview($this->getRequest(), 'pages');
@@ -324,7 +333,7 @@ class FrontendTest extends ControllerUnitTest
         $contentType = $this->getService('storage')->getContentType('pages');
         $contentType['viewless'] = true;
 
-        $storage = $this->getMock(Storage::class, ['getContentType'], [$this->getApp()]);
+        $storage = $this->getMockStorage();
         $storage->expects($this->once())
             ->method('getContentType')
             ->will($this->returnValue($contentType));
@@ -339,7 +348,7 @@ class FrontendTest extends ControllerUnitTest
     {
         $this->setRequest(Request::create('/faketaxonomy/main'));
 
-        $storage = $this->getMock(Storage::class, ['getTaxonomyType'], [$this->getApp()]);
+        $storage = $this->getMockStorage();
         $storage->expects($this->once())
             ->method('getTaxonomyType')
             ->will($this->returnValue(false));
@@ -423,7 +432,7 @@ class FrontendTest extends ControllerUnitTest
     {
         $this->setRequest(Request::create('/'));
 
-        $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
+        $users = $this->getMockUsers();
 
         $users->expects($this->once())
             ->method('getUsers')
@@ -441,7 +450,7 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/'));
         $this->getService('config')->set('general/maintenance_mode', true);
 
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(false));
@@ -457,7 +466,7 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/'));
         $this->getService('config')->set('general/maintenance_mode', true);
 
-        $permissions = $this->getMock('Bolt\AccessControl\Permissions', ['isAllowed'], [$this->getApp()]);
+        $permissions = $this->getMockPermissions();
         $permissions->expects($this->any())
             ->method('isAllowed')
             ->will($this->returnValue(true));

--- a/tests/phpunit/unit/Events/CronEventTest.php
+++ b/tests/phpunit/unit/Events/CronEventTest.php
@@ -19,14 +19,13 @@ class CronEventTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $app['cache'] = $this->getCacheMock();
+        $app['cache'] = $this->getMockCache();
         $app['cache']
             ->expects($this->exactly(1))
-            ->method('flushAll');
+            ->method('flushAll')
+        ;
 
-        $changeRepository = $app['storage']->getRepository('Bolt\Storage\Entity\LogChange');
-        $systemRepository = $app['storage']->getRepository('Bolt\Storage\Entity\LogSystem');
-        $app['logger.manager'] = $this->getMock('Bolt\Logger\Manager', ['trim'], [$app, $changeRepository, $systemRepository]);
+        $app['logger.manager'] = $this->getMockLoggerManager();
         $app['logger.manager']
             ->expects($this->exactly(2))
             ->method('trim');

--- a/tests/phpunit/unit/Events/MountEventTest.php
+++ b/tests/phpunit/unit/Events/MountEventTest.php
@@ -31,7 +31,7 @@ class MountEventTest extends BoltUnitTest
         $app = $this->getApp();
 
         $route = new Route('/');
-        $controllers = $this->getMock('Silex\ControllerCollection', ['mount'], [$route]);
+        $controllers = $this->getMockControllerCollection(['mount'], $route);
         $controllers
             ->expects($this->once())
             ->method('mount')
@@ -46,7 +46,7 @@ class MountEventTest extends BoltUnitTest
         $app = $this->getApp();
 
         $route = new Route('/');
-        $controllers = $this->getMock('Silex\ControllerCollection', ['connect', 'mount'], [$route]);
+        $controllers = $this->getMockControllerCollection(['connect', 'mount'], $route);
         $controllers
             ->expects($this->never())
             ->method('mount')
@@ -62,7 +62,7 @@ class MountEventTest extends BoltUnitTest
         $app = $this->getApp();
 
         $route = new Route('/');
-        $controllers = $this->getMock('Silex\ControllerCollection', ['connect', 'mount'], [$route]);
+        $controllers = $this->getMockControllerCollection(['connect', 'mount'], $route);
         $controllers
             ->expects($this->never())
             ->method('mount')
@@ -72,6 +72,22 @@ class MountEventTest extends BoltUnitTest
 
         $mountEvent = new MountEvent($app, $controllers);
         $mountEvent->mount('/', new ControllerMock($route));
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @param Route $route
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|ControllerCollection
+     */
+    protected function getMockControllerCollection($methods = ['connect', 'mount'], Route $route)
+    {
+        return $this->getMockBuilder(ControllerCollection::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$route])
+            ->getMock()
+        ;
     }
 }
 

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -9,6 +9,8 @@ use Bolt\Asset\Widget\Widget;
 use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\Handler\Directory;
+use Bolt\Filesystem\Handler\File;
+use Bolt\Filesystem\Manager;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\AssetExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
@@ -100,7 +102,10 @@ class AssetTraitTest extends BoltUnitTest
         $ext->setContainer($app);
         $ext->setBaseDirectory($dir);
 
-        $mockFile = $this->getMock('\Bolt\Filesystem\Handler\File', ['exists', 'getPath']);
+        $mockFile = $this->getMockBuilder(File::class)
+            ->setMethods(['exists', 'getPath'])
+            ->getMock()
+        ;
         $mockFile
             ->method('exists')
             ->willReturn(true)
@@ -109,7 +114,10 @@ class AssetTraitTest extends BoltUnitTest
             ->method('getPath')
             ->willReturn('/extensions/local/bolt/koala/test.js')
         ;
-        $mockDir = $this->getMock('\Bolt\Filesystem\Handler\Directory', ['getFile']);
+        $mockDir = $this->getMockBuilder(Directory::class)
+            ->setMethods(['getFile'])
+            ->getMock()
+        ;
         $mockDir
             ->method('getFile')
             ->willReturn($mockFile)
@@ -143,7 +151,11 @@ class AssetTraitTest extends BoltUnitTest
             'extensions' => new Filesystem(new Local($app['resources']->getPath('extensions'))),
             'cache'      => new Filesystem(new Local($app['resources']->getPath('cache'))),
         ];
-        $mock = $this->getMock('\Bolt\Filesystem\Manager', ['has'], [$mockParams]);
+        $mock = $this->getMockBuilder(Manager::class)
+            ->setMethods(['has'])
+            ->setConstructorArgs([$mockParams])
+            ->getMock()
+        ;
         $mock->expects($this->any())
             ->method('has')
             ->willReturn(true)

--- a/tests/phpunit/unit/Extension/ControllerMountTraitTest.php
+++ b/tests/phpunit/unit/Extension/ControllerMountTraitTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Extension;
 
+use Bolt\Events\MountEvent;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\ControllerMountExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
@@ -16,7 +17,7 @@ class ControllerMountTraitTest extends BoltUnitTest
     public function testControllerMountDefault()
     {
         $app = $this->getApp();
-        $event = $this->getMock('Bolt\Events\MountEvent', ['mount'], [$app, $app['controllers']]);
+        $event = $this->getMockMountEvent();
         $event->expects($this->exactly(0))->method('mount');
 
         $ext = new NormalExtension();
@@ -27,11 +28,27 @@ class ControllerMountTraitTest extends BoltUnitTest
     public function testControllerMount()
     {
         $app = $this->getApp();
-        $event = $this->getMock('Bolt\Events\MountEvent', ['mount'], [$app, $app['controllers']]);
+        $event = $this->getMockMountEvent();
         $event->expects($this->exactly(2))->method('mount');
 
         $ext = new ControllerMountExtension();
         $ext->setContainer($app);
         $ext->onMountControllers($event);
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return MountEvent|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockMountEvent($methods = ['mount'])
+    {
+        $app = $this->getApp();
+
+        return $this->getMockBuilder(MountEvent::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$app, $app['controllers']])
+            ->getMock()
+        ;
     }
 }

--- a/tests/phpunit/unit/Extension/ControllerTraitTest.php
+++ b/tests/phpunit/unit/Extension/ControllerTraitTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Extension;
 
+use Bolt\Events\MountEvent;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\ControllerExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
@@ -16,7 +17,7 @@ class ControllerTraitTest extends BoltUnitTest
     public function testRoutesDefault()
     {
         $app = $this->getApp();
-        $event = $this->getMock('Bolt\Events\MountEvent', ['mount'], [$app, $app['controllers']]);
+        $event = $this->getMockMountEvent();
         $event->expects($this->exactly(2))->method('mount');
 
         $ext = new NormalExtension();
@@ -27,11 +28,27 @@ class ControllerTraitTest extends BoltUnitTest
     public function testRoutes()
     {
         $app = $this->getApp();
-        $event = $this->getMock('Bolt\Events\MountEvent', ['mount'], [$app, $app['controllers']]);
+        $event = $this->getMockMountEvent();
         $event->expects($this->exactly(2))->method('mount');
 
         $ext = new ControllerExtension();
         $ext->setContainer($app);
         $ext->onMountRoutes($event);
+    }
+
+    /**
+     * @param array $methods
+     *
+     * @return MountEvent|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockMountEvent($methods = ['mount'])
+    {
+        $app = $this->getApp();
+
+        return $this->getMockBuilder(MountEvent::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([$app, $app['controllers']])
+            ->getMock()
+        ;
     }
 }

--- a/tests/phpunit/unit/Extension/SimpleExtensionTest.php
+++ b/tests/phpunit/unit/Extension/SimpleExtensionTest.php
@@ -16,7 +16,10 @@ class SimpleExtensionTest extends BoltUnitTest
     public function testRegister()
     {
         $app = $this->getApp();
-        $mock = $this->getMock('Bolt\Tests\Extension\Mock\NormalExtension', ['getContainer']);
+        $mock = $this->getMockBuilder(NormalExtension::class)
+            ->setMethods(['getContainer'])
+            ->getMock()
+        ;
         $mock->expects($this->atLeast(4))->method('getContainer')->willReturn($app);
 
         /** @var NormalExtension $mock */

--- a/tests/phpunit/unit/Extension/SnippetsTest.php
+++ b/tests/phpunit/unit/Extension/SnippetsTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Extensions;
 
 use Bolt\Asset\Target;
+use Bolt\Tests\Asset\AbstractExtensionsUnitTest;
 
 /**
  * Class to test correct operation and locations of extensions.

--- a/tests/phpunit/unit/Field/BaseFieldTest.php
+++ b/tests/phpunit/unit/Field/BaseFieldTest.php
@@ -14,7 +14,11 @@ class BaseFieldTest extends BoltUnitTest
     public function testFieldSetup()
     {
         /** @var Base $field */
-        $field = $this->getMock('Bolt\Storage\Field\Base', null, ['test', 'test.twig']);
+        $field = $this->getMockBuilder(Base::class)
+            ->setMethods(null)
+            ->setConstructorArgs(['test', 'test.twig'])
+            ->getMock()
+        ;
         $this->assertEquals('test', $field->getName());
         $this->assertEquals('test.twig', $field->getTemplate());
 

--- a/tests/phpunit/unit/Field/ManagerTest.php
+++ b/tests/phpunit/unit/Field/ManagerTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Tests\Field;
 
+use Bolt\Storage\Field\Base;
 use Bolt\Storage\Field\Manager;
 use Bolt\Tests\BoltUnitTest;
 
@@ -36,7 +37,12 @@ class ManagerTest extends BoltUnitTest
 
     public function testAddingFetchingfields()
     {
-        $field = $this->getMock('Bolt\Storage\Field\Base', null, ['test', 'test.twig']);
+        /** @var Base $field */
+        $field = $this->getMockBuilder(Base::class)
+            ->setMethods(null)
+            ->setConstructorArgs(['test', 'test.twig'])
+            ->getMock()
+        ;
         $manager = new Manager();
         $manager->addField($field);
         $this->assertTrue($manager->has('test'));

--- a/tests/phpunit/unit/Filesystem/Plugin/ThumbnailUrlTest.php
+++ b/tests/phpunit/unit/Filesystem/Plugin/ThumbnailUrlTest.php
@@ -19,7 +19,7 @@ class ThumbnailUrlTest extends BoltUnitTest
         $manager = new Manager([]);
         $manager->mountFilesystem('files', $fs);
 
-        $urlGenerator = $this->getMock(UrlGeneratorInterface::class);
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects($this->once())
             ->method('generate')
             ->with('thumb', [
@@ -39,7 +39,7 @@ class ThumbnailUrlTest extends BoltUnitTest
 
     public function testName()
     {
-        $urlGenerator = $this->getMock(UrlGeneratorInterface::class);
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $plugin = new Plugin\ThumbnailUrl($urlGenerator);
 
         $this->assertEquals('thumb', $plugin->getMethod());

--- a/tests/phpunit/unit/Logger/ChangeLogTest.php
+++ b/tests/phpunit/unit/Logger/ChangeLogTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bolt\Tests\Logger;
 
-use Bolt\Storage;
+use Bolt\Legacy\Storage;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/tests/phpunit/unit/Menu/MenuBuilderTest.php
+++ b/tests/phpunit/unit/Menu/MenuBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Menu;
 
+use Bolt\Legacy\Content;
 use Bolt\Legacy\Storage;
 use Bolt\Menu\MenuBuilder;
 use Bolt\Tests\BoltUnitTest;
@@ -193,7 +194,11 @@ class MenuBuilderTest extends BoltUnitTest
 
         $contentMock = null;
         if (false !== $content) {
-            $contentMock = $this->getMock('Bolt\Legacy\Content', ['getContent', 'link'], [$app], '', false);
+            $contentMock = $this->getMockBuilder(Content::class)
+                ->setMethods(['getContent', 'link'])
+                ->setConstructorArgs([$app])
+                ->getMock()
+            ;
             $contentMock->expects($this->once())
                 ->method('link')
                 ->will($this->returnValue($link));
@@ -203,7 +208,11 @@ class MenuBuilderTest extends BoltUnitTest
             }
         }
 
-        $storage = $this->getMock(Storage::class, ['getContent'], [$app]);
+        $storage = $this->getMockBuilder(Storage::class)
+            ->setMethods(['getContent', 'link'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
         $storage->expects($this->once())
             ->method('getContent')
             ->will($this->returnValue($contentMock));

--- a/tests/phpunit/unit/Menu/MenuBuilderTest.php
+++ b/tests/phpunit/unit/Menu/MenuBuilderTest.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace Bolt\Tests\Menu;
 
+use Bolt\Legacy\Storage;
 use Bolt\Menu\MenuBuilder;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;
@@ -201,7 +203,7 @@ class MenuBuilderTest extends BoltUnitTest
             }
         }
 
-        $storage = $this->getMock('Bolt\Storage', ['getContent'], [$app]);
+        $storage = $this->getMock(Storage::class, ['getContent'], [$app]);
         $storage->expects($this->once())
             ->method('getContent')
             ->will($this->returnValue($contentMock));

--- a/tests/phpunit/unit/Nut/CacheClearTest.php
+++ b/tests/phpunit/unit/Nut/CacheClearTest.php
@@ -16,7 +16,7 @@ class CacheClearTest extends BoltUnitTest
     public function testSuccessfulClear()
     {
         $app = $this->getApp();
-        $app['cache'] = $this->getCacheMock();
+        $app['cache'] = $this->getMockCache();
         $command = new CacheClear($app);
         $tester = new CommandTester($command);
         $tester->execute([]);
@@ -27,7 +27,7 @@ class CacheClearTest extends BoltUnitTest
     public function testWithFailures()
     {
         $app = $this->getApp();
-        $app['cache'] = $this->getCacheMock(null, false);
+        $app['cache'] = $this->getMockCache(null, false);
         $command = new CacheClear($app);
         $tester = new CommandTester($command);
 
@@ -36,9 +36,9 @@ class CacheClearTest extends BoltUnitTest
         $this->assertRegExp('/Failed to clear cache/', $result);
     }
 
-    protected function getCacheMock($path = null, $flushResult = true)
+    protected function getMockCache($path = null, $flushResult = true)
     {
-        $cache = parent::getCacheMock($path);
+        $cache = parent::getMockCache($path);
         $cache->expects($this->once())
             ->method('flushAll')
             ->will($this->returnValue($flushResult))

--- a/tests/phpunit/unit/Nut/ExtensionsDumpAutoloadTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsDumpAutoloadTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Nut;
 
+use Bolt\Composer\PackageManager;
 use Bolt\Nut\ExtensionsDumpAutoload;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -18,7 +19,11 @@ class ExtensionsDumpAutoloadTest extends BoltUnitTest
         $app = $this->getApp();
         $app['extend.action.options']->set('optimize-autoloader', true);
 
-        $runner = $this->getMock('Bolt\Composer\PackageManager', ['dumpAuoloader'], [$app]);
+        $runner = $this->getMockBuilder(PackageManager::class)
+            ->setMethods(['dumpAuoloader'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
         $runner->expects($this->any())
             ->method('dumpAuoloader')
             ->will($this->returnValue(0));

--- a/tests/phpunit/unit/Nut/ExtensionsInstallTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsInstallTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Tests\Nut;
 
+use Bolt\Composer\PackageManager;
 use Bolt\Nut\ExtensionsInstall;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -17,7 +18,11 @@ class ExtensionsInstallTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $runner = $this->getMock('Bolt\Composer\PackageManager', ['requirePackage'], [$app]);
+        $runner = $this->getMockBuilder(PackageManager::class)
+            ->setMethods(['requirePackage'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
         $runner->expects($this->any())
             ->method('requirePackage')
             ->will($this->returnValue(0));
@@ -36,7 +41,11 @@ class ExtensionsInstallTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $runner = $this->getMock('Bolt\Composer\PackageManager', ['requirePackage'], [$app]);
+        $runner = $this->getMockBuilder(PackageManager::class)
+            ->setMethods(['requirePackage'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
         $runner->expects($this->any())
             ->method('requirePackage')
             ->will($this->returnValue(1));

--- a/tests/phpunit/unit/Nut/ExtensionsTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsTest.php
@@ -22,7 +22,11 @@ class ExtensionsTest extends BoltUnitTest
         $testPackage->setDescription('An extension');
         $testPackage->setType('bolt-extension');
 
-        $runner = $this->getMock(PackageManager::class, ['showPackage'], [$app]);
+        $runner = $this->getMockBuilder(PackageManager::class)
+            ->setMethods(['showPackage'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
         $runner->expects($this->any())
             ->method('showPackage')
             ->will($this->returnValue(['test' => ['package' => $testPackage]]));

--- a/tests/phpunit/unit/Nut/ExtensionsUninstallTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsUninstallTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Bolt\Tests\Nut;
 
+use Bolt\Composer\PackageManager;
 use Bolt\Nut\ExtensionsUninstall;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -17,7 +18,11 @@ class ExtensionsUninstallTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $runner = $this->getMock('Bolt\Composer\PackageManager', ['removePackage'], [$app]);
+        $runner = $this->getMockBuilder(PackageManager::class)
+            ->setMethods(['removePackage'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
         $runner->expects($this->any())
             ->method('removePackage')
             ->will($this->returnValue(0));
@@ -39,7 +44,11 @@ class ExtensionsUninstallTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $runner = $this->getMock('Bolt\Composer\PackageManager', ['removePackage'], [$app]);
+        $runner = $this->getMockBuilder(PackageManager::class)
+            ->setMethods(['removePackage'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
         $runner->expects($this->any())
             ->method('removePackage')
             ->will($this->returnValue(1));

--- a/tests/phpunit/unit/Nut/LogClearTest.php
+++ b/tests/phpunit/unit/Nut/LogClearTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Nut;
 use Bolt\Nut\LogClear;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -20,7 +21,10 @@ class LogClearTest extends BoltUnitTest
         $command = new LogClear($app);
         $tester = new CommandTester($command);
 
-        $helper = $this->getMock('\Symfony\Component\Console\Helper\QuestionHelper', ['ask']);
+        $helper = $this->getMockBuilder(QuestionHelper::class)
+            ->setMethods(['ask'])
+            ->getMock()
+        ;
         $helper->expects($this->once())
             ->method('ask')
             ->will($this->returnValue(true));

--- a/tests/phpunit/unit/Nut/UserResetPasswordTest.php
+++ b/tests/phpunit/unit/Nut/UserResetPasswordTest.php
@@ -3,9 +3,11 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserResetPassword;
 use Bolt\Storage\Entity;
+use Bolt\Storage\Repository;
 use Bolt\Tests\BoltUnitTest;
 use PasswordLib\PasswordLib;
 use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -19,6 +21,7 @@ class UserResetPasswordTest extends BoltUnitTest
     {
         $this->resetDb();
         $app = $this->getApp();
+        /** @var Repository\UsersRepository $repo */
         $repo = $app['storage']->getRepository('Bolt\Storage\Entity\Users');
         $user = new Entity\Users([
             'username'    => 'koala',
@@ -32,7 +35,10 @@ class UserResetPasswordTest extends BoltUnitTest
         $command = new UserResetPassword($app);
         $tester = new CommandTester($command);
 
-        $helper = $this->getMock('\Symfony\Component\Console\Helper\QuestionHelper', ['ask']);
+        $helper = $this->getMockBuilder(QuestionHelper::class)
+            ->setMethods(['ask'])
+            ->getMock()
+        ;
         $helper->expects($this->once())
             ->method('ask')
             ->will($this->returnValue(true));

--- a/tests/phpunit/unit/Nut/UserRoleAddTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleAddTest.php
@@ -15,7 +15,7 @@ class UserRoleAddTest extends BoltUnitTest
     public function testAdd()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMock($app);
+        $app['users'] = $this->getUserMockWithReturns();
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 
@@ -27,7 +27,7 @@ class UserRoleAddTest extends BoltUnitTest
     public function testRoleExists()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMock($app, true);
+        $app['users'] = $this->getUserMockWithReturns(true);
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 
@@ -39,7 +39,7 @@ class UserRoleAddTest extends BoltUnitTest
     public function testRoleFails()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMock($app, false, false);
+        $app['users'] = $this->getUserMockWithReturns(false, false);
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 
@@ -48,9 +48,10 @@ class UserRoleAddTest extends BoltUnitTest
         $this->assertRegExp('/Could not add role/', trim($result));
     }
 
-    protected function getUserMock($app, $hasRole = false, $addRole = true)
+    protected function getUserMockWithReturns($hasRole = false, $addRole = true)
     {
-        $users = $this->getMock('Bolt\Users', ['hasRole', 'addRole'], [$app]);
+        /** @var \PHPUnit_Framework_MockObject_MockObject $users */
+        $users = $this->getMockUsers(['hasRole', 'addRole']);
         $users->expects($this->any())
             ->method('hasRole')
             ->will($this->returnValue($hasRole));

--- a/tests/phpunit/unit/Nut/UserRoleRemoveTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleRemoveTest.php
@@ -15,7 +15,7 @@ class UserRoleRemoveTest extends BoltUnitTest
     public function testRemove()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMock($app, true, true);
+        $app['users'] = $this->getUserMockWithReturns(true, true);
         $command = new UserRoleRemove($app);
         $tester = new CommandTester($command);
 
@@ -28,7 +28,7 @@ class UserRoleRemoveTest extends BoltUnitTest
     public function testRemoveFail()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMock($app, false, true);
+        $app['users'] = $this->getUserMockWithReturns(false, true);
         $command = new UserRoleRemove($app);
         $tester = new CommandTester($command);
 
@@ -40,7 +40,7 @@ class UserRoleRemoveTest extends BoltUnitTest
     public function testRemoveNonexisting()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMock($app, true, false);
+        $app['users'] = $this->getUserMockWithReturns(true, false);
         $command = new UserRoleRemove($app);
         $tester = new CommandTester($command);
 
@@ -49,9 +49,10 @@ class UserRoleRemoveTest extends BoltUnitTest
         $this->assertRegExp("/ already doesn't have role/", trim($result));
     }
 
-    protected function getUserMock($app, $remove = false, $has = false)
+    protected function getUserMockWithReturns($remove = false, $has = false)
     {
-        $users = $this->getMock('Bolt\Users', ['hasRole', 'removeRole'], [$app]);
+        /** @var \PHPUnit_Framework_MockObject_MockObject $users */
+        $users = $this->getMockUsers(['hasRole', 'removeRole']);
         $users->expects($this->any())
             ->method('removeRole')
             ->will($this->returnValue($remove));

--- a/tests/phpunit/unit/Provider/StorageServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/StorageServiceProviderTest.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace Bolt\Tests\Provider;
 
+use Bolt\Legacy\Storage;
 use Bolt\Provider\StorageServiceProvider;
+use Bolt\Storage\EntityManager;
 use Bolt\Tests\BoltUnitTest;
 
 /**
@@ -16,8 +19,8 @@ class StorageServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new StorageServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Storage\EntityManager', $app['storage']);
-        $this->assertInstanceOf('Bolt\Storage', $app['storage.legacy']);
+        $this->assertInstanceOf(EntityManager::class, $app['storage']);
+        $this->assertInstanceOf(Storage::class, $app['storage.legacy']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Stack/StackTest.php
+++ b/tests/phpunit/unit/Stack/StackTest.php
@@ -34,7 +34,7 @@ class StackTest extends BoltUnitTest
     protected function setUp()
     {
         $app = $this->getApp();
-        $this->users = $this->getMock(Users::class, ['getCurrentUser', 'saveUser'], [$app]);
+        $this->users = $this->getMockUsers(['getCurrentUser', 'saveUser']);
         $this->session = new Session(
             new MockArraySessionStorage()
         );

--- a/tests/phpunit/unit/Storage/PrefillTest.php
+++ b/tests/phpunit/unit/Storage/PrefillTest.php
@@ -27,8 +27,7 @@ class PrefillTest extends BoltUnitTest
             $request = new Request('GET', '/');
         }
 
-        $guzzle = $this->getMock('GuzzleHttp\Client', ['get']);
-
+        $guzzle = $this->getMockGuzzleClient();
         $guzzle->expects($this->once())
             ->method('get')
             ->with('http://loripsum.net/api/1/veryshort')

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -46,15 +46,25 @@ class StorageTest extends BoltUnitTest
 
         $fields = $app['config']->get('contenttypes/fakes/fields');
 
-        $mock = $this->getMock('Bolt\Legacy\Content', [], [$app], 'Fakes');
+        $mock = $this->getMockBuilder(Content::class)
+            ->setMethods([])
+            ->setConstructorArgs([$app])
+            ->setMockClassName('Fakes')
+            ->getMock()
+        ;
         $content = $storage->getContentObject(['class' => 'Fakes', 'fields' => $fields]);
         $this->assertInstanceOf('Fakes', $content);
         $this->assertInstanceOf('Bolt\Legacy\Content', $content);
 
         // Test that a class not instanceof Bolt\Legacy\Content fails
-        $mock = $this->getMock('stdClass', null, [], 'Failing');
+        $mock = $this->getMockBuilder(\stdClass::class)
+            ->setMethods(null)
+            ->setConstructorArgs([])
+            ->setMockClassName('Failing')
+            ->getMock()
+        ;
         $this->setExpectedException('Exception', 'Failing does not extend \Bolt\Legacy\Content.');
-        $content = $storage->getContentObject(['class' => 'Failing', 'fields' => $fields]);
+        $storage->getContentObject(['class' => 'Failing', 'fields' => $fields]);
     }
 
     public function testPreFill()

--- a/tests/phpunit/unit/Twig/BoltExtensionTest.php
+++ b/tests/phpunit/unit/Twig/BoltExtensionTest.php
@@ -71,7 +71,7 @@ class BoltExtensionTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $users = $this->getMock('Bolt\Users', ['getCurrentUser'], [$app]);
+        $users = $this->getMockUsers(['getCurrentUser']);
         $users
             ->expects($this->atLeastOnce())
             ->method('getCurrentUser')

--- a/tests/phpunit/unit/Twig/Runtime/AdminRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/AdminRuntimeTest.php
@@ -6,7 +6,6 @@ use Bolt\Stack;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Runtime\AdminRuntime;
 use Monolog\Logger;
-use Silex\Translator;
 
 /**
  * Class to test Bolt\Twig\Runtime\AdminRuntime
@@ -61,7 +60,7 @@ class AdminRuntimeTest extends BoltUnitTest
     public function testStackable()
     {
         $app = $this->getApp();
-        $stack = $this->getMock(Stack::class, [], [$app['filesystem.matcher'], $app['users'], $app['session'], []]);
+        $stack = $this->getMockStack();
         $stack
             ->expects($this->once())
             ->method('isStackable')
@@ -77,7 +76,7 @@ class AdminRuntimeTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $stack = $this->getMock(Stack::class, [], [$app['filesystem.matcher'], $app['users'], $app['session'], []]);
+        $stack = $this->getMockStack();
         $stack
             ->expects($this->exactly(3))
             ->method('getList')
@@ -176,7 +175,11 @@ class AdminRuntimeTest extends BoltUnitTest
     public function testTransArgsFour()
     {
         $app = $this->getApp();
-        $trans = $this->getMock('Silex\Translator', ['trans'], [$app, $app['translator.message_selector']]);
+        $trans = $this->getMockBuilder(\Silex\Translator::class)
+            ->setMethods(['trans'])
+            ->setConstructorArgs([$app, $app['translator.message_selector']])
+            ->getMock()
+        ;
         $trans
             ->expects($this->atLeastOnce())
             ->method('trans')
@@ -274,5 +277,19 @@ class AdminRuntimeTest extends BoltUnitTest
         $app = $this->getApp();
 
         return new AdminRuntime($app['config'], $app['stack'], $app['url_generator'], $app);
+    }
+
+    /**
+     * @return Stack|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockStack()
+    {
+        $app = $this->getApp();
+
+        return $this->getMockBuilder(Stack::class)
+            ->setMethods([])
+            ->setConstructorArgs([$app['filesystem.matcher'], $app['users'], $app['session'], []])
+            ->getMock()
+            ;
     }
 }

--- a/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
@@ -4,6 +4,8 @@ namespace Bolt\Tests\Twig\Runtime;
 
 use Bolt\Asset\Snippet\Snippet;
 use Bolt\Legacy\Content;
+use Bolt\Pager\Pager;
+use Bolt\Pager\PagerManager;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Runtime\RecordRuntime;
 use Symfony\Component\HttpFoundation\Request;
@@ -170,7 +172,15 @@ GRINGALET;
         $app['request_stack']->push($request);
 
         $handler = $this->getRecordRuntime();
-        $content = new Content($app, 'pages', ['id' => 42, 'slug' => 'koala']);
+        $content = $this->getMockBuilder(Content::class)
+            ->setMethods(['link'])
+            ->setConstructorArgs([$app])
+            ->getMock()
+        ;
+        $content->expects($this->atLeastOnce())
+            ->method('link')
+            ->will($this->returnValue('/pages/koala'))
+        ;
 
         $result = $handler->current($content);
         $this->assertTrue($result);
@@ -446,8 +456,10 @@ GRINGALET;
     public function testPagerEmptyPager()
     {
         $app = $this->getApp();
-
-        $pager = $this->getMock('\Bolt\Pager\PagerManager', ['isEmptyPager'], []);
+        $pager = $this->getMockBuilder(PagerManager::class)
+            ->setMethods(['isEmptyPager'])
+            ->getMock()
+        ;
         $pager
             ->expects($this->once())
             ->method('isEmptyPager')
@@ -469,10 +481,14 @@ GRINGALET;
     public function testPager()
     {
         $app = $this->getApp();
+        $manager = $this->getMockBuilder(PagerManager::class)
+            ->setMethods(['isEmptyPager', 'getPager'])
+            ->getMock()
+        ;
 
-        $manager = $this->getMock('\Bolt\Pager\PagerManager', ['isEmptyPager', 'getPager'], []);
-
-        $pager = $this->getMock('\Bolt\Pager\Pager');
+        $pager = $this->getMockBuilder(Pager::class)
+            ->getMock()
+        ;
         $pager->for = $pagerName = 'Clippy';
         $pager->totalpages = $surr = 2;
 

--- a/tests/phpunit/unit/Twig/Runtime/TextRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/TextRuntimeTest.php
@@ -62,7 +62,7 @@ class TextRuntimeTest extends BoltUnitTest
             ->method('setlocale')
             ->will($this->returnValue(false))
         ;
-        $logger = $this->getMock('Monolog\Logger', ['error'], ['dropbear']);
+        $logger = $this->getMockMonolog();
         $logger
             ->expects($this->once())
             ->method('error')

--- a/tests/phpunit/unit/Twig/Runtime/UserRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/UserRuntimeTest.php
@@ -97,7 +97,7 @@ class UserRuntimeTest extends BoltUnitTest
     public function testIsAllowedObject()
     {
         $app = $this->getApp();
-        $users = $this->getMock('Bolt\Users', ['isAllowed'], [$app]);
+        $users = $this->getMockUsers();
         $users
             ->expects($this->atLeastOnce())
             ->method('isAllowed')
@@ -114,7 +114,7 @@ class UserRuntimeTest extends BoltUnitTest
     public function testIsAllowedArray()
     {
         $app = $this->getApp();
-        $users = $this->getMock('Bolt\Users', ['isAllowed'], [$app]);
+        $users = $this->getMockUsers();
         $users
             ->expects($this->atLeastOnce())
             ->method('isAllowed')
@@ -130,7 +130,7 @@ class UserRuntimeTest extends BoltUnitTest
     public function testIsAllowedString()
     {
         $app = $this->getApp();
-        $users = $this->getMock('Bolt\Users', ['isAllowed'], [$app]);
+        $users = $this->getMockUsers();
         $users
             ->expects($this->atLeastOnce())
             ->method('isAllowed')

--- a/tests/phpunit/unit/Twig/Runtime/UtilsRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/UtilsRuntimeTest.php
@@ -55,7 +55,7 @@ class UtilsRuntimeTest extends BoltUnitTest
         $app['debug'] = true;
         $app['config']->set('general/debug_show_loggedoff', true);
 
-        $logger = $this->getMock('\Monolog\Logger', ['info'], ['testlogger']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
         ->method('info');
         $app['logger.firebug'] = $logger;
@@ -71,7 +71,7 @@ class UtilsRuntimeTest extends BoltUnitTest
         $app['debug'] = true;
         $app['config']->set('general/debug_show_loggedoff', true);
 
-        $logger = $this->getMock('\Monolog\Logger', ['info'], ['testlogger']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
             ->method('info');
         $app['logger.firebug'] = $logger;
@@ -86,7 +86,7 @@ class UtilsRuntimeTest extends BoltUnitTest
         $app = $this->getApp();
         $app['debug'] = true;
 
-        $logger = $this->getMock('\Monolog\Logger', ['info'], ['testlogger']);
+        $logger = $this->getMockMonolog();
         $logger->expects($this->never())
             ->method('info');
         $app['logger.firebug'] = $logger;

--- a/tests/phpunit/unit/Twig/SetcontentTest.php
+++ b/tests/phpunit/unit/Twig/SetcontentTest.php
@@ -3,6 +3,7 @@ namespace Bolt\Tests\Twig;
 
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\SetcontentTokenParser;
+use Twig_Compiler;
 use Twig_Environment;
 use Twig_ExpressionParser;
 use Twig_Parser;
@@ -112,8 +113,13 @@ class SetcontentTest extends BoltUnitTest
         $this->assertSame('hydrate', $nodes[7]['key']->getAttribute('value'));
         $this->assertFalse($nodes[7]['value']->getAttribute('value'));
 
-        $env = new Twig_Environment($this->getMock('Twig_LoaderInterface'));
-        $compiler = $this->getMock('Twig_Compiler', ['addDebugInfo', 'raw', 'subcompile', 'write'], [$env]);
+        $mockLoader = $this->createMock('Twig_LoaderInterface');
+        $env = new Twig_Environment($mockLoader);
+        $compiler = $this->getMockBuilder(Twig_Compiler::class)
+            ->setMethods(['addDebugInfo', 'raw', 'subcompile', 'write'])
+            ->setConstructorArgs([$env])
+            ->getMock()
+        ;
         $compiler
             ->expects($this->once())
             ->method('addDebugInfo')

--- a/tests/phpunit/unit/Users/AuthenticationTest.php
+++ b/tests/phpunit/unit/Users/AuthenticationTest.php
@@ -34,7 +34,7 @@ class AuthenticationTest extends BoltUnitTest
     {
         // Setup test
         $app = $this->getApp();
-        $loginMock = $this->getLoginMock($app);
+        $loginMock = $this->getMockLogin();
 
         $loginMock->expects($this->once())->method('login')->willReturn(true);
 
@@ -52,7 +52,7 @@ class AuthenticationTest extends BoltUnitTest
     {
         // Setup test
         $app = $this->getApp();
-        $loginMock = $this->getLoginMock($app);
+        $loginMock = $this->getMockLogin();
         $loginMock->expects($this->once())->method('login')->willReturn(true);
 
         // Run test

--- a/tests/phpunit/unit/Users/CreateUsersTest.php
+++ b/tests/phpunit/unit/Users/CreateUsersTest.php
@@ -23,7 +23,7 @@ class CreateUsersTest extends BoltUnitTest
     {
         $this->addNewUser($this->getApp(), 'disabledadmin', 'DisabeldAdmin', 'root', false);
 
-        $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
+        $users = $this->getMockUsers(['getUsers']);
         $result = $users->getUser('disabledadmin');
 
         $this->assertFalse($result['enabled'], 'User was setup but is still enabled even after wanting to disable the user');
@@ -33,7 +33,7 @@ class CreateUsersTest extends BoltUnitTest
     {
         $this->addNewUser($this->getApp(), 'enabledadmin', 'EnabledAdmin', 'root', true);
 
-        $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
+        $users = $this->getMockUsers(['getUsers']);
         $result = $users->getUser('enabledadmin');
 
         $this->assertTrue($result['enabled'], 'User was setup but is disabled even after wanting to enable the user');

--- a/tests/phpunit/unit/Users/UsersTest.php
+++ b/tests/phpunit/unit/Users/UsersTest.php
@@ -2,6 +2,7 @@
 namespace Bolt\Tests\Users;
 
 use Bolt\Tests\BoltUnitTest;
+use Bolt\Users;
 
 /**
  * Class to test correct operation of src/Users.
@@ -34,7 +35,7 @@ class UsersTest extends BoltUnitTest
     public function testGetUserById()
     {
         // Setup test
-        $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
+        $users = $this->getMockUsers();
 
         // Run test
         $result = $users->getUser(2);
@@ -51,7 +52,7 @@ class UsersTest extends BoltUnitTest
     public function testGetUserByUnknownId()
     {
         // Setup test
-        $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
+        $users = $this->getMockUsers();
 
         // Run test
         $result = $users->getUser(0);
@@ -66,7 +67,7 @@ class UsersTest extends BoltUnitTest
     public function testGetUserByUsername()
     {
         // Setup test
-        $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
+        $users = $this->getMockUsers();
 
         // Run test
         $result = $users->getUser('editor');
@@ -83,7 +84,7 @@ class UsersTest extends BoltUnitTest
     public function testGetUserByUnknownUsername()
     {
         // Setup test
-        $users = $this->getMock('Bolt\Users', ['getUsers'], [$this->getApp()]);
+        $users = $this->getMockUsers();
 
         // Run test
         $result = $users->getUser('anotheruser');


### PR DESCRIPTION
This is a back port of the **unit test** updates in #6083 … with the one addition being a helper function in `BoltUnitTest` that exists in PHPUnit 5.0+ and will get dropped from master on branch merge.

Basically `$this->getMock()` is deprecated in PHPUnit 5.0 and makes a lot of noise at test time, hence part of #6083. As we need to take a bit of a look at our testing, it make sense to use forward compatible tests from the start.