### PR TITLE
TemplateView

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -454,3 +454,10 @@ hash_strength: 10
 #        disable: true     # Disable news panel. Defaults to false. "Alerts" will still be shown.
 #    stack:
 #        disable: true     # Disable stack usage. Defaults to false.
+
+# Options that will be forced in next major version
+compatibility:
+    # Whether to return TemplateView instead of TemplateResponse from Controller\Base::render()
+    # Response methods cannot be used on TemplateView objects.
+    # Setting this value to false is deprecated.
+    template_view: true

--- a/src/Controller/Backend/FileManager.php
+++ b/src/Controller/Backend/FileManager.php
@@ -42,11 +42,7 @@ class FileManager extends BackendBase
             ->assert('namespace', '[^/]+')
             ->value('namespace', 'files')
             ->bind('fileedit')
-            ->after(function (Request $request, Response $response) {
-                if ($request->isMethod('POST')) {
-                    $response->headers->set('X-XSS-Protection', '0');
-                }
-            });
+        ;
 
         $c->match('/files/{namespace}/{path}', 'manage')
             ->assert('namespace', '[^/]+')

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -3,7 +3,9 @@
 namespace Bolt\Controller;
 
 use Bolt\AccessControl\Token\Token;
+use Bolt\Helpers\Deprecated;
 use Bolt\Response\TemplateResponse;
+use Bolt\Response\TemplateView;
 use Bolt\Routing\DefaultControllerClassAwareInterface;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Repository;
@@ -71,7 +73,7 @@ abstract class Base implements ControllerProviderInterface
      * @param array           $context  Context variables
      * @param array           $globals  Global variables
      *
-     * @return \Bolt\Response\TemplateResponse
+     * @return TemplateResponse|TemplateView
      */
     protected function render($template, array $context = [], array $globals = [])
     {
@@ -83,6 +85,16 @@ abstract class Base implements ControllerProviderInterface
             $twig->addGlobal($name, $value);
         }
         $globals = $twig->getGlobals();
+
+        if ($this->getOption('compatibility/template_view', false)) {
+            return new TemplateView($template->getTemplateName(), $context);
+        }
+        Deprecated::warn(
+            'Returning a TemplateResponse from Bolt\Controller\Base::render',
+            3.3,
+            'Be sure no Response methods are used from return value and then set "compatibility/template_view"' .
+            ' to true in config.yml. This changes render() to return a TemplateView instead.'
+        );
 
         $response = new TemplateResponse($template->getTemplateName(), $context, $globals);
         $response->setContent($template->render($context));

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -81,8 +81,10 @@ abstract class Base implements ControllerProviderInterface
 
         $template = $twig->resolveTemplate($template);
 
-        foreach ($globals as $name => $value) {
-            $twig->addGlobal($name, $value);
+        if ($this->getOption('compatibility/twig_globals', true)) {
+            foreach ($globals as $name => $value) {
+                $twig->addGlobal($name, $value);
+            }
         }
         $context += $globals;
 

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -98,8 +98,8 @@ abstract class Base implements ControllerProviderInterface
             ' to true in config.yml. This changes render() to return a TemplateView instead.'
         );
 
-        $response = new TemplateResponse($template->getTemplateName(), $context);
-        $response->setContent($template->render($context));
+        $content = $template->render($context);
+        $response = new TemplateResponse($template->getTemplateName(), $context, $content);
 
         return $response;
     }

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -84,6 +84,7 @@ abstract class Base implements ControllerProviderInterface
         foreach ($globals as $name => $value) {
             $twig->addGlobal($name, $value);
         }
+        $context += $globals;
 
         if ($this->getOption('compatibility/template_view', false)) {
             return new TemplateView($template->getTemplateName(), $context);

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -84,7 +84,6 @@ abstract class Base implements ControllerProviderInterface
         foreach ($globals as $name => $value) {
             $twig->addGlobal($name, $value);
         }
-        $globals = $twig->getGlobals();
 
         if ($this->getOption('compatibility/template_view', false)) {
             return new TemplateView($template->getTemplateName(), $context);
@@ -96,7 +95,7 @@ abstract class Base implements ControllerProviderInterface
             ' to true in config.yml. This changes render() to return a TemplateView instead.'
         );
 
-        $response = new TemplateResponse($template->getTemplateName(), $context, $globals);
+        $response = new TemplateResponse($template->getTemplateName(), $context);
         $response->setContent($template->render($context));
 
         return $response;

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -236,21 +236,8 @@ class Frontend extends ConfigurableBase
             'record'                      => $content,
             $contenttype['singular_slug'] => $content,
         ];
-        $response = $this->render($template, [], $globals);
 
