### PR TITLE
Refactor lazy logic out of FieldCollection

### DIFF
--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -2,36 +2,37 @@
 
 namespace Bolt\Storage\Field\Collection;
 
-use Bolt\Storage\Entity\Content;
-use Bolt\Storage\EntityManager;
-use Doctrine\Common\Collections\AbstractLazyCollection;
+use Bolt\Storage\Entity\FieldValue;
 use Doctrine\Common\Collections\ArrayCollection;
+use Webmozart\Assert\Assert;
 
 /**
- *  This class is used by lazily loaded field values. It stores a reference to an array of rows and
- *  fetches from the database on demand.
+ * A mapping of FieldValues.
  *
- *  @author Ross Riley <riley.ross@gmail.com>
+ * @author Ross Riley <riley.ross@gmail.com>
+ * @author Carson Full <carsonfull@gmail.com>
  */
-class FieldCollection extends AbstractLazyCollection
+class FieldCollection extends ArrayCollection implements FieldCollectionInterface
 {
-    public $references = [];
-    protected $em;
+    /** @var int */
     protected $grouping;
-    protected $toRemove = [];
 
     /**
-     * @param array              $references
-     * @param EntityManager|null $em
+     * Constructor.
+     *
+     * @param FieldValue[] $elements
      */
-    public function __construct(array $references = [], EntityManager $em = null)
+    public function __construct(array $elements = [])
     {
-        $this->references = $references;
-        $this->em = $em;
+        parent::__construct([]);
+
+        foreach ($elements as $value) {
+            $this->add($value);
+        }
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getNew()
     {
@@ -47,7 +48,7 @@ class FieldCollection extends AbstractLazyCollection
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getExisting()
     {
@@ -63,107 +64,60 @@ class FieldCollection extends AbstractLazyCollection
     }
 
     /**
-     * @param mixed $grouping
+     * {@inheritdoc}
+     */
+    public function get($key)
+    {
+        $result = parent::get($key);
+
+        if ($result instanceof FieldValue) {
+            $result = $result->getValue();
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function setGrouping($grouping)
     {
         $this->grouping = $grouping;
-    }
 
-    /**
-     * @param mixed $element
-     *
-     * @return bool
-     */
-    public function add($element)
-    {
-        $element->setGrouping($this->grouping);
-
-        return parent::add($element);
-    }
-
-    /**
-     * Helper method to get the value for a specific field
-     * this is compatible with content.get(contentkey) calls from twig.
-     *
-     * @param $key
-     *
-     * @return mixed
-     */
-    public function get($key)
-    {
-        $this->initialize();
-
-        foreach ($this->collection as $field) {
-            if ($field->getFieldname() == $key) {
-                return $field->getValue();
-            }
+        foreach ($this as $entity) {
+            $entity->setGrouping($grouping);
         }
-
-        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function add($value)
     {
-        $this->initialize();
+        Assert::isInstanceOf($value, FieldValue::class);
 
-        foreach ($this->collection as $field) {
-            if ($field->getFieldname() === $offset) {
-                return true;
-            }
-        }
+        $this->set($value->getFieldname(), $value);
 
-        return false;
+        return true;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function set($key, $value)
     {
-        return $this->get($offset);
+        Assert::isInstanceOf($value, FieldValue::class);
+
+        $value->setGrouping($this->grouping);
+
+        parent::set($key, $value);
     }
 
     /**
-     * Handles the conversion of references to entities.
+     * @return \Iterator|FieldValue[]
      */
-    protected function doInitialize()
+    public function getIterator()
     {
-        $objects = [];
-        if ($this->references) {
-            $repo = $this->em->getRepository('Bolt\Storage\Entity\FieldValue');
-            $instances = $repo->findBy(['id' => $this->references]);
-
-            foreach ((array) $instances as $val) {
-                $fieldtype = $val->getFieldtype();
-                $field = $this->em->getFieldManager()->getFieldFor($fieldtype);
-                $type = $field->getStorageType();
-                $typeCol = 'value_' . $type->getName();
-
-                // Because there's a potential for custom fields that use json storage to 'double hydrate' this causes
-                // json_decode to throw a warning. Here we prevent that by replacing the error handler.
-                set_error_handler(
-                    function ($errNo, $errStr, $errFile) {},
-                    E_WARNING
-                );
-                $hydratedVal = $this->em->getEntityBuilder($val->getContenttype())->getHydratedValue($val->$typeCol, $val->getName(), $val->getFieldname());
-                restore_error_handler();
-
-                // If we do not have a hydrated value returned then we fall back to the one passed in
-                if ($hydratedVal) {
-                    $val->setValue($hydratedVal);
-                } else {
-                    $val->setValue($val->$typeCol);
-                }
-
-                $objects[$val->getFieldname()] = $val;
-            }
-        }
-
-        $this->collection = new ArrayCollection($objects);
-        $this->em = null;
+        return parent::getIterator();
     }
 }

--- a/src/Storage/Field/Collection/FieldCollectionInterface.php
+++ b/src/Storage/Field/Collection/FieldCollectionInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Bolt\Storage\Field\Collection;
+
+use Bolt\Storage\Entity\FieldValue;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * A map of FieldValues.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+interface FieldCollectionInterface extends Collection
+{
+    /**
+     * @return int[]
+     */
+    public function getNew();
+
+    /**
+     * @return int[]
+     */
+    public function getExisting();
+
+    /**
+     * @param int $grouping
+     */
+    public function setGrouping($grouping);
+
+    /**
+     * Adds a field value to the map.
+     *
+     * @param FieldValue $value
+     *
+     * @return bool
+     */
+    public function add($value);
+
+    /**
+     * Adds a field value to the map with the specified key.
+     *
+     * @param string     $key
+     * @param FieldValue $value
+     */
+    public function set($key, $value);
+
+    /**
+     * @return \Iterator|FieldValue[]
+     */
+    public function getIterator();
+}

--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Bolt\Storage\Field\Collection;
+
+use Bolt\Storage\Entity\FieldValue;
+use Bolt\Storage\EntityManager;
+use Doctrine\Common\Collections\AbstractLazyCollection;
+
+/**
+ * This class is used by lazily loaded field values. It stores a reference to an array of rows and
+ * fetches from the database on demand.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class LazyFieldCollection extends AbstractLazyCollection implements FieldCollectionInterface
+{
+    /** @var int[] */
+    protected $references = [];
+    /** @var EntityManager|null */
+    protected $em;
+    /** @var int */
+    protected $grouping;
+    /** @var FieldCollectionInterface */
+    protected $collection;
+
+    /**
+     * Constructor.
+     *
+     * @param int[]              $references
+     * @param EntityManager|null $em
+     */
+    public function __construct(array $references = [], EntityManager $em = null)
+    {
+        $this->references = $references;
+        $this->em = $em;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNew()
+    {
+        $this->initialize();
+        return $this->collection->getNew();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExisting()
+    {
+        $this->initialize();
+        return $this->collection->getExisting();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setGrouping($grouping)
+    {
+        if (!$this->initialized) {
+            $this->grouping = $grouping;
+        } else {
+            $this->collection->setGrouping($grouping);
+        }
+    }
+
+    /**
+     * Handles the conversion of references to entities.
+     */
+    protected function doInitialize()
+    {
+        $this->collection = new FieldCollection();
+        $this->collection->setGrouping($this->grouping);
+
+        if ($this->references) {
+            $repo = $this->em->getRepository(FieldValue::class);
+            $instances = $repo->findBy(['id' => $this->references]);
+
+            foreach ((array) $instances as $val) {
+                $fieldtype = $val->getFieldtype();
+                $field = $this->em->getFieldManager()->getFieldFor($fieldtype);
+                $type = $field->getStorageType();
+                $typeCol = 'value_' . $type->getName();
+
+                // Because there's a potential for custom fields that use json storage to 'double hydrate' this causes
+                // json_decode to throw a warning. Here we prevent that by replacing the error handler.
+                set_error_handler(
+                    function ($errNo, $errStr, $errFile) {},
+                    E_WARNING
+                );
+                $hydratedVal = $this->em->getEntityBuilder($val->getContenttype())->getHydratedValue($val->$typeCol, $val->getName(), $val->getFieldname());
+                restore_error_handler();
+
+                // If we do not have a hydrated value returned then we fall back to the one passed in
+                if ($hydratedVal) {
+                    $val->setValue($hydratedVal);
+                } else {
+                    $val->setValue($val->$typeCol);
+                }
+
+                $this->collection->add($val);
+            }
+        }
+
+        $this->em = null;
+    }
+}

--- a/src/Storage/Field/Collection/RepeatingFieldCollection.php
+++ b/src/Storage/Field/Collection/RepeatingFieldCollection.php
@@ -5,6 +5,7 @@ namespace Bolt\Storage\Field\Collection;
 use Bolt\Exception\FieldConfigurationException;
 use Bolt\Storage\Entity\FieldValue;
 use Bolt\Storage\EntityManager;
+use Bolt\Storage\Field\Type\FieldTypeBase;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
@@ -33,7 +34,15 @@ class RepeatingFieldCollection extends ArrayCollection
     }
 
     /**
-     * @param FieldCollection $collection
+     * {@inheritdoc}
+     */
+    protected function createFrom(array $elements)
+    {
+        return new static($this->em, $this->mapping, $elements);
+    }
+
+    /**
+     * @param FieldCollectionInterface $collection
      *
      * @return bool
      */
@@ -51,7 +60,7 @@ class RepeatingFieldCollection extends ArrayCollection
      */
     public function addFromArray(array $fields, $grouping = 0, $entity = null)
     {
-        $collection = new FieldCollection([], $this->em);
+        $collection = new FieldCollection();
         $collection->setGrouping($grouping);
         foreach ($fields as $name => $value) {
             $storageTypeHandler = $this->getFieldType($name);
@@ -87,7 +96,7 @@ class RepeatingFieldCollection extends ArrayCollection
      */
     public function addFromReferences(array $ids, $grouping = 0)
     {
-        $collection = new FieldCollection($ids, $this->em);
+        $collection = new LazyFieldCollection($ids, $this->em);
         $collection->setGrouping($grouping);
         $this->add($collection);
     }
@@ -207,7 +216,7 @@ class RepeatingFieldCollection extends ArrayCollection
      *
      * @throws FieldConfigurationException
      *
-     * @return mixed
+     * @return FieldTypeBase
      */
     protected function getFieldType($field)
     {
@@ -239,6 +248,6 @@ class RepeatingFieldCollection extends ArrayCollection
 
     public function getEmptySet()
     {
-        return new FieldCollection([], $this->em);
+        return new FieldCollection();
     }
 }

--- a/src/Storage/FieldManager.php
+++ b/src/Storage/FieldManager.php
@@ -4,6 +4,7 @@ namespace Bolt\Storage;
 use Bolt\Config;
 use Bolt\Storage\Field\Sanitiser\SanitiserAwareInterface;
 use Bolt\Storage\Field\Sanitiser\SanitiserInterface;
+use Bolt\Storage\Field\Type\FieldTypeBase;
 
 /**
  * Uses a typemap to construct an instance of a Field
@@ -52,7 +53,7 @@ class FieldManager
      * @param $class
      * @param $mapping
      *
-     * @return mixed
+     * @return FieldTypeBase
      */
     public function get($class, $mapping)
     {

--- a/tests/phpunit/unit/Storage/FieldLoadTest.php
+++ b/tests/phpunit/unit/Storage/FieldLoadTest.php
@@ -2,6 +2,8 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Legacy\Storage;
+use Bolt\Storage\Entity\FieldValue;
+use Bolt\Storage\Field\Collection\FieldCollectionInterface;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Symfony\Component\HttpFoundation\Request;
@@ -51,9 +53,9 @@ class FieldLoadTest extends BoltUnitTest
         $this->assertInstanceOf('Bolt\Storage\Field\Collection\RepeatingFieldCollection', $record->repeater);
         $this->assertEquals(2, count($record->repeater));
         foreach ($record->repeater as $collection) {
-            $this->assertInstanceOf('Bolt\Storage\Field\Collection\FieldCollection', $collection);
+            $this->assertInstanceOf(FieldCollectionInterface::class, $collection);
             foreach ($collection as $fieldValue) {
-                $this->assertInstanceOf('Bolt\Storage\Entity\FieldValue', $fieldValue);
+                $this->assertInstanceOf(FieldValue::class, $fieldValue);
             }
         }
     }


### PR DESCRIPTION
This refactors `LazyFieldCollection` out of `FieldCollection`. `FieldCollection` is now just a mapping of `FieldValue` objects with some additional methods. `LazyFieldCollection` handles fetching references from db, hydrating results to `FieldValue` objects, and giving those to a `FieldCollection`. Both implement the new `FieldCollectionInterface`.

The motivation for this was that `FieldCollection::add` and `FieldCollection::set` did different things (as does `ArrayCollection`). `ArrayCollection` can be a `list` or `map`, but `FieldCollection` is always a `map`. Now the `add` and `set` methods of `FieldCollection` do the same thing. This also eliminates the need to override `offsetGet/Exists` since the objects are always stored in the collection correctly. Hopefully, this will reduce confusion.