### PR TITLE
Session Handlers Phase II

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,17 @@ before_install:
     fi
   # Start SMTP listener
   - sudo python -m smtpd -n -c DebuggingServer localhost:25 2>&1 > /dev/null &
-  # Increase PHP memory limit. Required for Composer & PHPUnit.
-  - echo "memory_limit=2G" ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  # Add Redis & Memcached extensions
+  - |
+    if [[ $TRAVIS_PHP_VERSION =~ ^[57] ]]; then
+        echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+        echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    fi
+  # Memcache to be removed in Bolt v4
+  - |
+    if [[ $TRAVIS_PHP_VERSION =~ ^5 ]]; then
+        echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    fi
 
 before_script:
   # Set up Composer
@@ -67,4 +76,3 @@ script:
 cache:
   directories:
     - $COMPOSER_CACHE_DIR
-

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
         "phpunit/dbunit": "^1.3",
         "phpunit/php-code-coverage": "^2.0",
         "phpunit/phpunit": "^4.8",
+        "predis/predis": "^1.1",
         "sebastian/phpcpd": "^2.0",
         "sorien/silex-pimple-dumper": "^1.0",
         "squizlabs/php_codesniffer": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,8 @@
         "phpunit/php-code-coverage": "^2.0",
         "phpunit/phpunit": "^4.8",
         "predis/predis": "^1.1",
+        "psr/cache": "^1.0",
+        "psr/simple-cache": "^1.0",
         "sebastian/phpcpd": "^2.0",
         "sorien/silex-pimple-dumper": "^1.0",
         "squizlabs/php_codesniffer": "^2.0",

--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -143,28 +143,22 @@ class SessionServiceProvider implements ServiceProviderInterface
                  *    - Options from ini (if enabled with "session.options.import_from_ini")
                  *    - Options hardcoded below
                  * 2) Converts options to an OptionsBag instance
+                 *
+                 * These defaults are limited to those that are useful and secure.
                  */
                 $defaults = [
                     'save_handler'    => 'files',
                     'save_path'       => '/tmp',
                     'name'            => 'PHPSESSID',
                     'lazy_write'      => true,
-                    //'auto_start' => false,
-                    //'serialize_handler' => null,
                     'gc_probability'  => 1,
                     'gc_divisor'      => 1000,
                     'gc_maxlifetime'  => 1440,
-                    //'referer_check' => '',
-                    //'use_strict_mode' => false,
                     'cookie_lifetime' => 0,
                     'cookie_path'     => '/',
                     'cookie_domain'   => null,
                     'cookie_secure'   => false,
                     'cookie_httponly' => false,
-                    // TODO Do started native sessions force "nocache" header in response?
-                    // We don't have a way to force that, should we?
-                    //'cache_limiter' => 'nocache',
-                    //'cache_expire'  => 180,
                     'restrict_realm'  => false,
                 ];
 

--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -7,6 +7,7 @@ use Bolt\Session\Handler\FileHandler;
 use Bolt\Session\Handler\FilesystemHandler;
 use Bolt\Session\Handler\MemcacheHandler;
 use Bolt\Session\Handler\RedisHandler;
+use Bolt\Session\IniBag;
 use Bolt\Session\OptionsBag;
 use Bolt\Session\Serializer\NativeSerializer;
 use Bolt\Session\SessionListener;
@@ -165,8 +166,21 @@ class SessionServiceProvider implements ServiceProviderInterface
                 $options = new OptionsBag($defaults);
 
                 if ($app['session.options.import_from_ini']) {
+                    $ini = new IniBag('session');
                     foreach ($options as $key => $value) {
-                        $options[$key] = ini_get('session.' . $key);
+                        if (!$ini->has($key)) {
+                            continue;
+                        }
+
+                        if (is_int($value)) {
+                            $value = $ini->getInt($key);
+                        } elseif (is_bool($value)) {
+                            $value = $ini->getBoolean($key);
+                        } else {
+                            $value = $ini->get($key);
+                        }
+
+                        $options[$key] = $value;
                     }
                 }
 

--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -49,16 +49,20 @@ class SessionServiceProvider implements ServiceProviderInterface
 
         $app['session.storage'] = $app->share(
             function ($app) {
-                $options = $app['session.options_bag'];
-
-                $handler = $app['session.handler_factory']($options['save_handler'], $options);
-
                 return new SessionStorage(
-                    $options,
-                    $handler,
+                    $app['session.options_bag'],
+                    $app['session.handler'],
                     $app['session.generator'],
                     $app['session.serializer']
                 );
+            }
+        );
+
+        $app['session.handler'] = $app->share(
+            function ($app) {
+                $options = $app['session.options_bag'];
+
+                return $app['session.handler_factory']($options['save_handler'], $options);
             }
         );
 

--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -10,6 +10,7 @@ use Bolt\Session\Handler\Factory\PredisFactory;
 use Bolt\Session\Handler\Factory\RedisFactory;
 use Bolt\Session\Handler\FileHandler;
 use Bolt\Session\Handler\FilesystemHandler;
+use Bolt\Session\Handler\MemcachedHandler;
 use Bolt\Session\Handler\MemcacheHandler;
 use Bolt\Session\Handler\RedisHandler;
 use Bolt\Session\IniBag;