-        // Chrome (unlike Firefox and Internet Explorer) has a feature that helps prevent
-        // XSS attacks for uncareful people. It blocks embeds, links and src's that have
-        // a URL that's also in the request. In Bolt we wish to enable this type of embeds,
-        // because otherwise Youtube, Vimeo and Google Maps embeds will simply not show,
-        // causing confusion for the editor, because they don't know what's happening.
-        // Is this a security concern, you may ask? I believe it cannot be exploited:
-        //   - Disabled, the behaviour on Chrome matches Firefox and IE.
-        //   - The user must be logged in to see the 'preview' page at all.
-        //   - Our CSRF-token ensures that the user will only see their own posted preview.
-        // @see: http://security.stackexchange.com/questions/53474/is-chrome-completely-secure-against-reflected-xss
-        $response->headers->set('X-XSS-Protection', 0);
-
-        return $response;
+        return $this->render($template, [], $globals);
     }
 
     /**

--- a/src/EventListener/DisableXssProtectionListener.php
+++ b/src/EventListener/DisableXssProtectionListener.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Bolt\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Disable browser's XSS detection for given routes.
+ *
+ * These routes should still verify the request data with a CSRF token.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class DisableXssProtectionListener implements EventSubscriberInterface
+{
+    /** @var string[] */
+    protected $routes;
+
+    /**
+     * Constructor.
+     *
+     * @param string[] $routes
+     */
+    public function __construct(array $routes)
+    {
+        $this->routes = $routes;
+    }
+
+    /**
+     * Add X-XSS-Protection header if route matches, request is unsafe, and response has body.
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function onResponse(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if ($request->isMethodSafe()) {
+            return;
+        }
+
+        $route = $request->attributes->get('_route');
+
+        if (!in_array($route, $this->routes)) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        if ($response->isRedirection() || $response->isEmpty() || $response->isInformational()) {
+            return;
+        }
+
+        $response->headers->set('X-XSS-Protection', 0);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::RESPONSE => 'onResponse',
+        ];
+    }
+}

--- a/src/EventListener/TemplateViewListener.php
+++ b/src/EventListener/TemplateViewListener.php
@@ -58,8 +58,7 @@ class TemplateViewListener implements EventSubscriberInterface
     {
         $content = $this->twig->render($view->getTemplate(), $view->getContext()->toArray());
 
-        $response = new TemplateResponse($view->getTemplate(), $view->getContext());
-        $response->setContent($content);
+        $response = new TemplateResponse($view->getTemplate(), $view->getContext(), $content);
 
         return $response;
     }

--- a/src/EventListener/TemplateViewListener.php
+++ b/src/EventListener/TemplateViewListener.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Bolt\EventListener;
+
+use Bolt\Response\TemplateResponse;
+use Bolt\Response\TemplateView;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Twig_Environment as TwigEnvironment;
+
+/**
+ * Converts controller results that are TemplateView's to TemplateResponse's.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class TemplateViewListener implements EventSubscriberInterface
+{
+    /** @var TwigEnvironment */
+    protected $twig;
+
+    /**
+     * Constructor.
+     *
+     * @param TwigEnvironment $twig
+     */
+    public function __construct(TwigEnvironment $twig)
+    {
+        $this->twig = $twig;
+    }
+
+    /**
+     * If controller result is a TemplateView, convert it to a TemplateResponse.
+     *
+     * @param GetResponseForControllerResultEvent $event
+     */
+    public function onView(GetResponseForControllerResultEvent $event)
+    {
+        $result = $event->getControllerResult();
+
+        if (!$result instanceof TemplateView) {
+            return;
+        }
+
+        $response = $this->render($result);
+
+        $event->setResponse($response);
+    }
+
+    /**
+     * Render TemplateView to a TemplateResponse.
+     *
+     * @param TemplateView $view
+     *
+     * @return TemplateResponse
+     */
+    public function render(TemplateView $view)
+    {
+        $content = $this->twig->render($view->getTemplate(), $view->getContext()->toArray());
+
+        $response = new TemplateResponse($view->getTemplate(), $view->getContext());
+        $response->setContent($content);
+
+        return $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::VIEW => 'onView',
+        ];
+    }
+}

--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -119,6 +119,12 @@ class EventListenerServiceProvider implements ServiceProviderInterface
             }
         );
 
+        $app['listener.template_view'] = $app->share(
+            function ($app) {
+                return new Listener\TemplateViewListener($app['twig']);
+            }
+        );
+
         $app['listener.zone_guesser'] = $app->share(
             function ($app) {
                 return new Listener\ZoneGuesser($app);
@@ -140,6 +146,7 @@ class EventListenerServiceProvider implements ServiceProviderInterface
             'snippet',
             'redirect',
             'flash_logger',
+            'template_view',
             'zone_guesser',
             'pager',
         ];

--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -27,6 +27,16 @@ class EventListenerServiceProvider implements ServiceProviderInterface
             }
         );
 
