### PR TITLE
🚧 🔨 Fix/clean up  sub fields

### DIFF
--- a/app/theme_defaults/_sub_fields.twig
+++ b/app/theme_defaults/_sub_fields.twig
@@ -32,7 +32,7 @@
 
 {# Output a text-like field with the wrapper for live editing. #}
 {% macro textfield(object, key) %}
-    <div data-bolt-field="{{key}}">{{ object.decodedValue(key) }}</div>
+    <div data-bolt-field="{{key}}">{{ object.renderedValue(key) }}</div>
 {% endmacro %}
 
 {% macro imagelistfield(images) %}

--- a/app/theme_defaults/_sub_fields.twig
+++ b/app/theme_defaults/_sub_fields.twig
@@ -30,15 +30,9 @@
 
 {# SECTION 2: MACROS #}
 
-{# If 'allowtwig' is true for this field, we'll need to parse it as
-   Twig here. Note, that we're doing this inside a macro, so the
-   snippet has a limited scope. No global variables, etc. #}
-{% macro parsetextfield(key, value, contenttype) %}
-    {% if contenttype.fields[key].allowtwig is defined and contenttype.fields[key].allowtwig == true %}
-        {% set value = include(template_from_string(value), sandboxed = true) %}
-    {% endif %}
-
-    <div {% if key is not empty %}data-bolt-field="{{key}}"{% endif %}>{{ value }}</div>
+{# Output a text-like field with the wrapper for live editing. #}
+{% macro textfield(object, key) %}
+    <div data-bolt-field="{{key}}">{{ object.decodedValue(key) }}</div>
 {% endmacro %}
 
 {% macro imagelistfield(images) %}
@@ -52,17 +46,15 @@
 {% endmacro %}
 
 {# Macro for "basic" fields like HTML, Markdown, Textarea and Text #}
-{% macro commonfields(key, value, fieldtype, contenttype) %}
+{% macro commonfield(object, key) %}
         {% import _self as macro %}
 
-        {# HTML, Textarea, Text fields #}
-        {% if fieldtype in ['html', 'textarea', 'text'] %}
-            {{ macro.parsetextfield(key, value, contenttype) }}
-        {% endif %}
+        {% set fieldtype = object.fieldtype(key) %}
+        {% set value = object.get(key) %}
 
-        {# Markdown fields #}
-        {% if fieldtype == "markdown" %}
-            {{ macro.parsetextfield(key, value|markdown, contenttype) }}
+        {# HTML, Textarea, Text and Markdown fields #}
+        {% if fieldtype in ['html', 'textarea', 'text', 'markdown'] %}
+            {{ macro.textfield(object, key) }}
         {% endif %}
 
         {# Image fields #}
@@ -80,7 +72,11 @@
 {% endmacro %}
 
 {# Macro for other field types, like Geo, Select, Checkbox and others. #}
-{% macro extendedfields(key, value, fieldtype) %}
+{% macro extendedfield(object, key) %}
+        {% import _self as macro %}
+
+        {% set fieldtype = object.fieldtype(key) %}
+        {% set value = object.get(key) %}
 
         {# Geolocation field #}
         {% if fieldtype == "geolocation" and value.latitude is defined %}
@@ -128,54 +124,30 @@
     {# Fields that are considered 'common': 'html', 'markdown', 'textarea',
        'text', 'image', 'video' and 'imagelist' #}
     {% if common == true %}
-
-        {% set fieldtype = record.fieldtype(key) %}
-        {{ macro.commonfields(key, value, fieldtype, record.contenttype) }}
-
+        {{ macro.commonfield(record, key) }}
     {% endif %}
 
     {# The rest of the built-in fieldtypes #}
     {% if extended == true %}
-
-        {% set fieldtype = record.fieldtype(key) %}
-        {{ macro.extendedfields(key, value, fieldtype) }}
-
+        {{ macro.extendedfield(record, key) }}
     {% endif %}
 
     {# Finally, the repeaters #}
     {% if repeaters == true and record.fieldtype(key) == "repeater" %}
-
         {% for repeater in value %}
-
-            {% for repeaterfield in repeater %}
-
-                {% set fieldtype = repeaterfield.getFieldtype() %}
-                {% set value = repeaterfield.getValue() %}
-                {{ macro.commonfields('', value, fieldtype, record.contenttype) }}
-                {{ macro.extendedfields('', value, fieldtype) }}
-
+            {% for key, repeaterfield in repeater %}
+                {{ macro.commonfield(repeater, key) }}
+                {{ macro.extendedfield(repeater, key) }}
             {% endfor %}
-
         {% endfor %}
-
     {% endif %}
 
 {% endfor %}
 
-{# We do the same for the templatefields, if set and not empty. #}
-{% set templatefields = record.values.templatefields.values|default() %}
-{% if templatefields is defined and templatefields is not empty %}
-
-    {# Note: This needs to be expanded upon!! For better detection the 'virtual'
-       contenttype for the templatefields should know about the types of fields. #}
-    {% set templatefieldsfieldtypes = attribute(record.contenttype.templatefields|first, 'fields') %}
-
-    {% for key, value in templatefields if (key not in omittedkeys) %}
-
-        {% set fieldtype = attribute(attribute(templatefieldsfieldtypes, key), 'type')  %}
-        {{ macro.commonfields(key, value, fieldtype, record.contenttype) }}
-        {{ macro.extendedfields(key, value, fieldtype) }}
-
+{# We do the same for the templatefields, if there are any. #}
+{% if record.templatefields %}
+    {% for key, value in record.templatefields.values if (key not in omittedkeys) %}
+        {{ macro.commonfield(record.templatefields, key) }}
+        {{ macro.extendedfield(record.templatefields, key) }}
     {% endfor %}
-
 {% endif %}

--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -193,6 +193,18 @@ class Content implements \ArrayAccess
     }
 
     /**
+     * @internal Forward comparability for to forward legacy calls to getDecodedValue()
+     *
+     * @param string $fieldName
+     *
+     * @return mixed
+     */
+    public function getRenderedValue($fieldName)
+    {
+        return $this->getDecodedValue($fieldName);
+    }
+
+    /**
      * If passed snippet contains Twig tags, parse the string as Twig, and return the results.
      *
      * @param string  $snippet

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -120,4 +120,32 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
     {
         return parent::getIterator();
     }
+
+    /**
+     * Returns the type of a given $fieldName
+     *
+     * @param $fieldName
+     * @return string|null
+     */
+    public function getFieldType($fieldName)
+    {
+        $field = parent::get($fieldName);
+
+        if ($field) {
+            return $field->getFieldType();
+        }
+    }
+
+    /**
+     *  Alias to the standard get method that matches compatibility with the Legacy content entity.
+     *  This can be removed once the deprecation of legacy content is complete.
+     *
+     * @param $fieldName
+     * @return mixed
+     */
+    public function getDecodedValue($fieldName)
+    {
+        return $this->get($fieldName);
+    }
+
 }

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -123,10 +123,7 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
     }
 
     /**
-     * Returns the type of a given $fieldName
-     *
-     * @param $fieldName
-     * @return string|null
+     * {@inheritdoc}
      */
     public function getFieldType($fieldName)
     {
@@ -138,12 +135,7 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
     }
 
     /**
-     * Alias to the standard get method that matches compatibility with the Legacy
-     * content entity. This can be refactored to something better, once the
-     * deprecation of legacy content is complete.
-     *
-     * @param $fieldName
-     * @return mixed
+     * {@inheritdoc}
      */
     public function getDecodedValue($fieldName)
     {

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -132,6 +132,8 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
         if ($field) {
             return $field->getFieldType();
         }
+
+        return null;
     }
 
     /**
@@ -139,16 +141,21 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
      */
     public function getDecodedValue($fieldName)
     {
-        $fieldType = $this->getFieldType($fieldName);
+        $field = parent::get($fieldName);
 
-        $value = $this->get($fieldName);
+        if (!$field instanceof FieldValue) {
+            return null;
+        }
 
-        if ($fieldType == 'markdown') {
+        $fieldType = $field->getFieldType();
+        $value = $field->getValue();
+
+        if ($fieldType === 'markdown') {
             $markdown = new Markdown();
             $value = $markdown->text($value);
         }
 
-        if (in_array($fieldType, ['markdown', 'html', 'text', 'textarea'])) {
+        if (in_array($fieldType, ['markdown', 'html', 'text', 'textarea'], true)) {
             $value = new \Twig_Markup($value, 'UTF-8');
         }
 

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -4,6 +4,7 @@ namespace Bolt\Storage\Field\Collection;
 
 use Bolt\Storage\Entity\FieldValue;
 use Doctrine\Common\Collections\ArrayCollection;
+use ParsedownExtra as Markdown;
 use Webmozart\Assert\Assert;
 
 /**
@@ -137,15 +138,29 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
     }
 
     /**
-     *  Alias to the standard get method that matches compatibility with the Legacy content entity.
-     *  This can be removed once the deprecation of legacy content is complete.
+     * Alias to the standard get method that matches compatibility with the Legacy
+     * content entity. This can be refactored to something better, once the
+     * deprecation of legacy content is complete.
      *
      * @param $fieldName
      * @return mixed
      */
     public function getDecodedValue($fieldName)
     {
-        return $this->get($fieldName);
+        $fieldType = $this->getFieldType($fieldName);
+
+        $value = $this->get($fieldName);
+
+        if ($fieldType == 'markdown') {
+            $markdown = new Markdown();
+            $value = $markdown->text($value);
+        }
+
+        if (in_array($fieldType, ['markdown', 'html', 'text', 'textarea'])) {
+            $value = new \Twig_Markup($value, 'UTF-8');
+        }
+
+        return $value;
     }
 
 }

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -139,7 +139,7 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
     /**
      * {@inheritdoc}
      */
-    public function getDecodedValue($fieldName)
+    public function getRenderedValue($fieldName)
     {
         $field = parent::get($fieldName);
 

--- a/src/Storage/Field/Collection/FieldCollectionInterface.php
+++ b/src/Storage/Field/Collection/FieldCollectionInterface.php
@@ -48,4 +48,22 @@ interface FieldCollectionInterface extends Collection
      * @return \Iterator|FieldValue[]
      */
     public function getIterator();
+
+    /**
+     * Returns the type of a given $fieldName
+     *
+     * @param $fieldName
+     * @return string|null
+     */
+    public function getFieldType($fieldName);
+
+    /**
+     * Alias to the standard get method that matches compatibility with the Legacy
+     * content entity. This can be refactored to something better, once the
+     * deprecation of legacy content is complete.
+     *
+     * @param $fieldName
+     * @return mixed
+     */
+    public function getDecodedValue($fieldName);
 }

--- a/src/Storage/Field/Collection/FieldCollectionInterface.php
+++ b/src/Storage/Field/Collection/FieldCollectionInterface.php
@@ -52,17 +52,20 @@ interface FieldCollectionInterface extends Collection
     /**
      * Returns the type of a given $fieldName
      *
-     * @param $fieldName
+     * @param string $fieldName
+     *
      * @return string|null
      */
     public function getFieldType($fieldName);
 
     /**
-     * Alias to the standard get method that matches compatibility with the Legacy
-     * content entity. This can be refactored to something better, once the
+     * Returns the rendered version of a value for Twig.
+     *
+     * This can be refactored to something better, once the
      * deprecation of legacy content is complete.
      *
-     * @param $fieldName
+     * @param string $fieldName
+     *
      * @return mixed
      */
     public function getDecodedValue($fieldName);

--- a/src/Storage/Field/Collection/FieldCollectionInterface.php
+++ b/src/Storage/Field/Collection/FieldCollectionInterface.php
@@ -61,6 +61,8 @@ interface FieldCollectionInterface extends Collection
     /**
      * Returns the rendered version of a value for Twig.
      *
+     * @internal
+     *
      * This can be refactored to something better, once the
      * deprecation of legacy content is complete.
      *
@@ -68,5 +70,5 @@ interface FieldCollectionInterface extends Collection
      *
      * @return mixed
      */
-    public function getDecodedValue($fieldName);
+    public function getRenderedValue($fieldName);
 }

--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -67,6 +67,31 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
         }
     }
 
+    /** Returns the type of a given $fieldName
+     *
+     * @param $fieldName
+     * @return string|null
+     */
+    public function getFieldType($fieldName)
+    {
+        $this->initialize();
+
+        return $this->collection->getFieldType($fieldName);
+    }
+
+    /**
+     *  Alias to the standard get method that matches compatibility with the Legacy content entity.
+     *
+     * @param $fieldName
+     * @return mixed
+     */
+    public function getDecodedValue($fieldName)
+    {
+        $this->initialize();
+
+        return $this->collection->getDecodedValue($fieldName);
+    }
+
     /**
      * Handles the conversion of references to entities.
      */

--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -80,11 +80,11 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
     /**
      * {@inheritdoc}
      */
-    public function getDecodedValue($fieldName)
+    public function getRenderedValue($fieldName)
     {
         $this->initialize();
 
-        return $this->collection->getDecodedValue($fieldName);
+        return $this->collection->getRenderedValue($fieldName);
     }
 
     /**

--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -67,10 +67,8 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
         }
     }
 
-    /** Returns the type of a given $fieldName
-     *
-     * @param $fieldName
-     * @return string|null
+    /**
+     * {@inheritdoc}
      */
     public function getFieldType($fieldName)
     {
@@ -80,12 +78,7 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
     }
 
     /**
-     * Alias to the standard get method that matches compatibility with the Legacy
-     * content entity. This can be refactored to something better, once the
-     * deprecation of legacy content is complete.
-     *
-     * @param $fieldName
-     * @return mixed
+     * {@inheritdoc}
      */
     public function getDecodedValue($fieldName)
     {

--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -80,7 +80,9 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
     }
 
     /**
-     *  Alias to the standard get method that matches compatibility with the Legacy content entity.
+     * Alias to the standard get method that matches compatibility with the Legacy
+     * content entity. This can be refactored to something better, once the
+     * deprecation of legacy content is complete.
      *
      * @param $fieldName
      * @return mixed

--- a/tests/phpunit/unit/Content/ContentTest.php
+++ b/tests/phpunit/unit/Content/ContentTest.php
@@ -67,6 +67,25 @@ class ContentTest extends BoltUnitTest
     {
     }
 
+    public function testGetRenderedValue()
+    {
+        $app = $this->getApp();
+        $mockContent =$this->getMockBuilder(Content::class)
+            ->setConstructorArgs([$app, 'pages'])
+            ->setMethods(['getDecodedValue'])
+            ->getMock()
+        ;
+        $mockContent
+            ->expects($this->atLeastOnce())
+            ->method('getDecodedValue')
+            ->with('title')
+        ;
+
+        /** @var \Bolt\Legacy\Content $mockContent */
+        $mockContent->setValue('title', 'koala');
+        $mockContent->getRenderedValue('title');
+    }
+
     public function testpreParse()
     {
     }

--- a/theme/base-2016/page.twig
+++ b/theme/base-2016/page.twig
@@ -15,7 +15,7 @@
     {{ record.body }}
 
     {# If there are repeaters, we should output them. #}
-    {{ fields(common = false, extended = false, repeaters = true) }}
+    {{ fields(template = 'partials/_sub_fields.twig', common = false, repeaters = true) }}
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}

--- a/theme/base-2016/partials/_sub_fields.twig
+++ b/theme/base-2016/partials/_sub_fields.twig
@@ -30,15 +30,9 @@
 
 {# SECTION 2: MACROS #}
 
-{# If 'allowtwig' is true for this field, we'll need to parse it as
-   Twig here. Note, that we're doing this inside a macro, so the
-   snippet has a limited scope. No global variables, etc. #}
-{% macro parsetextfield(key, value, contenttype) %}
-    {% if contenttype.fields[key].allowtwig is defined and contenttype.fields[key].allowtwig == true %}
-        {% set value = value|twig %}
-    {% endif %}
-
-    <div {% if key is not empty %}data-bolt-field="{{key}}"{% endif %}>{{ value }}</div>
+{# Output a text-like field with the wrapper for live editing. #}
+{% macro textfield(object, key) %}
+    <div data-bolt-field="{{key}}">{{ object.decodedValue(key) }}</div>
 {% endmacro %}
 
 {% macro imagelistfield(images) %}
@@ -52,17 +46,15 @@
 {% endmacro %}
 
 {# Macro for "basic" fields like HTML, Markdown, Textarea and Text #}
-{% macro commonfields(key, value, fieldtype, contenttype) %}
+{% macro commonfield(object, key) %}
         {% import _self as macro %}
 
-        {# HTML, Textarea, Text fields #}
-        {% if fieldtype in ['html', 'textarea', 'text'] %}
-            {{ macro.parsetextfield(key, value, contenttype) }}
-        {% endif %}
+        {% set fieldtype = object.fieldtype(key) %}
+        {% set value = object.get(key) %}
 
-        {# Markdown fields #}
-        {% if fieldtype == "markdown" %}
-            {{ macro.parsetextfield(key, value|markdown, contenttype) }}
+        {# HTML, Textarea, Text and Markdown fields #}
+        {% if fieldtype in ['html', 'textarea', 'text', 'markdown'] %}
+            {{ macro.textfield(object, key) }}
         {% endif %}
 
         {# Image fields #}
@@ -80,7 +72,11 @@
 {% endmacro %}
 
 {# Macro for other field types, like Geo, Select, Checkbox and others. #}
-{% macro extendedfields(key, value, fieldtype) %}
+{% macro extendedfield(object, key) %}
+        {% import _self as macro %}
+
+        {% set fieldtype = object.fieldtype(key) %}
+        {% set value = object.get(key) %}
 
         {# Geolocation field #}
         {% if fieldtype == "geolocation" and value.latitude is defined %}
@@ -128,54 +124,30 @@
     {# Fields that are considered 'common': 'html', 'markdown', 'textarea',
        'text', 'image', 'video' and 'imagelist' #}
     {% if common == true %}
-
-        {% set fieldtype = record.fieldtype(key) %}
-        {{ macro.commonfields(key, value, fieldtype, record.contenttype) }}
-
+        {{ macro.commonfield(record, key) }}
     {% endif %}
 
     {# The rest of the built-in fieldtypes #}
     {% if extended == true %}
-
-        {% set fieldtype = record.fieldtype(key) %}
-        {{ macro.extendedfields(key, value, fieldtype) }}
-
+        {{ macro.extendedfield(record, key) }}
     {% endif %}
 
     {# Finally, the repeaters #}
     {% if repeaters == true and record.fieldtype(key) == "repeater" %}
-
         {% for repeater in value %}
-
-            {% for repeaterfield in repeater %}
-
-                {% set fieldtype = repeaterfield.getFieldtype() %}
-                {% set value = repeaterfield.getValue() %}
-                {{ macro.commonfields('', value, fieldtype, record.contenttype) }}
-                {{ macro.extendedfields('', value, fieldtype) }}
-
+            {% for key, repeaterfield in repeater %}
+                {{ macro.commonfield(repeater, key) }}
+                {{ macro.extendedfield(repeater, key) }}
             {% endfor %}
-
         {% endfor %}
-
     {% endif %}
 
 {% endfor %}
 
-{# We do the same for the templatefields, if set and not empty. #}
-{% set templatefields = record.values.templatefields.values|default() %}
-{% if templatefields is defined and templatefields is not empty %}
-
-    {# Note: This needs to be expanded upon!! For better detection the 'virtual'
-       contenttype for the templatefields should know about the types of fields. #}
-    {% set templatefieldsfieldtypes = attribute(record.contenttype.templatefields|first, 'fields') %}
-
-    {% for key, value in templatefields if (key not in omittedkeys) %}
-
-        {% set fieldtype = attribute(attribute(templatefieldsfieldtypes, key), 'type')  %}
-        {{ macro.commonfields(key, value, fieldtype, record.contenttype) }}
-        {{ macro.extendedfields(key, value, fieldtype) }}
-
+{# We do the same for the templatefields, if there are any. #}
+{% if record.templatefields %}
+    {% for key, value in record.templatefields.values if (key not in omittedkeys) %}
+        {{ macro.commonfield(record.templatefields, key) }}
+        {{ macro.extendedfield(record.templatefields, key) }}
     {% endfor %}
-
 {% endif %}

--- a/theme/base-2016/partials/_sub_fields.twig
+++ b/theme/base-2016/partials/_sub_fields.twig
@@ -32,7 +32,7 @@
 
 {# Output a text-like field with the wrapper for live editing. #}
 {% macro textfield(object, key) %}
-    <div data-bolt-field="{{key}}">{{ object.decodedValue(key) }}</div>
+    <div data-bolt-field="{{key}}">{{ object.renderedValue(key) }}</div>
 {% endmacro %}
 
 {% macro imagelistfield(images) %}


### PR DESCRIPTION
This PR makes sure the vilified-but-necessary `_sub_fields`: 

 - don't rely on `|raw`, `|twig`, `template_from_string()` or any such hackishness
 - have the same treatment for regular fields, template fields and repeaters

~~Might needs some final touch-ups after #6472 has landed.~~

**Edit:** 

 - Works correctly for HTML, text, textarea and Markdown fields now.
 - Works correctly for repeaters now. (note: No support for `allowtwig: true` in repeaters. It was never supported, but this PR doesn't add it either)
 - Incorporates @rossriley 's changes in #6473. 
 - Closes #6472, as this PR provides a viable workaround for that issue, without changing stuff that might have unforeseen consequences. 

After this is merged, I will update the docs for 3.3 accordingly, because iterating over repeaters can be done more similar to how it's done for "normal" fields or templatefields. 