@@ -22,7 +23,6 @@ use Silex\ServiceProviderInterface;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcachedSessionHandler as MemcachedHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 
 /**

--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -81,7 +81,13 @@ class SessionServiceProvider implements ServiceProviderInterface
                 return new NativeGenerator($app['session.generator.bytes_length']);
             }
         );
-        $app['session.generator.bytes_length'] = 32;
+        $app['session.generator.bytes_length'] = $app->share(
+            function ($app) {
+                $options = $app['session.options_bag'];
+
+                return $options->getInt('sid_length', 32);
+            }
+        );
 
         $app['session.serializer'] = $app->share(
             function () {
@@ -166,6 +172,8 @@ class SessionServiceProvider implements ServiceProviderInterface
                     'cookie_domain'   => null,
                     'cookie_secure'   => false,
                     'cookie_httponly' => false,
+                    'sid_length'      => 32,
+
                     'restrict_realm'  => false,
                 ];
 

--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -276,6 +276,7 @@ class SessionServiceProvider implements ServiceProviderInterface
      */
     protected function registerMemcacheHandler(Application $app)
     {
+        // @deprecated
         $app['session.handler_factory.backing_memcache'] = $app->protect(
             function (OptionsBag $options) {
                 return (new MemcacheFactory())->create($options);
@@ -290,6 +291,10 @@ class SessionServiceProvider implements ServiceProviderInterface
 
         $app['session.handler_factory.memcache'] = $app->protect(
             function (OptionsBag $options, $key = 'memcache') use ($app) {
+                if ($key === 'memcache') {
+                    Deprecated::warn('"memcache" session handler', 3.3, 'Use "memcached" instead.');
+                }
+
                 $memcache = $app['session.handler_factory.backing_' . $key]($options);
 
                 $handlerOptions = new OptionsBag($options->get('options', []));

--- a/src/Session/Handler/AbstractHandler.php
+++ b/src/Session/Handler/AbstractHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bolt\Session\Handler;
+
+/**
+ * Implements common session handler methods that are not used.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+abstract class AbstractHandler implements \SessionHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function open($savePath, $sessionName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function gc($maxlifetime)
+    {
+        return true;
+    }
+}

--- a/src/Session/Handler/DoctrineCacheHandler.php
+++ b/src/Session/Handler/DoctrineCacheHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Bolt\Session\Handler;
+
+use Doctrine\Common\Cache\Cache;
+
+/**
+ * Doctrine Cache Session Handler.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class DoctrineCacheHandler extends AbstractHandler
+{
+    /** @var Cache */
+    protected $cache;
+    /** @var int */
+    protected $ttl;
+
+    /**
+     * Constructor.
+     *
+     * @param Cache $cache The cache instance
+     * @param int   $ttl   Number of seconds before session expires
+     */
+    public function __construct(Cache $cache, $ttl = 86400)
+    {
+        $this->cache = $cache;
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($sessionId)
+    {
+        return $this->cache->fetch($sessionId) ?: '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($sessionId, $data)
+    {
+        return $this->cache->save($sessionId, $data, $this->ttl);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($sessionId)
+    {
+        return $this->cache->delete($sessionId);
+    }
+}

--- a/src/Session/Handler/Factory/AbstractFactory.php
+++ b/src/Session/Handler/Factory/AbstractFactory.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Bolt\Session\Handler\Factory;
+
+use Bolt\Helpers\Deprecated;
+use Bolt\Session\OptionsBag;
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Abstract Factory with common functions to help create connections to services.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+abstract class AbstractFactory
+{
+    /**
+     * Parse the session options to connection parameters.
+     *
+     * @param OptionsBag $sessionOptions
+     *
+     * @return OptionsBag[]
+     */
+    public function parse(OptionsBag $sessionOptions)
+    {
+        if ($sessionOptions['save_path']) {
+            return $this->parseConnectionsFromSavePath($sessionOptions['save_path']);
+        }
+
+        return $this->parseConnectionsFromOptions($sessionOptions);
+    }
+
+    /**
+     * Parses session save_path into a list of connection parameters.
+     *
+     * @param string $savePath
+     *
+     * @return OptionsBag[]
+     */
+    protected function parseConnectionsFromSavePath($savePath)
+    {
+        $connections = (array) explode(',', $savePath);
+        $connections = array_map('trim', $connections);
+
+        return array_map([$this, 'parseConnectionItemFromSavePath'], $connections);
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return OptionsBag
+     */
+    abstract protected function parseConnectionItemFromSavePath($path);
+
+    /**
+     * Parses session options with array configuration into a list of connection parameters.
+     *
+     * @param OptionsBag $options
+     *
+     * @return OptionsBag[]
+     */
+    protected function parseConnectionsFromOptions(OptionsBag $options)
+    {
+        if ($options->has('connections')) {
+            $connections = $options->get('connections');
+        } elseif ($options->has('connection')) {
+            $connections = [$options->get('connection')];
+        } elseif ($options->has('host') || $options->has('port')) {
+            Deprecated::warn('Specifying "host" and other options directly in session config', 3.3, 'Move them under the "connection" key.');
+
+            $connections = [$options->all()];
+        } else {
+            $connections = [[]];
+        }
+
+        return array_map([$this, 'parseConnectionItemFromOptions'], $connections);
+    }
+
+    /**
+     * @param array|string $item
+     *
+     * @return OptionsBag
+     */
+    abstract protected function parseConnectionItemFromOptions($item);
+
+    /**
+     * @param string $uri
+     *
+     * @return UriInterface
+     */
+    protected function parseUri($uri)
+    {
+        if ($uri && stripos($uri, 'unix://') === 0) {
+            // parse_url() doesn't like "unix:///foo", but parses "unix:/foo" fine.
+            $uri = str_ireplace('unix://', 'unix:', $uri);
+
+        } elseif ($uri && $uri[0] !== '/' && !preg_match('#^\w+://?.+#', $uri)) {
+            // If no scheme given and path exists and isn't absolute, assume tcp scheme is wanted.
+            // This allows both "127.0.0.1" and "/foo.sock" to work without specifying scheme.
+            // If non absolute path is wanted, specify the scheme: "unix://foo.sock"
+            $uri = 'tcp://' . $uri;
+        }
+
+        $parsed = new Uri($uri);
+
+        return $parsed;
+    }
+
+    /**
+     * @param UriInterface $uri
+     *
+     * @return OptionsBag
+     */
+    protected function parseQuery(UriInterface $uri)
+    {
+        $query = \GuzzleHttp\Psr7\parse_query($uri->getQuery());
+
+        return new OptionsBag($query);
+    }
+}

--- a/src/Session/Handler/Factory/MemcacheFactory.php
+++ b/src/Session/Handler/Factory/MemcacheFactory.php
@@ -10,6 +10,8 @@ use RuntimeException;
 /**
  * Factory for creating Memcache instances from Session options.
  *
+ * @deprecated since 3.3, will be removed in 4.0.
+ *
  * @author Carson Full <carsonfull@gmail.com>
  */
 class MemcacheFactory extends AbstractFactory

--- a/src/Session/Handler/Factory/MemcacheFactory.php
+++ b/src/Session/Handler/Factory/MemcacheFactory.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Bolt\Session\Handler\Factory;
+
+use Bolt\Session\OptionsBag;
+use InvalidArgumentException;
+use Memcache;
+use RuntimeException;
+
+/**
+ * Factory for creating Memcache instances from Session options.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class MemcacheFactory extends AbstractFactory
+{
+    /** @var string */
+    protected $class;
+
+    /**
+     * Constructor.
+     *
+     * @param string|null $class Memcache class name. Mostly for tests.
+     */
+    public function __construct($class = Memcache::class)
+    {
+        if (!extension_loaded('memcache')) {
+            throw new RuntimeException('Unable to use "memcache" session handler as memcache extension is not installed and enabled. Install the extension or try the "memcached" session handler instead.');
+        }
+
+        $this->class = $class ?: Memcache::class;
+
+        if (!is_a($this->class, Memcache::class, true)) {
+            throw new InvalidArgumentException(sprintf('Class name "%s" is not Memcache or a subclass of Memcache.', $this->class));
+        }
+    }
+
+    /**
+     * Creates a Memcache instance from the session options.
+     *
+     * @param OptionsBag $options
+     *
+     * @return Memcache
+     */
+    public function create(OptionsBag $options)
+    {
+        $connections = $this->parse($options);
+
+        $class = $this->class;
+        $memcache = new $class();
+
+        return $this->configure($memcache, $connections);
+    }
+
+    /**
+     * @param Memcache $memcache
+     * @param array    $connections
+     *
+     * @return Memcache
+     */
+    public function configure(Memcache $memcache, array $connections)
+    {
+        foreach ($connections as $conn) {
+            $memcache->addServer($conn['host'], $conn['port'], $conn['persistent'], $conn['weight'], $conn['timeout'], $conn['retry_interval']);
+        }
+
+        return $memcache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionItemFromSavePath($path)
+    {
+        $uri = $this->parseUri($path);
+        $query = $this->parseQuery($uri);
+
+        $conn = new OptionsBag([
+            'weight' => $query->getInt('weight', 1),
+            'persistent' => $query->getBoolean('persistent'),
+            'timeout' => $query->getInt('timeout', 1),
+            'retry_interval' => $query->getInt('retry_interval', 0),
+        ]);
+
+        if ($uri->getHost()) {
+            $conn['host'] = $uri->getHost();
+            $conn['port'] = $uri->getPort() ?: 11211;
+        } else { // unix path
+            $conn['host'] = 'unix://' . $uri->getPath();
+            $conn['port'] = 0;
+        }
+
+        if ((!$conn['host'] && !$conn['path']) || $conn['weight'] <= 0 || $conn['timeout'] <= 0) {
+            throw new InvalidArgumentException('Failed to parse session save_path');
+        }
+
+        return $conn;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionItemFromOptions($item)
+    {
+        if (is_string($item)) {
+            $uri = $this->parseUri($item);
+            $item = [
+                'host' => $uri->getHost(),
+                'port' => $uri->getPort(),
+                'path' => $uri->getPath(),
+            ];
+        }
+
+        $item = new OptionsBag($item);
+
+        $conn = new OptionsBag([
+            'host' => $item->get('host') ?: '127.0.0.1',
+            'port' => $item->getInt('port') ?: 11211,
+            'weight' => $item->getInt('weight', 1),
+            'persistent' => $item->getBoolean('persistent', false),
+            'timeout' => $item->getInt('timeout', 1),
+            'retry_interval' => $item->getInt('retry_interval', 0),
+        ]);
+
+        if ($item['path']) {
+            $conn['host'] = 'unix://' . $item['path'];
+            $conn['port'] = 0;
+        }
+
+        return $conn;
+    }
+}

--- a/src/Session/Handler/Factory/MemcachedFactory.php
+++ b/src/Session/Handler/Factory/MemcachedFactory.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace Bolt\Session\Handler\Factory;
+
+use Bolt\Helpers\Deprecated;
+use Bolt\Session\IniBag;
+use Bolt\Session\OptionsBag;
+use InvalidArgumentException;
+use Memcached;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * Factory for creating Memcached instances from Session options and memcached ini options.
+ *
+ * We will support v2.0 of the extension until support for PHP 5 is dropped.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class MemcachedFactory extends AbstractFactory
+{
+    /** @var ParameterBag */
+    protected $ini;
+    /** @var string */
+    protected $class;
+
+    /**
+     * Constructor.
+     *
+     * @param ParameterBag|null $ini   ini values. Mostly for tests.
+     * @param string|null       $class Memcached class name. Mostly for tests.
+     */
+    public function __construct(ParameterBag $ini = null, $class = Memcached::class)
+    {
+        if (!extension_loaded('memcached')) {
+            throw new RuntimeException('Unable to use "memcached" session handler as memcached extension is not installed and enabled. Install the extension or try the "memcache" session handler instead.');
+        }
+        if (version_compare(phpversion('memcached'), '2.0.0', '<')) {
+            throw new RuntimeException('Unable to use "memcached" session handler as memcached extension is too old. Version 2.0.0 or higher is required.');
+        }
+
+        $this->ini = $ini ?: new IniBag('memcached', 'sess_');
+        $this->class = $class ?: Memcached::class;
+
+        if (!is_a($this->class, Memcached::class, true)) {
+            throw new InvalidArgumentException(sprintf('Class name "%s" is not Memcached or a subclass of Memcached.', $this->class));
+        }
+    }
+
+    /**
+     * Creates a Memcached instance from the session options.
+     *
+     * @param OptionsBag $sessionOptions
+     *
+     * @return Memcached
+     */
+    public function create(OptionsBag $sessionOptions)
+    {
+        $options = $this->parseOptions($sessionOptions);
+
+        $connections = $this->parse($sessionOptions);
+
+        $persistentId = null;
+        if ($options['persistent']) {
+            $persistentId = $this->parsePersistentId($connections, $options, $sessionOptions);
+        }
+
+        $class = $this->class;
+        /** @var Memcached $memcached */
+        $memcached = new $class(
+            $persistentId,
+            function (Memcached $memcached) use ($connections, $options) {
+                $this->configure($memcached, $connections, $options);
+            }
+        );
+
+        return $memcached;
+    }
+
+    /**
+     * Configure a new Memcached instance. This isn't needed for existing persisted connections.
+     *
+     * @param Memcached  $memcached
+     * @param array      $connections
+     * @param OptionsBag $options
+     */
+    protected function configure(Memcached $memcached, array $connections, OptionsBag $options)
+    {
+        $binary = $options->getBoolean('binary_protocol');
+        $needsAuth = $options->get('username') && $options->get('password');
+
+        if ($needsAuth) {
+            // SASL is only supported with binary protocol,
+            // just enable it instead of throwing exception.
+            $binary = true;
+
+            if (!constant($this->class . '::HAVE_SASL')) {
+                throw new RuntimeException('memcached extension needs to be built with SASL support to use username and password');
+            }
+        }
+
+        $memcached->setOptions([
+            Memcached::OPT_BINARY_PROTOCOL => $binary,
+            Memcached::OPT_LIBKETAMA_COMPATIBLE => $options->getBoolean('consistent_hash'),
+            Memcached::OPT_SERVER_FAILURE_LIMIT => $options->getInt('server_failure_limit'),
+            Memcached::OPT_NUMBER_OF_REPLICAS => $options->getInt('number_of_replicas'),
+            Memcached::OPT_RANDOMIZE_REPLICA_READ => $options->getBoolean('randomize_replica_read'),
+            Memcached::OPT_REMOVE_FAILED_SERVERS => $options->getBoolean('remove_failed_servers'),
+            Memcached::OPT_CONNECT_TIMEOUT => $options->getInt('connect_timeout'),
+        ]);
+
+        if ($needsAuth) {
+            $memcached->setSaslAuthData($options->get('username'), $options->get('password'));
+        }
+
+        foreach ($connections as $conn) {
+            $memcached->addServer($conn['host'], $conn['port'], $conn['weight']);
+        }
+    }
+
+    /**
+     * Parse Memcached options from session options and from ini.
+     *
+     * @param OptionsBag $sessionOptions
+     *
+     * @return OptionsBag
+     */
+    protected function parseOptions(OptionsBag $sessionOptions)
+    {
+        $options = new OptionsBag($sessionOptions->get('options', []));
+
+        $iniKeys = [
+            'persistent' => 'bool',
+            'binary_protocol' => 'bool',
+            'consistent_hash' => 'bool',
+            'server_failure_limit' => 'int',
+            'remove_failed_servers' => 'bool',
+            'randomize_replica_read' => 'bool',
+            'number_of_replicas' => 'int',
+            'connect_timeout' => 'int',
+            'sasl_username' => 'string',
+            'sasl_password' => 'string',
+            'prefix' => 'string',
+        ];
+        $v2IniKeys = [
+            'remove_failed_servers' => ['remove_failed', 'bool'],
+            'binary_protocol'       => ['binary', 'bool'],
+        ];
+
+        // If user specified v2 option, warn and replace with new name
+        foreach ($v2IniKeys as $new => list($old, $type)) {
+            if ($options->has($old)) {
+                Deprecated::warn("Memcached option \"$old\"", 3.3, "Use \"$new\" instead.");
+
+                if (!$options->has($new)) {
+                    $options->set($new, $options->get($old));
+                }
+
+                $options->remove($old);
+            }
+        }
+
+        // Merge ini values in as defaults.
+        foreach ($iniKeys as $key => $type) {
+            if (!$options->has($key) && $this->ini->has($key)) {
+                if ($type === 'bool') {
+                    $value = $this->ini->getBoolean($key);
+                } elseif ($type === 'int') {
+                    $value = $this->ini->getInt($key);
+                } else {
+                    $value = $this->ini->get($key);
+                }
+                $options[$key] = $value;
+            }
+        }
+
+        // Merge v2 ini values in as defaults.
+        foreach ($v2IniKeys as $new => list($old, $type)) {
+            if (!$options->has($new) && $this->ini->has($old)) {
+                if ($type === 'bool') {
+                    $value = $this->ini->getBoolean($old);
+                } elseif ($type === 'int') {
+                    $value = $this->ini->getInt($old);
+                } else {
+                    $value = $this->ini->get($old);
+                }
+                $options[$new] = $value;
+            }
+        }
+
+        // Convert sasl_username/sasl_password to username/password
+        if (!$options->has('username')) {
+            $options['username'] = $options->get('sasl_username');
+        }
+        if (!$options->has('password')) {
+            $options['password'] = $options->get('sasl_password');
+        }
+        $options->remove('sasl_username');
+        $options->remove('sasl_password');
+
+        return $options;
+    }
+
+    /**
+     * Parse the Persistent ID from save_path and sets it on options.
+     *
+     * 1. Given in save_path "PERSISTENT=foo"
+     * 2. Given in options via "persistent_id"
+     * 3. Determined automatically based on current connections and options.
+     *
+     * @param OptionsBag[] $connections
+     * @param OptionsBag   $options
+     * @param OptionsBag   $sessionOptions
+     *
+     * @return string
+     */
+    protected function parsePersistentId(array $connections, OptionsBag $options, OptionsBag $sessionOptions)
+    {
+        // Try based on save_path.
+        $savePath = $sessionOptions['save_path'];
+        $savePath = trim($savePath); // Just in case.
+        if ($savePath) {
+            // v3.0 uses save path for ID (from what I can tell)
+            $persistentId = 'memc-session:' . $savePath;
+
+            // v2.0 uses "PERSISTENT=foo servers", so parse that.
+            if (strpos($savePath, 'PERSISTENT=') === 0) {
+                $end = strpos($savePath, ' ');
+                if ($end === false) {
+                    throw new InvalidArgumentException('Unable to parse session save_path');
+                }
+
+                $persistentId = substr($savePath, 11, $end - 11);
+            }
+
+            return $persistentId;
+        }
+
+        // Try based on specified value in options.
+        if ($options->has('persistent_id')) {
+            return $options['persistent_id'];
+        }
+
+        // Determine automatically.
+        $hashParts = [];
+
+        foreach ($connections as $conn) {
+            $hashParts[] = sprintf('%s:%s:%s', $conn['host'], $conn['port'], $conn['weight']);
+        }
+        foreach ($options as $key => $value) {
+            $hashParts[] = $key . ':' . $value;
+        }
+
+        $hash = hash('sha256', join(',', $hashParts));
+
+        return $hash;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionsFromSavePath($savePath)
+    {
+        // v2.0 uses "PERSISTENT=foo servers", so remove that.
+        if (strpos($savePath, 'PERSISTENT=') === 0) {
+            $end = strpos($savePath, ' ');
+            if ($end === false) {
+                throw new InvalidArgumentException('Unable to parse session save_path');
+            }
+
+            $savePath = substr($savePath, $end + 1);
+        }
+
+        return parent::parseConnectionsFromSavePath($savePath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionItemFromSavePath($path)
+    {
+        $connection = trim($path);
+
+        $parts = explode(':', $connection);
+
+        $uri = $this->parseUri($parts[0]);
+
+        if (!$uri->getHost() && !$uri->getPath()) {
+            throw new InvalidArgumentException('Failed to parse session save_path');
+        }
+
+        if ($uri->getPath()) {
+            $host = $uri->getPath();
+            $port = 0;
+        } else {
+            $host = $uri->getHost();
+            $port = (int) isset($parts[1]) ? $parts[1] : 11211;
+        }
+        $weight = (int) isset($parts[2]) ? $parts[2] : 1;
+
+        return new OptionsBag([
+            'host'   => $host,
+            'port'   => $port,
+            'weight' => $weight,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionItemFromOptions($item)
+    {
+        if (is_string($item)) {
+            $uri = $this->parseUri($item);
+            $item = [
+                'host' => $uri->getHost(),
+                'port' => $uri->getPort(),
+                'path' => $uri->getPath(),
+            ];
+        }
+
+        $item = new OptionsBag($item);
+
+        $conn = new OptionsBag([
+            'host' => $item->get('host') ?: '127.0.0.1',
+            'port' => $item->getInt('port') ?: 11211,
+            'weight' => $item->getInt('weight', 1),
+        ]);
+
+        if ($item['path']) {
+            $conn['host'] = $item['path'];
+            $conn['port'] = 0;
+        }
+
+        return $conn;
+    }
+}

--- a/src/Session/Handler/Factory/MemcachedFactory.php
+++ b/src/Session/Handler/Factory/MemcachedFactory.php
@@ -33,7 +33,7 @@ class MemcachedFactory extends AbstractFactory
     public function __construct(ParameterBag $ini = null, $class = Memcached::class)
     {
         if (!extension_loaded('memcached')) {
-            throw new RuntimeException('Unable to use "memcached" session handler as memcached extension is not installed and enabled. Install the extension or try the "memcache" session handler instead.');
+            throw new RuntimeException('Unable to use "memcached" session handler as memcached extension is not installed and enabled.');
         }
         if (version_compare(phpversion('memcached'), '2.0.0', '<')) {
             throw new RuntimeException('Unable to use "memcached" session handler as memcached extension is too old. Version 2.0.0 or higher is required.');

--- a/src/Session/Handler/Factory/PredisFactory.php
+++ b/src/Session/Handler/Factory/PredisFactory.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Bolt\Session\Handler\Factory;
+
+use Bolt\Helpers\Deprecated;
+use Bolt\Session\OptionsBag;
+use Predis;
+
+/**
+ * Factory for creating Predis instances from Session options.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class PredisFactory extends AbstractFactory
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        if (!class_exists('Predis\Client')) {
+            throw new \RuntimeException('Unable to use "predis" session handler as the Predis library is not installed.');
+        }
+    }
+
+    /**
+     * Creates a Predis instance from the session options.
+     *
+     * @param OptionsBag $sessionOptions
+     *
+     * @return Predis\Client
+     */
+    public function create(OptionsBag $sessionOptions)
+    {
+        $connections = $this->parse($sessionOptions);
+
+        $options = $this->parseOptions($sessionOptions);
+
+        return new Predis\Client($connections, $options);
+    }
+
+    /**
+     * Parse Predis options from session options.
+     *
+     * @param OptionsBag $sessionOptions
+     *
+     * @return array
+     */
+    protected function parseOptions(OptionsBag $sessionOptions)
+    {
+        $options = $sessionOptions->get('options', []);
+
+        if ($sessionOptions->get('prefix')) {
+            Deprecated::warn('Specifying "prefix" directly in session config', 3.3, 'Move it under the "options" key.');
+
+            $options['prefix'] = $sessionOptions->get('prefix');
+        }
+
+        return $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionsFromOptions(OptionsBag $options)
+    {
+        $connections = parent::parseConnectionsFromOptions($options);
+
+        // If only one connection, don't give list to Predis since it will unnecessarily use cluster logic.
+        if (count($connections) === 1 && array_key_exists(0, $connections)) {
+            $connections = $connections[0];
+        }
+
+        return $connections;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionItemFromOptions($item)
+    {
+        return $item;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionsFromSavePath($savePath)
+    {
+        throw new \InvalidArgumentException('Using "save_path" is unsupported with "predis" session handler.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionItemFromSavePath($path)
+    {
+    }
+}

--- a/src/Session/Handler/Factory/RedisFactory.php
+++ b/src/Session/Handler/Factory/RedisFactory.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Bolt\Session\Handler\Factory;
+
+use Bolt\Helpers\Deprecated;
+use Bolt\Session\OptionsBag;
+use InvalidArgumentException;
+use Redis;
+use RuntimeException;
+
+/**
+ * Factory for creating Redis instances from Session options.
+ *
+ * Note: This is only for the PHP extension, not Predis.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class RedisFactory extends AbstractFactory
+{
+    /** @var string */
+    protected $class;
+
+    /**
+     * Constructor.
+     *
+     * @param string|null $class Redis class name. Mostly for tests.
+     */
+    public function __construct($class = Redis::class)
+    {
+        if (!extension_loaded('redis')) {
+            throw new RuntimeException('Unable to use "redis" session handler as redis extension is not installed and enabled. Install the extension or use "predis" session handler instead.');
+        }
+
+        $this->class = $class ?: Redis::class;
+
+        if (!is_a($this->class, Redis::class, true)) {
+            throw new InvalidArgumentException(sprintf('Class name "%s" is not Redis or a subclass of Redis.', $this->class));
+        }
+    }
+
+    /**
+     * Creates a Redis instance from the session options.
+     *
+     * @param OptionsBag $sessionOptions
+     *
+     * @return Redis
+     */
+    public function create(OptionsBag $sessionOptions)
+    {
+        $connections = $this->parse($sessionOptions);
+
+        $conn = $this->selectConnection($connections);
+
+        $class = $this->class;
+        $redis = new $class();
+
+        return $this->configure($redis, $conn);
+    }
+
+    /**
+     * Configure the Redis instance with the parsed connection parameters.
+     *
+     * @param Redis      $redis
+     * @param OptionsBag $conn
+     *
+     * @return Redis
+     */
+    public function configure(Redis $redis, OptionsBag $conn)
+    {
+        if ($conn['persistent']) {
+            $redis->pconnect($conn['host'], $conn['port'], $conn['timeout']);
+        } else {
+            $redis->connect($conn['host'], $conn['port'], $conn['timeout'], $conn['retry_interval']);
+        }
+
+        if ($conn['password']) {
+            $redis->auth($conn['password']);
+        }
+
+        if ($conn['database'] >= 0) {
+            $redis->select($conn['database']);
+        }
+
+        if ($conn['prefix']) {
+            $redis->setOption(Redis::OPT_PREFIX, $conn['prefix']);
+        }
+
+        return $redis;
+    }
+
+    /**
+     * Select connection randomly accounting for weight.
+     *
+     * @param array $connections
+     *
+     * @return OptionsBag
+     */
+    public function selectConnection(array $connections)
+    {
+        $weighted = [];
+
+        foreach ($connections as $connection) {
+            foreach (range(0, $connection['weight']) as $i) {
+                $weighted[] = $connection;
+            }
+        }
+
+        $index = rand(0, count($weighted) - 1);
+
+        return $weighted[$index];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(OptionsBag $sessionOptions)
+    {
+        $connections = parent::parse($sessionOptions);
+
+        // Copy prefix/options.prefix to connections if it doesn't have one already
+        $prefix = 'PHPREDIS_SESSION:';
+        $options = new OptionsBag($sessionOptions->get('options', []));
+        if ($options->has('prefix')) {
+            $prefix = $options->get('prefix');
+        } elseif ($sessionOptions->has('prefix')) {
+            Deprecated::warn('Specifying "prefix" directly in session config', 3.3, 'Move it under the "options" key.');
+
+            $prefix = $sessionOptions->get('prefix');
+        }
+
+        foreach ($connections as $connection) {
+            if (!$connection['prefix']) {
+                $connection['prefix'] = $prefix;
+            }
+        }
+
+        return $connections;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionItemFromSavePath($path)
+    {
+        $uri = $this->parseUri($path);
+        $query = $this->parseQuery($uri);
+
+        $conn = new OptionsBag([
+            'password' => $query->get('auth'),
+            'database' => $query->getInt('database', 0),
+            'weight' => $query->getInt('weight', 1),
+            'persistent' => $query->getBoolean('persistent'),
+            'prefix' => $query->get('prefix'),
+            'timeout' => (float) $query->get('timeout', 86400.0),
+            'retry_interval' => $query->getInt('retry_interval', 0),
+        ]);
+
+        if ($uri->getHost()) {
+            $conn['host'] = $uri->getHost();
+            $conn['port'] = $uri->getPort() ?: 6379;
+        } else { // unix path
+            $conn['host'] = $uri->getPath();
+            $conn['port'] = 0;
+        }
+
+        if ((!$conn['host'] && !$conn['path']) || $conn['weight'] <= 0 || $conn['timeout'] <= 0) {
+            throw new InvalidArgumentException('Failed to parse session save_path');
+        }
+
+        return $conn;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parseConnectionItemFromOptions($item)
+    {
+        if (is_string($item)) {
+            $uri = $this->parseUri($item);
+            $item = [
+                'host' => $uri->getHost(),
+                'port' => $uri->getPort(),
+                'path' => $uri->getPath(),
+            ];
+        }
+
+        $item = new OptionsBag($item);
+
+        if ($prefix = $item->get('prefix')) {
+            Deprecated::warn('Specifying "prefix" under the "connection(s)" key', 3.3, 'Move it under the "options" key.');
+        }
+
+        $conn = new OptionsBag([
+            'host' => $item->get('host') ?: '127.0.0.1',
+            'port' => $item->getInt('port') ?: 6379,
+            'persistent' => $item->getBoolean('persistent', false),
+            'timeout' => (float) $item->get('timeout', 86400.0),
+            'retry_interval' => $item->getInt('retry_interval', 0),
+            'weight' => $item->getInt('weight', 1),
+            'database' => $item->getInt('database', 0),
+            'prefix' => $prefix,
+            'password' => $item->get('password'),
+        ]);
+
+        if ($item['path']) {
+            $conn['host'] = $item['path'];
+            $conn['port'] = 0;
+        }
+
+        if ($item['auth']) { // Not sure if needed for BC
+            Deprecated::warn('Connection key "auth"', 3.3, 'Use "password" instead.');
+
+            $conn['password'] = $item['auth'];
+        }
+
+        return $conn;
+    }
+}

--- a/src/Session/Handler/FileHandler.php
+++ b/src/Session/Handler/FileHandler.php
@@ -14,7 +14,7 @@ use Symfony\Component\Finder\Finder;
  * @author Carson Full <carsonfull@gmail.com>
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class FileHandler implements \SessionHandlerInterface, LazyWriteHandlerInterface
+class FileHandler extends AbstractHandler implements LazyWriteHandlerInterface
 {
     /** @var integer */
     protected $depth;
@@ -69,22 +69,6 @@ class FileHandler implements \SessionHandlerInterface, LazyWriteHandlerInterface
         $this->depth = $depth;
         $this->mode = $mode;
         $this->savePath = $savePath;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function open($savePath, $sessionName)
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function close()
-    {
-        return true;
     }
 
     /**

--- a/src/Session/Handler/FilesystemHandler.php
+++ b/src/Session/Handler/FilesystemHandler.php
@@ -11,7 +11,7 @@ use Bolt\Filesystem\Handler\FileInterface;
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
-class FilesystemHandler implements \SessionHandlerInterface
+class FilesystemHandler extends AbstractHandler
 {
     /** @var DirectoryInterface */
     protected $directory;
@@ -75,19 +75,5 @@ class FilesystemHandler implements \SessionHandlerInterface
             /** @var $file FileInterface */
             $file->delete();
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function open($savePath, $sessionName)
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function close()
-    {
     }
 }

--- a/src/Session/Handler/MemcacheHandler.php
+++ b/src/Session/Handler/MemcacheHandler.php
@@ -7,6 +7,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcacheSessionHand
 /**
  * Fixed to not close memcache connection on session close.
  *
+ * @deprecated since 3.3, will be removed in 4.0. Use {@see Bolt\Session\Handler\MemcachedHandler} instead.
+ *
  * @author Carson Full <carsonfull@gmail.com>
  */
 class MemcacheHandler extends MemcacheSessionHandler

--- a/src/Session/Handler/MemcachedHandler.php
+++ b/src/Session/Handler/MemcachedHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Bolt\Session\Handler;
+
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcachedSessionHandler;
+
+/**
+ * {@inheritdoc}
+ *
+ * Added lazy write support.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class MemcachedHandler extends MemcachedSessionHandler implements LazyWriteHandlerInterface
+{
+    /** @var int Time to live in seconds */
+    protected $ttl;
+    /** @var string Key prefix for shared environments */
+    protected $prefix;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(\Memcached $memcached, array $options = [])
+    {
+        parent::__construct($memcached, $options);
+
+        $this->ttl = isset($options['expiretime']) ? (int) $options['expiretime'] : 86400;
+        $this->prefix = isset($options['prefix']) ? $options['prefix'] : 'sf2s';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateTimestamp($sessionId, $data)
+    {
+        $this->getMemcached()->touch($this->prefix . $sessionId, time() + $this->ttl);
+    }
+}

--- a/src/Session/Handler/PsrCacheHandler.php
+++ b/src/Session/Handler/PsrCacheHandler.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Bolt\Session\Handler;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * PSR-6 Cache Session Handler.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class PsrCacheHandler extends AbstractHandler
+{
+    /** @var CacheItemPoolInterface */
+    protected $pool;
+    /** @var int */
+    protected $ttl;
+
+    /**
+     * Constructor.
+     *
+     * @param CacheItemPoolInterface $pool The cache instance
+     * @param int|null               $ttl  Number of seconds before session expires.
+     *                                     Null for default value from cache pool.
+     */
+    public function __construct(CacheItemPoolInterface $pool, $ttl = null)
+    {
+        $this->pool = $pool;
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($sessionId)
+    {
+        $item = $this->pool->getItem($sessionId);
+
+        return $item->isHit() ? $item->get() : '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($sessionId, $data)
+    {
+        $item = $this->pool->getItem($sessionId);
+
+        $item->set($data);
+        $item->expiresAfter($this->ttl);
+
+        return $this->pool->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($sessionId)
+    {
+        return $this->pool->deleteItem($sessionId);
+    }
+}

--- a/src/Session/Handler/PsrSimpleCacheHandler.php
+++ b/src/Session/Handler/PsrSimpleCacheHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Bolt\Session\Handler;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * PSR-16 Simple Cache Session Handler.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class PsrSimpleCacheHandler extends AbstractHandler
+{
+    /** @var CacheInterface */
+    protected $cache;
+    /** @var int */
+    protected $ttl;
+
+    /**
+     * Constructor.
+     *
+     * @param CacheInterface $cache The cache instance
+     * @param int|null       $ttl   Number of seconds before session expires.
+     *                              Null for default value from cache pool.
+     */
+    public function __construct(CacheInterface $cache, $ttl = null)
+    {
+        $this->cache = $cache;
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($sessionId)
+    {
+        return $this->cache->get($sessionId, '');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($sessionId, $data)
+    {
+        return $this->cache->set($sessionId, $data, $this->ttl);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($sessionId)
+    {
+        return $this->cache->delete($sessionId);
+    }
+}

--- a/src/Session/Handler/RedisHandler.php
+++ b/src/Session/Handler/RedisHandler.php
@@ -10,7 +10,7 @@ use Redis;
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
-class RedisHandler implements \SessionHandlerInterface, LazyWriteHandlerInterface
+class RedisHandler extends AbstractHandler implements LazyWriteHandlerInterface
 {
     /** @var Redis|Predis */
     protected $redis;
@@ -35,14 +35,6 @@ class RedisHandler implements \SessionHandlerInterface, LazyWriteHandlerInterfac
     /**
      * {@inheritdoc}
      */
-    public function open($savePath, $sessionName)
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function read($sessionId)
     {
         if ($data = $this->redis->get($sessionId)) {
@@ -50,14 +42,6 @@ class RedisHandler implements \SessionHandlerInterface, LazyWriteHandlerInterfac
         }
 
         return '';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function gc($maxlifetime)
-    {
-        return true;
     }
 
     /**
@@ -86,13 +70,5 @@ class RedisHandler implements \SessionHandlerInterface, LazyWriteHandlerInterfac
     public function updateTimestamp($sessionId, $data)
     {
         $this->redis->expire($sessionId, $this->ttl);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function close()
-    {
-        return true;
     }
 }

--- a/src/Session/IniBag.php
+++ b/src/Session/IniBag.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Bolt\Session;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * IniBag is a container for ini options.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class IniBag extends OptionsBag
+{
+    /** @var string|null */
+    private $extension;
+    /** @var string|null */
+    private $prefix;
+    /** @var array ini keys and whether they are editable */
+    private $cache;
+
+    /**
+     * Constructor.
+     *
+     * Note that extension and prefix, if given, are removed from the beginning of all keys.
+     *
+     * @param string|null $extension The extension name to pull ini values from, or null for all ini values.
+     * @param string|null $prefix    An additional prefix to filter by.
+     */
+    public function __construct($extension = null, $prefix = null)
+    {
+        if ($extension) {
+            if (!extension_loaded($extension)) {
+                throw new \InvalidArgumentException(sprintf('Extension "%s" does not exist.', $extension));
+            }
+
+            $prefix = $extension . '.' . $prefix;
+        }
+
+        $this->extension = $extension;
+        $this->prefix = $prefix;
+
+        parent::__construct([]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all()
+    {
+        $values = ini_get_all($this->extension);
+
+        $cache = [];
+        $parameters = [];
+
+        $prefixLength = strlen($this->prefix);
+
+        foreach ($values as $key => $value) {
+            // Filter out values that don't match the prefix.
+            if ($this->prefix && strpos($key, $this->prefix) === false) {
+                continue;
+            }
+            $key = substr($key, $prefixLength);
+            $parameters[$key] = $value['local_value'];
+
+            if ($this->cache === null) {
+                $cache[$key] = $value['access'] === 1 /* user */ || $value['access'] === 7 /* all */;
+            }
+        }
+
+        if ($this->cache === null) {
+            $this->cache = $cache;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Returns all the options that are editable.
+     *
+     * @return array
+     */
+    public function allEditable()
+    {
+        $editable = [];
+
+        foreach ($this as $key => $value) {
+            if ($this->cache[$key]) {
+                $editable[$key] = $value;
+            }
+        }
+
+        return $editable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function keys()
+    {
+        if ($this->cache === null) {
+            $this->all();
+        }
+
+        return array_keys($this->cache);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Use set() logic.
+     */
+    public function add(array $parameters = [])
+    {
+        foreach ($parameters as $key => $value) {
+            $this->set($key, $value);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Replace the values given, but don't remove any since that's not possible.
+     */
+    public function replace(array $parameters = [])
+    {
+        $this->add($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key, $default = null, $deep = false)
+    {
+        if (!$this->has($key)) {
+            return $default;
+        }
+
+        return ini_get($this->prefix . $key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $value)
+    {
+        Assert::nullOrScalar($value, 'ini values must be scalar or null. Got: %s');
+
+        $origValue = $value;
+
+        // false is converted to empty string
+        // converting to '0' is more consistent
+        if ($value === false) {
+            $value = '0';
+        }
+
+        $fullKey = $this->prefix . $key;
+
+        $ex = null;
+        set_error_handler(function ($severity, $message, $file, $line) use (&$ex) {
+            $ex = new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $result = ini_set($fullKey, $value);
+        } finally {
+            restore_error_handler();
+        }
+
+        if ($result === false || $ex !== null) {
+            if ($this->has($key)) {
+                if (!$this->cache[$key]) {
+                    throw new \RuntimeException(sprintf('Unable to change ini option "%s", because it is not editable at runtime.', $fullKey, $value), 0, $ex);
+                }
+
+                if (is_string($origValue)) {
+                    $value = '"' . $origValue . '"';
+                } elseif ($origValue === false) {
+                    $value = 'false';
+                } elseif ($origValue === true) {
+                    $value = 'true';
+                } elseif ($origValue === null) {
+                    $value = 'null';
+                }
+
+                throw new \RuntimeException(sprintf('Unable to change ini option "%s" to %s.', $fullKey, $value), 0, $ex);
+            }
+
+            throw new \RuntimeException(sprintf('The ini option "%s" does not exist. New ini options cannot be added.', $fullKey), 0, $ex);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Check existence after keys cache is populated.
+     */
+    public function has($key)
+    {
+        if ($this->cache === null) {
+            $this->all();
+        }
+
+        return array_key_exists($key, $this->cache);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($key)
+    {
+        throw new \BadMethodCallException('ini options cannot be removed.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->all());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        if ($this->cache === null) {
+            $this->all();
+        }
+
+        return count($this->cache);
+    }
+}

--- a/src/Session/SessionStorage.php
+++ b/src/Session/SessionStorage.php
@@ -214,6 +214,10 @@ class SessionStorage implements SessionStorageInterface
      */
     public function registerBag(SessionBagInterface $bag)
     {
+        if ($this->started) {
+            throw new \LogicException('Cannot register a bag when the session is already started.');
+        }
+
         $this->bags[$bag->getName()] = $bag;
     }
 

--- a/src/Session/SessionStorage.php
+++ b/src/Session/SessionStorage.php
@@ -31,9 +31,6 @@ class SessionStorage implements SessionStorageInterface
     /** @var boolean */
     protected $started = false;
 
-    /** @var boolean */
-    protected $closed = false;
-
     /** @var SessionBagInterface[] */
     protected $bags;
 
@@ -186,15 +183,14 @@ class SessionStorage implements SessionStorageInterface
      */
     public function save()
     {
-        if (!$this->started || $this->closed) {
-            throw new \RuntimeException('Trying to save a session that was not started yet or was already closed');
+        if (!$this->started) {
+            throw new \RuntimeException('Trying to save a session that was not started yet.');
         }
 
         $this->write();
 
         $this->handler->close();
 
-        $this->closed = true;
         $this->started = false;
     }
 
@@ -344,7 +340,6 @@ class SessionStorage implements SessionStorageInterface
         }
 
         $this->started = true;
-        $this->closed = false;
     }
 
     protected function collectGarbage()

--- a/tests/phpunit/unit/Session/Handler/Factory/MemcacheFactoryTest.php
+++ b/tests/phpunit/unit/Session/Handler/Factory/MemcacheFactoryTest.php
@@ -1,0 +1,332 @@
+<?php
+
+namespace Bolt\Tests\Session\Handler\Factory;
+
+use Bolt\Session\Handler\Factory\MemcacheFactory;
+use Bolt\Session\OptionsBag;
+use Bolt\Tests\Session\Handler\Factory\Mock\MockMemcache;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * @requires extension memcache
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class MemcacheFactoryTest extends TestCase
+{
+    public function createProvider()
+    {
+        return [
+            'empty' => [
+                [
+                ],
+                [
+                    [
+                        'host' => '127.0.0.1',
+                        'port' => 11211,
+                    ]
+                ]
+            ],
+
+            'connection string - only host' => [
+                [
+                    'connection' => '10.0.0.1',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                    ]
+                ]
+            ],
+
+            'connection string - host and port' => [
+                [
+                    'connection' => '10.0.0.1:11212',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                    ]
+                ]
+            ],
+
+            'connection string with scheme' => [
+                [
+                    'connection' => 'tcp://10.0.0.1:11212',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                    ]
+                ]
+            ],
+
+            'connection array' => [
+                [
+                    'connection' => [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                        'persistent' => true,
+                        'timeout' => 5,
+                        'retry_interval' => 5,
+                        'weight' => 3,
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                        'persistent' => true,
+                        'timeout' => 5,
+                        'retry_interval' => 5,
+                        'weight' => 3,
+                    ]
+                ]
+            ],
+
+            'connection unix socket string' => [
+                [
+                    'connection' => '/path/to/memcache.sock',
+                ],
+                [
+                    [
+                        'host' => 'unix:///path/to/memcache.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+
+            'connection unix socket array' => [
+                [
+                    'connection' => [
+                        'path' => '/path/to/memcache.sock',
+                    ]
+                ],
+                [
+                    [
+                        'host' => 'unix:///path/to/memcache.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+
+            // deprecated
+            'connection at root' => [
+                [
+                    'host' => '10.0.0.1',
+                    'port' => 11212,
+                    'timeout' => 34,
+                    'persistent' => true,
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                        'timeout' => 34.0,
+                        'persistent' => true,
+                    ]
+                ]
+            ],
+
+            'connections strings' => [
+                [
+                    'connections' => [
+                        '10.0.0.1:11212',
+                        '10.0.0.2:11212',
+                        '10.0.0.3',
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                    ],
+                    [
+                        'host' => '10.0.0.2',
+                        'port' => 11212,
+                    ],
+                    [
+                        'host' => '10.0.0.3',
+                    ]
+                ]
+            ],
+
+            'connections arrays' => [
+                [
+                    'connections' => [
+                        [
+                            'host' => '10.0.0.1',
+                            'port' => 11212,
+                            'persistent' => true,
+                            'timeout' => 5,
+                            'retry_interval' => 5,
+                            'weight' => 3,
+                        ],
+                        [
+                            'host' => '10.0.0.2',
+                            'port' => 11213,
+                            'persistent' => true,
+                            'timeout' => 6,
+                            'retry_interval' => 7,
+                            'weight' => 3,
+                        ],
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                        'persistent' => true,
+                        'timeout' => 5,
+                        'retry_interval' => 5,
+                        'weight' => 3,
+                    ],
+                    [
+                        'host' => '10.0.0.2',
+                        'port' => 11213,
+                        'persistent' => true,
+                        'timeout' => 6,
+                        'retry_interval' => 7,
+                        'weight' => 3,
+                    ]
+                ]
+            ],
+
+            'save path single host' => [
+                [
+                    'save_path' => 'host1:11212?weight=2&timeout=2&prefix=foo&persistent=1',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 11212,
+                        'persistent' => true,
+                        'timeout' => 2,
+                        'weight' => 2,
+                    ]
+                ]
+            ],
+
+            'save path single host with scheme' => [
+                [
+                    'save_path' => 'tcp://host1:11212?weight=2&timeout=2&prefix=foo&persistent=1',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 11212,
+                        'persistent' => true,
+                        'timeout' => 2,
+                        'weight' => 2,
+                    ]
+                ]
+            ],
+
+            'save path multiple hosts' => [
+                [
+                    'save_path' => 'tcp://host1:11212?weight=2&timeout=2&persistent=1, tcp://host2:11211?weight=2&timeout=2.5, host3:11211, tcp://host4',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 11212,
+                        'persistent' => true,
+                        'timeout' => 2,
+                        'weight' => 2,
+                    ],
+                    [
+                        'host' => 'host2',
+                        'timeout' => 2,
+                        'weight' => 2,
+                    ],
+                    [
+                        'host' => 'host3',
+                    ],
+                    [
+                        'host' => 'host4',
+                    ]
+                ]
+            ],
+
+            'save path unix path scheme and slashes' => [
+                [
+                    'save_path' => 'unix:///var/run/memcache.sock?persistent=1&weight=2',
+                ],
+                [
+                    [
+                        'host' => 'unix:///var/run/memcache.sock',
+                        'port' => 0,
+                        'persistent' => true,
+                        'weight' => 2,
+                    ]
+                ]
+            ],
+            'save path unix path no scheme' => [
+                [
+                    'save_path' => '/var/run/memcache.sock',
+                ],
+                [
+                    [
+                        'host' => 'unix:///var/run/memcache.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+            'save path unix path scheme' => [
+                [
+                    'save_path' => 'unix:/var/run/memcache.sock',
+                ],
+                [
+                    [
+                        'host' => 'unix:///var/run/memcache.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider createProvider
+     *
+     * @param array $sessionOptions
+     * @param array $expectedConnections
+     */
+    public function testCreate($sessionOptions, $expectedConnections)
+    {
+        $sessionOptions = new OptionsBag($sessionOptions);
+
+        $factory = new MemcacheFactory(MockMemcache::class);
+
+        /** @var MockMemcache $memcache */
+        $memcache = $factory->create($sessionOptions);
+
+        $this->assertInstanceOf(MockMemcache::class, $memcache);
+
+        $this->assertServers($expectedConnections, $memcache->getServers());
+    }
+
+    /**
+     * @param array        $expected
+     * @param OptionsBag[] $actual
+     */
+    private function assertServers($expected, $actual)
+    {
+        $expectedServers = [];
+
+        foreach ($expected as $item) {
+            $expectedServers[] = $item + [
+                'host' => '127.0.0.1',
+                'port' => 11211,
+                'weight' => 1,
+                'persistent' => false,
+                'timeout' => 1,
+                'retry_interval' => 0,
+            ];
+        }
+
+        $this->assertEquals($expectedServers, $actual);
+    }
+}

--- a/tests/phpunit/unit/Session/Handler/Factory/MemcachedFactoryTest.php
+++ b/tests/phpunit/unit/Session/Handler/Factory/MemcachedFactoryTest.php
@@ -1,0 +1,641 @@
+<?php
+
+namespace Bolt\Tests\Session\Handler\Factory;
+
+use Bolt\Session\Handler\Factory\MemcachedFactory;
+use Bolt\Session\OptionsBag;
+use Bolt\Tests\Session\Handler\Factory\Mock\MockMemcached;
+use Memcached;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * @requires extension memcached
+ * @requires extension memcached 2.0.0
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class MemcachedFactoryTest extends TestCase
+{
+    public function parseProvider()
+    {
+        return [
+            'empty' => [
+                [
+                ],
+                [
+                    [
+                        'host' => '127.0.0.1',
+                        'port' => 11211,
+                    ]
+                ]
+            ],
+
+            'connection string - only host' => [
+                [
+                    'connection' => '10.0.0.1',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                    ]
+                ]
+            ],
+
+            'connection string - host and port' => [
+                [
+                    'connection' => '10.0.0.1:11212',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                    ]
+                ]
+            ],
+
+            'connection string with scheme' => [
+                [
+                    'connection' => 'tcp://10.0.0.1:11212',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                    ]
+                ]
+            ],
+
+            'connection array' => [
+                [
+                    'connection' => [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                        'weight' => 3,
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                        'weight' => 3,
+                    ]
+                ]
+            ],
+
+            'connection unix socket string' => [
+                [
+                    'connection' => '/path/to/memcache.sock',
+                ],
+                [
+                    [
+                        'host' => '/path/to/memcache.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+
+            'connection unix socket array' => [
+                [
+                    'connection' => [
+                        'path' => '/path/to/memcache.sock',
+                    ]
+                ],
+                [
+                    [
+                        'host' => '/path/to/memcache.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+
+            // deprecated
+            'connection at root' => [
+                [
+                    'host' => '10.0.0.1',
+                    'port' => 11212,
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                    ]
+                ]
+            ],
+
+            'connections strings' => [
+                [
+                    'connections' => [
+                        '10.0.0.1:11212',
+                        '10.0.0.2:11212',
+                        '10.0.0.3',
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                    ],
+                    [
+                        'host' => '10.0.0.2',
+                        'port' => 11212,
+                    ],
+                    [
+                        'host' => '10.0.0.3',
+                    ]
+                ]
+            ],
+
+            'connections arrays' => [
+                [
+                    'connections' => [
+                        [
+                            'host' => '10.0.0.1',
+                            'port' => 11212,
+                            'weight' => 3,
+                        ],
+                        [
+                            'host' => '10.0.0.2',
+                            'port' => 11213,
+                            'weight' => 3,
+                        ],
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 11212,
+                        'weight' => 3,
+                    ],
+                    [
+                        'host' => '10.0.0.2',
+                        'port' => 11213,
+                        'weight' => 3,
+                    ]
+                ]
+            ],
+
+            'save path host' => [
+                [
+                    'save_path' => 'host1:11212:2',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 11212,
+                        'weight' => 2,
+                    ]
+                ]
+            ],
+
+            // for v2 of extension. support will be removed once PHP 5 support is dropped.
+            'save path with persistent id' => [
+                [
+                    'save_path' => 'PERSISTENT=foo host1:11212:2',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 11212,
+                        'weight' => 2,
+                    ]
+                ]
+            ],
+
+            'save path unix path' => [
+                [
+                    'save_path' => '/var/run/memcache.sock',
+                ],
+                [
+                    [
+                        'host' => '/var/run/memcache.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+
+            'save path unix path with weight' => [
+                [
+                    'save_path' => '/var/run/memcache.sock:0:2',
+                ],
+                [
+                    [
+                        'host' => '/var/run/memcache.sock',
+                        'port' => 0,
+                        'weight' => 2,
+                    ]
+                ]
+            ],
+
+            'save path multiple' => [
+                [
+                    'save_path' => 'host1:11212:2, /var/run/memcache.sock:0:4, host3:11211, host4',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 11212,
+                        'weight' => 2,
+                    ],
+                    [
+                        'host' => '/var/run/memcache.sock',
+                        'port' => 0,
+                        'weight' => 4,
+                    ],
+                    [
+                        'host' => 'host3',
+                    ],
+                    [
+                        'host' => 'host4',
+                    ]
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parseProvider
+     *
+     * @param array $sessionOptions
+     * @param array $expectedConnections
+     */
+    public function testParse($sessionOptions, $expectedConnections)
+    {
+        $sessionOptions = new OptionsBag($sessionOptions);
+
+        $factory = new MemcachedFactory();
+
+        $connections = $factory->parse($sessionOptions);
+
+        $this->assertConnections($expectedConnections, $connections);
+    }
+
+    /**
+     * @param array        $expected
+     * @param OptionsBag[] $actual
+     */
+    private function assertConnections($expected, $actual)
+    {
+        $expectedConnections = [];
+
+        foreach ($expected as $item) {
+            $expectedConnections[] = $item + [
+                'host' => '127.0.0.1',
+                'port' => 11211,
+                'weight' => 1,
+            ];
+        }
+
+        $actualConnections = [];
+
+        foreach ($actual as $item) {
+            $actualConnections[] = $item->all();
+        }
+
+        $this->assertEquals($expectedConnections, $actualConnections);
+    }
+
+    public function parseOptionsProvider()
+    {
+        return [
+            'all options from user' => [
+                [
+                    'options' => [
+                        'persistent' => true,
+                        'binary_protocol' => true,
+                        'consistent_hash' => true,
+                        'server_failure_limit' => 5,
+                        'remove_failed_servers' => true,
+                        'randomize_replica_read' => true,
+                        'number_of_replicas' => 5,
+                        'connect_timeout' => 50,
+                        'username' => 'admin',
+                        'password' => 'password',
+                        'prefix' => 'sessions:',
+                    ]
+                ],
+                [
+                    'persistent' => false,
+                    'binary_protocol' => false,
+                    'consistent_hash' => false,
+                    'server_failure_limit' => 0,
+                    'remove_failed_servers' => false,
+                    'randomize_replica_read' => false,
+                    'number_of_replicas' => 0,
+                    'connect_timeout' => 0,
+                    'sasl_username' => 'herp',
+                    'sasl_password' => 'derp',
+                ],
+                [
+                    'persistent' => true,
+                    'binary_protocol' => true,
+                    'consistent_hash' => true,
+                    'server_failure_limit' => true,
+                    'remove_failed_servers' => true,
+                    'randomize_replica_read' => true,
+                    'number_of_replicas' => 5,
+                    'connect_timeout' => 50,
+                    'username' => 'admin',
+                    'password' => 'password',
+                    'prefix' => 'sessions:',
+                ]
+            ],
+
+            'no options from user' => [
+                [],
+                [
+                    'persistent' => true,
+                    'binary_protocol' => true,
+                    'consistent_hash' => true,
+                    'server_failure_limit' => 5,
+                    'remove_failed_servers' => true,
+                    'randomize_replica_read' => true,
+                    'number_of_replicas' => 5,
+                    'connect_timeout' => 50,
+                    'sasl_username' => 'admin',
+                    'sasl_password' => 'password',
+                    'prefix' => 'sessions:',
+                ],
+                [
+                    'persistent' => true,
+                    'binary_protocol' => true,
+                    'consistent_hash' => true,
+                    'server_failure_limit' => 5,
+                    'remove_failed_servers' => true,
+                    'randomize_replica_read' => true,
+                    'number_of_replicas' => 5,
+                    'connect_timeout' => 50,
+                    'username' => 'admin',
+                    'password' => 'password',
+                    'prefix' => 'sessions:',
+                ]
+            ],
+
+            'v2 options from user are ignored if v3 are specified as well' => [
+                [
+                    'options' => [
+                        'remove_failed' => false,
+                        'remove_failed_servers' => true,
+
+                        'persistent' => true,
+                        'binary_protocol' => true,
+                        'consistent_hash' => true,
+                        'server_failure_limit' => 5,
+                        'randomize_replica_read' => true,
+                        'number_of_replicas' => 5,
+                        'connect_timeout' => 50,
+                        'sasl_username' => 'admin',
+                        'sasl_password' => 'password',
+                    ],
+                ],
+                [
+                ],
+                [
+                    'remove_failed_servers' => true,
+
+                    'persistent' => true,
+                    'binary_protocol' => true,
+                    'consistent_hash' => true,
+                    'server_failure_limit' => 5,
+                    'randomize_replica_read' => true,
+                    'number_of_replicas' => 5,
+                    'connect_timeout' => 50,
+                    'username' => 'admin',
+                    'password' => 'password',
+                ]
+            ],
+
+            'v2 options from user are replaced with v3 options' => [
+                [
+                    'options' => [
+                        'remove_failed' => true,
+
+                        'persistent' => true,
+                        'binary_protocol' => true,
+                        'consistent_hash' => true,
+                        'server_failure_limit' => 5,
+                        'randomize_replica_read' => true,
+                        'number_of_replicas' => 5,
+                        'connect_timeout' => 50,
+                        'username' => 'admin',
+                        'password' => 'password',
+                    ],
+                ],
+                [
+                ],
+                [
+                    'remove_failed_servers' => true,
+
+                    'persistent' => true,
+                    'binary_protocol' => true,
+                    'consistent_hash' => true,
+                    'server_failure_limit' => 5,
+                    'randomize_replica_read' => true,
+                    'number_of_replicas' => 5,
+                    'connect_timeout' => 50,
+                    'username' => 'admin',
+                    'password' => 'password',
+                ]
+            ],
+
+            'v2 options are defaulted from ini' => [
+                [
+                    'options' => [
+                        'persistent' => true,
+                        'consistent_hash' => true,
+                        'server_failure_limit' => 5,
+                        'randomize_replica_read' => true,
+                        'number_of_replicas' => 5,
+                        'connect_timeout' => 50,
+                        'sasl_username' => 'admin',
+                        'sasl_password' => 'password',
+                    ],
+                ],
+                [
+                    'remove_failed' => true,
+                    'binary' => true,
+                ],
+                [
+                    'remove_failed_servers' => true,
+                    'binary_protocol' => true,
+
+                    'persistent' => true,
+                    'consistent_hash' => true,
+                    'server_failure_limit' => 5,
+                    'randomize_replica_read' => true,
+                    'number_of_replicas' => 5,
+                    'connect_timeout' => 50,
+                    'username' => 'admin',
+                    'password' => 'password',
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parseOptionsProvider
+     *
+     * @param $sessionOptions
+     * @param $iniValues
+     * @param $expected
+     */
+    public function testParseOptions($sessionOptions, $iniValues, $expected)
+    {
+        $sessionOptions = new OptionsBag($sessionOptions);
+        $ini = new OptionsBag($iniValues);
+
+        $factory = new MemcachedFactory($ini);
+
+        $parseOptions = new \ReflectionMethod($factory, 'parseOptions');
+        $parseOptions->setAccessible(true);
+
+        /** @var OptionsBag $actual */
+        $actual = $parseOptions->invoke($factory, $sessionOptions);
+
+        $this->assertInstanceOf(OptionsBag::class, $actual);
+
+        $this->assertEquals($expected, $actual->all());
+    }
+
+    public function parsePersistentIdProvider()
+    {
+        return [
+            'save path' => [
+                [
+                    'save_path' => 'PERSISTENT=foo host1:11212:2',
+                ],
+                'foo'
+            ],
+
+            'persistent_id option' => [
+                [
+                    'options' => [
+                        'persistent_id' => 'foo',
+                    ],
+                ],
+                'foo'
+            ],
+
+            'automatically - options #1' => [
+                [
+                    'connection' => '10.0.0.1',
+                    'options' => [
+                        'username' => 'admin',
+                        'password' => 'secret',
+                    ],
+                ],
+                '46c7e1ddb20f90417c9afece27e3425de24925d3ef83948a71eee5d0ba1875ff'
+            ],
+
+            'automatically - options #2' => [
+                [
+                    'connection' => '10.0.0.1',
+                    'options' => [
+                        'username' => 'admin2',
+                        'password' => 'secret2',
+                    ],
+                ],
+                'e9d327285e9884438896bbcce238504ac1d0116385ca0d5b7ce3d6f55b59fd35'
+            ],
+
+            'automatically - connection #1' => [
+                [
+                    'connection' => '10.0.0.1',
+                ],
+                '7008acbaf8ca22813791d882cfcc3bef3c4ddd98c211feea1ac6c16747f68061'
+            ],
+
+            'automatically - connection #2' => [
+                [
+                    'connection' => '10.0.0.2',
+                ],
+                'e387cfa01af95592ca93630442178c027a7b7d879cb1213316b3f801cf9b5d6c'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parsePersistentIdProvider
+     *
+     * @param $sessionOptions
+     * @param $expected
+     */
+    public function testPersistentIdFromSavePath($sessionOptions, $expected)
+    {
+        $sessionOptions = new OptionsBag($sessionOptions);
+
+        $factory = new MemcachedFactory(new ParameterBag());
+
+        $connections = $factory->parse($sessionOptions);
+
+        $parseOptions = new \ReflectionMethod($factory, 'parseOptions');
+        $parseOptions->setAccessible(true);
+
+        /** @var OptionsBag $actual */
+        $options = $parseOptions->invoke($factory, $sessionOptions);
+
+        $parsePersistentId = new \ReflectionMethod($factory, 'parsePersistentId');
+        $parsePersistentId->setAccessible(true);
+
+        $id = $parsePersistentId->invoke($factory, $connections, $options, $sessionOptions);
+
+        $this->assertEquals($expected, $id);
+    }
+
+    public function testCreate()
+    {
+        $sessionOptions = new OptionsBag([
+            'connections' => [
+                [
+                    'host' => '10.0.0.1',
+                    'port' => 11212,
+                    'weight' => 4,
+                ],
+                '10.0.0.2',
+                '/var/run/memcache.sock',
+            ],
+            'options' => [
+                'persistent' => true,
+                'persistent_id' => 'foo',
+                'binary_protocol' => false,
+                'consistent_hash' => true,
+                'number_of_replicas' => 5,
+                'randomize_replica_read' => true,
+                'server_failure_limit' => 2,
+                'remove_failed_servers' => true,
+                'connect_timeout' => 10,
+                'username' => 'admin',
+                'password' => 'secret',
+            ],
+        ]);
+
+        $factory = new MemcachedFactory(new ParameterBag(), MockMemcached::class);
+
+        /** @var MockMemcached $memcached */
+        $memcached = $factory->create($sessionOptions);
+
+        $this->assertInstanceOf(MockMemcached::class, $memcached);
+
+        $this->assertEquals('foo', $memcached->getPersistentId());
+
+        $expectedServers = [
+            ['10.0.0.1', 11212, 4],
+            ['10.0.0.2', 11211, 1],
+            ['/var/run/memcache.sock', 0, 1],
+        ];
+        $this->assertEquals($expectedServers, $memcached->getServerList());
+
+        $expectedOptions = [
+            Memcached::OPT_BINARY_PROTOCOL => true, // enabled because username/password were given.
+            Memcached::OPT_LIBKETAMA_COMPATIBLE => true,
+            Memcached::OPT_SERVER_FAILURE_LIMIT => 2,
+            Memcached::OPT_NUMBER_OF_REPLICAS => 5,
+            Memcached::OPT_RANDOMIZE_REPLICA_READ => true,
+            Memcached::OPT_REMOVE_FAILED_SERVERS => true,
+            Memcached::OPT_CONNECT_TIMEOUT => 10,
+        ];
+        $this->assertEquals($expectedOptions, $memcached->getOptions());
+
+        $this->assertEquals(['admin', 'secret'], $memcached->getSaslAuthData());
+    }
+}

--- a/tests/phpunit/unit/Session/Handler/Factory/Mock/MockMemcache.php
+++ b/tests/phpunit/unit/Session/Handler/Factory/Mock/MockMemcache.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bolt\Tests\Session\Handler\Factory\Mock;
+
+class MockMemcache extends \Memcache
+{
+    private $servers = [];
+
+    public function addServer(
+        $host,
+        $port = 11211,
+        $persistent = true,
+        $weight = null,
+        $timeout = 1,
+        $retry_interval = 15,
+        $status = true,
+        callable $failure_callback = null
+    ) {
+        $this->servers[] = [
+            'host' => $host,
+            'port' => $port,
+            'persistent' => $persistent,
+            'weight' => $weight,
+            'timeout' => $timeout,
+            'retry_interval' => $retry_interval,
+        ];
+    }
+
+    public function getServers()
+    {
+        return $this->servers;
+    }
+}

--- a/tests/phpunit/unit/Session/Handler/Factory/Mock/MockMemcached.php
+++ b/tests/phpunit/unit/Session/Handler/Factory/Mock/MockMemcached.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Bolt\Tests\Session\Handler\Factory\Mock;
+
+class MockMemcached extends \Memcached
+{
+    const HAVE_SASL = 1;
+
+    private $servers = [];
+    private $options = [];
+    private $username;
+    private $password;
+    private $persistentId;
+
+    public function __construct($persistentId, $callback)
+    {
+        $this->persistentId = $persistentId;
+        $callback($this, $persistentId);
+    }
+
+    public function getPersistentId()
+    {
+        return $this->persistentId;
+    }
+
+    public function addServer($host, $port, $weight = 1)
+    {
+        $this->servers[] = [$host, $port, $weight];
+    }
+
+    public function addServers(array $servers)
+    {
+        $this->servers = $servers;
+    }
+
+    public function getServerList()
+    {
+        return $this->servers;
+    }
+
+    public function getOption($option)
+    {
+        return isset($this->options[$option]) ? $this->options[$option] : false;
+    }
+
+    public function setOption($option, $value)
+    {
+        $this->options[$value];
+    }
+
+    public function setOptions(/** @noinspection PhpSignatureMismatchDuringInheritanceInspection */ $options)
+    {
+        $this->options = $options;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function setSaslAuthData($username, $password)
+    {
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    public function getSaslAuthData()
+    {
+        return [$this->username, $this->password];
+    }
+}

--- a/tests/phpunit/unit/Session/Handler/Factory/Mock/MockRedis.php
+++ b/tests/phpunit/unit/Session/Handler/Factory/Mock/MockRedis.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Bolt\Tests\Session\Handler\Factory\Mock;
+
+class MockRedis extends \Redis
+{
+    public $host;
+    public $port;
+    public $persistent;
+    public $timeout;
+    public $retryInterval;
+    public $password;
+    public $database;
+    public $options = [];
+
+    public function connect($host, $port = 6379, $timeout = 0.0, $retryInterval = 0)
+    {
+        $this->host = $host;
+        $this->port = $port;
+        $this->timeout = $timeout;
+        $this->retryInterval = $retryInterval;
+        $this->persistent = false;
+    }
+
+    public function pconnect($host, $port = 6379, $timeout = 0.0)
+    {
+        $this->host = $host;
+        $this->port = $port;
+        $this->timeout = $timeout;
+        $this->persistent = true;
+    }
+
+    public function auth($password)
+    {
+        $this->password = $password;
+    }
+
+    public function select($dbindex)
+    {
+        $this->database = $dbindex;
+    }
+
+    public function setOption($name, $value)
+    {
+        $this->options[$name] = $value;
+    }
+
+    public function getOption($name)
+    {
+        return isset($this->options[$name]) ? $this->options[$name] : null;
+    }
+}

--- a/tests/phpunit/unit/Session/Handler/Factory/PredisFactoryTest.php
+++ b/tests/phpunit/unit/Session/Handler/Factory/PredisFactoryTest.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace Bolt\Tests\Session\Handler\Factory;
+
+use Bolt\Session\Handler\Factory\PredisFactory;
+use Bolt\Session\OptionsBag;
+use PHPUnit_Framework_TestCase as TestCase;
+use Predis\ClientInterface;
+use Predis\Command\Processor\KeyPrefixProcessor;
+use Predis\Connection\Aggregate\PredisCluster;
+use Predis\Connection\ParametersInterface;
+use Predis\Connection\StreamConnection;
+
+/**
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class PredisFactoryTest extends TestCase
+{
+    public function singleConnectionCreationProvider()
+    {
+        return [
+            'empty' => [
+                [
+                ],
+                [
+                    'host' => '127.0.0.1',
+                    'port' => 6379,
+                ]
+            ],
+
+            'connection string only host' => [
+                [
+                    'connection' => '10.0.0.1',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                    ]
+                ]
+            ],
+
+            'connection string' => [
+                [
+                    'connection' => 'tcp://10.0.0.1:6380?alias=master',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                        'alias' => 'master',
+                    ]
+                ]
+            ],
+
+            'connection array' => [
+                [
+                    'connection' => [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                        'alias' => 'master',
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                        'alias' => 'master',
+                    ]
+                ]
+            ],
+
+            'unix socket string' => [
+                [
+                    'connection' => 'unix:/path/to/redis.sock?alias=master',
+                ],
+                [
+                    [
+                        'scheme' => 'unix',
+                        'path' => '/path/to/redis.sock',
+                        'alias' => 'master',
+                    ]
+                ]
+            ],
+
+            'unix socket array' => [
+                [
+                    'connection' => [
+                        'scheme' => 'unix',
+                        'path' => '/path/to/redis.sock',
+                    ]
+                ],
+                [
+                    [
+                        'scheme' => 'unix',
+                        'path' => '/path/to/redis.sock',
+                        'alias' => 'master',
+                    ]
+                ]
+            ],
+
+            'with options' => [
+                [
+                    'connection' => [],
+                    'options' => [
+                        'prefix' => 'foo',
+                    ],
+                ],
+                [],
+                [
+                    'prefix' => 'foo',
+                ]
+            ],
+
+            'with prefix at root' => [
+                [
+                    'connection' => [],
+                    'prefix' => 'foo',
+                ],
+                [],
+                [
+                    'prefix' => 'foo',
+                ]
+            ],
+
+            // deprecated
+            'at root' => [
+                [
+                    'scheme' => 'tcp',
+                    'host' => 'redis.test',
+                    'port' => 6380,
+                    'timeout' => 34.0,
+                    'persistent' => true,
+                    'password' => 'secret',
+                    'database' => 4,
+                    'prefix' => 'foo',
+                ],
+                [
+                    [
+                        'scheme' => 'tcp',
+                        'host' => 'redis.test',
+                        'port' => 6380,
+                        'timeout' => 34.0,
+                        'persistent' => true,
+                        'password' => 'secret',
+                        'database' => 4,
+                    ]
+                ],
+                [
+                    'prefix' => 'foo',
+                ]
+            ],
+        ];
+    }
+
+    public function clusterConnectionCreationProvider()
+    {
+        $expectedConnections = [
+            [
+                'scheme' => 'tcp',
+                'host' => '10.0.0.1',
+            ],
+            [
+                'scheme' => 'tcp',
+                'host' => '10.0.0.2',
+            ],
+            [
+                'scheme' => 'tcp',
+                'host' => '10.0.0.3',
+            ],
+        ];
+
+        return [
+            'cluster strings' => [
+                [
+                    'connections' => [
+                        'tcp://10.0.0.1',
+                        'tcp://10.0.0.2',
+                        'tcp://10.0.0.3',
+                    ],
+                ],
+                $expectedConnections,
+            ],
+
+            'cluster array' => [
+                [
+                    'connections' => [
+                        [
+                            'host' => '10.0.0.1',
+                        ],
+                        [
+                            'host' => '10.0.0.2',
+                        ],
+                        [
+                            'host' => '10.0.0.3',
+                        ],
+                    ],
+                ],
+                $expectedConnections,
+            ],
+        ];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Using "save_path" is unsupported with "predis" session handler.
+     */
+    public function testSavePath()
+    {
+        $sessionOptions = new OptionsBag([
+            'save_path' => 'asdf',
+        ]);
+
+        $factory = new PredisFactory();
+
+        $factory->create($sessionOptions);
+    }
+
+    /**
+     * @dataProvider singleConnectionCreationProvider
+     *
+     * @param array $sessionOptions
+     * @param array $expectedParameters
+     * @param array $expectedOptions
+     */
+    public function testSingleConnectionCreation($sessionOptions, $expectedParameters, $expectedOptions = [])
+    {
+        $sessionOptions = new OptionsBag($sessionOptions);
+
+        $factory = new PredisFactory();
+
+        $client = $factory->create($sessionOptions);
+
+        $this->assertSingleConnection($client, $expectedParameters);
+
+        $this->assertOptions($client, $expectedOptions);
+    }
+
+    /**
+     * @dataProvider clusterConnectionCreationProvider
+     *
+     * @param       $sessionOptions
+     * @param       $expectedParameters
+     * @param array $expectedOptions
+     */
+    public function testCluster($sessionOptions, $expectedParameters = [], $expectedOptions = [])
+    {
+        $sessionOptions = new OptionsBag($sessionOptions);
+
+        $factory = new PredisFactory();
+
+        $client = $factory->create($sessionOptions);
+
+        $this->assertClusterConnection($client, $expectedParameters);
+
+        $this->assertOptions($client, $expectedOptions);
+    }
+
+    private function assertClusterConnection(ClientInterface $client, $expected)
+    {
+        /** @var PredisCluster|StreamConnection[] $cluster */
+        $cluster = $client->getConnection();
+        $this->assertInstanceOf(PredisCluster::class, $cluster);
+        foreach ($cluster as $connection) {
+            $this->assertParameters($connection->getParameters(), $expected);
+        }
+    }
+
+    private function assertSingleConnection(ClientInterface $client, $expected)
+    {
+        /** @var StreamConnection $connection */
+        $connection = $client->getConnection();
+        $this->assertInstanceOf(StreamConnection::class, $connection);
+        $this->assertParameters($connection->getParameters(), $expected);
+    }
+
+    private function assertParameters(ParametersInterface $params, $expected)
+    {
+        // Taken from Predis\Connection\ParametersInterface
+        $keys = ['scheme', 'host', 'port', 'path', 'alias', 'timeout', 'read_write_timeout', 'async_connect', 'tcp_nodelay', 'persistent', 'password', 'database'];
+
+        foreach ($keys as $key) {
+            if (isset($expected[$key])) {
+                $this->assertEquals($expected[$key], $params->$key);
+            }
+        }
+    }
+
+    private function assertOptions(ClientInterface $client, $expected)
+    {
+        $options = $client->getOptions();
+
+        /** @var KeyPrefixProcessor|null $prefix */
+        $prefix = $options->prefix;
+        if (isset($expected['prefix'])) {
+            $this->assertInstanceOf(KeyPrefixProcessor::class, $prefix);
+            $this->assertEquals($expected['prefix'], $prefix->getPrefix());
+        } else {
+            $this->assertNull($prefix);
+        }
+    }
+}

--- a/tests/phpunit/unit/Session/Handler/Factory/RedisFactoryTest.php
+++ b/tests/phpunit/unit/Session/Handler/Factory/RedisFactoryTest.php
@@ -1,0 +1,402 @@
+<?php
+
+namespace Bolt\Tests\Session\Handler\Factory;
+
+use Bolt\Session\Handler\Factory\RedisFactory;
+use Bolt\Session\OptionsBag;
+use Bolt\Tests\Session\Handler\Factory\Mock\MockRedis;
+use PHPUnit_Framework_TestCase as TestCase;
+use Redis;
+
+/**
+ * @requires extension redis
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class RedisFactoryTest extends TestCase
+{
+    public function parseProvider()
+    {
+        return [
+            'empty' => [
+                [
+                ],
+                [
+                    [
+                        'host' => '127.0.0.1',
+                        'port' => 6379,
+                    ]
+                ]
+            ],
+
+            'connection string - only host' => [
+                [
+                    'connection' => '10.0.0.1',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                    ]
+                ]
+            ],
+
+            'connection string - host and port' => [
+                [
+                    'connection' => '10.0.0.1:6380',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                    ]
+                ]
+            ],
+
+            'connection string with scheme' => [
+                [
+                    'connection' => 'tcp://10.0.0.1:6380',
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                    ]
+                ]
+            ],
+
+            'connection array' => [
+                [
+                    'connection' => [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                        'persistent' => true,
+                        'timeout' => 5.0,
+                        'retry_interval' => 500,
+                        'weight' => 3,
+                        'database' => 4,
+                        'auth' => 'secret', // deprecated
+                    ],
+                    'options' => [
+                        'prefix' => 'foo',
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                        'persistent' => true,
+                        'timeout' => 5.0,
+                        'retry_interval' => 500,
+                        'weight' => 3,
+                        'database' => 4,
+                        'prefix' => 'foo',
+                        'password' => 'secret',
+                    ]
+                ]
+            ],
+
+            'connection unix socket string' => [
+                [
+                    'connection' => '/path/to/redis.sock',
+                ],
+                [
+                    [
+                        'host' => '/path/to/redis.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+
+            'connection unix socket array' => [
+                [
+                    'connection' => [
+                        'path' => '/path/to/redis.sock',
+                    ]
+                ],
+                [
+                    [
+                        'host' => '/path/to/redis.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+
+            // deprecated
+            'connection at root' => [
+                [
+                    'host' => 'redis.test',
+                    'port' => 6380,
+                    'timeout' => 34.0,
+                    'persistent' => true,
+                    'password' => 'secret',
+                    'database' => 4,
+                    'prefix' => 'foo',
+                ],
+                [
+                    [
+                        'host' => 'redis.test',
+                        'port' => 6380,
+                        'timeout' => 34.0,
+                        'persistent' => true,
+                        'password' => 'secret',
+                        'database' => 4,
+                        'prefix' => 'foo',
+                    ]
+                ]
+            ],
+
+            'connections strings' => [
+                [
+                    'connections' => [
+                        '10.0.0.1:6380',
+                        '10.0.0.2:6380',
+                        '10.0.0.3',
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                    ],
+                    [
+                        'host' => '10.0.0.2',
+                        'port' => 6380,
+                    ],
+                    [
+                        'host' => '10.0.0.3',
+                    ]
+                ]
+            ],
+
+            'connections arrays' => [
+                [
+                    'connections' => [
+                        [
+                            'host' => '10.0.0.1',
+                            'port' => 6380,
+                            'persistent' => true,
+                            'timeout' => 5.0,
+                            'retry_interval' => 500,
+                            'weight' => 3,
+                            'database' => 4,
+                            'auth' => 'secret', // deprecated
+                        ],
+                        [
+                            'host' => '10.0.0.2',
+                            'port' => 6381,
+                            'persistent' => true,
+                            'timeout' => 6.0,
+                            'retry_interval' => 501,
+                            'weight' => 3,
+                            'database' => 3,
+                            'password' => 'secret2',
+                        ],
+                    ],
+                    'options' => [
+                        'prefix' => 'foo',
+                    ],
+                ],
+                [
+                    [
+                        'host' => '10.0.0.1',
+                        'port' => 6380,
+                        'persistent' => true,
+                        'timeout' => 5.0,
+                        'retry_interval' => 500,
+                        'weight' => 3,
+                        'database' => 4,
+                        'prefix' => 'foo',
+                        'password' => 'secret',
+                    ],
+                    [
+                        'host' => '10.0.0.2',
+                        'port' => 6381,
+                        'persistent' => true,
+                        'timeout' => 6.0,
+                        'retry_interval' => 501,
+                        'weight' => 3,
+                        'database' => 3,
+                        'prefix' => 'foo',
+                        'password' => 'secret2',
+                    ]
+                ]
+            ],
+
+            'save path single host' => [
+                [
+                    'save_path' => 'tcp://host1:6381?weight=2&timeout=2.5&database=3&prefix=foo&auth=secret&persistent=1',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 6381,
+                        'persistent' => true,
+                        'timeout' => 2.5,
+                        'weight' => 2,
+                        'database' => 3,
+                        'prefix' => 'foo',
+                        'password' => 'secret',
+                    ]
+                ]
+            ],
+
+            'save path single host without scheme' => [
+                [
+                    'save_path' => 'host1:6381',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 6381,
+                    ]
+                ]
+            ],
+
+            'save path multiple hosts' => [
+                [
+                    'save_path' => 'tcp://host1:6381?weight=2&timeout=2.5&database=3&prefix=foo&auth=secret&persistent=1, tcp://host2:6379?weight=2&timeout=2.5, host3:6379, tcp://host4',
+                ],
+                [
+                    [
+                        'host' => 'host1',
+                        'port' => 6381,
+                        'persistent' => true,
+                        'timeout' => 2.5,
+                        'weight' => 2,
+                        'database' => 3,
+                        'prefix' => 'foo',
+                        'password' => 'secret',
+                    ],
+                    [
+                        'host' => 'host2',
+                        'port' => 6379,
+                        'timeout' => 2.5,
+                        'weight' => 2,
+                    ],
+                    [
+                        'host' => 'host3',
+                    ],
+                    [
+                        'host' => 'host4',
+                    ]
+                ]
+            ],
+
+            'save path unix path scheme and slashes' => [
+                [
+                    'save_path' => 'unix:///var/run/redis/redis.sock?persistent=1&weight=2&database=1',
+                ],
+                [
+                    [
+                        'host' => '/var/run/redis/redis.sock',
+                        'port' => 0,
+                        'persistent' => true,
+                        'weight' => 2,
+                        'database' => 1,
+                    ]
+                ]
+            ],
+            'save path unix path no scheme' => [
+                [
+                    'save_path' => '/var/run/redis/redis.sock',
+                ],
+                [
+                    [
+                        'host' => '/var/run/redis/redis.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+            'save path unix path scheme' => [
+                [
+                    'save_path' => 'unix:/var/run/redis/redis.sock',
+                ],
+                [
+                    [
+                        'host' => '/var/run/redis/redis.sock',
+                        'port' => 0,
+                    ]
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parseProvider
+     *
+     * @param array $sessionOptions
+     * @param array $expectedConnections
+     */
+    public function testParse($sessionOptions, $expectedConnections)
+    {
+        $sessionOptions = new OptionsBag($sessionOptions);
+
+        $factory = new RedisFactory();
+
+        $connections = $factory->parse($sessionOptions);
+
+        $this->assertConnections($expectedConnections, $connections);
+    }
+
+    /**
+     * @param array        $expected
+     * @param OptionsBag[] $actual
+     */
+    private function assertConnections($expected, $actual)
+    {
+        $expectedConnections = [];
+
+        foreach ($expected as $item) {
+            $expectedConnections[] = $item + [
+                'host' => '127.0.0.1',
+                'port' => 6379,
+                'persistent' => false,
+                'timeout' => 86400.0,
+                'retry_interval' => 0,
+                'weight' => 1,
+                'database' => 0,
+                'prefix' => 'PHPREDIS_SESSION:',
+                'password' => null,
+            ];
+        }
+
+        $actualConnections = [];
+
+        foreach ($actual as $item) {
+            $actualConnections[] = $item->all();
+        }
+
+        $this->assertEquals($expectedConnections, $actualConnections);
+    }
+
+    public function testCreate()
+    {
+        $sessionOptions = new OptionsBag([
+            'connection' => [
+                'host' => '10.0.0.1',
+                'port' => 6380,
+                'persistent' => true,
+                'timeout' => 5.0,
+                'weight' => 3,
+                'database' => 4,
+                'prefix' => 'foo',
+                'password' => 'secret',
+            ],
+        ]);
+
+        $factory = new RedisFactory(MockRedis::class);
+
+        /** @var MockRedis $redis */
+        $redis = $factory->create($sessionOptions);
+
+        $this->assertInstanceOf(MockRedis::class, $redis);
+
+        $this->assertEquals('10.0.0.1', $redis->host);
+        $this->assertEquals(6380, $redis->port);
+        $this->assertTrue($redis->persistent);
+        $this->assertEquals(5.0, $redis->timeout);
+        $this->assertEquals(4, $redis->database);
+        $this->assertEquals('foo', $redis->getOption(Redis::OPT_PREFIX));
+        $this->assertEquals('secret', $redis->password);
+    }
+}

--- a/tests/phpunit/unit/Session/IniBagTest.php
+++ b/tests/phpunit/unit/Session/IniBagTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Bolt\Tests\Session;
+
+use Bolt\Session\IniBag;
+use PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * IniBag Tests
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class IniBagTest extends TestCase
+{
+    public function testAllGlobal()
+    {
+        $ini = new IniBag();
+
+        $expectedSubset = [
+            'allow_url_fopen'   => ini_get('allow_url_fopen'),
+            'allow_url_include' => ini_get('allow_url_include'),
+        ];
+        $actual = $ini->all();
+
+        $this->assertArraySubset($expectedSubset, $actual);
+    }
+
+    public function testAllGlobalAndPrefix()
+    {
+        $ini = new IniBag(null, 'allow_url_');
+
+        $expectedSubset = [
+            'fopen'   => ini_get('allow_url_fopen'),
+            'include' => ini_get('allow_url_include'),
+        ];
+        $actual = $ini->all();
+
+        $this->assertArraySubset($expectedSubset, $actual);
+    }
+
+    public function testAllExtension()
+    {
+        $ini = new IniBag('session');
+
+        $expectedSubset = [
+            'name'         => ini_get('session.name'),
+            'save_handler' => ini_get('session.save_handler'),
+        ];
+        $actual = $ini->all();
+
+        $this->assertArraySubset($expectedSubset, $actual);
+    }
+
+    public function testAllExtensionAndPrefix()
+    {
+        $ini = new IniBag('date', 'default_');
+
+        $expectedSubset = [
+            'latitude'  => ini_get('date.default_latitude'),
+            'longitude' => ini_get('date.default_longitude'),
+        ];
+        $actual = $ini->all();
+
+        $this->assertArraySubset($expectedSubset, $actual);
+    }
+
+    public function testAllEditable()
+    {
+        $ini = new IniBag();
+
+        $actual = $ini->allEditable();
+
+        $this->assertArrayHasKey('date.timezone', $actual);
+        $this->assertArrayNotHasKey('allow_url_fopen', $actual);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Extension "foo" does not exist.
+     */
+    public function testInvalidExtension()
+    {
+        new IniBag('foo');
+    }
+
+    public function testIterator()
+    {
+        $ini = new IniBag();
+
+        $expected = ini_get_all(null, false);
+
+        $actual = iterator_to_array($ini);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testCount()
+    {
+        $ini = new IniBag();
+
+        $expected = count(ini_get_all());
+
+        $this->assertCount($expected, $ini);
+    }
+
+    public function testKeys()
+    {
+        $ini = new IniBag('session');
+
+        $keys = $ini->keys();
+
+        $this->assertContains('name', $keys, '', false, true, true);
+        $this->assertContains('save_handler', $keys, '', false, true, true);
+    }
+
+    public function testGet()
+    {
+        $ini = new IniBag('session');
+
+        $expected = ini_get('session.name');
+
+        $actual = $ini->get('name');
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testHas()
+    {
+        $ini = new IniBag('session');
+
+        $this->assertTrue($ini->has('name'));
+        $this->assertFalse($ini->has('kajhsdfakjsdfh'));
+    }
+
+    public function testSet()
+    {
+        $ini = new IniBag('session');
+
+        $backup = ini_get('session.name');
+
+        try {
+            $ini->set('name', 'foo');
+            $this->assertSame('foo', ini_get('session.name'));
+        } finally {
+            ini_set('session.name', $backup);
+        }
+    }
+
+    public function testSetBoolean()
+    {
+        $ini = new IniBag();
+
+        $backup = ini_get('assert.bail');
+
+        try {
+            $ini->set('assert.bail', false);
+            $this->assertSame('0', ini_get('assert.bail'));
+
+            $ini->set('assert.bail', true);
+            $this->assertSame('1', ini_get('assert.bail'));
+        } finally {
+            ini_set('assert.bail', $backup);
+        }
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to change ini option "precision" to -2.
+     */
+    public function testSetInvalidValue()
+    {
+        $ini = new IniBag();
+
+        $ini->set('precision', -2);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage ini values must be scalar or null. Got: array
+     */
+    public function testSetInvalidType()
+    {
+        $ini = new IniBag();
+
+        $ini->set('precision', []);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The ini option "session.derp" does not exist. New ini options cannot be added.
+     */
+    public function testSetNewKey()
+    {
+        $ini = new IniBag('session');
+
+        $ini->set('derp', 'foo');
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to change ini option "allow_url_fopen", because it is not editable at runtime.
+     */
+    public function testSetUnauthorized()
+    {
+        $ini = new IniBag();
+
+        $ini->set('allow_url_fopen', true);
+    }
+
+    public function testAdd()
+    {
+        $ini = new IniBag('session');
+
+        $backup = ini_get('session.name');
+
+        try {
+            $ini->add(['name' => 'foo']);
+            $this->assertSame('foo', ini_get('session.name'));
+        } finally {
+            ini_set('session.name', $backup);
+        }
+    }
+
+    public function testReplace()
+    {
+        $ini = new IniBag('session');
+
+        $backup = ini_get('session.name');
+
+        try {
+            $ini->replace(['name' => 'foo']);
+            $this->assertSame('foo', ini_get('session.name'));
+
+            // Assert keys can't be removed
+            $this->assertArrayHasKey('session.save_handler', ini_get_all());
+        } finally {
+            ini_set('session.name', $backup);
+        }
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testRemove()
+    {
+        $ini = new IniBag();
+
+        $ini->remove('why though');
+    }
+}


### PR DESCRIPTION
# Configuring Handlers

In my previous attempt, I tried to normalize all connection parameters and options for `Memcache`, `Memcached`, `Redis`, and `Predis`. In reality this became confusing and didn't work well.

Now all that logic has been moved into factory classes. In addition there were several bugs in how each client was configured that have been resolved. All the factories are under unit tests as well 👏 

These do still need to be documented I know. I was hesitant to document the configuration before, because I didn't like how it turned out and wanted to change it. But there's only so much one can handle looking at undocumented PHP C source code 😉 
Now I'm happy(er) with it, and will take a stab at the docs.

Also it's important to note that `predis` is its own type now separate from the `redis` type which is just for the php extension.

# IniBag

Why is everything builtin to PHP garbage?

`IniBag` abstracts away the `ini_get`, `ini_set`, `ini_get_all` methods and provides helpful error messages when something goes wrong.

It's currently used for [importing session ini options](https://github.com/CarsonF/bolt/blob/improvements/sessions/src/Provider/SessionServiceProvider.php#L175-L190) and configuring Memcached options ([here](https://github.com/CarsonF/bolt/blob/improvements/sessions/src/Session/Handler/Factory/MemcachedFactory.php#L42) and [here](https://github.com/CarsonF/bolt/blob/improvements/sessions/src/Session/Handler/Factory/MemcachedFactory.php#L162-L188)).

# Cache Handlers

Added session handlers for [Doctrine Cache](https://github.com/CarsonF/bolt/blob/improvements/sessions/src/Session/Handler/DoctrineCacheHandler.php), [PSR-6 Cache](https://github.com/CarsonF/bolt/blob/improvements/sessions/src/Session/Handler/PsrCacheHandler.php), and [PSR-16 Simple Cache](https://github.com/CarsonF/bolt/blob/improvements/sessions/src/Session/Handler/PsrSimpleCacheHandler.php).

# Misc

- Moved session handler creation to its own container key which allows all factory logic to be skipped.
```php
$app['session.handler'] = $app->share(function () {
    return MyCustomSessionHandler();
});
```
- Throw exception when trying to register a bag after the session has started.
- Removed unused session options