### PR TITLE
Ensure fields are using new interface before calling methods

### DIFF
--- a/src/Storage/Entity/Builder.php
+++ b/src/Storage/Entity/Builder.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Storage\Entity;
 
+use Bolt\Storage\Field\Type\FieldTypeInterface;
 use Bolt\Storage\FieldManager;
 use Bolt\Storage\Mapping\ClassMetadata;
 use Bolt\Storage\Mapping\MetadataDriver;
@@ -162,7 +163,9 @@ class Builder
         // set fields
         foreach ((array) $fields as $key => $mapping) {
             $fieldType = $this->fieldManager->get($mapping['fieldtype'], $mapping);
-            call_user_func_array([$fieldType, 'hydrate'], [$data, $entity]);
+            if ($fieldType instanceof FieldTypeInterface) {
+                call_user_func_array([$fieldType, 'hydrate'], [$data, $entity]);
+            }
         }
 
         return $entity;

--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -8,6 +8,7 @@ use Bolt\Events\StorageEvent;
 use Bolt\Events\StorageEvents;
 use Bolt\Storage\Entity\Builder;
 use Bolt\Storage\Entity\Entity;
+use Bolt\Storage\Field\Type\FieldTypeInterface;
 use Bolt\Storage\Mapping\ClassMetadata;
 use Bolt\Storage\Query\QueryInterface;
 use Doctrine\Common\Persistence\ObjectRepository;
@@ -307,7 +308,9 @@ class Repository implements ObjectRepository
             }
 
             $field = $this->getFieldManager()->get($field['fieldtype'], $field);
-            $field->persist($queries, $entity);
+            if ($field instanceof FieldTypeInterface) {
+                $field->persist($queries, $entity);
+            }
         }
     }
 

--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -262,7 +262,9 @@ class Repository implements ObjectRepository
         $metadata = $this->getClassMetadata();
         foreach ($metadata->getFieldMappings() as $field) {
             $fieldtype = $this->getFieldManager()->get($field['fieldtype'], $field);
-            $fieldtype->load($query, $metadata);
+            if ($fieldtype instanceof FieldTypeInterface) {
+                $fieldtype->load($query, $metadata);
+            }
         }
     }
 
@@ -279,7 +281,9 @@ class Repository implements ObjectRepository
 
         foreach ($metadata->getFieldMappings() as $field) {
             $fieldtype = $this->getFieldManager()->get($field['fieldtype'], $field);
-            $fieldtype->query($query, $metadata);
+            if ($fieldtype instanceof FieldTypeInterface) {
+                $fieldtype->query($query, $metadata);
+            }
         }
     }
 


### PR DESCRIPTION
This ensures that custom fields that are still using the old interface don't break by wrapping the specific method calls in an `instanceof FieldTypeInterface` check.

Fixes #6420
Also fixes #6273 