### PR TITLE
Update pager template to use blocks

### DIFF
--- a/app/theme_defaults/_sub_pager.twig
+++ b/app/theme_defaults/_sub_pager.twig
@@ -1,37 +1,5 @@
-{% set link = pager.makelink() %}
-
-{% if pager.totalpages > 1 %}
-<div class="pagination pagination-centered {{class}}">
-  <ul class="pagination">
-{# 'first' and 'prev' #}
-{% if pager.current > 1 and class!="narrow" %}
-    <li><a href="{{link}}{{pager.current-1}}" rel="noindex, follow">&lsaquo; </a></li>
-{% endif %}
-{% if pager.current > surr+1 %}
-    <li><a href="{{link}}{{1}}">&laquo; 1</a></li>
-{% endif %}
-
-{# start with '..' if there are more than surr+1 before currentpage.. #}
-{% if pager.current > surr+2 %}
-    <li class="disabled"><a>…</a></li>
-{% endif %}
-
-{% for i in max(1, pager.current-surr)..min(pager.current+surr, pager.totalpages) %}
-    <li {% if i==pager.current %}class='active'{%endif%}><a href="{{link}}{{i}}" {% if i != 1 %}rel="noindex, follow"{% endif %}>{{i}}</a></li>
-{% endfor %}
-
-{# end with '..' if there are more than surr+1 after currentpage.. #}
-{% if pager.current < (pager.totalpages - surr - 1) %}
-    <li class="disabled"><a>…</a></li>
-{% endif %}
-
-{# 'next' and 'last' #}
-{% if pager.current < pager.totalpages-surr %}
-    <li><a href="{{link}}{{pager.totalpages}}" rel="noindex, follow">{{pager.totalpages}} &raquo; </a></li>
-{% endif %}
-{% if pager.current < pager.totalpages and class!="narrow" %}
-    <li><a href="{{link}}{{pager.current+1}}" rel="noindex, follow">&rsaquo;</a></li>
-{% endif %}
-  </ul>
-</div>
+{% if class|default == 'narrow' %}
+    {% extends 'pager/narrow.twig' %}
+{% else %}
+    {% extends 'pager/default.twig' %}
 {% endif %}

--- a/app/theme_defaults/pager/_base.twig
+++ b/app/theme_defaults/pager/_base.twig
@@ -1,0 +1,161 @@
+{% if pager.totalpages|default(0) > 1 %}
+    {% block list %}
+        {{ block('items') }}
+    {% endblock %}
+{% endif %}
+
+{# Only define these blocks below, don't display them #}
+{% if false %}
+
+{% block items %}
+    {% if pager.current > 1 %}
+        {% with {i: pager.current - 1, prefix: 'prev_'} %}
+            {{ block('render_item') }}
+        {% endwith %}
+    {% endif %}
+
+    {% if pager.current > surround + 1 %}
+        {% with {i: 1} %}
+            {{ block('render_item') }}
+        {% endwith %}
+    {% endif %}
+
+    {# start with '..' if there are more than surround + 1 before current page.. #}
+    {% if pager.current > surround + 2 %}
+        {{ block('render_collapsed_item') }}
+    {% endif %}
+
+    {% for i in max(1, pager.current - surround)..min(pager.current + surround, pager.totalpages) %}
+        {{ block('render_item') }}
+    {% endfor %}
+
+    {# end with '..' if there are more than surround + 1 after current page.. #}
+    {% if pager.current < (pager.totalpages - surround - 1) %}
+        {{ block('render_collapsed_item') }}
+    {% endif %}
+
+    {% if pager.current < pager.totalpages - surround %}
+        {% with {i: pager.totalpages} %}
+            {{ block('render_item') }}
+        {% endwith %}
+    {% endif %}
+
+    {% if pager.current < pager.totalpages %}
+        {% with {i: pager.current + 1, prefix: 'next_'} %}
+            {{ block('render_item') }}
+        {% endwith %}
+    {% endif %}
+{% endblock %}
+
+{% block render_item %}
+    {% with {
+        page: i,
+        link: i == 1 ? canonical() : pager.makelink() ~ i,
+        active: i == pager.current,
+        first: i == 1,
+        last: i == pager.totalpages,
+        pager: pager,
+        _block_prefix: prefix|default(i == 1 ? 'first_' : i == pager.totalpages ? 'last_' : '')
+    } only %}
+        {% set label = block(_block_prefix ~ 'label') %}
+        {{ block(_block_prefix ~ 'item') }}
+    {% endwith %}
+{% endblock %}
+
+{% block render_collapsed_item %}
+    {% with {} only %}
+        {{ block('collapsed_item') }}
+    {% endwith %}
+{% endblock %}
+
+{#
+ # Normal item block.
+ #
+ # Context (variables you can use):
+ #   label: string - the item label (normally page number)
+ #   link: string - url
+ #   page: string - the page number (favor label over this)
+ #   first: bool - whether this is the first item
+ #   last: bool - whether this is the last item
+ #   active: bool - whether this item is the current page
+ #}
+{% block item %}
+    {{ label }}
+{% endblock %}
+
+{#
+ # The item to show when when omitting pages, normally labeled as an ellipsis.
+ # No context (variables) is given to this block.
+ #}
+{% block collapsed_item %}
+{% endblock %}
+
+{#
+ # The item for the first page.
+ # See item block for context.
+ #}
+{% block first_item %}
+    {{ block('item') }}
+{% endblock %}
+
+{#
+ # The item for the previous page.
+ # See item block for context.
+ #}
+{% block prev_item %}
+    {{ block('item') }}
+{% endblock %}
+
+{#
+ # The item for the next page.
+ # See item block for context.
+ #}
+{% block next_item %}
+    {{ block('item') }}
+{% endblock %}
+
+{#
+ # The item for the last page.
+ # See item block for context.
+ #}
+{% block last_item %}
+    {{ block('item') }}
+{% endblock %}
+
+
+{#
+ # The label for normal pages.
+ #}
+{% block label %}
+    {{- page -}}
+{% endblock %}
+
+{#
+ # The label for the first page.
+ #}
+{% block first_label %}
+    {{- block('label') -}}
+{% endblock %}
+
+{#
+ # The label for the previous page.
+ #}
+{% block prev_label %}
+    {{- block('label') -}}
+{% endblock %}
+
+{#
+ # The label for the next page.
+ #}
+{% block next_label %}
+    {{- block('label') -}}
+{% endblock %}
+
+{#
+ # The label for the last page.
+ #}
+{% block last_label %}
+    {{- block('label') -}}
+{% endblock %}
+
+{% endif %}

--- a/app/theme_defaults/pager/default.twig
+++ b/app/theme_defaults/pager/default.twig
@@ -1,19 +1,19 @@
 {% extends 'pager/_base.twig' %}
 
 {% block list %}
-    <div class="pagination text-center {{ class|default }}">
+    <div class="pagination pagination-centered {{ class|default }}">
         <ul class="pagination">
             {{ block('items') }}
         </ul>
     </div>
 {% endblock %}
 
-{% block prev_label '←' %}
-{% block next_label '→' %}
+{% block prev_label '‹' %}
+{% block next_label '›' %}
 {% block first_label '« ' ~ page %}
 {% block last_label page ~ ' »' %}
 
-{% block item %}
+{%- block item -%}
     <li{% if active %} class="active"{% endif %}>
         <a
             {%- if not active %} href="{{ link }}"{% endif -%}
@@ -22,7 +22,7 @@
             {{- label|raw -}}
         </a>
     </li>
-{% endblock %}
+{%- endblock -%}
 
 {% block collapsed_item %}
     <li class="disabled"><a>…</a></li>

--- a/app/theme_defaults/pager/narrow.twig
+++ b/app/theme_defaults/pager/narrow.twig
@@ -1,0 +1,7 @@
+{% extends 'pager/default.twig' %}
+
+{% block prev_item %}
+{% endblock %}
+
+{% block next_item %}
+{% endblock %}

--- a/app/view/twig/components/pager.twig
+++ b/app/view/twig/components/pager.twig
@@ -1,48 +1,33 @@
-{% set link = context.pager.makelink() %}
+{% extends 'pager/default.twig' %}
 
-{% if context.pager.totalpages|default(0) > 1 %}
+{% block list %}
     <div style="text-align: center">
         <ul class="pagination pagination-centered">
-            {# Showing {{ context.pager.for }} {{ context.pager.showingFrom }} - {{ context.pager.showingTo }} of {{ context.pager.count }} #}
+            {# Showing {{ for }} {{ showingFrom }} - {{ showingTo }} of {{ count }} #}
             <li><span>{{ __('general.phrase.pager-showing-from-to-of', {
-                    '%pager_for%': context.pager.for,
-                    '%from%': context.pager.showingFrom,
-                    '%to%': context.pager.showingTo,
-                    '%count%': context.pager.count})
+                    '%pager_for%': pager.for,
+                    '%from%': pager.showingFrom,
+                    '%to%': pager.showingTo,
+                    '%count%': pager.count})
                 }}</span>
             </li>
-
-            {# 'first' and 'prev' #}
-            {% if context.pager.current > 1 %}
-                <li><a href="{{ link }}{{ context.pager.current - 1 }}"><i class="fa fa-angle-left" style="font-weight: bold;"></i></a></li>
-            {% endif %}
-
-            {% if context.pager.current > context.surr+1 %}
-                <li><a href="{{ link }}{{ 1 }}"><i class="fa fa-double-angle-left" style="font-weight: bold;"></i> 1</a></li>
-            {% endif %}
-
-            {# start with '...' if there are more than context.surr+1 before currentpage. #}
-            {% if context.pager.current > context.surr + 2 %}
-                <li class="disabled"><a href="#">...</a></li>
-            {% endif %}
-
-            {% for i in max(1, context.pager.current - context.surr) .. min(context.pager.current + context.surr, context.pager.totalpages) %}
-                <li {% if i == context.pager.current %}class="active"{% endif %}><a href="{{ link }}{{ i }}">{{ i }}</a></li>
-            {% endfor %}
-
-            {# end with '...' if there are more than context.surr+1 after currentpage. #}
-            {% if context.pager.current < (context.pager.totalpages - context.surr - 1) %}
-                <li class="disabled"><a href="#">...</a></li>
-            {% endif %}
-
-            {# 'next' and 'last' #}
-            {% if context.pager.current < context.pager.totalpages - context.surr %}
-                <li><a href="{{ link }}{{ context.pager.totalpages }}">{{ context.pager.totalpages }} <i class="fa fa-double-angle-right" style="font-weight: bold;"></i></a></li>
-            {% endif %}
-
-            {% if context.pager.current < context.pager.totalpages %}
-                <li><a href="{{ link }}{{ context.pager.current + 1 }}"><i class="fa fa-angle-right" style="font-weight: bold;"></i></a></li>
-            {% endif %}
+            {{ block('items') }}
         </ul>
     </div>
-{% endif %}
+{% endblock %}
+
+{%- block prev_label -%}
+    <i class="fa fa-angle-left" style="font-weight: bold;"></i>
+{%- endblock -%}
+
+{%- block next_label -%}
+    <i class="fa fa-angle-right" style="font-weight: bold;"></i>
+{%- endblock -%}
+
+{%- block first_label -%}
+    <i class="fa fa-angle-double-left" style="font-weight: bold;"></i> {{ page }}
+{%- endblock -%}
+
+{%- block last_label -%}
+    {{ page }} <i class="fa fa-angle-double-right" style="font-weight: bold;"></i>
+{%- endblock -%}

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -146,16 +146,6 @@ class FieldCollection extends AbstractLazyCollection
     }
 
     /**
-     * Overrides the default array access method and passes on to the get method
-     * @param mixed $offset
-     * @return mixed
-     */
-    public function offsetGet($offset)
-    {
-        return $this->get($offset);
-    }
-
-    /**
      * Handles the conversion of references to entities.
      */
     protected function doInitialize()

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -239,13 +239,13 @@ class RecordRuntime
 
         $context = [
             'pager' => $thisPager,
-            'surr'  => $surr,
+            'surr'  => $surr, // @deprecated
+            'surround' => $surr,
             'class' => $class,
         ];
 
         /* Little hack to avoid doubling this function and having context without breaking frontend */
         if ($template === 'backend') {
-            $context = ['context' => $context];
             $template = '@bolt/components/pager.twig';
         }
 

--- a/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
@@ -6,6 +6,7 @@ use Bolt\Asset\Snippet\Snippet;
 use Bolt\Legacy\Content;
 use Bolt\Pager\Pager;
 use Bolt\Pager\PagerManager;
+use Bolt\Routing\Canonical;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Runtime\RecordRuntime;
 use Symfony\Component\HttpFoundation\Request;
@@ -481,10 +482,6 @@ GRINGALET;
     public function testPager()
     {
         $app = $this->getApp();
-        $manager = $this->getMockBuilder(PagerManager::class)
-            ->setMethods(['isEmptyPager', 'getPager'])
-            ->getMock()
-        ;
 
         $pager = $this->getMockBuilder(Pager::class)
             ->getMock()
@@ -492,6 +489,22 @@ GRINGALET;
         $pager->for = $pagerName = 'Clippy';
         $pager->totalpages = $surr = 2;
 
+        $canonical = $this->getMockBuilder(Canonical::class)
+            ->setMethods(['getUrl'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $canonical
+            ->expects($this->atLeastOnce())
+            ->method('getUrl')
+            ->will($this->returnValue('1'))
+        ;
+        $app['canonical'] = $canonical;
+
+        $manager = $this->getMockBuilder(PagerManager::class)
+            ->setMethods(['isEmptyPager', 'getPager'])
+            ->getMock()
+        ;
         $manager
             ->expects($this->atLeastOnce())
             ->method('isEmptyPager')
@@ -511,8 +524,8 @@ GRINGALET;
 
         $result = $handler->pager($env, $pagerName, $surr, $template, $class);
 
-        $this->assertRegExp('#<li ><a href="1">1</a></li>#', (string) $result);
-        $this->assertRegExp('#<li ><a href="2">2</a></li>#', (string) $result);
+        $this->assertRegExp('#<a href="1"#', (string) $result);
+        $this->assertRegExp('#<a href="2"#', (string) $result);
     }
 
     public function testSelectFieldEmptyContentStartEmpty()


### PR DESCRIPTION
This abstracts the logic around creating a pager into simple blocks.

See the [pager/default.twig](https://github.com/CarsonF/bolt/blob/feature/pager-blocks/app/theme_defaults/pager/default.twig) for an example.