### PR TITLE
Remove default value for cookies_domain

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -345,32 +345,6 @@ class Config
         // Merge the array with the defaults. Setting the required values that aren't already set.
         $general = Arr::mergeRecursiveDistinct($this->defaultConfig, $general);
 
-        // Make sure the cookie_domain for the sessions is set properly.
-        if (empty($general['cookies_domain'])) {
-            $request = Request::createFromGlobals();
-            if ($request->server->get('HTTP_HOST', false)) {
-                $hostSegments = explode(':', $request->server->get('HTTP_HOST'));
-                $hostname = reset($hostSegments);
-            } elseif ($request->server->get('SERVER_NAME', false)) {
-                $hostname = $request->server->get('SERVER_NAME');
-            } else {
-                $hostname = '';
-            }
-
-            // Don't set the domain for a cookie on a "TLD" - like 'localhost', or if the server_name is an IP-address
-            if ((strpos($hostname, '.') > 0) && preg_match('/[a-z0-9]/i', $hostname)) {
-                if (preg_match('/^www[0-9]*./', $hostname)) {
-                    $general['cookies_domain'] = '.' . preg_replace('/^www[0-9]*./', '', $hostname);
-                } else {
-                    $general['cookies_domain'] = '.' . $hostname;
-                }
-                // Make sure we don't have consecutive '.'-s in the cookies_domain.
-                $general['cookies_domain'] = str_replace('..', '.', $general['cookies_domain']);
-            } else {
-                $general['cookies_domain'] = '';
-            }
-        }
-
         // Make sure Bolt's mount point is OK:
         $general['branding']['path'] = '/' . Str::makeSafe($general['branding']['path']);
 


### PR DESCRIPTION
Fixes #6431

The only thing this did differently than PHP's default domain is removed
the `www.` prefix allowing the cookie to assigned to `foo.com` and `www.foo.com`.

It was decided this isn't a big enough use case to warrant keeping this logic.
Note that fixing this caching bug would mean moving the logic to 3 different
places (or 2 with larger refactoring).