+        $app['disable_xss_protection_routes'] = [
+            'preview',
+            'fileedit',
+        ];
+        $app['listener.disable_xss_protection'] = $app->share(
+            function ($app) {
+                return new Listener\DisableXssProtectionListener($app['disable_xss_protection_routes']);
+            }
+        );
+
         $app['listener.exception'] = $app->share(
             function ($app) {
                 return new Listener\ExceptionListener(
@@ -123,6 +133,7 @@ class EventListenerServiceProvider implements ServiceProviderInterface
 
         $listeners = [
             'general',
+            'disable_xss_protection',
             'exception_json',
             'not_found',
             'system_logger',

--- a/src/Render.php
+++ b/src/Render.php
@@ -73,11 +73,10 @@ class Render
         foreach ($globals as $name => $value) {
             $this->app['twig']->addGlobal($name, $value);
         }
-        $globals = $this->app['twig']->getGlobals();
 
         $html = twig_include($this->app['twig'], $context, $template, [], true, false, $this->safe);
 
-        $response = new TemplateResponse($template->getTemplateName(), $context, $globals);
+        $response = new TemplateResponse($template->getTemplateName(), $context);
         $response->setContent($html);
 
         return $response;

--- a/src/Render.php
+++ b/src/Render.php
@@ -76,8 +76,7 @@ class Render
 
         $html = twig_include($this->app['twig'], $context, $template, [], true, false, $this->safe);
 
-        $response = new TemplateResponse($template->getTemplateName(), $context);
-        $response->setContent($html);
+        $response = new TemplateResponse($template->getTemplateName(), $context, $html);
 
         return $response;
     }

--- a/src/Response/TemplateResponse.php
+++ b/src/Response/TemplateResponse.php
@@ -17,22 +17,18 @@ class TemplateResponse extends Response
     protected $template;
     /** @var ImmutableBag */
     protected $context;
-    /** @var array */
-    protected $globals = [];
 
     /**
      * Constructor.
      *
      * @param string   $template
      * @param iterable $context
-     * @param array    $globals
      */
-    public function __construct($template, $context = [], array $globals = [])
+    public function __construct($template, $context = [])
     {
         parent::__construct();
         $this->template = $template;
         $this->setContext($context);
-        $this->globals = $globals;
     }
 
     /**
@@ -49,14 +45,6 @@ class TemplateResponse extends Response
     public function getContext()
     {
         return $this->context;
-    }
-
-    /**
-     * @return array
-     */
-    public function getGlobals()
-    {
-        return $this->globals;
     }
 
     /**

--- a/src/Response/TemplateResponse.php
+++ b/src/Response/TemplateResponse.php
@@ -14,7 +14,7 @@ use Webmozart\Assert\Assert;
 class TemplateResponse extends Response
 {
     /** @var string */
-    protected $templateName;
+    protected $template;
     /** @var ImmutableBag */
     protected $context;
     /** @var array */
@@ -23,14 +23,14 @@ class TemplateResponse extends Response
     /**
      * Constructor.
      *
-     * @param string   $templateName
+     * @param string   $template
      * @param iterable $context
      * @param array    $globals
      */
-    public function __construct($templateName, $context = [], array $globals = [])
+    public function __construct($template, $context = [], array $globals = [])
     {
         parent::__construct();
-        $this->templateName = $templateName;
+        $this->template = $template;
         $this->setContext($context);
         $this->globals = $globals;
     }
@@ -38,9 +38,9 @@ class TemplateResponse extends Response
     /**
      * @return string
      */
-    public function getTemplateName()
+    public function getTemplate()
     {
-        return $this->templateName;
+        return $this->template;
     }
 
     /**

--- a/src/Response/TemplateResponse.php
+++ b/src/Response/TemplateResponse.php
@@ -2,7 +2,9 @@
 
 namespace Bolt\Response;
 
+use Bolt\Collection\ImmutableBag;
 use Symfony\Component\HttpFoundation\Response;
+use Webmozart\Assert\Assert;
 
 /**
  * Template based response.
@@ -13,23 +15,23 @@ class TemplateResponse extends Response
 {
     /** @var string */
     protected $templateName;
-    /** @var array */
-    protected $context = [];
+    /** @var ImmutableBag */
+    protected $context;
     /** @var array */
     protected $globals = [];
 
     /**
      * Constructor.
      *
-     * @param string $templateName
-     * @param array  $context
-     * @param array  $globals
+     * @param string   $templateName
+     * @param iterable $context
+     * @param array    $globals
      */
-    public function __construct($templateName, array $context = [], array $globals = [])
+    public function __construct($templateName, $context = [], array $globals = [])
     {
         parent::__construct();
         $this->templateName = $templateName;
-        $this->context = $context;
+        $this->setContext($context);
         $this->globals = $globals;
     }
 
@@ -42,7 +44,7 @@ class TemplateResponse extends Response
     }
 
     /**
-     * @return array
+     * @return ImmutableBag
      */
     public function getContext()
     {
@@ -55,5 +57,26 @@ class TemplateResponse extends Response
     public function getGlobals()
     {
         return $this->globals;
+    }
+
+    /**
+     * @param iterable $context
+     */
+    protected function setContext($context)
+    {
+        Assert::isTraversable($context);
+
+        $this->context = ImmutableBag::from($context);
+    }
+
+    /**
+     * Don't call directly.
+     *
+     * @internal
+     */
+    public function __clone()
+    {
+        parent::__clone();
+        $this->context = clone $this->context;
     }
 }

--- a/src/Response/TemplateResponse.php
+++ b/src/Response/TemplateResponse.php
@@ -21,14 +21,33 @@ class TemplateResponse extends Response
     /**
      * Constructor.
      *
-     * @param string   $template
-     * @param iterable $context
+     * @param string   $template The template name
+     * @param iterable $context  The context given to the template
+     * @param mixed    $content  The response content, see setContent()
+     * @param int      $status   The response status code
+     * @param array    $headers  An array of response headers
      */
-    public function __construct($template, $context = [])
+    public function __construct($template, $context = [], $content = '', $status = 200, $headers = [])
     {
-        parent::__construct();
+        parent::__construct($content, $status, $headers);
         $this->template = $template;
         $this->setContext($context);
+    }
+
+    /**
+     * Factory method for chainability.
+     *
+     * @param string   $template The template name
+     * @param iterable $context  The context given to the template
+     * @param mixed    $content  The response content, see setContent()
+     * @param int      $status   The response status code
+     * @param array    $headers  An array of response headers
+     *
+     * @return TemplateResponse
+     */
+    public static function create($template = '', $context = [], $content = '', $status = 200, $headers = [])
+    {
+        return new static($template, $context, $content, $status, $headers);
     }
 
     /**

--- a/src/Response/TemplateView.php
+++ b/src/Response/TemplateView.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Bolt\Response;
+
+use Bolt\Collection\Bag;
+use Webmozart\Assert\Assert;
+
+/**
+ * A view that will be rendered with Twig and converted to a response.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class TemplateView
+{
+    /** @var string */
+    protected $template;
+    /** @var Bag */
+    protected $context;
+
+    /**
+     * Constructor.
+     *
+     * @param string   $template
+     * @param iterable $context
+     */
+    public function __construct($template, $context = [])
+    {
+        $this->setTemplate($template);
+        $this->setContext($context);
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplate()
+    {
+        return $this->template;
+    }
+
+    /**
+     * @param string $template
+     *
+     * @return TemplateView
+     */
+    public function setTemplate($template)
+    {
+        Assert::string($template);
+
+        $this->template = $template;
+
+        return $this;
+    }
+
+    /**
+     * @return Bag
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * @param iterable $context
+     *
+     * @return TemplateView
+     */
+    public function setContext($context)
+    {
+        Assert::isTraversable($context);
+
+        $this->context = Bag::from($context);
+
+        return $this;
+    }
+
+    /**
+     * Don't call directly.
+     *
+     * @internal
+     */
+    public function __clone()
+    {
+        $this->context = clone $this->context;
+    }
+}

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -67,7 +67,7 @@ abstract class BoltUnitTest extends TestCase
     /**
      * @param bool $boot
      *
-     * @return Application
+     * @return \Silex\Application
      */
     protected function getApp($boot = true)
     {
@@ -92,7 +92,7 @@ abstract class BoltUnitTest extends TestCase
     }
 
     /**
-     * @return Application
+     * @return \Silex\Application
      */
     protected function makeApp()
     {

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -62,7 +62,7 @@ class FilesystemManagerTest extends ControllerUnitTest
 
         $this->assertInstanceOf(TemplateResponse::class, $response);
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals('@bolt/async/browse.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/async/browse.twig', $response->getTemplate());
     }
 
     public function testCreateFolder()
@@ -277,7 +277,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $response = $this->controller()->recordBrowser();
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/recordbrowser/recordbrowser.twig', $response->getTemplateName());
+        $this->assertSame('@bolt/recordbrowser/recordbrowser.twig', $response->getTemplate());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 

--- a/tests/phpunit/unit/Controller/Async/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Async/GeneralTest.php
@@ -59,7 +59,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->changeLogRecord('pages', 1);
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/panel-change-record.twig', $response->getTemplateName());
+        $this->assertSame('@bolt/components/panel-change-record.twig', $response->getTemplate());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
@@ -131,7 +131,7 @@ class GeneralTest extends ControllerUnitTest
 
         $response = $this->controller()->dashboardNews($this->getRequest());
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/panel-news.twig', $response->getTemplateName());
+        $this->assertSame('@bolt/components/panel-news.twig', $response->getTemplate());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
@@ -142,7 +142,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->lastModified('page', 1);
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/panel-lastmodified.twig', $response->getTemplateName());
+        $this->assertSame('@bolt/components/panel-lastmodified.twig', $response->getTemplate());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
@@ -153,7 +153,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->latestActivity();
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/panel-activity.twig', $response->getTemplateName());
+        $this->assertSame('@bolt/components/panel-activity.twig', $response->getTemplate());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 

--- a/tests/phpunit/unit/Controller/Async/StackTest.php
+++ b/tests/phpunit/unit/Controller/Async/StackTest.php
@@ -53,7 +53,7 @@ class StackTest extends ControllerUnitTest
         $response = $this->controller()->show(Request::create('/async/stack/show'));
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('@bolt/components/stack/panel.twig', $response->getTemplateName());
+        $this->assertSame('@bolt/components/stack/panel.twig', $response->getTemplate());
         $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 

--- a/tests/phpunit/unit/Controller/Backend/AuthenticationTest.php
+++ b/tests/phpunit/unit/Controller/Backend/AuthenticationTest.php
@@ -83,7 +83,7 @@ class AuthenticationTest extends ControllerUnitTest
         $this->setRequest($request);
         /** @var TemplateResponse $response */
         $response = $this->controller()->postLogin($request);
-        $this->assertEquals('@bolt/login/login.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/login/login.twig', $response->getTemplate());
     }
 
     public function testLoginSuccess()

--- a/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
+++ b/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
@@ -33,7 +33,7 @@ class DatabaseTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/dbcheck'));
 
         $response = $this->controller()->check($this->getRequest());
-        $this->assertEquals('@bolt/dbcheck/dbcheck.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/dbcheck/dbcheck.twig', $response->getTemplate());
     }
 
     public function testUpdate()
