### PR TITLE
Fix renaming files in sub-subfolders

### DIFF
--- a/app/view/twig/files/_files.twig
+++ b/app/view/twig/files/_files.twig
@@ -97,7 +97,7 @@
                             <ul class="dropdown-menu pull-right hidden-xs">
                                 <li>
                                     <a href="#"
-                                       data-action="Bolt.files.renameFile('{{ context.namespace }}', '{{ file.path }}', '{{ file.filename }}', this);">
+                                       data-action="Bolt.files.renameFile('{{ context.namespace }}', '{{ context.pathsegments|join('/') }}', '{{ file.filename }}', this);">
 
                                         <i class="fa fa-keyboard-o"></i>
                                         {{ __('general.phrase.rename-foldername', {'%foldername%': file.filename}) }}

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -325,6 +325,7 @@ class FilesystemManager extends AsyncBase
     public function renameFile(Request $request)
     {
         $namespace = $request->request->get('namespace');
+        $parentPath = $request->request->get('parent');
         $oldName = $request->request->get('oldname');
         $newName = $request->request->get('newname');
 
@@ -333,9 +334,9 @@ class FilesystemManager extends AsyncBase
         }
 
         try {
-            $this->filesystem()->rename(sprintf('%s://%s', $namespace, $oldName), $newName);
+            $this->filesystem()->rename(sprintf('%s://%s/%s', $namespace, $parentPath, $oldName), sprintf('%s/%s', $parentPath, $newName));
 
-            return $this->json($newName, Response::HTTP_OK);
+            return $this->json(sprintf('%s/%s', $parentPath, $newName), Response::HTTP_OK);
         } catch (ExceptionInterface $e) {
             $msg = Trans::__('Unable to rename file: %FILE%', ['%FILE%' => $oldName]);
             $this->logException($msg, $e);


### PR DESCRIPTION
Renaming file in sub-subfolders didn't work since we only prepended the namespace, not the parentpath. This fixes that.