### PR TITLE
Don't save an empty repeater block

### DIFF
--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -2,6 +2,9 @@
 
 namespace Bolt\Helpers;
 
+use RecursiveArrayIterator;
+use RecursiveIteratorIterator;
+
 class Arr
 {
     /**
@@ -96,5 +99,18 @@ class Arr
         }
 
         return true;
+    }
+
+    public static function isEmptyArray($input)
+    {
+        if (!is_array($input)) {
+            return false;
+        }
+        $empty = true;
+        foreach (new RecursiveIteratorIterator(new RecursiveArrayIterator($input), RecursiveIteratorIterator::CATCH_GET_CHILD) as $key => $value) {
+            $empty = empty($value);
+        }
+
+        return $empty;
     }
 }

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -107,8 +107,11 @@ class Arr
             return false;
         }
         $empty = true;
-        foreach (new RecursiveIteratorIterator(new RecursiveArrayIterator($input), RecursiveIteratorIterator::CATCH_GET_CHILD) as $key => $value) {
-            $empty = empty($value);
+        foreach (new RecursiveIteratorIterator(new RecursiveArrayIterator($input), RecursiveIteratorIterator::LEAVES_ONLY) as $key => $value) {
+            $empty = (empty($value) && $value !== '0' && $value !== 0);
+            if (!$empty) {
+                return false;
+            }
         }
 
         return $empty;

--- a/src/Storage/ContentRequest/Save.php
+++ b/src/Storage/ContentRequest/Save.php
@@ -4,6 +4,7 @@ namespace Bolt\Storage\ContentRequest;
 
 use Bolt\Config;
 use Bolt\Exception\AccessControlException;
+use Bolt\Helpers\Arr;
 use Bolt\Helpers\Input;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Storage\Entity;
@@ -184,7 +185,7 @@ class Save
             if ($name === 'relation' || $name === 'taxonomy') {
                 continue;
             } else {
-                $content->set($name, empty($value) ? null : $value);
+                $content->set($name, (empty($value) || Arr::isEmptyArray($value)) ? null : $value);
             }
         }
         $this->setPostedRelations($content, $formValues);


### PR DESCRIPTION
On standard fields we do an empty check before saving in the database, problem with repeaters was that although all the fields are empty an array of empty values still evaluates to true on `empty($value)`

This adds a recursive helper to check wether an array is empty and if it is the value of the repeater is set to null.

This solves a bug that a few people have reported whereby in the templates there was no way to check if a repeater collection was empty because there was always one value in it.

With this fix you can go back to using `{% if record.repeaterfield|length %}....` to test whether you have some collections.