@@ -62,7 +62,7 @@ class DatabaseTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/dbupdate_result'));
 
         $response = $this->controller()->updateResult();
-        $this->assertEquals('@bolt/dbcheck/dbcheck.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/dbcheck/dbcheck.twig', $response->getTemplate());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Backend/ExtendTest.php
+++ b/tests/phpunit/unit/Controller/Backend/ExtendTest.php
@@ -36,10 +36,10 @@ class ExtendTest extends ControllerUnitTest
 
         $this->setRequest(Request::create('/bolt/extend'));
         $response = $this->controller()->overview();
-        $this->assertEquals('@bolt/extend/extend.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/extend/extend.twig', $response->getTemplate());
 
         $response = $this->controller()->installPackage();
-        $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplate());
 
         $this->setRequest(Request::create('/', 'GET', ['package' => 'bolt/theme-2014']));
         $controller = $this->getMockBuilder(Extend::class)
@@ -81,7 +81,7 @@ class ExtendTest extends ControllerUnitTest
         $response = $this->controller()->overview();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals('@bolt/extend/extend.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/extend/extend.twig', $response->getTemplate());
     }
 
     public function testInstallPackage()
@@ -93,7 +93,7 @@ class ExtendTest extends ControllerUnitTest
         $response = $this->controller()->installPackage();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
