### PR TITLE
Add "extension" to list of contexts

### DIFF
--- a/app/view/twig/activity/systemlog.twig
+++ b/app/view/twig/activity/systemlog.twig
@@ -39,6 +39,7 @@
                         <option value="cron">cron</option>
                         <option value="deprecated">deprecated</option>
                         <option value="exception">exception</option>
+                        <option value="extension">extension</option>
                         <option value="news">news</option>
                         <option value="nut">nut</option>
                         <option value="security">security</option>


### PR DESCRIPTION
There's an `extension` option according to https://docs.bolt.cm/3.2/internals/container-service-references#app-logger-system which was missing:

![systemlog](https://cloud.githubusercontent.com/assets/4630335/23036828/8ead2b14-f484-11e6-8104-d34a189c98bc.png)
