### PR TITLE
[4.0] Raise minimum requirement to PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - hhvm

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Bolt 4 (Early Development)
   * **Should be considered unstable**
   * **Not suitable for production use**
   * **API is not stable and subject to change**
+  * **PHP 7 is now the minimum requirement** 
 
 ---
 

--- a/app/nut
+++ b/app/nut
@@ -4,7 +4,7 @@
  * This could be loaded on a very old version of PHP so no syntax/methods over 5.2 in this file.
  */
 
-$minVersion = '5.5.9';
+$minVersion = '7.0.0';
 if (version_compare(PHP_VERSION, $minVersion, '<')) {
     echo sprintf("\033[37;41mBolt requires PHP \033[1m%s\033[22m or higher. You have PHP \033[1m%s\033[22m, so Bolt will not run on your current setup.\033[39;49m%s", $minVersion, PHP_VERSION, PHP_EOL);
     exit(1);

--- a/app/web.php
+++ b/app/web.php
@@ -4,7 +4,7 @@
  */
 use Bolt\Exception\BootException;
 
-if (version_compare(PHP_VERSION, '5.5.9', '<')) {
+if (version_compare(PHP_VERSION, '7.0.0', '<')) {
     require dirname(__DIR__) . '/src/Exception/BootException.php';
 
     BootException::earlyExceptionVersion();

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "monolog/monolog": "^1.21",
         "nesbot/carbon": "^1.21",
         "paragonie/random_compat": "^1.4",
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "silex/silex": "^1.3",
         "silex/web-profiler": "1.0.x-dev#2c5df830c864bec709307e706176771b57440be5@dev",
         "siriusphp/upload": "^1.3",

--- a/src/Application.php
+++ b/src/Application.php
@@ -27,7 +27,7 @@ class Application extends Silex\Application
         AppSingleton::set($this);
 
         /** @internal Parameter to track a deprecated PHP version */
-        $values['deprecated.php'] = version_compare(PHP_VERSION, '5.5.9', '<');
+        $values['deprecated.php'] = version_compare(PHP_VERSION, '7.0.0', '<');
 
         // Debug 1st phase: Register early error & exception handlers
         $this->register(new Provider\DebugServiceProvider());

--- a/src/Exception/BootException.php
+++ b/src/Exception/BootException.php
@@ -105,7 +105,7 @@ EOM;
     public static function earlyExceptionVersion()
     {
         $message = <<<EOM
-Bolt requires PHP <u>5.5.9</u>, or higher. 
+Bolt requires PHP <u>7.0.0</u>, or higher. 
 <br><br>
 You are running PHP <u>%s</u>, so Bolt will not run on your current setup.
 EOM;


### PR DESCRIPTION
As agreed, and re-confirmed last night, we're implementing Twig 2 for Bolt v4 … and [their minimum PHP `require` is 7.0](https://github.com/twigphp/Twig/blob/v2.0.0/composer.json#L30) … so be ours.

This is an increasing trend too, but keeps us moving forward instead of supporting PHP 5.2+ still kinda thing :wink: 