-        $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplate());
     }
 
     public function testInstallInfo()

--- a/tests/phpunit/unit/Controller/Backend/FileManagerTest.php
+++ b/tests/phpunit/unit/Controller/Backend/FileManagerTest.php
@@ -24,7 +24,7 @@ class FileManagerTest extends ControllerUnitTest
         /** @var TemplateResponse $response */
         $response = $this->controller()->edit($this->getRequest(), 'config', 'config.yml');
 
-        $this->assertEquals('@bolt/editfile/editfile.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/editfile/editfile.twig', $response->getTemplate());
     }
 
     public function testManage()
@@ -34,7 +34,7 @@ class FileManagerTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/files'));
 
         $response = $this->controller()->manage($this->getRequest(), 'files', '');
-        $context = $response->getContext()['context'];
+        $context = $response->getContext()->get('context');
 
         /** @var DirectoryInterface $dir */
         $dir = $context['directory'];

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -47,7 +47,7 @@ class GeneralTest extends ControllerUnitTest
 
         $response = $this->controller()->about();
 
-        $this->assertEquals('@bolt/about/about.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/about/about.twig', $response->getTemplate());
     }
 
     public function testClearCache()
@@ -77,12 +77,12 @@ class GeneralTest extends ControllerUnitTest
             ->method('success');
 
         $response = $this->controller()->clearCache();
-        $this->assertEquals('@bolt/clearcache/clearcache.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/clearcache/clearcache.twig', $response->getTemplate());
 
         $this->setRequest(Request::create('/bolt/clearcache'));
 
         $response = $this->controller()->clearCache();
-        $this->assertEquals('@bolt/clearcache/clearcache.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/clearcache/clearcache.twig', $response->getTemplate());
     }
 
     public function testDashboard()
@@ -91,7 +91,7 @@ class GeneralTest extends ControllerUnitTest
 
         $response = $this->controller()->dashboard();
 
-        $this->assertEquals('@bolt/dashboard/dashboard.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/dashboard/dashboard.twig', $response->getTemplate());
         $context = $response->getContext();
         $this->assertArrayHasKey('context', $context);
         $this->assertArrayHasKey('latest', $context['context']);
@@ -105,7 +105,7 @@ class GeneralTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/omnisearch', 'GET', ['q' => 'test']));
 
         $response = $this->controller()->omnisearch($this->getRequest());
-        $this->assertEquals('@bolt/omnisearch/omnisearch.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/omnisearch/omnisearch.twig', $response->getTemplate());
     }
 
     public function testPrefill()
