### PR TITLE
[3.2][Scrutinizer] Remove unused metrics

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -22,8 +22,6 @@ tools:
         filter:
             paths:
                 - src/
-#    external_code_coverage:
-#        timeout: 1200
 build_failure_conditions:
 #   - 'elements.rating(<= D).exists'               # No classes/methods with a rating of D or worse
     - 'elements.rating(<= D).new.exists'           # No new classes/methods with a rating of D or worse
@@ -35,12 +33,4 @@ build_failure_conditions:
     - 'issues.severity(>= MAJOR).new.exists'       # New issues of major or higher severity
 
     # Note that this should be increased when we get our quality socre up
-    - 'project.metric("scrutinizer.quality", < 5.0)'        # Code Quality Rating drops below 6
-    - 'project.metric("scrutinizer.test_coverage", < 0.60)' # Code Coverage drops below 60%
-
-    # Code Coverage decreased from previous inspection
-    - 'project.metric_change("scrutinizer.test_coverage", < 0)'
-
-    # Code Coverage decreased from previous inspection by more than 10%
-    - 'project.metric_change("scrutinizer.test_coverage", < -0.10)'
-
+    - 'project.metric("scrutinizer.quality", < 8.0)'        # Code Quality Rating drops below 8


### PR DESCRIPTION
The Bolt org repo hasn't used Scrutinizer for a while, and we've almost finished a cut over to CodeClimate, however I am still running it on my own fork as part of the comparative analysis during said cut-over.

This just removes a little noise from my view while I work on it, and shortly we can just delete this file completely.