### PR TITLE
[3.2] Mark Arr::isEmptyArray() @internal

### DIFF
--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -2,9 +2,6 @@
 
 namespace Bolt\Helpers;
 
-use RecursiveArrayIterator;
-use RecursiveIteratorIterator;
-
 class Arr
 {
     /**
@@ -99,21 +96,5 @@ class Arr
         }
 
         return true;
-    }
-
-    public static function isEmptyArray($input)
-    {
-        if (!is_array($input)) {
-            return false;
-        }
-        $empty = true;
-        foreach (new RecursiveIteratorIterator(new RecursiveArrayIterator($input), RecursiveIteratorIterator::LEAVES_ONLY) as $key => $value) {
-            $empty = (empty($value) && $value !== '0' && $value !== 0);
-            if (!$empty) {
-                return false;
-            }
-        }
-
-        return $empty;
     }
 }

--- a/src/Storage/ContentRequest/Save.php
+++ b/src/Storage/ContentRequest/Save.php
@@ -2,6 +2,9 @@
 
 namespace Bolt\Storage\ContentRequest;
 
+
+use RecursiveArrayIterator;
+use RecursiveIteratorIterator;
 use Bolt\Config;
 use Bolt\Exception\AccessControlException;
 use Bolt\Helpers\Arr;
@@ -185,7 +188,7 @@ class Save
             if ($name === 'relation' || $name === 'taxonomy') {
                 continue;
             } else {
-                $content->set($name, (empty($value) || Arr::isEmptyArray($value)) ? null : $value);
+                $content->set($name, (empty($value) || $this->isEmptyArray($value)) ? null : $value);
             }
         }
         $this->setPostedRelations($content, $formValues);
@@ -415,5 +418,28 @@ class Save
         $generator = $this->urlGenerator;
 
         return $generator->generate($name, $params, $referenceType);
+    }
+
+    /**
+     * Check wether an array is empty and if it is the value of the repeater is set to null.
+     *
+     * @param array $input
+     *
+     * @return bool
+     */
+    private function isEmptyArray($input)
+    {
+        if (!is_array($input)) {
+            return false;
+        }
+        $empty = true;
+        foreach (new RecursiveIteratorIterator(new RecursiveArrayIterator($input), RecursiveIteratorIterator::LEAVES_ONLY) as $key => $value) {
+            $empty = (empty($value) && $value !== '0' && $value !== 0);
+            if (!$empty) {
+                return false;
+            }
+        }
+
+        return $empty;
     }
 }


### PR DESCRIPTION
Please please please can we not add this to the API to support in a tagged version.

I get we need something for repeaters, and I don't have a better solution myself but this has support liability attached we don't want to have to live with even for 3.x