### PR TITLE
Allow an initial number to be passed in the repeater field config

### DIFF
--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -3,7 +3,7 @@
 
 {% set data_bolt_widget = {
     fieldRepeater: {
-        minimum: 1,
+        minimum: field.initial|default(1),
         maximum: field.limit|default(0),
         name:    name,
     }


### PR DESCRIPTION
As a corresponding configuration to the existing `limit` option this introduces support for the `initial` value to be set.

The current default is 1, which replicates the current behaviour of showing an empty set when a record has no repeaters set.

This is useful as described in #6378 where sets have required fields but you don't want to force at least one set.

Field configuration will look like this:

```yaml
        images:
            type: repeater
            initial: 0
            limit: 10
            separator: true
            fields:
                repeattitle:
                    type: text
                    required: true
                repeatimage:
                    type: image
```