### PR TITLE
Fix mcrypt deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: hhvm
-    - php: 7.1
 
 services:
   - mysql

--- a/src/Helpers/RandomLibFactory.php
+++ b/src/Helpers/RandomLibFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bolt\Helpers;
+
+use RandomLib;
+
+/**
+ * @internal This is removed in 3.3.
+ *
+ * Don't load mcrypt mixers as they are deprecated in PHP 7.1
+ * We weren't using them anyways.
+ */
+class RandomLibFactory extends RandomLib\Factory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function registerMixer($name, $class)
+    {
+        if (strpos($name, 'Mcrypt') === false) {
+            parent::registerMixer($name, $class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Provider/RandomGeneratorServiceProvider.php
+++ b/src/Provider/RandomGeneratorServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Provider;
 
-use RandomLib;
+use Bolt\Helpers\RandomLibFactory;
 use SecurityLib\Strength;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -13,7 +13,7 @@ class RandomGeneratorServiceProvider implements ServiceProviderInterface
     {
         $app['randomgenerator'] = $app->share(
             function () {
-                $factory = new RandomLib\Factory();
+                $factory = new RandomLibFactory();
 
                 return $factory->getGenerator(new Strength(Strength::MEDIUM));
             }


### PR DESCRIPTION
I know this is fixed in 3.3, but Travis won't even finish the runs for 7.1. So this fixes it for the mean time. It won't even be in 3.3.