### PR TITLE
[4.0] Use commit hash to prevent SAT resolver loop pre-Silex 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "PasswordLib/PasswordLib": "^1.0@beta",
         "php": "^5.6 || ^7.0",
         "silex/silex": "^1.3",
-        "silex/web-profiler": "1.0.x@dev",
+        "silex/web-profiler": "1.0.x-dev#2c5df830c864bec709307e706176771b57440be5@dev",
         "siriusphp/upload": "^1.3",
         "stecman/symfony-console-completion": "~0.7",
         "swiftmailer/swiftmailer": "^5.4.5",


### PR DESCRIPTION
Currently master will install vendor requirements fine on a git install where `silex/web-profiler` is required by the root project. But when Bolt is required as a dependency, the Composer SAT gets into a permanent loop with CPU pinned around 99%.

This is a simple hack that will be obvious to remove when we're ready for the Silex 2 cutover, but allow Composer installs for ~~idiots~~ brave people like myself.