### PR TITLE
[4.0] Remove PasswordLib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "monolog/monolog": "^1.21",
         "nesbot/carbon": "^1.21",
         "paragonie/random_compat": "^1.4",
-        "PasswordLib/PasswordLib": "^1.0@beta",
         "php": "^5.6 || ^7.0",
         "silex/silex": "^1.3",
         "silex/web-profiler": "1.0.x-dev#2c5df830c864bec709307e706176771b57440be5@dev",

--- a/src/AccessControl/Password.php
+++ b/src/AccessControl/Password.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\AccessControl;
 
 use Bolt\Events\AccessControlEvents;
@@ -125,7 +126,7 @@ class Password
 
         // Generate shadow password and hash
         $shadowPassword = $this->app['randomgenerator']->generateString(12);
-        $shadowPasswordHash = $this->app['password_factory']->createHash($shadowPassword, '$2y$');
+        $shadowPasswordHash = $this->app['password_hash.manager']->createHash($shadowPassword, '$2y$');
 
         // Generate shadow token and hash
         $shadowToken = $this->app['randomgenerator']->generateString(32);

--- a/src/AccessControl/PasswordHashManager.php
+++ b/src/AccessControl/PasswordHashManager.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Bolt\AccessControl;
+
+use Bolt\Exception\PasswordHashException;
+use Bolt\Exception\PasswordLegacyHashException;
+
+/**
+ * Password hash management service.
+ *
+ * @deprecated Deprecated since 4.0-dev to be removed in 4.0.0.
+ *             This is a transitory service to allow for the replacement of
+ *             PasswordLib, while migrating to Symfony Security.
+ *             DO NOT RELY ON IT BEING AVAILABLE IN A STABLE RELEASE!
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class PasswordHashManager
+{
+    /** @var int */
+    protected $algorithm;
+    /** @var array */
+    protected $options = [];
+
+    /**
+     * Constructor.
+     *
+     * @param int   $algorithm
+     * @param array $options
+     */
+    public function __construct($algorithm = PASSWORD_DEFAULT, array $options = [])
+    {
+        $this->algorithm = $algorithm;
+        $this->options = $options;
+    }
+
+    /**
+     * Create a hash for a given password.
+     *
+     * @param $password
+     *
+     * @throws PasswordHashException
+     *
+     * @return bool|string
+     */
+    public function createHash($password)
+    {
+        if (strlen($password) < 6) {
+            throw new PasswordHashException('Can not save a password with a length shorter than 6 characters!');
+        }
+        if ($this->algorithm === PASSWORD_BCRYPT && $this->isBlowfish($password)) {
+            return $password;
+        }
+        if ($this->isPHPass($password)) {
+            throw new PasswordLegacyHashException();
+        }
+
+        $hash = password_hash($password, $this->algorithm, $this->options);
+        if ($hash === false) {
+            throw new PasswordHashException('Unable to hash password.');
+        }
+
+        return $hash;
+    }
+
+    /**
+     * Determine if a password matches the stored hash.
+     *
+     * @param string $password
+     * @param string $hash
+     *
+     * @throws PasswordHashException
+     *
+     * @return bool
+     */
+    public function verifyHash($password, $hash)
+    {
+        if ($this->isPHPass($password)) {
+            throw new PasswordLegacyHashException();
+        }
+
+        return password_verify($password, $hash);
+    }
+
+    /**
+     * Determine if the hash was made with PHPass.
+     *
+     * @param string $hash
+     *
+     * @return bool
+     */
+    private function isPHPass($hash)
+    {
+        $prefix = preg_quote('$P$', '/');
+
+        return (bool) preg_match('/^'.$prefix.'[a-zA-Z0-9.\/]{31}$/', $hash);
+    }
+
+    /**
+     * Determine if the hash was made with Blowfish.
+     *
+     * @param string $hash
+     *
+     * @return bool
+     */
+    private function isBlowfish($hash)
+    {
+        $regex = '/^\$2[ay]\$(0[4-9]|[1-2][0-9]|3[0-1])\$[a-zA-Z0-9.\/]{53}/';
+
+        return (bool) preg_match($regex, $hash);
+    }
+}

--- a/src/Exception/AccessControlException.php
+++ b/src/Exception/AccessControlException.php
@@ -2,9 +2,11 @@
 
 namespace Bolt\Exception;
 
+use RuntimeException;
+
 /**
  * Access exceptions.
  */
