### PR TITLE
The continued war on slugs

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2598,7 +2598,11 @@ class Storage
 
         // Get the contenttype from first $content
         $first = reset($content);
-        $contenttypeslug = $first->contenttype['slug'];
+        // Try with the key first, if this isn't available then fall back to using the slug
+        $contenttypeslug = $first->contenttype['key'];
+        if ($contenttypeslug === null) {
+            $contenttypeslug = $first->contenttype['slug'];
+        }
         $contenttype = $this->getContentType($contenttypeslug);
         $repo = $this->app['storage']->getRepository('Bolt\Storage\Entity\FieldValue');
 

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2599,10 +2599,7 @@ class Storage
         // Get the contenttype from first $content
         $first = reset($content);
         // Try with the key first, if this isn't available then fall back to using the slug
-        $contenttypeslug = $first->contenttype['key'];
-        if ($contenttypeslug === null) {
-            $contenttypeslug = $first->contenttype['slug'];
-        }
+        $contenttypeslug = (isset($first->contenttype['key'])) ? $first->contenttype['key'] : $first->contenttype['slug'] ;
         $contenttype = $this->getContentType($contenttypeslug);
         $repo = $this->app['storage']->getRepository('Bolt\Storage\Entity\FieldValue');
 


### PR DESCRIPTION
Fixes #6438

The legacy patch that fills in repeaters to old content objects was slacking on the job. We should give priority to the contenttype 'key' property only falling back to the slug if the key isn't set (which also means that the slug is the same as the key)