### PR TITLE
Fixes: Status not passed to `$values` error

### DIFF
--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -468,7 +468,7 @@ trait ContentValuesTrait
         }
 
         // Make sure we have a proper status.
-        if (!in_array($values['status'], ['published', 'timed', 'held', 'draft'])) {
+        if (!isset($values['status']) || (isset($values['status']) && !in_array($values['status'], ['published', 'timed', 'held', 'draft']))) {
             if ($this['status']) {
                 $values['status'] = $this['status'];
             } else {


### PR DESCRIPTION
In Bolt 3.2.6 I came across a weird instance where preview was not passing a status. This therefore threw an error since it wasn't a defined key in the `$values` array.

![screenshot from 2017-02-06 11-50-42](https://cloud.githubusercontent.com/assets/1901969/22646287/7de90312-ec63-11e6-90e6-75312033b60c.png)

Wrapping it in an `isset` fixes the issue but this might be a deeper problem than I realise?