### PR TITLE
Allow "direct" access to fields from FieldCollection in Twig

### DIFF
--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -99,6 +99,32 @@ class FieldCollection extends AbstractLazyCollection
                 return $field->getValue();
             }
         }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        $this->initialize();
+
+        foreach ($this->collection as $field) {
+            if ($field->getFieldname() === $offset) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
     }
 
     /**


### PR DESCRIPTION
Example:
```twig
{{ content.foo }} {# <- works now #}
{{ content.get("foo") }} {# <- for reference #}
```

The thing I can't figure out is in [`RepeatingFieldCollection::addFromArray`](https://github.com/bolt/bolt/blob/release/3.2/src/Storage/Field/Collection/RepeatingFieldCollection.php#L78) the `FieldValue` object is added to the collection as if the `FieldCollection` is a _list_.
But in [`FieldCollection::doInitialize`](https://github.com/bolt/bolt/blob/release/3.2/src/Storage/Field/Collection/FieldCollection.php#L136) the `FieldValue` object is set on the collection like a _hash_.

So is `FieldCollection` supposed to be a list or a hash? I would think the latter, due to the example above. Maybe the line in `RepeatingFieldCollection` is a derp?