### PR TITLE
[3.3] Throw an exception when a collection is created missing a handler

### DIFF
--- a/src/Storage/Collection/CollectionManager.php
+++ b/src/Storage/Collection/CollectionManager.php
@@ -3,6 +3,7 @@
 namespace Bolt\Storage\Collection;
 
 use Bolt\Storage\EntityManager;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Collection Manager class
@@ -33,10 +34,19 @@ class CollectionManager
         $this->em = $em;
     }
 
+    /**
+     * @param string $class
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return ArrayCollection
+     */
     public function create($class)
     {
-        if (isset($this->collections[$class])) {
-            return call_user_func($this->collections[$class]);
+        if (!isset($this->collections[$class])) {
+            throw new \InvalidArgumentException(sprintf('No collection handler exists for %s', $class));
         }
+
+        return call_user_func($this->collections[$class]);
     }
 }


### PR DESCRIPTION
\Bolt\Storage\Collection\CollectionManager::create() is called from:
  * \Bolt\Storage\Field\Type\TaxonomyType::persist()
  * \Bolt\Storage\EntityManager::createCollection()

All callers demand an object ot be returned an none of them do, or should have to, check if anything is returned, leading potentially to vague exceptions conditions.

… Smoke 'em if ya got 'em