### PR TITLE
Lock select2 at 4.0.0

### DIFF
--- a/app/src/package.json
+++ b/app/src/package.json
@@ -47,7 +47,7 @@
         "node-sass": "~3.11.3",
         "postcss-single-charset": "~1.0.0",
         "request": "~2.79.0",
-        "select2": "~4.0.3"
+        "select2": "4.0.0"
     },
     "scripts": {
         "start": "grunt",


### PR DESCRIPTION
Fixes #5676 for now, we will have to look into unlocking it when 4.0.5 is released.