### PR TITLE
Change app path to always be user directory

### DIFF
--- a/src/Configuration/Composer.php
+++ b/src/Configuration/Composer.php
@@ -22,7 +22,6 @@ class Composer extends Standard
     {
         parent::__construct($path, $request, $pathResolverFactory);
         $this->setPath('composer', realpath(dirname(__DIR__) . '/../'), false);
-        $this->setPath('app', realpath(dirname(__DIR__) . '/../app/'), false);
         $this->setPath('view', '%web%/bolt-public/view');
         $this->setPath('web', 'public');
         $this->setUrl('app', '/bolt-public/');

--- a/src/Configuration/ForwardToPathResolver.php
+++ b/src/Configuration/ForwardToPathResolver.php
@@ -18,6 +18,7 @@ class ForwardToPathResolver extends ResourceManager
     {
         parent::__construct($container);
         $paths = [
+            'app',
             'cache',
             'config',
             'database',

--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -27,13 +27,14 @@ class PathResolver
     public static function defaultPaths()
     {
         return [
-            'app'               => 'app',
+            'site'              => '.',
+            'app'               => '%site%/app',
             'cache'             => '%app%/cache',
             'config'            => '%app%/config',
             'database'          => '%app%/database',
-            'extensions'        => 'extensions',
+            'extensions'        => '%site%/extensions',
             'extensions_config' => '%config%/extensions',
-            'web'               => 'public',
+            'web'               => '%site%/public',
             'files'             => '%web%/files',
             'themes'            => '%web%/theme',
             'bolt_assets'       => '%web%/bolt-public/view',

--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -27,9 +27,10 @@ class PathResolver
     public static function defaultPaths()
     {
         return [
-            'cache'             => 'app/cache',
-            'config'            => 'app/config',
-            'database'          => 'app/database',
+            'app'               => 'app',
+            'cache'             => '%app%/cache',
+            'config'            => '%app%/config',
+            'database'          => '%app%/database',
             'extensions'        => 'extensions',
             'extensions_config' => '%config%/extensions',
             'web'               => 'public',


### PR DESCRIPTION
I deprecated `app` path (months ago) because it was pointing to Bolt's core _app_ directory. This was confusing for users since they also have an _app_ directory. I wanted to reintroduce the path in v4.0 as a user path (always pointing to the users _app_ directory instead of Bolt's). But since core no longer references this path, and it had no use to users previously, this change can happen now.

This also fixes a "bug" where the path is seemingly "out of sync" between PathResolver and ResourceManager.

I still would discourage use of this to resolve paths directly. It should only be used to configure other paths. For example, don't do
```php
$resolver->resolve('%app%/config/foo.yml');
```
but instead reference `config` directly.
```php
$resolver->resolve('%config%/foo.yml');
```
That isn't new though, we've been pushing that with ResourceManager for over a year now.

For this reason the `app` filesystem is still deprecated, even with this alias back in use.

---

I also added a `site` path alias to act as the root path for a site. `root` path can't be used for this because it is fixed to the directory containing `composer.json`. It is fixed to that because PHP source file paths are made relative to this directory. 

Now with `site` you can move all of your site directories based on this one path, i.e. `app`, `public` and `extensions`.

Disclaimer: `site` may not be the best name. It definitely does **NOT** imply multi-site setup out of the box.