### PR TITLE
[3.2] Force mbstring functions call on root namespace

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -28,8 +28,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 return call_user_func(function () {
     // Use UTF-8 for all multi-byte functions
-    mb_internal_encoding('UTF-8');
-    mb_http_output('UTF-8');
+    \mb_internal_encoding('UTF-8');
+    \mb_http_output('UTF-8');
 
     // Resolve Bolt-root
     $boltRootPath = realpath(__DIR__ . '/..');


### PR DESCRIPTION
In cases where someone hasn't enabled/installed PHP's mbstring extension, the following exception will be  thrown:

```
PHP Fatal error: Uncaught Error: 
Call to undefined function Bolt\mb_internal_encoding() 
in /var/www/vendor/bolt/bolt/app/bootstrap.php:31
```

The `Bolt\mb_internal_encoding()` part of the error is confusing as it indicates to the average user that the problem is with Bolt, and not the PHP installation.