@@ -161,7 +161,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->translation($this->getRequest(), 'contenttypes', 'en_CY');
 
         $this->assertTrue($response instanceof TemplateResponse, 'Response is not instance of TemplateResponse');
-        $this->assertEquals('@bolt/editlocale/editlocale.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/editlocale/editlocale.twig', $response->getTemplate());
         $context = $response->getContext();
         $this->assertEquals('contenttypes.en_CY.yml', $context['context']['basename']);
 

--- a/tests/phpunit/unit/Controller/Backend/LogTest.php
+++ b/tests/phpunit/unit/Controller/Backend/LogTest.php
@@ -51,7 +51,7 @@ class LogTest extends ControllerUnitTest
 
         $this->setRequest(Request::create('/bolt/changelog'));
         $response = $this->controller()->changeOverview($this->getRequest());
-        $this->assertEquals('@bolt/activity/changelog.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/activity/changelog.twig', $response->getTemplate());
     }
 
     public function testChangeRecord()
@@ -195,7 +195,7 @@ class LogTest extends ControllerUnitTest
 
         $this->setRequest(Request::create('/bolt/systemlog'));
         $response = $this->controller()->systemOverview($this->getRequest());
-        $this->assertEquals('@bolt/activity/systemlog.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/activity/systemlog.twig', $response->getTemplate());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Backend/UsersTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UsersTest.php
@@ -279,7 +279,7 @@ class UsersTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/profile'));
         $response = $this->controller()->profile($this->getRequest());
         $context = $response->getContext();
-        $this->assertEquals('@bolt/edituser/edituser.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/edituser/edituser.twig', $response->getTemplate());
         $this->assertEquals('profile', $context['context']['kind']);
 
         // Now try a POST to update the profile
@@ -339,7 +339,7 @@ class UsersTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/roles'));
         $response = $this->controller()->viewRoles();
         $context = $response->getContext();
-        $this->assertEquals('@bolt/roles/roles.twig', $response->getTemplateName());
+        $this->assertEquals('@bolt/roles/roles.twig', $response->getTemplate());
         $this->assertNotEmpty($context['context']['global_permissions']);
         $this->assertNotEmpty($context['context']['effective_permissions']);
     }

--- a/tests/phpunit/unit/Controller/ControllerUnitTest.php
+++ b/tests/phpunit/unit/Controller/ControllerUnitTest.php
@@ -31,6 +31,11 @@ abstract class ControllerUnitTest extends BoltUnitTest
         return $this->getApp()->offsetGet('request');
     }
 
