### PR TITLE
[WIP] Api compatibility with legacy content objects

### DIFF
--- a/src/Storage/Entity/FieldValue.php
+++ b/src/Storage/Entity/FieldValue.php
@@ -135,4 +135,14 @@ class FieldValue extends Entity
         $typeCol = 'value_' . $type->getName();
         $this->$typeCol = $this->getValue();
     }
+
+    /** Alias to the standard get method that matches compatibility with the Legacy content entity
+     *  This can be removed once the deprecation of legacy content is complete.
+     * 
+     * @return mixed
+     */
+    public function getDecodedValue()
+    {
+        return $this->getValue();
+    }
 }

--- a/src/Storage/Entity/FieldValue.php
+++ b/src/Storage/Entity/FieldValue.php
@@ -136,14 +136,4 @@ class FieldValue extends Entity
         $this->$typeCol = $this->getValue();
     }
 
-    /**
-     *  Alias to the standard get method that matches compatibility with the Legacy content entity.
-     *  This can be removed once the deprecation of legacy content is complete.
-     *
-     * @return mixed
-     */
-    public function getDecodedValue()
-    {
-        return $this->getValue();
-    }
 }

--- a/src/Storage/Entity/FieldValue.php
+++ b/src/Storage/Entity/FieldValue.php
@@ -136,9 +136,10 @@ class FieldValue extends Entity
         $this->$typeCol = $this->getValue();
     }
 
-    /** Alias to the standard get method that matches compatibility with the Legacy content entity
+    /**
+     *  Alias to the standard get method that matches compatibility with the Legacy content entity.
      *  This can be removed once the deprecation of legacy content is complete.
-     * 
+     *
      * @return mixed
      */
     public function getDecodedValue()

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -129,7 +129,7 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
      */
     public function getFieldType($fieldName)
     {
-        $field = $this->get($fieldName);
+        $field = parent::get($fieldName);
         if ($field) {
             return $field->getFieldType();
         }

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -120,4 +120,18 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
     {
         return parent::getIterator();
     }
+
+    /**
+     * Returns the type of a given $fieldName
+     *
+     * @param $fieldName
+     * @return string|null
+     */
+    public function getFieldType($fieldName)
+    {
+        $field = $this->get($fieldName);
+        if ($field) {
+            return $field->getFieldType();
+        }
+    }
 }

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -134,4 +134,17 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
             return $field->getFieldType();
         }
     }
+
+    /**
+     *  Alias to the standard get method that matches compatibility with the Legacy content entity.
+     *  This can be removed once the deprecation of legacy content is complete.
+     *
+     * @param $fieldName
+     * @return mixed
+     */
+    public function getDecodedValue($fieldName)
+    {
+        return $this->get($fieldName);
+    }
+
 }

--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -68,6 +68,19 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
     }
 
     /**
+     * Returns the type of a given $fieldName
+     *
+     * @param $fieldName
+     * @return string|null
+     */
+    public function getFieldType($fieldName)
+    {
+        $this->initialize();
+
+        return $this->collection->getFieldType($fieldName);
+    }
+
+    /**
      * Handles the conversion of references to entities.
      */
     protected function doInitialize()

--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -81,6 +81,20 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
     }
 
     /**
+     *  Alias to the standard get method that matches compatibility with the Legacy content entity.
+     *  This can be removed once the deprecation of legacy content is complete.
+     *
+     * @param $fieldName
+     * @return mixed
+     */
+    public function getDecodedValue($fieldName)
+    {
+        $this->initialize();
+
+        return $this->collection->getDecodedValue($fieldName);
+    }
+
+    /**
      * Handles the conversion of references to entities.
      */
     protected function doInitialize()


### PR DESCRIPTION
As agreed this PR adds one method to each of the Repeater collection and Repeater field objects.

It matches the API of dealing with existing content items.

