### PR TITLE
Update DatabaseExceptionTrait.php

### DIFF
--- a/src/Exception/Database/DatabaseExceptionTrait.php
+++ b/src/Exception/Database/DatabaseExceptionTrait.php
@@ -7,7 +7,7 @@ trait DatabaseExceptionTrait
     /** @var string */
     protected $driver;
 
-    private static $driverNames = [
+    protected static $driverNames = [
         'pdo_mysql'   => 'MySQL',
         'mysql'       => 'MySQL',
         'mysql2'      => 'MySQL',


### PR DESCRIPTION
I ran into an error when I'd configured a wrong database name for a mysql database. This threw an exception as expected but the exception threw an error because it could not access the `$driveNames` property. I could fix this by setting the visibility to protected.