-class AccessControlException extends \Exception
+class AccessControlException extends RuntimeException
 {
 }

--- a/src/Exception/PasswordHashException.php
+++ b/src/Exception/PasswordHashException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Bolt\Exception;
+
+/**
+ * Password hash creation/verification exceptions.
+ */
+class PasswordHashException extends AccessControlException
+{
+}

--- a/src/Exception/PasswordLegacyHashException.php
+++ b/src/Exception/PasswordLegacyHashException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bolt\Exception;
+
+/**
+ * Exception thrown when attempting to use PHPass hashes.
+ */
+class PasswordLegacyHashException extends PasswordHashException
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->message = 'This user password has is stored using the legacy PHPass algorithm, and is no longer secure to use. ' .
+            'Please use the password reset functionality to set a new password.';
+    }
+}

--- a/src/Provider/AccessControlServiceProvider.php
+++ b/src/Provider/AccessControlServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Bolt\Provider;
 
 use Bolt\AccessControl;
-use PasswordLib\Password\Factory as PasswordFactory;
+use Bolt\AccessControl\PasswordHashManager;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -65,9 +65,20 @@ class AccessControlServiceProvider implements ServiceProviderInterface
             }
         );
 
-        $app['password_factory'] = $app->share(
+        /** @deprecated Deprecated since 4.0-dev to be removed BEFORE 4.0.0 is released */
+        $app['password_hash.algorithm'] = PASSWORD_DEFAULT;
+        /** @deprecated Deprecated since 4.0-dev to be removed BEFORE 4.0.0 is released */
+        $app['password_hash.options'] = $app->share(
             function () {
-                return new PasswordFactory();
+                return [
+                    'cost' => 8,
+                ];
+            }
+        );
+        /** @deprecated Deprecated since 4.0-dev to be removed BEFORE 4.0.0 is released */
+        $app['password_hash.manager'] = $app->share(
+            function ($app) {
+                return new PasswordHashManager($app['password_hash.algorithm'], $app['password_hash.options']);
             }
         );
 

--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Bolt\Provider;
 
 use Bolt\Configuration\ConfigurationValueProxy;
@@ -281,7 +282,7 @@ class StorageServiceProvider implements ServiceProviderInterface
                     $app['schema.lazy'],
                     $app['url_generator.lazy'],
                     $app['logger.flash'],
-                    $app['password_factory'],
+                    $app['password_hash.manager'],
                     $app['access_control.hash.strength'],
                     $app['config']->get('general/performance/timed_records/use_cron', false)
                 );

--- a/tests/phpunit/unit/AccessControl/PasswordTest.php
+++ b/tests/phpunit/unit/AccessControl/PasswordTest.php
@@ -2,11 +2,11 @@
 namespace Bolt\Tests;
 
 use Bolt\AccessControl\Password;
+use Bolt\AccessControl\PasswordHashManager;
 use Bolt\Events\AccessControlEvent;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Repository;
 use Carbon\Carbon;
-use PasswordLib\PasswordLib;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -42,8 +42,8 @@ class PasswordTest extends BoltUnitTest
         $userEntity = $repo->getUser('admin');
         $userAuth = $repo->getUserAuthData($userEntity->getId());
 
-        $crypt = new PasswordLib();
-        $compare = $crypt->verifyPasswordHash($newPass, $userAuth->getPassword());
+        $crypt = new PasswordHashManager();
+        $compare = $crypt->verifyHash($newPass, $userAuth->getPassword());
 
         $this->assertTrue($compare);
         $this->assertEmpty($userEntity->getShadowpassword());

--- a/tests/phpunit/unit/Nut/UserAddTest.php
+++ b/tests/phpunit/unit/Nut/UserAddTest.php
@@ -1,9 +1,9 @@
 <?php
 namespace Bolt\Tests\Nut;
 
+use Bolt\AccessControl\PasswordHashManager;
 use Bolt\Nut\UserAdd;
 use Bolt\Tests\BoltUnitTest;
-use PasswordLib\PasswordLib;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -36,8 +36,8 @@ class UserAddTest extends BoltUnitTest
         $repo = $app['storage']->getRepository('Bolt\Storage\Entity\Users');
         $userEntity = $repo->getUser('test');
         $userAuth = $repo->getUserAuthData($userEntity->getId());
-        $crypt = new PasswordLib();
-        $auth = $crypt->verifyPasswordHash('testPass', $userAuth->getPassword());
+        $crypt = new PasswordHashManager();
+        $auth = $crypt->verifyHash('testPass', $userAuth->getPassword());
         $this->assertTrue($auth);
     }
 

