### PR TITLE
Fix to allow extension interface backwards compatibility

### DIFF
--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -100,7 +100,7 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
             $value = $this->getSanitiser()->sanitise($value, $isWysiwyg);
         }
 
-        $type = $this->getStorageType();
+        $type = $this->getStorageTypeObject();
 
         if (null !== $value) {
             $value = $type->convertToDatabaseValue($value, $this->getPlatform());
@@ -118,7 +118,7 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
     public function hydrate($data, $entity)
     {
         $key = $this->mapping['fieldname'];
-        $type = $this->getStorageType();
+        $type = $this->getStorageTypeObject();
         $val = isset($data[$key]) ? $data[$key] : null;
         if ($val !== null) {
             $value = $type->convertToPHPValue($val, $this->getPlatform());
@@ -188,6 +188,22 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
     }
 
     /**
+     * Helper method to bridge compatibility between old and new Field interfaces. Previously a string storage
+     * type was allowed whereas new behaviour is to expect a Type object.
+     *
+     * @return Type
+     */
+    protected function getStorageTypeObject()
+    {
+        $type = $this->getStorageType();
+        if (is_string($type)) {
+            $type = Type::getType($type);
+        }
+
+        return $type;
+    }
+
+    /**
      * @deprecated
      * Here to maintain compatibility with the old interface
      */
@@ -246,6 +262,4 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
 
         return json_last_error() === JSON_ERROR_NONE;
     }
-
-
 }


### PR DESCRIPTION
Fixes #6413

This is a temporary fix to bridge to 4.0 which allows FieldTypeBase to support both strings and objects returned via the `getStorageType()` method in fields.