### PR TITLE
Sync PathResolver paths to ResourceManager without bootstrap

### DIFF
--- a/src/Configuration/ForwardToPathResolver.php
+++ b/src/Configuration/ForwardToPathResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Bolt\Configuration;
+
+/**
+ * Forwards all relevant paths to PathResolver.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ *
+ * @deprecated since 3.3, to be removed in 4.0.
+ */
+class ForwardToPathResolver extends ResourceManager
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(\ArrayAccess $container)
+    {
+        parent::__construct($container);
+        $paths = [
+            'cache',
+            'config',
+            'database',
+            'extensions',
+            'extensions_config',
+            'web',
+            'files',
+            'themes',
+            'bolt_assets',
+            'themebase',
+            'extensionsconfig',
+            'view',
+        ];
+        foreach ($paths as $path) {
+            $this->setPath($path, "%$path%", false);
+        }
+    }
+}

--- a/src/Provider/PathServiceProvider.php
+++ b/src/Provider/PathServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Bolt\Provider;
 
 use Bolt\Configuration\Composer;
+use Bolt\Configuration\ForwardToPathResolver;
 use Bolt\Configuration\LazyPathsProxy;
 use Bolt\Configuration\PathResolverFactory;
 use Bolt\Configuration\PreBoot\ConfigurationFile;
@@ -75,7 +76,7 @@ class PathServiceProvider implements ServiceProviderInterface
         if (!isset($app['resources'])) {
             $app['resources'] = $app->share(
                 function ($app) {
-                    $resources = new ResourceManager(new \ArrayObject([
+                    $resources = new ForwardToPathResolver(new \ArrayObject([
                         'rootpath'              => $app['path_resolver.root'],
                         'path_resolver'         => $app['path_resolver'],
                         'path_resolver_factory' => $app['path_resolver_factory'],


### PR DESCRIPTION
If not using `bootstrap.php` and only using new code, then paths are not synced to resources. This fixes that.

My use case:
```php
class Application extends \Bolt\Application
{
    public function __construct($siteDir, array $values = [])
    {
        parent::__construct();

        $this['path_resolver.root'] = Common\Config::getProjectDir();
        $this['path_resolver.paths'] = [
            'site'       => $siteDir,
            'cache'      => '%site%/app/cache',
            'config'     => '%site%/app/config',
            'database'   => '%site%/app/database',
            'extensions' => '%site%/app/extensions',
            'web'        => '%site%/public',
        ];
    }
}
```