### PR TITLE
[3.3] Adding the Pimple dumper as a require-dev & Nut command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ extensions/*
 thumbs/
 vendor/
 phpunit.xml
+pimple.json
 theme/*
 !theme/base-*
 !theme/default
@@ -62,5 +63,4 @@ Vagrantfile
 .project
 /bolt.log
 coverage.xml
-pimple.json
 dump.php

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "phpunit/php-code-coverage": "^2.0",
         "phpunit/phpunit": "^4.8",
         "sebastian/phpcpd": "^2.0",
+        "sorien/silex-pimple-dumper": "^1.0",
         "squizlabs/php_codesniffer": "^2.0",
         "symfony/phpunit-bridge": "^2.8"
     },

--- a/src/Nut/PimpleDumpCommand.php
+++ b/src/Nut/PimpleDumpCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Sorien\Provider\PimpleDumpProvider;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Pimple container dumper command for PhpStorm & IntelliJ IDEA.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class PimpleDumpCommand extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled()
+    {
+        return class_exists('\Sorien\Provider\PimpleDumpProvider');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+        $this->setName('pimple:dump')
+            ->setDescription('Pimple container dumper for PhpStorm & IntelliJ IDEA.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $app = $this->app;
+        $app['debug'] = true;
+
+        $dumper = new PimpleDumpProvider();
+        $app->register($dumper);
+        $dumper->boot($app);
+
+        $request = Request::create('/');
+        $response = $app->handle($request);
+        $app->terminate($request, $response);
+    }
+}

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -50,6 +50,7 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\Init($app),
                     new Nut\LogClear($app),
                     new Nut\LogTrim($app),
+                    new Nut\PimpleDumpCommand($app),
                     new Nut\ServerRun($app),
                     new Nut\SetupSync($app),
                     new Nut\TestRunner($app),


### PR DESCRIPTION
As per discussion in RFC #6394 and on Slack.

## Set up for PhpStorm or IntelliJ IDEA  

1. Install the plugin from JetBrains repositories:
   * Settings → Plugins → Browse repositories and search for "Silex"
2. Restart PhpStorm/IntelliJ
3. Enable the plugin:
   * Per-project:
     * Settings → Other Settings → Silex Plugin  → Click "Enable Plugin"
   * All projects:
     * Default Settings → Other Settings → Silex Plugin  → Click "Enable Plugin"

For more information, the plugin source repository can be [found on GitHub][silex-idea-plugin]

## Usage

From the project root direction simply run:

```bash
php ./app/nut pimple:dump
```

--- 

[silex-pimple-dumper]: https://github.com/Sorien/silex-pimple-dumper
[silex-idea-plugin]: https://github.com/Sorien/silex-idea-plugin