--- a/tests/phpunit/unit/Nut/UserResetPasswordTest.php
+++ b/tests/phpunit/unit/Nut/UserResetPasswordTest.php
@@ -1,11 +1,11 @@
 <?php
 namespace Bolt\Tests\Nut;
 
+use Bolt\AccessControl\PasswordHashManager;
 use Bolt\Nut\UserResetPassword;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Repository;
 use Bolt\Tests\BoltUnitTest;
-use PasswordLib\PasswordLib;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -54,15 +54,15 @@ class UserResetPasswordTest extends BoltUnitTest
         $repo = $app['storage']->getRepository('Bolt\Storage\Entity\Users');
         $userEntity = $repo->getUser('koala');
         $userAuth = $repo->getUserAuthData($userEntity->getId());
-        $crypt = new PasswordLib();
+        $crypt = new PasswordHashManager();
 
         // Check the old password isn't valid
-        $auth = $crypt->verifyPasswordHash('GumL3@ve$', $userAuth->getPassword());
+        $auth = $crypt->verifyHash('GumL3@ve$', $userAuth->getPassword());
         $this->assertFalse($auth);
 
         // Check the new password is valid
         $bits = explode(' ', trim($result));
-        $auth = $crypt->verifyPasswordHash($bits[5], $userAuth->getPassword());
+        $auth = $crypt->verifyHash($bits[5], $userAuth->getPassword());
         $this->assertTrue($auth);
     }
 }

--- a/tests/phpunit/unit/PasswordHashTest.php
+++ b/tests/phpunit/unit/PasswordHashTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Bolt\Tests;
+
+use Bolt\AccessControl\PasswordHashManager;
+
+/**
+ * PasswordHash test
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class PasswordHashTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreateHash()
+    {
+        $passwordHasher = new PasswordHashManager();
+        $hash = $passwordHasher->createHash('dropbear');
+
+        $this->assertSame($hash, $passwordHasher->createHash($hash));
+    }
+
+    /**
+     * It should throw an exception if the password is shorter than 6 characters.
+     *
+     * @expectedException \Bolt\Exception\PasswordHashException
+     * @expectedExceptionMessage Can not save a password with a length shorter than 6 characters!
+     */
+    public function testCreateHashShortPassword()
+    {
+        $passwordHasher = new PasswordHashManager();
+        $passwordHasher->createHash('koala');
+    }
+
+    public function testCreateHashAlreadyBlowfish()
+    {
+        $passwordHasher = new PasswordHashManager();
+        $hash = password_hash('dropbear', PASSWORD_BCRYPT);
+
+        $this->assertSame($hash, $passwordHasher->createHash($hash));
+    }
+
+    /**
+     * @expectedException \Bolt\Exception\PasswordLegacyHashException
+     * @expectedExceptionMessageRegExp /This user password has is stored using the legacy PHPass algorithm, and is no longer secure to use/
+     */
+    public function testCreateHashAlreadyPHPass()
+    {
+        $passwordHasher = new PasswordHashManager();
+        $passwordHasher->createHash('$P$6vinaigregCze.fI75./Bj..B51oL3.');
+    }
+
+    public function verifyHash()
+    {
+        $passwordHasher = new PasswordHashManager();
+        $hash = password_hash('dropbear', PASSWORD_BCRYPT);
+
+        $this->assertTrue($passwordHasher->verifyHash('dropbear', $hash));
+    }
+
+    /**
+     * @expectedException \Bolt\Exception\PasswordLegacyHashException
+     * @expectedExceptionMessageRegExp /This user password has is stored using the legacy PHPass algorithm, and is no longer secure to use/
+     */
+    public function verifyHashAlreadyPHPass()
+    {
+        $passwordHasher = new PasswordHashManager();
+        $passwordHasher->verifyHash('dropbear', '$P$6vinaigregCze.fI75./Bj..B51oL3.');
+    }
+}


### PR DESCRIPTION
Open to discussion on pretty much everything.

This simply removes PasswordLib (which is abandoned), and introduces a configurable service that advanced users can customise.

We're still 10 months out from release, but let the dominoes start to fall :wink: 

**UPDATE:** For people referring back to this, the concept of this PR & the `PasswordHashManager` service is a transitory **hack** during 4.0-dev until we can cut over to both Silex 2 & Symfony Security proper.