+    /**
+     * @inheritdoc
+     *
+     * @return \Silex\Application
+     */
     protected function getApp($boot = true)
     {
         if (!$this->app) {
@@ -43,7 +48,6 @@ abstract class ControllerUnitTest extends BoltUnitTest
     protected function makeApp()
     {
         $app = parent::makeApp();
-        $app->initialize();
 
         $verifier = new Validator(
             $app['config'],

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -80,7 +80,7 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/'));
 
         $response = $this->controller()->homepage($this->getRequest());
-        $globals = $response->getGlobals();
+        $globals = $this->getTwigGlobals();
 
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertInstanceOf(Content::class, $globals['record']);
@@ -92,7 +92,9 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/'));
         $app['config']->set('general/homepage', 'pages');
 
-        $globals = $this->controller()->homepage($this->getRequest())->getGlobals();
+        $this->controller()->homepage($this->getRequest());
+
+        $globals = $this->getTwigGlobals();
         foreach ($globals['records'] as $record) {
             $this->assertInstanceOf(Content::class, $record);
         }
@@ -111,7 +113,6 @@ class FrontendTest extends ControllerUnitTest
 
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertSame('page.twig', $response->getTemplate());
-        $this->assertNotEmpty($response->getGlobals());
     }
 
     /**
@@ -197,8 +198,6 @@ class FrontendTest extends ControllerUnitTest
 
     public function testNumericRecord()
     {
-        /** @var \Silex\Application $app */
-        $app = $this->getApp();
         $this->setService('twig.runtime.bolt_html', $this->getHtmlRuntime());
 
         $this->setRequest(Request::create('/pages/', 'GET', ['id' => 5]));
@@ -221,7 +220,6 @@ class FrontendTest extends ControllerUnitTest
 
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertSame('page.twig', $response->getTemplate());
-        $this->assertNotEmpty($response->getGlobals());
     }
 
     /**
@@ -293,9 +291,6 @@ class FrontendTest extends ControllerUnitTest
         $this->controller()->record($this->getRequest(), 'pages', 'test');
     }
 
-    /**
-     * @runInSeparateProcess
-     **/
     public function testPreview()
     {
         $this->setRequest(Request::create('/pages'));
@@ -317,7 +312,6 @@ class FrontendTest extends ControllerUnitTest
 
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertSame('record.twig', $response->getTemplate());
-        $this->assertNotEmpty($response->getGlobals());
     }
 
     public function testListing()
@@ -327,7 +321,6 @@ class FrontendTest extends ControllerUnitTest
 
         $this->assertSame('listing.twig', $response->getTemplate());
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertNotEmpty($response->getGlobals());
     }
 
     /**
@@ -374,7 +367,6 @@ class FrontendTest extends ControllerUnitTest
 
         $response = $this->controller()->taxonomy($this->getRequest(), 'tags', 'fake');
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertNotEmpty($response->getGlobals());
     }
 
     public function testTaxonomyListing()
@@ -386,7 +378,6 @@ class FrontendTest extends ControllerUnitTest
 
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertSame('listing.twig', $response->getTemplate());
-        $this->assertNotEmpty($response->getGlobals());
     }
 
     public function testSimpleTemplateRender()
@@ -416,7 +407,6 @@ class FrontendTest extends ControllerUnitTest
 
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertSame('search.twig', $response->getTemplate());
-        $this->assertNotEmpty($response->getGlobals());
     }
 
     public function testSearchWithFilters()
@@ -432,7 +422,6 @@ class FrontendTest extends ControllerUnitTest
 
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertSame('search.twig', $response->getTemplate());
-        $this->assertNotEmpty($response->getGlobals());
     }
 
     public function testBeforeHandlerForFirstUser()
@@ -511,5 +500,12 @@ class FrontendTest extends ControllerUnitTest
     protected function controller()
     {
         return $this->getService('controller.frontend');
+    }
+
+    protected function getTwigGlobals()
+    {
+        $app = $this->getApp();
+
+        return $app['twig']->getGlobals();
     }
 }

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -49,7 +49,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->homepage($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('index.twig', $response->getTemplateName());
+        $this->assertSame('index.twig', $response->getTemplate());
     }
 
     public function testConfiguredConfigHomepageTemplate()
@@ -60,7 +60,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->homepage($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('index.twig', $response->getTemplateName());
+        $this->assertSame('index.twig', $response->getTemplate());
     }
 
     public function testConfiguredThemeHomepageTemplate()
@@ -72,7 +72,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->homepage($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('custom-home.twig', $response->getTemplateName());
+        $this->assertSame('custom-home.twig', $response->getTemplate());
     }
 
     public function testHomepageContent()
@@ -110,7 +110,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->record($request, 'pages', 'test');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('page.twig', $response->getTemplateName());
+        $this->assertSame('page.twig', $response->getTemplate());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -220,7 +220,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->record($this->getRequest(), 'pages', 5);
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('page.twig', $response->getTemplateName());
+        $this->assertSame('page.twig', $response->getTemplate());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -316,7 +316,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->preview($this->getRequest(), 'pages');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('record.twig', $response->getTemplateName());
+        $this->assertSame('record.twig', $response->getTemplate());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -325,7 +325,7 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/pages'));
         $response = $this->controller()->listing($this->getRequest(), 'pages');
 
-        $this->assertSame('listing.twig', $response->getTemplateName());
+        $this->assertSame('listing.twig', $response->getTemplate());
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertNotEmpty($response->getGlobals());
     }
@@ -385,7 +385,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->taxonomy($this->getRequest(), 'categories', 'news');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('listing.twig', $response->getTemplateName());
+        $this->assertSame('listing.twig', $response->getTemplate());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -396,7 +396,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->template('index');
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('index.twig', $response->getTemplateName());
+        $this->assertSame('index.twig', $response->getTemplate());
     }
 
     /**
@@ -415,7 +415,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->search($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('search.twig', $response->getTemplateName());
+        $this->assertSame('search.twig', $response->getTemplate());
         $this->assertNotEmpty($response->getGlobals());
     }
 
@@ -431,7 +431,7 @@ class FrontendTest extends ControllerUnitTest
         $response = $this->controller()->search($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('search.twig', $response->getTemplateName());
+        $this->assertSame('search.twig', $response->getTemplate());
         $this->assertNotEmpty($response->getGlobals());
     }
 

--- a/tests/phpunit/unit/Response/TemplateResponseTest.php
+++ b/tests/phpunit/unit/Response/TemplateResponseTest.php
@@ -19,14 +19,12 @@ class TemplateResponseTest extends BoltUnitTest
         $template = $twig->resolveTemplate('error.twig');
 
         $context = ['foo' => 'bar'];
-        $globals = ['hello' => 'world'];
-        $response = new TemplateResponse($template, $context, $globals);
+        $response = new TemplateResponse($template, $context);
 
         $this->assertInstanceOf(TemplateResponse::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('error.twig', $response->getTemplate());
         $this->assertInstanceOf(ImmutableBag::class, $response->getContext());
         $this->assertEquals($context, $response->getContext()->toArray());
-        $this->assertEquals($globals, $response->getGlobals());
     }
 }

--- a/tests/phpunit/unit/Response/TemplateResponseTest.php
+++ b/tests/phpunit/unit/Response/TemplateResponseTest.php
@@ -15,15 +15,27 @@ class TemplateResponseTest extends BoltUnitTest
 {
     public function testCreate()
     {
-        $twig = new \Twig_Environment(new \Twig_Loader_Array(['error.twig' => '']));
-        $template = $twig->resolveTemplate('error.twig');
-
+        $template = 'error.twig';
         $context = ['foo' => 'bar'];
-        $response = new TemplateResponse($template, $context);
 
+        $response = new TemplateResponse($template, $context);
+        $this->assertResponse($response, $template, $context);
+
+        $response = TemplateResponse::create($template, $context);
+        $this->assertResponse($response, $template, $context);
+    }
+
+    /**
+     * @param TemplateResponse $response
+     * @param string           $template
+     * @param array            $context
+     * @param int              $status
+     */
+    protected function assertResponse($response, $template, $context, $status = 200)
+    {
         $this->assertInstanceOf(TemplateResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('error.twig', $response->getTemplate());
+        $this->assertEquals($status, $response->getStatusCode());
+        $this->assertEquals($template, $response->getTemplate());
         $this->assertInstanceOf(ImmutableBag::class, $response->getContext());
         $this->assertEquals($context, $response->getContext()->toArray());
     }

--- a/tests/phpunit/unit/Response/TemplateResponseTest.php
+++ b/tests/phpunit/unit/Response/TemplateResponseTest.php
@@ -24,7 +24,7 @@ class TemplateResponseTest extends BoltUnitTest
 
         $this->assertInstanceOf(TemplateResponse::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('error.twig', $response->getTemplateName());
+        $this->assertEquals('error.twig', $response->getTemplate());
         $this->assertInstanceOf(ImmutableBag::class, $response->getContext());
         $this->assertEquals($context, $response->getContext()->toArray());
         $this->assertEquals($globals, $response->getGlobals());

--- a/tests/phpunit/unit/Response/TemplateResponseTest.php
+++ b/tests/phpunit/unit/Response/TemplateResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Response;
 
+use Bolt\Collection\ImmutableBag;
 use Bolt\Response\TemplateResponse;
 use Bolt\Tests\BoltUnitTest;
 
@@ -24,7 +25,8 @@ class TemplateResponseTest extends BoltUnitTest
         $this->assertInstanceOf(TemplateResponse::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('error.twig', $response->getTemplateName());
-        $this->assertEquals($context, $response->getContext());
+        $this->assertInstanceOf(ImmutableBag::class, $response->getContext());
+        $this->assertEquals($context, $response->getContext()->toArray());
         $this->assertEquals($globals, $response->getGlobals());
     }
 }

--- a/tests/phpunit/unit/Response/TemplateViewTest.php
+++ b/tests/phpunit/unit/Response/TemplateViewTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Bolt\Tests\Response;
+
+use Bolt\Collection\Bag;
+use Bolt\Response\TemplateView;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class TemplateViewTest extends TestCase
+{
+    public function testTemplate()
+    {
+        $view = new TemplateView('foo.twig');
+
+        $this->assertSame('foo.twig', $view->getTemplate());
+
+        $view->setTemplate('bar.twig');
+
+        $this->assertSame('bar.twig', $view->getTemplate());
+    }
+
+    public function testContext()
+    {
+        $view = new TemplateView('', ['foo' => 'bar']);
+
+        $this->assertInstanceOf(Bag::class, $view->getContext());
+        $this->assertSame('bar', $view->getContext()->get('foo'));
+
+        $view->setContext(['hello' => 'world']);
+        $this->assertInstanceOf(Bag::class, $view->getContext());
+        $this->assertEquals(['hello' => 'world'], $view->getContext()->toArray());
+
+        $view->setContext(Bag::from(['foo' => 'bar']));
+        $this->assertEquals(['foo' => 'bar'], $view->getContext()->toArray());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testTemplateBadConstructor()
+    {
+        new TemplateView(false);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testTemplateBadSetter()
+    {
+        $view = new TemplateView('');
+
+        $view->setTemplate(false);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testContextBadConstructor()
+    {
+        new TemplateView('', false);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testContextBadSetter()
+    {
+        $view = new TemplateView('');
+
+        $view->setContext(false);
+    }
+}


### PR DESCRIPTION
In regards to #6382

Working on how this can be done without breaking BC, but it's proving challenging.

The only response method called in Frontend was the `X-XSS-Protection` header in record route. So I moved it out.

Now you can do something like:
```php
class MyFrontend extends Frontend
{
    protected function render($template, array $context = [], array $globals = [])
    {
        return new TemplateView($template, array_replace($context, $globals));
    }
}
```

and then replace the `controller.frontend` service with that class.


Open to ideas about how to integrate this further. I don't think changing `Controller\Base::render` directly is wise though, since others can base their controllers on it. But maybe if it's something just for Frontend / Backend classes that would be ok. I'm not sure if a separate shortcut even makes much since given how terse the line actually is.