### PR TITLE
[3.3][Tests] Deprecations … another sweep

### DIFF
--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -43,7 +43,7 @@ class Records extends BackendBase
      * @param string  $contenttypeslug The content type slug
      * @param integer $id              The content ID
      *
-     * @return \Bolt\Response\TemplateResponse|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return \Bolt\Response\TemplateResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function edit(Request $request, $contenttypeslug, $id)
     {

--- a/tests/phpunit/BoltListener.php
+++ b/tests/phpunit/BoltListener.php
@@ -3,6 +3,10 @@
 namespace Bolt\Tests;
 
 use Bolt\Application;
+use PHPUnit\Framework\BaseTestListener;
+use PHPUnit_Framework_Test as Test;
+use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit_Framework_TestSuite as TestSuite;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -11,7 +15,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class BoltListener implements \PHPUnit_Framework_TestListener
+class BoltListener extends BaseTestListener
 {
     /** @var array */
     protected $configs = [
@@ -38,7 +42,7 @@ class BoltListener implements \PHPUnit_Framework_TestListener
     /**
      * Called on init of PHPUnit exectution.
      *
-     * @see PHPUnit_Util_Configuration
+     * @see \PHPUnit_Util_Configuration
      *
      * @param array   $configs Location of configuration files
      * @param bool    $theme   Location of the theme
@@ -147,117 +151,28 @@ class BoltListener implements \PHPUnit_Framework_TestListener
     }
 
     /**
-     * An error occurred.
-     *
-     * @see PHPUnit_Framework_TestListener::addError()
-     *
-     * @param \PHPUnit_Framework_Test $test
-     * @param \Exception              $e
-     * @param float                   $time
+     * {@inheritdoc}
      */
-    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function endTest(Test $test, $time)
     {
-    }
-
-    /**
-     * A failure occurred.
-     *
-     * @see PHPUnit_Framework_TestListener::addFailure()
-     *
-     * @param \PHPUnit_Framework_Test                 $test
-     * @param \PHPUnit_Framework_AssertionFailedError $e
-     * @param float                                   $time
-     */
-    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
-    {
-    }
-
-    /**
-     * A test was incomplete.
-     *
-     * @see PHPUnit_Framework_TestListener::addIncompleteTest()
-     *
-     * @param \PHPUnit_Framework_Test $test
-     * @param \Exception              $e
-     * @param float                   $time
-     */
-    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    /**
-     * A test  is deemed risky.
-     *
-     * @see PHPUnit_Framework_TestListener::addRiskyTest()
-     *
-     * @param \PHPUnit_Framework_Test $test
-     * @param \Exception              $e
-     * @param float                   $time
-     */
-    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    /**
-     * Test has been skipped.
-     *
-     * @see PHPUnit_Framework_TestListener::addSkippedTest()
-     *
-     * @param \PHPUnit_Framework_Test $test
-     * @param \Exception              $e
-     * @param float                   $time
-     */
-    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    /**
-     * A test started.
-     *
-     * @see PHPUnit_Framework_TestListener::startTest()
-     *
-     * @param \PHPUnit_Framework_Test $test
-     */
-    public function startTest(\PHPUnit_Framework_Test $test)
-    {
-    }
-
-    /**
-     * A test ended.
-     *
-     * @see PHPUnit_Framework_TestListener::endTest()
-     *
-     * @param \PHPUnit_Framework_Test $test
-     * @param float                   $time
-     */
-    public function endTest(\PHPUnit_Framework_Test $test, $time)
-    {
-        /** @var \PHPUnit_Framework_TestCase $test */
+        /** @var TestCase $test */
         $name = $test->getName();
         $suite = end($this->currentSuite);
         $this->tracker[$suite . '::' . $name] = $time;
     }
 
     /**
-     * A test suite started.
-     *
-     * @see PHPUnit_Framework_TestListener::startTestSuite()
-     *
-     * @param \PHPUnit_Framework_TestSuite $suite
+     * {@inheritdoc}
      */
-    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    public function startTestSuite(TestSuite $suite)
     {
         array_push($this->currentSuite, $suite->getName());
     }
 
     /**
-     * A test suite ended.
-     *
-     * @see PHPUnit_Framework_TestListener::endTestSuite()
-     *
-     * @param \PHPUnit_Framework_TestSuite $suite
+     * {@inheritdoc}
      */
-    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    public function endTestSuite(TestSuite $suite)
     {
         array_pop($this->currentSuite);
     }

--- a/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
+++ b/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
@@ -27,14 +27,16 @@ class AccessCheckerTest extends BoltUnitTest
         $this->assertInstanceOf('Bolt\AccessControl\AccessChecker', $accessControl);
     }
 
+    /**
+     * @expectedException        \Bolt\Exception\AccessControlException
+     * @expectedExceptionMessage Can not validate session with an empty token.
+     */
     public function testIsValidSessionNoCookie()
     {
         $accessControl = $this->getAccessControl();
         $this->assertInstanceOf('Bolt\AccessControl\AccessChecker', $accessControl);
 
-        $this->setExpectedException('Bolt\Exception\AccessControlException', 'Can not validate session with an empty token.');
-
-        $response = $accessControl->isValidSession(null);
+        $accessControl->isValidSession(null);
     }
 
     /**

--- a/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
+++ b/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Bolt\Tests;
+namespace Bolt\Tests\AccessControl;
 
 use Bolt\AccessControl\AccessChecker;
 use Bolt\AccessControl\Token\Token;
 use Bolt\Logger\FlashLogger;
 use Bolt\Storage\Entity;
+use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
+++ b/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
@@ -24,7 +24,7 @@ class AccessCheckerTest extends BoltUnitTest
     public function testLoadAccessControl()
     {
         $accessControl = $this->getAccessControl();
-        $this->assertInstanceOf('Bolt\AccessControl\AccessChecker', $accessControl);
+        $this->assertInstanceOf(AccessChecker::class, $accessControl);
     }
 
     /**
@@ -34,7 +34,7 @@ class AccessCheckerTest extends BoltUnitTest
     public function testIsValidSessionNoCookie()
     {
         $accessControl = $this->getAccessControl();
-        $this->assertInstanceOf('Bolt\AccessControl\AccessChecker', $accessControl);
+        $this->assertInstanceOf(AccessChecker::class, $accessControl);
 
         $accessControl->isValidSession(null);
     }
@@ -59,7 +59,7 @@ class AccessCheckerTest extends BoltUnitTest
         $app['session']->set('authentication', $token);
 
         $accessControl = $this->getAccessControl();
-        $this->assertInstanceOf('Bolt\AccessControl\AccessChecker', $accessControl);
+        $this->assertInstanceOf(AccessChecker::class, $accessControl);
 
         $response = $accessControl->isValidSession($token);
         $this->assertFalse($response);
@@ -85,7 +85,7 @@ class AccessCheckerTest extends BoltUnitTest
         $app['session']->set('authentication', $token);
 
         $accessControl = $this->getAccessControl();
-        $this->assertInstanceOf('Bolt\AccessControl\AccessChecker', $accessControl);
+        $this->assertInstanceOf(AccessChecker::class, $accessControl);
 
         $response = $accessControl->isValidSession($token);
         $this->assertFalse($response);

--- a/tests/phpunit/unit/AccessControl/LoginTest.php
+++ b/tests/phpunit/unit/AccessControl/LoginTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Bolt\Tests;
+namespace Bolt\Tests\AccessControl;
 
 use Bolt\AccessControl\Login;
 use Bolt\AccessControl\Token;
 use Bolt\Events\AccessControlEvent;
+use Bolt\Tests\BoltUnitTest;
 use Carbon\Carbon;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/tests/phpunit/unit/AccessControl/LoginTest.php
+++ b/tests/phpunit/unit/AccessControl/LoginTest.php
@@ -5,6 +5,8 @@ namespace Bolt\Tests\AccessControl;
 use Bolt\AccessControl\Login;
 use Bolt\AccessControl\Token;
 use Bolt\Events\AccessControlEvent;
+use Bolt\Storage\Entity;
+use Bolt\Storage\Repository\UsersRepository;
 use Bolt\Tests\BoltUnitTest;
 use Carbon\Carbon;
 use Symfony\Component\HttpFoundation\Request;
@@ -78,8 +80,8 @@ class LoginTest extends BoltUnitTest
             ->with($this->equalTo('Your account is disabled. Sorry about that.'));
         $app['logger.flash'] = $logger;
 
-        $entityName = 'Bolt\Storage\Entity\Users';
-        $repo = $app['storage']->getRepository($entityName);
+        /** @var UsersRepository $repo */
+        $repo = $app['storage']->getRepository(Entity\Users::class);
         $userEntity = $repo->getUser('admin');
         $userEntity->setEnabled(false);
         $repo->save($userEntity);

--- a/tests/phpunit/unit/AccessControl/LoginTest.php
+++ b/tests/phpunit/unit/AccessControl/LoginTest.php
@@ -21,6 +21,10 @@ class LoginTest extends BoltUnitTest
         $this->resetDb();
     }
 
+    /**
+     * @expectedException        \Bolt\Exception\AccessControlException
+     * @expectedExceptionMessage Invalid login parameters.
+     */
     public function testLoginNoCredentials()
     {
         $app = $this->getApp();
@@ -35,8 +39,6 @@ class LoginTest extends BoltUnitTest
         $app['logger.system'] = $logger;
 
         $login = new Login($app);
-
-        $this->setExpectedException('Bolt\Exception\AccessControlException', 'Invalid login parameters.');
         $login->login(null, null, new AccessControlEvent(new Request()));
     }
 

--- a/tests/phpunit/unit/AccessControl/PasswordTest.php
+++ b/tests/phpunit/unit/AccessControl/PasswordTest.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Bolt\Tests;
+namespace Bolt\Tests\AccessControl;
 
 use Bolt\AccessControl\Password;
 use Bolt\Events\AccessControlEvent;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Repository;
+use Bolt\Tests\BoltUnitTest;
 use Carbon\Carbon;
 use PasswordLib\PasswordLib;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/phpunit/unit/AccessControl/PasswordTest.php
+++ b/tests/phpunit/unit/AccessControl/PasswordTest.php
@@ -27,9 +27,8 @@ class PasswordTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $this->addDefaultUser($app);
-        $entityName = 'Bolt\Storage\Entity\Users';
         /** @var Repository\UsersRepository $repo */
-        $repo = $app['storage']->getRepository($entityName);
+        $repo = $app['storage']->getRepository(Entity\Users::class);
 
         $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
@@ -57,9 +56,8 @@ class PasswordTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $this->addDefaultUser($app);
-        $entityName = 'Bolt\Storage\Entity\Users';
         /** @var Repository\UsersRepository $repo */
-        $repo = $app['storage']->getRepository($entityName);
+        $repo = $app['storage']->getRepository(Entity\Users::class);
 
         $shadowToken = $app['randomgenerator']->generateString(32);
         $shadowTokenHash = md5($shadowToken . '-' . str_replace('.', '-', '8.8.8.8'));
@@ -86,9 +84,8 @@ class PasswordTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $this->addDefaultUser($app);
-        $entityName = 'Bolt\Storage\Entity\Users';
         /** @var Repository\UsersRepository $repo */
-        $repo = $app['storage']->getRepository($entityName);
+        $repo = $app['storage']->getRepository(Entity\Users::class);
 
         $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
@@ -116,9 +113,8 @@ class PasswordTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $this->addDefaultUser($app);
-        $entityName = 'Bolt\Storage\Entity\Users';
         /** @var Repository\UsersRepository $repo */
-        $repo = $app['storage']->getRepository($entityName);
+        $repo = $app['storage']->getRepository(Entity\Users::class);
 
         $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
@@ -146,9 +142,8 @@ class PasswordTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $this->addDefaultUser($app);
-        $entityName = 'Bolt\Storage\Entity\Users';
         /** @var Repository\UsersRepository $repo */
-        $repo = $app['storage']->getRepository($entityName);
+        $repo = $app['storage']->getRepository(Entity\Users::class);
 
         $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())

--- a/tests/phpunit/unit/AccessControl/PermissionParserTest.php
+++ b/tests/phpunit/unit/AccessControl/PermissionParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bolt\Tests;
+namespace Bolt\Tests\AccessControl;
 
 use Bolt\AccessControl\PermissionParser;
 

--- a/tests/phpunit/unit/AccessControl/PermissionParserTest.php
+++ b/tests/phpunit/unit/AccessControl/PermissionParserTest.php
@@ -3,8 +3,9 @@
 namespace Bolt\Tests\AccessControl;
 
 use Bolt\AccessControl\PermissionParser;
+use PHPUnit\Framework\TestCase;
 
-class PermissionParserTest extends \PHPUnit_Framework_TestCase
+class PermissionParserTest extends TestCase
 {
     /**
      * @dataProvider lexProvider

--- a/tests/phpunit/unit/AccessControl/TokenGeneratorTest.php
+++ b/tests/phpunit/unit/AccessControl/TokenGeneratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Bolt\Tests;
+namespace Bolt\Tests\AccessControl;
 
 use Bolt\AccessControl\Token\Generator;
+use Bolt\Tests\BoltUnitTest;
 
 /**
  * Test for AccessControl\Token\Generator

--- a/tests/phpunit/unit/AccessControl/TokenTokenTest.php
+++ b/tests/phpunit/unit/AccessControl/TokenTokenTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\AccessControl;
 
 use Bolt\AccessControl\Token\Token;
 use Bolt\Storage\Entity;
+use Bolt\Storage\Entity\AuthToken;
 use Bolt\Tests\BoltUnitTest;
 
 /**
@@ -19,7 +20,7 @@ class TokenTokenTest extends BoltUnitTest
         $tokenEntity = new Entity\Authtoken();
         $token = new Token($userEntity, $tokenEntity);
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
+        $this->assertInstanceOf(Token::class, $token);
     }
 
     public function testStringCast()
@@ -28,7 +29,7 @@ class TokenTokenTest extends BoltUnitTest
         $tokenEntity = new Entity\Authtoken(['token' => 'cookies']);
         $token = new Token($userEntity, $tokenEntity);
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
+        $this->assertInstanceOf(Token::class, $token);
         $this->assertSame('cookies', (string) $token);
     }
 
@@ -38,14 +39,14 @@ class TokenTokenTest extends BoltUnitTest
         $tokenEntity = new Entity\Authtoken();
         $token = new Token($userEntity, $tokenEntity);
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
+        $this->assertInstanceOf(Token::class, $token);
         $this->assertTrue($token->isEnabled());
 
         $userEntity = new Entity\Users(['enabled' => false]);
         $tokenEntity = new Entity\Authtoken();
         $token = new Token($userEntity, $tokenEntity);
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
+        $this->assertInstanceOf(Token::class, $token);
         $this->assertFalse($token->isEnabled());
     }
 
@@ -56,8 +57,8 @@ class TokenTokenTest extends BoltUnitTest
         $token = new Token($userEntity, $tokenEntity);
         $user = $token->getUser();
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
-        $this->assertInstanceOf('Bolt\Storage\Entity\Users', $user);
+        $this->assertInstanceOf(Token::class, $token);
+        $this->assertInstanceOf(Entity\Users::class, $user);
         $this->assertSame('koala', $user->getUsername());
     }
 
@@ -67,14 +68,14 @@ class TokenTokenTest extends BoltUnitTest
         $tokenEntity = new Entity\Authtoken();
         $token = new Token($userEntity, $tokenEntity);
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
+        $this->assertInstanceOf(Token::class, $token);
 
         $userEntity = new Entity\Users(['username' => 'clippy']);
         $token->setUser($userEntity);
 
         $user = $token->getUser();
 
-        $this->assertInstanceOf('Bolt\Storage\Entity\Users', $user);
+        $this->assertInstanceOf(Entity\Users::class, $user);
         $this->assertSame('clippy', $user->getUsername());
     }
 
@@ -85,8 +86,8 @@ class TokenTokenTest extends BoltUnitTest
         $token = new Token($userEntity, $tokenEntity);
         $authToken = $token->getToken();
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
-        $this->assertInstanceOf('Bolt\Storage\Entity\AuthToken', $authToken);
+        $this->assertInstanceOf(Token::class, $token);
+        $this->assertInstanceOf(AuthToken::class, $authToken);
         $this->assertSame('gum-leaves', $authToken->getToken());
     }
 
@@ -96,7 +97,7 @@ class TokenTokenTest extends BoltUnitTest
         $tokenEntity = new Entity\Authtoken(['token' => 'gum-leaves']);
         $token = new Token($userEntity, $tokenEntity);
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
+        $this->assertInstanceOf(Token::class, $token);
 
         $tokenEntity = new Entity\Authtoken(['token' => 'cookies']);
         $token->setToken($tokenEntity);
@@ -113,7 +114,7 @@ class TokenTokenTest extends BoltUnitTest
         $tokenEntity = new Entity\Authtoken();
         $token = new Token($userEntity, $tokenEntity);
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
+        $this->assertInstanceOf(Token::class, $token);
 
         $checked = $token->getChecked();
         $this->assertGreaterThan(time() - 1, $checked);
@@ -126,7 +127,7 @@ class TokenTokenTest extends BoltUnitTest
         $tokenEntity = new Entity\Authtoken();
         $token = new Token($userEntity, $tokenEntity);
 
-        $this->assertInstanceOf('Bolt\AccessControl\Token\Token', $token);
+        $this->assertInstanceOf(Token::class, $token);
 
         $token->setChecked();
         $checked = $token->getChecked();

--- a/tests/phpunit/unit/AccessControl/TokenTokenTest.php
+++ b/tests/phpunit/unit/AccessControl/TokenTokenTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Bolt\Tests;
+namespace Bolt\Tests\AccessControl;
 
 use Bolt\AccessControl\Token\Token;
 use Bolt\Storage\Entity;
+use Bolt\Tests\BoltUnitTest;
 
 /**
  * Test for AccessControl\Token\Token

--- a/tests/phpunit/unit/Application/ApplicationTest.php
+++ b/tests/phpunit/unit/Application/ApplicationTest.php
@@ -10,9 +10,9 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $this->arrayHasKey($app, 'bolt_version');
-        $this->arrayHasKey($app, 'bolt_name');
-        $this->arrayHasKey($app, 'bolt_released');
-        $this->arrayHasKey($app, 'bolt_long_version');
+        $this->assertArrayHasKey('bolt_version', $app);
+        $this->assertArrayHasKey('bolt_name', $app);
+        $this->assertArrayHasKey('bolt_released', $app);
+        $this->assertArrayHasKey('bolt_long_version', $app);
     }
 }

--- a/tests/phpunit/unit/Application/ApplicationTest.php
+++ b/tests/phpunit/unit/Application/ApplicationTest.php
@@ -3,8 +3,9 @@
 namespace Bolt\Tests;
 
 use Bolt\Application;
+use PHPUnit\Framework\TestCase;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     public function testConstructorSetBoltVersion()
     {

--- a/tests/phpunit/unit/Asset/AbstractExtensionsUnitTest.php
+++ b/tests/phpunit/unit/Asset/AbstractExtensionsUnitTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Asset;
 
 use Bolt\Tests\BoltUnitTest;
+use PHPUnit_Extension_FunctionMocker as FunctionMocker;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -16,7 +17,7 @@ abstract class AbstractExtensionsUnitTest extends BoltUnitTest
 {
     public function setup()
     {
-        $this->php = \PHPUnit_Extension_FunctionMocker::start($this, 'Bolt')
+        $this->php = FunctionMocker::start($this, 'Bolt')
             ->mockFunction('file_exists')
             ->mockFunction('is_readable')
             ->mockFunction('is_dir')
@@ -24,14 +25,14 @@ abstract class AbstractExtensionsUnitTest extends BoltUnitTest
             ->mockFunction('file_get_contents')
             ->getMock();
 
-        $this->php2 = \PHPUnit_Extension_FunctionMocker::start($this, 'Bolt\Tests\Asset\Mock')
+        $this->php2 = FunctionMocker::start($this, 'Bolt\Tests\Asset\Mock')
             ->mockFunction('file_get_contents')
             ->getMock();
     }
 
     public function tearDown()
     {
-        \PHPUnit_Extension_FunctionMocker::tearDown();
+        FunctionMocker::tearDown();
 
         $fs = new Filesystem();
         if ($fs->exists(PHPUNIT_WEBROOT . '/app/cache/config-cache.json')) {

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -17,7 +17,8 @@ use Bolt\Users;
 use Doctrine\Common\Cache\VoidCache;
 use GuzzleHttp\Client;
 use Monolog\Logger;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Swift_Mailer;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -29,7 +30,7 @@ use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  **/
-abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
+abstract class BoltUnitTest extends TestCase
 {
     private $app;
 
@@ -251,7 +252,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
      * @param \Silex\Application $app
      * @param array              $methods Defaults to ['isValidSession']
      *
-     * @return \Bolt\AccessControl\AccessChecker|PHPUnit_Framework_MockObject_MockObject
+     * @return \Bolt\AccessControl\AccessChecker|MockObject
      */
     protected function getMockAccessChecker($app, $methods = ['isValidSession'])
     {
@@ -276,7 +277,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return VoidCache|PHPUnit_Framework_MockObject_MockObject
+     * @return VoidCache|MockObject
      */
     protected function getMockCache()
     {
@@ -289,7 +290,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods
      *
-     * @return CsrfTokenManager|PHPUnit_Framework_MockObject_MockObject
+     * @return CsrfTokenManager|MockObject
      */
     protected function getMockCsrfTokenManager($methods = ['isTokenValid'])
     {
@@ -301,7 +302,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return Client|\PHPUnit_Framework_MockObject_MockObject
+     * @return Client|MockObject
      */
     protected function getMockGuzzleClient()
     {
@@ -314,7 +315,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods
      *
-     * @return FlashLogger|PHPUnit_Framework_MockObject_MockObject
+     * @return FlashLogger|MockObject
      */
     protected function getMockFlashLogger($methods = ['danger', 'error', 'success'])
     {
@@ -327,7 +328,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods Defaults to ['login']
      *
-     * @return PHPUnit_Framework_MockObject_MockObject A mocked \Bolt\AccessControl\Login
+     * @return MockObject A mocked \Bolt\AccessControl\Login
      */
     protected function getMockLogin($methods = ['login'])
     {
@@ -341,7 +342,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods
      *
-     * @return Manager|PHPUnit_Framework_MockObject_MockObject
+     * @return Manager|MockObject
      */
     protected function getMockLoggerManager($methods = ['clear', 'error', 'info', 'trim'])
     {
@@ -359,7 +360,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods
      *
-     * @return Logger|PHPUnit_Framework_MockObject_MockObject
+     * @return Logger|MockObject
      */
     protected function getMockMonolog($methods = ['alert', 'clear', 'debug', 'error', 'info'])
     {
@@ -373,7 +374,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods
      *
-     * @return Permissions|PHPUnit_Framework_MockObject_MockObject
+     * @return Permissions|MockObject
      */
     protected function getMockPermissions($methods = ['isAllowed', 'isAllowedToManipulate'])
     {
@@ -387,7 +388,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods
      *
-     * @return PHPUnit_Framework_MockObject_MockObject|Swift_Mailer
+     * @return MockObject|Swift_Mailer
      */
     protected function getMockSwiftMailer($methods = ['send'])
     {
@@ -401,7 +402,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods
      *
-     * @return Storage|PHPUnit_Framework_MockObject_MockObject
+     * @return Storage|MockObject
      */
     protected function getMockStorage($methods = ['getContent', 'getContentType', 'getTaxonomyType'])
     {
@@ -415,7 +416,7 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
     /**
      * @param array $methods
      *
-     * @return Users|PHPUnit_Framework_MockObject_MockObject
+     * @return Users|MockObject
      */
     protected function getMockUsers($methods = ['getUsers', 'isAllowed'])
     {

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -193,65 +193,6 @@ abstract class BoltUnitTest extends \PHPUnit_Framework_TestCase
         $app['access_control'] = $auth;
     }
 
-    /**
-     * @param \Silex\Application $app
-     * @param array              $functions Defaults to ['isValidSession']
-     *
-     * @return \Bolt\AccessControl\AccessChecker|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function getAccessCheckerMock($app, $functions = ['isValidSession'])
-    {
-        $accessCheckerMock = $this->getMock(
-            'Bolt\AccessControl\AccessChecker',
-            $functions,
-            [
-                $app['storage.lazy'],
-                $app['request_stack'],
-                $app['session'],
-                $app['dispatcher'],
-                $app['logger.flash'],
-                $app['logger.system'],
-                $app['permissions'],
-                $app['randomgenerator'],
-                $app['access_control.cookie.options'],
-            ]
-        );
-
-        return $accessCheckerMock;
-    }
-
-    /**
-     * @param \Silex\Application $app
-     * @param array              $functions Defaults to ['login']
-     *
-     * @return \PHPUnit_Framework_MockObject_MockObject A mocked \Bolt\AccessControl\Login
-     */
-    protected function getLoginMock($app, $functions = ['login'])
-    {
-        $loginMock = $this->getMock('Bolt\AccessControl\Login', $functions, [$app]);
-
-        return $loginMock;
-    }
-
-    protected function getCacheMock($path = null)
-    {
-        $app = $this->getApp();
-        if ($path === null) {
-            $path = $app['path_resolver']->resolve('cache');
-        }
-
-        $params = [
-            $path,
-            \Bolt\Cache::EXTENSION,
-            0002,
-            $app['filesystem'],
-        ];
-
-        $cache = $this->getMock('Bolt\Cache', ['flushAll'], $params);
-
-        return $cache;
-    }
-
     protected function removeCSRF($app)
     {
         // Symfony forms need a CSRF token so we have to mock this too

--- a/tests/phpunit/unit/Configuration/ComposerConfigurationTest.php
+++ b/tests/phpunit/unit/Configuration/ComposerConfigurationTest.php
@@ -5,6 +5,9 @@ namespace Bolt\Tests\Configuration;
 use Bolt\Configuration\Composer;
 use Bolt\Configuration\ComposerChecks;
 use Bolt\Exception\BootException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Extension_FunctionMocker as FunctionMocker;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Class to test correct operation and locations of composer configuration.
@@ -15,11 +18,14 @@ use Bolt\Exception\BootException;
  *
  * @runTestsInSeparateProcesses
  */
-class ComposerConfigurationTest extends \PHPUnit_Framework_TestCase
+class ComposerConfigurationTest extends TestCase
 {
+    /** @var MockObject */
+    protected $php;
+
     public function setup()
     {
-        $this->php = \PHPUnit_Extension_FunctionMocker::start($this, 'Bolt\Configuration')
+        $this->php = FunctionMocker::start($this, 'Bolt\Configuration')
             ->mockFunction('is_writable')
             ->mockFunction('is_dir')
             ->getMock();

--- a/tests/phpunit/unit/Configuration/ConfigVerificationTest.php
+++ b/tests/phpunit/unit/Configuration/ConfigVerificationTest.php
@@ -4,13 +4,14 @@ namespace Bolt\Tests\Configuration;
 
 use Bolt\Configuration\LowlevelChecks;
 use Bolt\Configuration\Standard;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class to test correct operation and locations of composer configuration.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ConfigVerificationTest extends \PHPUnit_Framework_TestCase
+class ConfigVerificationTest extends TestCase
 {
     public function testInitWithVerifier()
     {

--- a/tests/phpunit/unit/Configuration/PathResolverTest.php
+++ b/tests/phpunit/unit/Configuration/PathResolverTest.php
@@ -38,18 +38,21 @@ class PathResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $resolver->resolve($path));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Failed to resolve path. Alias %nope% is not defined.
+     */
     public function testUndefinedAliasFails()
     {
-        $this->setExpectedException(\InvalidArgumentException::class, 'Failed to resolve path. Alias %nope% is not defined.');
-
         $resolver = new PathResolver('/root/');
         $resolver->resolve('%nope%/foo/bar');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testRelativeRootFails()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
-
         new PathResolver('foo');
     }
 

--- a/tests/phpunit/unit/Configuration/PathResolverTest.php
+++ b/tests/phpunit/unit/Configuration/PathResolverTest.php
@@ -3,8 +3,9 @@
 namespace Bolt\Tests\Configuration;
 
 use Bolt\Configuration\PathResolver;
+use PHPUnit\Framework\TestCase;
 
-class PathResolverTest extends \PHPUnit_Framework_TestCase
+class PathResolverTest extends TestCase
 {
     public function pathResolutionProvider()
     {

--- a/tests/phpunit/unit/Configuration/ResourceManagerTest.php
+++ b/tests/phpunit/unit/Configuration/ResourceManagerTest.php
@@ -8,6 +8,7 @@ use Bolt\Configuration\Standard;
 use Bolt\Tests\BoltUnitTest;
 use Eloquent\Pathogen\FileSystem\Factory\PlatformFileSystemPathFactory;
 use Eloquent\Pathogen\FileSystem\PlatformFileSystemPath as Path;
+use Eloquent\Pathogen\PathInterface;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -95,7 +96,7 @@ class ResourceManagerTest extends BoltUnitTest
         $this->assertEquals(Path::fromString(PHPUNIT_WEBROOT), $config->getPath('rootpath'));
         $this->assertEquals(Path::fromString(PHPUNIT_WEBROOT . '/app'), $config->getPath('app'));
         $this->assertEquals(Path::fromString(PHPUNIT_WEBROOT . '/public/files'), $config->getPath('files'));
-        $this->assertInstanceOf('Eloquent\Pathogen\PathInterface', $config->getPathObject('root'));
+        $this->assertInstanceOf(PathInterface::class, $config->getPathObject('root'));
     }
 
     public function testRelativePathCreation()

--- a/tests/phpunit/unit/Configuration/ResourceManagerTest.php
+++ b/tests/phpunit/unit/Configuration/ResourceManagerTest.php
@@ -8,6 +8,7 @@ use Bolt\Configuration\Standard;
 use Bolt\Tests\BoltUnitTest;
 use Eloquent\Pathogen\FileSystem\Factory\PlatformFileSystemPathFactory;
 use Eloquent\Pathogen\FileSystem\PlatformFileSystemPath as Path;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -28,7 +29,7 @@ class ResourceManagerTest extends BoltUnitTest
             ]
         );
         $config = new ResourceManager($container);
-        $this->assertEquals(Path::fromString(PHPUNIT_WEBROOT), \PHPUnit_Framework_Assert::readAttribute($config, 'root'));
+        $this->assertEquals(Path::fromString(PHPUNIT_WEBROOT), Assert::readAttribute($config, 'root'));
     }
 
     public function testDefaultPaths()

--- a/tests/phpunit/unit/Configuration/StandardConfigurationTest.php
+++ b/tests/phpunit/unit/Configuration/StandardConfigurationTest.php
@@ -5,6 +5,7 @@ namespace Bolt\Tests\Configuration;
 use Bolt\Application;
 use Bolt\Configuration\Standard;
 use Composer\Autoload\ClassLoader;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Debug\DebugClassLoader;
 
 /**
@@ -14,7 +15,7 @@ use Symfony\Component\Debug\DebugClassLoader;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class StandardConfigurationTest extends \PHPUnit_Framework_TestCase
+class StandardConfigurationTest extends TestCase
 {
     public function testInitWithClassloader()
     {

--- a/tests/phpunit/unit/Configuration/Validation/AbstractValidationTest.php
+++ b/tests/phpunit/unit/Configuration/Validation/AbstractValidationTest.php
@@ -7,8 +7,9 @@ use Bolt\Configuration\PathResolver;
 use Bolt\Configuration\Validation;
 use Bolt\Configuration\Validation\Validator;
 use Bolt\Logger\FlashLogger;
-use PHPUnit_Extension_FunctionMocker;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Extension_FunctionMocker as FunctionMocker;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Abstract validation tests.
@@ -17,7 +18,7 @@ use PHPUnit_Framework_TestCase;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-abstract class AbstractValidationTest extends PHPUnit_Framework_TestCase
+abstract class AbstractValidationTest extends TestCase
 {
     /** @var Validator */
     protected $validator;
@@ -28,14 +29,14 @@ abstract class AbstractValidationTest extends PHPUnit_Framework_TestCase
     /** @var FlashLogger */
     protected $flashLogger;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject */
     protected $_filesystem;
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject */
     protected $_validation;
 
     public function setUp()
     {
-        $this->_filesystem = PHPUnit_Extension_FunctionMocker::start($this, 'Symfony\Component\Filesystem')
+        $this->_filesystem = FunctionMocker::start($this, 'Symfony\Component\Filesystem')
             ->mockFunction('file_exists')
             ->mockFunction('is_dir')
             ->mockFunction('is_readable')
@@ -46,7 +47,7 @@ abstract class AbstractValidationTest extends PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
-        $this->_validation = PHPUnit_Extension_FunctionMocker::start($this, 'Bolt\Configuration\Validation')
+        $this->_validation = FunctionMocker::start($this, 'Bolt\Configuration\Validation')
             ->mockFunction('extension_loaded')
             ->mockFunction('file_exists')
             ->mockFunction('get_magic_quotes_gpc')
@@ -73,7 +74,7 @@ abstract class AbstractValidationTest extends PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        PHPUnit_Extension_FunctionMocker::tearDown();
+        FunctionMocker::tearDown();
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Backend/AuthenticationTest.php
+++ b/tests/phpunit/unit/Controller/Backend/AuthenticationTest.php
@@ -63,15 +63,9 @@ class AuthenticationTest extends ControllerUnitTest
         $this->assertTrue($response->isRedirect('/bolt'));
     }
 
-    public function testPostLoginFailures()
+    public function testPostLoginFailure()
     {
-        $this->setRequest(Request::create('/bolt/login', 'POST', [
-            'action'   => 'login',
-            'username' => 'test',
-            'password' => 'pass',
-        ]));
-
-        $app = $this->getApp();
+        $this->getApp();
         $loginMock = $this->getMockLogin();
         $loginMock->expects($this->once())
             ->method('login')
@@ -79,23 +73,21 @@ class AuthenticationTest extends ControllerUnitTest
             ->will($this->returnValue(false));
         $this->setService('access_control.login', $loginMock);
 
+        $request = Request::create('/bolt/login', 'POST', [
+            'action'   => 'login',
+            'username' => 'test',
+            'password' => 'pass',
+        ]);
+
+        $this->setRequest($request);
         /** @var TemplateResponse $response */
-        $response = $this->controller()->postLogin($this->getRequest());
+        $response = $this->controller()->postLogin($request);
         $this->assertEquals('@bolt/login/login.twig', $response->getTemplateName());
-
-        // Test missing data fails
-        $this->setRequest(Request::create('/bolt/login', 'POST', ['action' => 'fake']));
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'Invalid request');
-        $this->controller()->postLogin($this->getRequest());
-
-        $this->setRequest(Request::create('/bolt/login', 'POST', []));
-        $response = $this->controller()->postLogin($this->getRequest());
-        $this->assertEquals('error.twig', $response->getTemplateName());
     }
 
     public function testLoginSuccess()
     {
-        $app = $this->getApp();
+        $this->getApp();
         $loginMock = $this->getMockLogin();
         $loginMock->expects($this->once())
             ->method('login')

--- a/tests/phpunit/unit/Controller/Backend/AuthenticationTest.php
+++ b/tests/phpunit/unit/Controller/Backend/AuthenticationTest.php
@@ -7,6 +7,7 @@ use Bolt\Logger\FlashLogger;
 use Bolt\Response\TemplateResponse;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -177,7 +178,7 @@ class AuthenticationTest extends ControllerUnitTest
     /**
      * @param array $methods
      *
-     * @return Password|\PHPUnit_Framework_MockObject_MockObject
+     * @return Password|MockObject
      */
     protected function getMockPassword(array $methods)
     {

--- a/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
+++ b/tests/phpunit/unit/Controller/Backend/DatabaseTest.php
@@ -5,6 +5,7 @@ namespace Bolt\Tests\Controller\Backend;
 use Bolt\Storage\Database\Schema\Manager;
 use Bolt\Storage\Database\Schema\SchemaCheck;
 use Bolt\Tests\Controller\ControllerUnitTest;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -75,7 +76,7 @@ class DatabaseTest extends ControllerUnitTest
     /**
      * @param array $methods
      *
-     * @return Manager|\PHPUnit_Framework_MockObject_MockObject
+     * @return Manager|MockObject
      */
     protected function getMockSchemaManager(array $methods)
     {

--- a/tests/phpunit/unit/Controller/Backend/ExtendTest.php
+++ b/tests/phpunit/unit/Controller/Backend/ExtendTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Controller\Backend;
 
+use Bolt\Composer\PackageManager;
 use Bolt\Composer\Satis\QueryService;
 use Bolt\Controller\Backend\Extend;
 use Bolt\Tests\Controller\ControllerUnitTest;
@@ -25,7 +26,7 @@ class ExtendTest extends ControllerUnitTest
         $this->assertNotEmpty($this->getService('extend.site'));
         $this->assertNotEmpty($this->getService('extend.repo'));
 
-        $this->assertInstanceOf('Bolt\Composer\PackageManager', $this->getService('extend.manager'));
+        $this->assertInstanceOf(PackageManager::class, $this->getService('extend.manager'));
     }
 
     public function testMethodsReturnTemplates()

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -9,6 +9,7 @@ use Bolt\Logger\FlashLogger;
 use Bolt\Response\TemplateResponse;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Prophecy\Argument\Token\StringContainsToken;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -113,7 +114,7 @@ class GeneralTest extends ControllerUnitTest
         $response = $this->controller()->prefill($this->getRequest());
         $context = $response->getContext();
         $this->assertEquals(4, count($context['context']['contenttypes']));
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $context['context']['form']);
+        $this->assertInstanceOf(FormView::class, $context['context']['form']);
 
         // Test the post
         $this->setRequest(Request::create('/bolt/prefill', 'POST', ['contenttypes' => 'pages']));

--- a/tests/phpunit/unit/Controller/Backend/LogTest.php
+++ b/tests/phpunit/unit/Controller/Backend/LogTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Logger\Manager;
+use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -68,7 +69,7 @@ class LogTest extends ControllerUnitTest
         $response = $this->controller()->changeRecord($this->getRequest(), 'pages', 1, 1);
 
         $context = $response->getContext();
-        $this->assertInstanceOf('Bolt\Storage\Entity\LogChange', $context['context']['entry']);
+        $this->assertInstanceOf(Entity\LogChange::class, $context['context']['entry']);
     }
 
     /**
@@ -167,8 +168,8 @@ class LogTest extends ControllerUnitTest
     {
         $this->allowLogin($this->getApp());
 
-        $changeRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogChange');
-        $systemRepository = $this->getService('storage')->getRepository('Bolt\Storage\Entity\LogSystem');
+        $changeRepository = $this->getService('storage')->getRepository(Entity\LogChange::class);
+        $systemRepository = $this->getService('storage')->getRepository(Entity\LogSystem::class);
         $log = $this->getMockBuilder(Manager::class)
             ->setMethods(['clear', 'trim'])
             ->setConstructorArgs([$this->getApp(), $changeRepository, $systemRepository])

--- a/tests/phpunit/unit/Controller/Backend/LogTest.php
+++ b/tests/phpunit/unit/Controller/Backend/LogTest.php
@@ -69,9 +69,16 @@ class LogTest extends ControllerUnitTest
 
         $context = $response->getContext();
         $this->assertInstanceOf('Bolt\Storage\Entity\LogChange', $context['context']['entry']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function testChangeRecordNonExisting()
+    {
+        $this->getService('config')->set('general/changelog/enabled', true);
 
         // Test non-existing entry
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'exist');
         $this->setRequest(Request::create('/bolt/changelog/pages/1/100'));
         $response = $this->controller()->changeRecord($this->getRequest(), 'pages', 1, 100);
         $response->getContext();

--- a/tests/phpunit/unit/Controller/Backend/RecordsTest.php
+++ b/tests/phpunit/unit/Controller/Backend/RecordsTest.php
@@ -78,6 +78,10 @@ class RecordsTest extends ControllerUnitTest
         $this->assertEquals('', $new['ownerid']);
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage Something went wrong
+     */
     public function testEditCSRF()
     {
         $csrf = $this->getMockCsrfTokenManager();
@@ -93,7 +97,6 @@ class RecordsTest extends ControllerUnitTest
         $this->setService('permissions', $permissions);
 
         $this->setRequest(Request::create('/bolt/editcontent/showcases/3', 'POST'));
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'Something went wrong');
         $this->controller()->edit($this->getRequest(), 'showcases', 3);
     }
 

--- a/tests/phpunit/unit/Controller/Backend/RecordsTest.php
+++ b/tests/phpunit/unit/Controller/Backend/RecordsTest.php
@@ -2,7 +2,9 @@
 
 namespace Bolt\Tests\Controller\Backend;
 
+use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -36,14 +38,14 @@ class RecordsTest extends ControllerUnitTest
         $response = $this->controller()->edit($this->getRequest(), 'pages', 4);
         $context = $response->getContext();
         $this->assertEquals('Pages', $context['context']['contenttype']['name']);
-        $this->assertInstanceOf('Bolt\Storage\Entity\Content', $context['context']['content']);
+        $this->assertInstanceOf(Entity\Content::class, $context['context']['content']);
 
         // Test creation
         $this->setRequest(Request::create('/bolt/editcontent/pages'));
         $response = $this->controller()->edit($this->getRequest(), 'pages', null);
         $context = $response->getContext();
         $this->assertEquals('Pages', $context['context']['contenttype']['name']);
-        $this->assertInstanceOf('Bolt\Storage\Entity\Content', $context['context']['content']);
+        $this->assertInstanceOf(Entity\Content::class, $context['context']['content']);
         $this->assertNull($context['context']['content']->id);
 
         // Test that non-existent throws a redirect
@@ -175,7 +177,7 @@ class RecordsTest extends ControllerUnitTest
         $response = $this->controller()->edit($this->getRequest(), 'pages', 4);
         $returned = json_decode($response->getContent());
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
+        $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals($original['title'], $returned->title);
     }
 

--- a/tests/phpunit/unit/Controller/Backend/RecordsTest.php
+++ b/tests/phpunit/unit/Controller/Backend/RecordsTest.php
@@ -4,10 +4,6 @@ namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
-use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
 
 /**
  * Class to test correct operation of src/Controller/Backend/Records.

--- a/tests/phpunit/unit/Controller/Backend/UploadTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UploadTest.php
@@ -110,6 +110,10 @@ class UploadTest extends ControllerUnitTest
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
 
+    /**
+     * @expectedException \Bolt\Filesystem\Exception\FileNotFoundException
+     * @expectedExceptionMessage File not found at path: logo.png
+     */
     public function testMultipleHandlerParsing()
     {
         $this->getApp()->flush();
@@ -130,7 +134,6 @@ class UploadTest extends ControllerUnitTest
         ));
 
         // Not properly implemented as yet, this will need to be revisited on implementation
-        $this->setExpectedException('Bolt\Filesystem\Exception\FileNotFoundException', 'File not found at path: logo.png');
         $this->controller()->uploadNamespace($this->getRequest(), 'files');
     }
 

--- a/tests/phpunit/unit/Controller/Backend/UploadTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UploadTest.php
@@ -173,29 +173,6 @@ class UploadTest extends ControllerUnitTest
         return $this->getRequest();
     }
 
-//     protected function getApp($boot = true)
-//     {
-//         $bolt = parent::getApp();
-
-//         return $this->authApp($bolt);
-//     }
-
-//     protected function authApp(Application $bolt)
-//     {
-//         $users = $this->getMock('Bolt\Users', ['isValidSession', 'isAllowed'], [$bolt]);
-//         $users->expects($this->any())
-//             ->method('isValidSession')
-//             ->will($this->returnValue(true));
-
-//         $users->expects($this->any())
-//             ->method('isAllowed')
-//             ->will($this->returnValue(true));
-
-//         $bolt['users'] = $users;
-
-//         return $bolt;
-//     }
-
     /**
      * @return \Bolt\Controller\Backend\Upload
      */

--- a/tests/phpunit/unit/Controller/Backend/UsersTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UsersTest.php
@@ -5,10 +5,6 @@ namespace Bolt\Tests\Controller\Backend;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
-use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
 
 /**
  * Class to test correct operation of src/Controller/Backend/Users.

--- a/tests/phpunit/unit/Controller/Backend/UsersTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UsersTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Controller\Backend;
 
 use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -44,7 +45,7 @@ class UsersTest extends ControllerUnitTest
         $response = $this->controller()->edit($this->getRequest(), 1);
         $context = $response->getContext();
         $this->assertEquals('edit', $context['context']['kind']);
-        $this->assertInstanceOf('Symfony\Component\Form\FormView', $context['context']['form']);
+        $this->assertInstanceOf(FormView::class, $context['context']['form']);
         $this->assertEquals('Admin', $context['context']['displayname']);
 
         // Test that an empty user gives a create form

--- a/tests/phpunit/unit/Controller/ControllerUnitTest.php
+++ b/tests/phpunit/unit/Controller/ControllerUnitTest.php
@@ -2,7 +2,6 @@
 
 namespace Bolt\Tests\Controller;
 
-use Bolt\AccessControl\Permissions;
 use Bolt\Configuration\Validation\Validator;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -230,6 +230,10 @@ class FrontendTest extends ControllerUnitTest
         );
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage not found
+     */
     public function testNoRecord()
     {
         $this->setRequest(Request::create('/pages/', 'GET', ['id' => 5]));
@@ -240,15 +244,13 @@ class FrontendTest extends ControllerUnitTest
             ->will($this->returnValue(false));
         $this->setService('storage', $storage);
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'not found');
-
-        $response = $this->controller()->record($this->getRequest(), 'pages');
-
-        $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('record.twig', $response->getTemplateName());
-        $this->assertNotEmpty($response->getGlobals());
+        $this->controller()->record($this->getRequest(), 'pages');
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage not found
+     */
     public function testRecordNoTemplate()
     {
         $this->setRequest(Request::create('/pages/', 'GET', ['id' => 5]));
@@ -259,15 +261,13 @@ class FrontendTest extends ControllerUnitTest
             ->will($this->returnValue(false));
         $this->setService('storage', $storage);
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'not found');
-
-        $response = $this->controller()->record($this->getRequest(), 'pages');
-
-        $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('record.twig', $response->getTemplateName());
-        $this->assertNotEmpty($response->getGlobals());
+        $this->controller()->record($this->getRequest(), 'pages');
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage not found
+     */
     public function testViewlessRecord()
     {
         $this->setRequest(Request::create('/pages/test'));
@@ -281,13 +281,7 @@ class FrontendTest extends ControllerUnitTest
             ->will($this->returnValue($contentType));
         $this->setService('storage', $storage);
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'not found');
-
-        $response = $this->controller()->record($this->getRequest(), 'pages', 'test');
-
-        $this->assertTrue($response instanceof TemplateResponse);
-        $this->assertSame('record.twig', $response->getTemplateName());
-        $this->assertNotEmpty($response->getGlobals());
+        $this->controller()->record($this->getRequest(), 'pages', 'test');
     }
 
     /**
@@ -327,6 +321,10 @@ class FrontendTest extends ControllerUnitTest
         $this->assertNotEmpty($response->getGlobals());
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage not found
+     */
     public function testViewlessListing()
     {
         $this->setRequest(Request::create('/'));
@@ -339,7 +337,6 @@ class FrontendTest extends ControllerUnitTest
             ->will($this->returnValue($contentType));
         $this->setService('storage', $storage);
 
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'not found');
         $response = $this->controller()->listing($this->getRequest(), 'pages');
         $this->assertTrue($response instanceof TemplateResponse);
     }
@@ -358,11 +355,13 @@ class FrontendTest extends ControllerUnitTest
         $this->assertFalse($response);
     }
 
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage No slug
+     */
     public function testNoContent404()
     {
         $this->setRequest(Request::create('/tags/fake'));
-
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', 'No slug');
 
         $response = $this->controller()->taxonomy($this->getRequest(), 'tags', 'fake');
         $this->assertTrue($response instanceof TemplateResponse);
@@ -389,7 +388,6 @@ class FrontendTest extends ControllerUnitTest
 
         $this->assertTrue($response instanceof TemplateResponse);
         $this->assertSame('index.twig', $response->getTemplateName());
-//$this->assertNotEmpty($response->getGlobals());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -9,6 +9,7 @@ use Bolt\Response\TemplateResponse;
 use Bolt\TemplateChooser;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Bolt\Twig\Runtime\HtmlRuntime;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -34,7 +35,7 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create('/'));
 
         $request = $this->getRequest();
-        $kernel = $this->createMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
+        $kernel = $this->createMock(HttpKernelInterface::class);
         $app['dispatcher']->dispatch(KernelEvents::REQUEST, new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST));
 
         $this->assertEquals('frontend', Zone::get($request));
@@ -439,7 +440,7 @@ class FrontendTest extends ControllerUnitTest
 
         $response = $this->controller()->before($this->getRequest());
 
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertEquals('/bolt/userfirst', $response->getTargetUrl());
     }
 

--- a/tests/phpunit/unit/EventListener/StorageEventListenerTest.php
+++ b/tests/phpunit/unit/EventListener/StorageEventListenerTest.php
@@ -10,10 +10,11 @@ use Bolt\Storage\Entity\Users;
 use Bolt\Storage\EventProcessor\TimedRecord;
 use PasswordLib\Password\Factory as PasswordFactory;
 use PasswordLib\Password\Implementation\Blowfish;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class StorageEventListenerTest extends \PHPUnit_Framework_TestCase
+class StorageEventListenerTest extends TestCase
 {
     /** @var Users */
     private $user;

--- a/tests/phpunit/unit/Events/ControllerEventsTest.php
+++ b/tests/phpunit/unit/Events/ControllerEventsTest.php
@@ -19,7 +19,7 @@ class ControllerEventsTest extends BoltUnitTest
 
     public function testSingletonConstructor()
     {
-        $reflection = new \ReflectionClass('Bolt\Events\ControllerEvents');
+        $reflection = new \ReflectionClass(ControllerEvents::class);
         $method = $reflection->getMethod('__construct');
 
         $this->assertTrue($method->isConstructor());

--- a/tests/phpunit/unit/Events/CronEventTest.php
+++ b/tests/phpunit/unit/Events/CronEventTest.php
@@ -2,7 +2,6 @@
 
 namespace Bolt\Tests\Events;
 
-use Bolt\Cache;
 use Bolt\Events\CronEvent;
 use Bolt\Events\CronEvents;
 use Bolt\Tests\BoltUnitTest;

--- a/tests/phpunit/unit/Events/MountEventTest.php
+++ b/tests/phpunit/unit/Events/MountEventTest.php
@@ -41,6 +41,10 @@ class MountEventTest extends BoltUnitTest
         $mountEvent->mount('/', $controllers);
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The "mount" method takes either a "ControllerCollection" or a "ControllerProviderInterface" instance.
+     */
     public function testMountInvalidCollection()
     {
         $app = $this->getApp();
@@ -52,11 +56,14 @@ class MountEventTest extends BoltUnitTest
             ->method('mount')
         ;
 
-        $this->setExpectedException('LogicException', 'The "mount" method takes either a "ControllerCollection" or a "ControllerProviderInterface" instance.');
         $mountEvent = new MountEvent($app, $controllers);
         $mountEvent->mount('/', $route);
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage The method "Bolt\Tests\Events\ControllerMock::connect" must return a "ControllerCollection" instance. Got: "Bolt\Tests\Events\ClippyKoala"
+     */
     public function testMountInvalidCollectionConnect()
     {
         $app = $this->getApp();
@@ -67,8 +74,6 @@ class MountEventTest extends BoltUnitTest
             ->expects($this->never())
             ->method('mount')
         ;
-
-        $this->setExpectedException('LogicException', 'The method "Bolt\Tests\Events\ControllerMock::connect" must return a "ControllerCollection" instance. Got: "Bolt\Tests\Events\ClippyKoala"');
 
         $mountEvent = new MountEvent($app, $controllers);
         $mountEvent->mount('/', new ControllerMock($route));

--- a/tests/phpunit/unit/Events/MountEventTest.php
+++ b/tests/phpunit/unit/Events/MountEventTest.php
@@ -23,8 +23,8 @@ class MountEventTest extends BoltUnitTest
         $controllers = new ControllerCollection(new Route('/'));
         $mountEvent = new MountEvent($app, $controllers);
 
-        $this->assertInstanceOf('Bolt\Events\MountEvent', $mountEvent);
-        $this->assertInstanceOf('Silex\Application', $mountEvent->getApp());
+        $this->assertInstanceOf(MountEvent::class, $mountEvent);
+        $this->assertInstanceOf(Application::class, $mountEvent->getApp());
     }
 
     public function testMount()
@@ -82,7 +82,6 @@ class MountEventTest extends BoltUnitTest
 
     /**
      * @param array $methods
-     *
      * @param Route $route
      *
      * @return MockObject|ControllerCollection
@@ -93,7 +92,7 @@ class MountEventTest extends BoltUnitTest
             ->setMethods($methods)
             ->setConstructorArgs([$route])
             ->getMock()
-        ;
+            ;
     }
 }
 

--- a/tests/phpunit/unit/Events/MountEventTest.php
+++ b/tests/phpunit/unit/Events/MountEventTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Events;
 
 use Bolt\Events\MountEvent;
 use Bolt\Tests\BoltUnitTest;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\ControllerProviderInterface;
@@ -84,7 +85,7 @@ class MountEventTest extends BoltUnitTest
      *
      * @param Route $route
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject|ControllerCollection
+     * @return MockObject|ControllerCollection
      */
     protected function getMockControllerCollection($methods = ['connect', 'mount'], Route $route)
     {

--- a/tests/phpunit/unit/Extension/AbstractExtensionTest.php
+++ b/tests/phpunit/unit/Extension/AbstractExtensionTest.php
@@ -2,10 +2,12 @@
 
 namespace Bolt\Tests\Extension;
 
+use Bolt\Extension\AbstractExtension;
 use Bolt\Filesystem\Handler\Directory;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\BasicExtension;
 use Bolt\Tests\Extension\Mock\Extension;
+use Silex\Application;
 
 /**
  * Class to test Bolt\Extension\AbstractExtension
@@ -16,12 +18,12 @@ class AbstractExtensionTest extends BoltUnitTest
 {
     public function testClassProperties()
     {
-        $this->assertClassHasAttribute('container', 'Bolt\Extension\AbstractExtension');
-        $this->assertClassHasAttribute('baseDirectory', 'Bolt\Extension\AbstractExtension');
-        $this->assertClassHasAttribute('webDirectory', 'Bolt\Extension\AbstractExtension');
-        $this->assertClassHasAttribute('name', 'Bolt\Extension\AbstractExtension');
-        $this->assertClassHasAttribute('vendor', 'Bolt\Extension\AbstractExtension');
-        $this->assertClassHasAttribute('namespace', 'Bolt\Extension\AbstractExtension');
+        $this->assertClassHasAttribute('container', AbstractExtension::class);
+        $this->assertClassHasAttribute('baseDirectory', AbstractExtension::class);
+        $this->assertClassHasAttribute('webDirectory', AbstractExtension::class);
+        $this->assertClassHasAttribute('name', AbstractExtension::class);
+        $this->assertClassHasAttribute('vendor', AbstractExtension::class);
+        $this->assertClassHasAttribute('namespace', AbstractExtension::class);
     }
 
     public function testContainer()
@@ -29,7 +31,7 @@ class AbstractExtensionTest extends BoltUnitTest
         $ext = new BasicExtension();
         $ext->setContainer($this->getApp());
 
-        $this->assertInstanceOf('Silex\Application', $ext->getContainer());
+        $this->assertInstanceOf(Application::class, $ext->getContainer());
     }
 
     public function testBaseDirectory()
@@ -41,8 +43,8 @@ class AbstractExtensionTest extends BoltUnitTest
         $ext = new BasicExtension();
         $ext->setWebDirectory($webDir);
 
-        $this->assertInstanceOf('Bolt\Extension\AbstractExtension', $ext->setBaseDirectory($dir));
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Directory', $ext->getBaseDirectory());
+        $this->assertInstanceOf(AbstractExtension::class, $ext->setBaseDirectory($dir));
+        $this->assertInstanceOf(Directory::class, $ext->getBaseDirectory());
         $this->assertSame(__DIR__, $ext->getBaseDirectory()->getPath());
     }
 
@@ -53,7 +55,7 @@ class AbstractExtensionTest extends BoltUnitTest
         $ext = new BasicExtension();
         $ext->setWebDirectory($webDir);
 
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Directory', $ext->getWebDirectory());
+        $this->assertInstanceOf(Directory::class, $ext->getWebDirectory());
     }
 
     public function testGetId()

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -145,6 +145,10 @@ class AssetTraitTest extends BoltUnitTest
         $this->assertSame('theme', $queued->getPackageName());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Bolt\Tests\Extension\Mock\AssetExtension::registerAssets() should return a list of Bolt\Asset\AssetInterface objects. Got: string
+     */
     public function testRegisterInvalidAssets()
     {
         $app = $this->getApp();
@@ -160,10 +164,13 @@ class AssetTraitTest extends BoltUnitTest
         $ext->setBaseDirectory($dir);
         $ext->register($app);
 
-        $this->setExpectedException('InvalidArgumentException', 'Bolt\Tests\Extension\Mock\AssetExtension::registerAssets() should return a list of Bolt\Asset\AssetInterface objects. Got: string');
         $app['asset.queue.file']->getQueue();
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Extension file assets must have a path set.
+     */
     public function testRegisterInvalidPathAssets()
     {
         $app = $this->getApp();
@@ -179,7 +186,6 @@ class AssetTraitTest extends BoltUnitTest
         $ext->setBaseDirectory($dir);
         $ext->register($app);
 
-        $this->setExpectedException('RuntimeException', 'Extension file assets must have a path set.');
         $app['asset.queue.file']->getQueue();
     }
 }

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -83,10 +83,10 @@ class AssetTraitTest extends BoltUnitTest
         $snippetQueue = $app['asset.queue.snippet']->getQueue();
         $widgetQueue = $app['asset.queue.widget']->getQueue();
 
-        $this->assertInstanceOf('Bolt\Asset\File\JavaScript', reset($fileQueue['javascript']));
-        $this->assertInstanceOf('Bolt\Asset\File\Stylesheet', reset($fileQueue['stylesheet']));
-        $this->assertInstanceOf('Bolt\Asset\Snippet\Snippet', reset($snippetQueue));
-        $this->assertInstanceOf('Bolt\Asset\Widget\Widget', reset($widgetQueue));
+        $this->assertInstanceOf(JavaScript::class, reset($fileQueue['javascript']));
+        $this->assertInstanceOf(Stylesheet::class, reset($fileQueue['stylesheet']));
+        $this->assertInstanceOf(Snippet::class, reset($snippetQueue));
+        $this->assertInstanceOf(Widget::class, reset($widgetQueue));
     }
 
     public function testRegisterValidAssetsExtensionPath()

--- a/tests/phpunit/unit/Extension/ConfigTraitTest.php
+++ b/tests/phpunit/unit/Extension/ConfigTraitTest.php
@@ -143,6 +143,10 @@ class ConfigTraitTest extends BoltUnitTest
         $this->assertSame(['blame' => 'gnomes'], $conf);
     }
 
+    /**
+     * @expectedException \Bolt\Filesystem\Exception\ParseException
+     * @expectedExceptionMessage A YAML file cannot contain tabs as indentation
+     */
     public function testConfigFileInvalidYaml()
     {
         $app = $this->getApp();
@@ -161,8 +165,6 @@ class ConfigTraitTest extends BoltUnitTest
         $method->setAccessible(true);
 
         $ext->setContainer($app);
-
-        $this->setExpectedException('Bolt\Filesystem\Exception\ParseException', 'A YAML file cannot contain tabs as indentation');
 
         $conf = $method->invoke($ext);
         $this->assertSame(['blame' => 'gnomes'], $conf);

--- a/tests/phpunit/unit/Extension/ControllerMountTraitTest.php
+++ b/tests/phpunit/unit/Extension/ControllerMountTraitTest.php
@@ -6,6 +6,7 @@ use Bolt\Events\MountEvent;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\ControllerMountExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Class to test Bolt\Extension\ControllerMountTrait
@@ -39,7 +40,7 @@ class ControllerMountTraitTest extends BoltUnitTest
     /**
      * @param array $methods
      *
-     * @return MountEvent|\PHPUnit_Framework_MockObject_MockObject
+     * @return MountEvent|MockObject
      */
     protected function getMockMountEvent($methods = ['mount'])
     {

--- a/tests/phpunit/unit/Extension/ControllerTraitTest.php
+++ b/tests/phpunit/unit/Extension/ControllerTraitTest.php
@@ -6,6 +6,7 @@ use Bolt\Events\MountEvent;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\ControllerExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Class to test Bolt\Extension\ControllerTrait
@@ -39,7 +40,7 @@ class ControllerTraitTest extends BoltUnitTest
     /**
      * @param array $methods
      *
-     * @return MountEvent|\PHPUnit_Framework_MockObject_MockObject
+     * @return MountEvent|MockObject
      */
     protected function getMockMountEvent($methods = ['mount'])
     {

--- a/tests/phpunit/unit/Extension/SimpleExtensionTest.php
+++ b/tests/phpunit/unit/Extension/SimpleExtensionTest.php
@@ -3,8 +3,11 @@
 namespace Bolt\Tests\Extension;
 
 use Bolt\Events\ControllerEvents;
+use Bolt\Extension\AbstractExtension;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\NormalExtension;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Class to test Bolt\Extension\SimpleExtension
@@ -39,7 +42,7 @@ class SimpleExtensionTest extends BoltUnitTest
         $ext->boot($app);
 
         $listeners = $app['dispatcher']->getListeners('dropbear.sighting');
-        $this->assertInstanceOf('Bolt\Tests\Extension\Mock\NormalExtension', $listeners[0][0]);
+        $this->assertInstanceOf(NormalExtension::class, $listeners[0][0]);
 
         $app['dispatcher']->dispatch('dropbear.sighting');
     }
@@ -49,9 +52,9 @@ class SimpleExtensionTest extends BoltUnitTest
         $ext = new NormalExtension();
 
         $providers = $ext->getServiceProviders();
-        $this->assertInstanceOf('Bolt\Extension\AbstractExtension', $providers[0]);
-        $this->assertInstanceOf('Silex\ServiceProviderInterface', $providers[0]);
-        $this->assertInstanceOf('Symfony\Component\EventDispatcher\EventSubscriberInterface', $providers[0]);
+        $this->assertInstanceOf(AbstractExtension::class, $providers[0]);
+        $this->assertInstanceOf(ServiceProviderInterface::class, $providers[0]);
+        $this->assertInstanceOf(EventSubscriberInterface::class, $providers[0]);
     }
 
     public function testGetSubscribedEvents()

--- a/tests/phpunit/unit/Extension/SimpleExtensionTest.php
+++ b/tests/phpunit/unit/Extension/SimpleExtensionTest.php
@@ -27,6 +27,10 @@ class SimpleExtensionTest extends BoltUnitTest
         $mock->register($app);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Drop Bear Alert!
+     */
     public function testSubscribe()
     {
         $app = $this->getApp();
@@ -37,7 +41,6 @@ class SimpleExtensionTest extends BoltUnitTest
         $listeners = $app['dispatcher']->getListeners('dropbear.sighting');
         $this->assertInstanceOf('Bolt\Tests\Extension\Mock\NormalExtension', $listeners[0][0]);
 
-        $this->setExpectedException('RuntimeException', 'Drop Bear Alert!');
         $app['dispatcher']->dispatch('dropbear.sighting');
     }
 

--- a/tests/phpunit/unit/Filesystem/FilePermissionsTest.php
+++ b/tests/phpunit/unit/Filesystem/FilePermissionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bolt\Tests\FilePermissions;
+namespace Bolt\Tests\Filesystem;
 
 use Bolt\Filesystem\Exception\IOException;
 use Bolt\Filesystem\FilePermissions;

--- a/tests/phpunit/unit/Filesystem/FilesystemProviderTest.php
+++ b/tests/phpunit/unit/Filesystem/FilesystemProviderTest.php
@@ -1,6 +1,10 @@
 <?php
 
-namespace Bolt\Tests;
+namespace Bolt\Tests\Filesystem;
+
+use Bolt\Filesystem\Filesystem;
+use Bolt\Filesystem\Manager;
+use Bolt\Tests\BoltUnitTest;
 
 /**
  * Class to test correct operation of Filesystem Service Provider.
@@ -14,13 +18,13 @@ class FilesystemProviderTest extends BoltUnitTest
         $bolt = $this->getApp();
 
         $this->assertNotNull($bolt['filesystem']);
-        $this->assertInstanceOf('Bolt\\Filesystem\\Manager', $bolt['filesystem']);
+        $this->assertInstanceOf(Manager::class, $bolt['filesystem']);
     }
 
     public function testDefaultManagers()
     {
         $bolt = $this->getApp();
-        $this->assertInstanceOf('Bolt\Filesystem\Filesystem', $bolt['filesystem']->getFilesystem('root'));
-        $this->assertInstanceOf('Bolt\Filesystem\Filesystem', $bolt['filesystem']->getFilesystem('config'));
+        $this->assertInstanceOf(Filesystem::class, $bolt['filesystem']->getFilesystem('root'));
+        $this->assertInstanceOf(Filesystem::class, $bolt['filesystem']->getFilesystem('config'));
     }
 }

--- a/tests/phpunit/unit/Library/BoltLibraryTest.php
+++ b/tests/phpunit/unit/Library/BoltLibraryTest.php
@@ -135,12 +135,13 @@ class BoltLibraryTest extends BoltUnitTest
 
     /**
      * @runInSeparateProcess
+     * @expectedException \Symfony\Component\HttpKernel\Exception\HttpException
+     * @expectedExceptionMessage Redirecting to '/test2'.
      */
     public function testSimpleRedirectAbort()
     {
-        $app = $this->getApp();
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\HttpException', "Redirecting to '/test2'.");
+        $this->getApp();
         $this->expectOutputString("<p>Redirecting to <a href='/test2'>/test2</a>.</p><script>window.setTimeout(function () { window.location='/test2'; }, 500);</script>");
-        $redirect = Library::simpleredirect('/test2', true);
+        Library::simpleredirect('/test2', true);
     }
 }

--- a/tests/phpunit/unit/Library/BoltLibraryTest.php
+++ b/tests/phpunit/unit/Library/BoltLibraryTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Library;
 
 use Bolt\Library;
 use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -96,7 +97,7 @@ class BoltLibraryTest extends BoltUnitTest
         $app['request'] = $request;
 
         $response = Library::redirect('login');
-        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\RedirectResponse', $response);
+        $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertRegExp('|Redirecting to /bolt/login|', $response->getContent());
         $this->assertTrue($response->isRedirect(), "Response isn't a valid redirect condition.");
     }

--- a/tests/phpunit/unit/Logger/ChangeLogTest.php
+++ b/tests/phpunit/unit/Logger/ChangeLogTest.php
@@ -2,7 +2,8 @@
 
 namespace Bolt\Tests\Logger;
 
-use Bolt\Legacy\Storage;
+use Bolt\Legacy;
+use Bolt\Storage\Entity;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -19,7 +20,7 @@ class ChangeLogTest extends BoltUnitTest
         $app = $this->getApp();
         $app['config']->set('general/changelog/enabled', true);
         $this->addSomeContent();
-        $storage = new Storage($app);
+        $storage = new Legacy\Storage($app);
 
         $content = $storage->getContentObject('pages');
         $content['contentid'] = 1;
@@ -70,20 +71,21 @@ class ChangeLogTest extends BoltUnitTest
         //$all = $this->getLogChangeRepository()->getChangeLogByContentType('pages', []);
 
         $log = $this->getLogChangeRepository()->getChangeLogEntry('pages', 1, 1, '=');
-        $this->assertInstanceOf('\Bolt\Storage\Entity\LogChange', $log);
+        $this->assertInstanceOf(Entity\LogChange::class, $log);
     }
 
     public function testGetNextChangeLogEntry()
     {
         $app = $this->getApp();
         $app['config']->set('general/changelog/enabled', true);
-        $storage = new Storage($app);
+        $storage = new Legacy\Storage($app);
 
         // To generate an extra changelog we fetch and save a content item
         // For now we need to mock the request object.
         $app['request'] = Request::create('/');
+        /** @var Legacy\Content $content */
         $content = $storage->getContent('pages/1');
-        $this->assertInstanceOf('\Bolt\Legacy\Content', $content);
+        $this->assertInstanceOf(Legacy\Content::class, $content);
 
         $content->setValues(['status' => 'draft', 'ownerid' => 99]);
         $storage->saveContent($content, 'Test Suite Update');
@@ -107,6 +109,6 @@ class ChangeLogTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        return $app['storage']->getRepository('Bolt\Storage\Entity\LogChange');
+        return $app['storage']->getRepository(Entity\LogChange::class);
     }
 }

--- a/tests/phpunit/unit/Logger/LogManagerTest.php
+++ b/tests/phpunit/unit/Logger/LogManagerTest.php
@@ -54,14 +54,21 @@ class LogManagerTest extends BoltUnitTest
         $log->trim('change');
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid log type requested: invalid
+     */
     public function testInvalid()
     {
         $app = $this->getApp();
         $log = $this->getLogManager($app);
-        $this->setExpectedException('Exception', 'Invalid log type requested: invalid');
         $log->trim('invalid');
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid log type requested: invalid
+     */
     public function testClear()
     {
         $app = $this->getApp();
@@ -80,7 +87,6 @@ class LogManagerTest extends BoltUnitTest
         $log->clear('system');
         $log->clear('change');
 
-        $this->setExpectedException('Exception', 'Invalid log type requested: invalid');
         $log->clear('invalid');
     }
 
@@ -132,11 +138,14 @@ class LogManagerTest extends BoltUnitTest
         $log->getActivity('change', 10);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Invalid log type requested: invalid
+     */
     public function testGetActivityInvalid()
     {
         $app = $this->getApp();
         $log = $this->getLogManager($app);
-        $this->setExpectedException('Exception', 'Invalid log type requested: invalid');
         $log->getActivity('invalid', 10);
     }
 

--- a/tests/phpunit/unit/Logger/LogManagerTest.php
+++ b/tests/phpunit/unit/Logger/LogManagerTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Logger;
 
 use Bolt\Logger\Manager;
+use Bolt\Storage\Entity;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Mocks\DoctrineMockBuilder;
 use Symfony\Component\HttpFoundation\Request;
@@ -178,8 +179,8 @@ class LogManagerTest extends BoltUnitTest
      */
     protected function getLogManager($app)
     {
-        $changeRepository = $app['storage']->getRepository('Bolt\Storage\Entity\LogChange');
-        $systemRepository = $app['storage']->getRepository('Bolt\Storage\Entity\LogSystem');
+        $changeRepository = $app['storage']->getRepository(Entity\LogChange::class);
+        $systemRepository = $app['storage']->getRepository(Entity\LogSystem::class);
 
         return new Manager($app, $changeRepository, $systemRepository);
     }

--- a/tests/phpunit/unit/Logger/RecordChangeHandlerTest.php
+++ b/tests/phpunit/unit/Logger/RecordChangeHandlerTest.php
@@ -6,6 +6,7 @@ use Bolt\Logger\Handler\RecordChangeHandler;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Mocks\DoctrineMockBuilder;
 use Monolog\Logger;
+use PHPUnit\Framework\Assert;
 
 /**
  * Class to test src/Logger/Handler/RecordChangeHandler.
@@ -39,7 +40,7 @@ class RecordChangeHandlerTest extends BoltUnitTest
                 'comment'     => 'foo',
             ]
         );
-        $this->assertEquals('bolt_log_change', \PHPUnit_Framework_Assert::readAttribute($handler, 'tablename'));
+        $this->assertEquals('bolt_log_change', Assert::readAttribute($handler, 'tablename'));
     }
 
     public function testHandle()

--- a/tests/phpunit/unit/Logger/SystemHandlerTest.php
+++ b/tests/phpunit/unit/Logger/SystemHandlerTest.php
@@ -6,6 +6,7 @@ use Bolt\Logger\Handler\SystemHandler;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Mocks\DoctrineMockBuilder;
 use Monolog\Logger;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -28,7 +29,7 @@ class SystemHandlerTest extends BoltUnitTest
 
         $log->pushHandler($handler);
         $log->addRecord(Logger::DEBUG, 'test', ['id' => 5, 'title' => 'test']);
-        $this->assertEquals('bolt_log_system', \PHPUnit_Framework_Assert::readAttribute($handler, 'tablename'));
+        $this->assertEquals('bolt_log_system', Assert::readAttribute($handler, 'tablename'));
     }
 
     public function testHandle()

--- a/tests/phpunit/unit/Menu/MenuEntryTest.php
+++ b/tests/phpunit/unit/Menu/MenuEntryTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Menu;
 
 use Bolt\Menu\MenuEntry;
 use Bolt\Tests\BoltUnitTest;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -50,7 +51,7 @@ class MenuEntryTest extends BoltUnitTest
 
     public function testRoute()
     {
-        /** @var UrlGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject $urlGenerator */
+        /** @var UrlGeneratorInterface|MockObject $urlGenerator */
         $urlGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)->getMock();
         $urlGenerator->expects($this->once())
             ->method('generate')

--- a/tests/phpunit/unit/Mocks/DoctrineMockBuilder.php
+++ b/tests/phpunit/unit/Mocks/DoctrineMockBuilder.php
@@ -2,13 +2,16 @@
 
 namespace Bolt\Tests\Mocks;
 
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
 /**
  * Mock Builder for Doctrine objects
  */
-class DoctrineMockBuilder extends \PHPUnit_Framework_TestCase
+class DoctrineMockBuilder extends TestCase
 {
     /**
-     * @return \Doctrine\DBAL\Platforms\AbstractPlatform|\PHPUnit_Framework_MockObject_MockObject
+     * @return \Doctrine\DBAL\Platforms\AbstractPlatform|MockObject
      */
     public function getDatabasePlatformMock()
     {
@@ -32,7 +35,7 @@ class DoctrineMockBuilder extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \Doctrine\DBAL\Connection|\PHPUnit_Framework_MockObject_MockObject
+     * @return \Doctrine\DBAL\Connection|MockObject
      */
     public function getConnectionMock()
     {
@@ -95,7 +98,7 @@ class DoctrineMockBuilder extends \PHPUnit_Framework_TestCase
     /**
      * @param mixed $returnValue
      *
-     * @return \Doctrine\DBAL\Driver\Statement|\PHPUnit_Framework_MockObject_MockObject
+     * @return \Doctrine\DBAL\Driver\Statement|MockObject
      */
     public function getStatementMock($returnValue = 1)
     {
@@ -120,7 +123,7 @@ class DoctrineMockBuilder extends \PHPUnit_Framework_TestCase
      * @param string $class   The class name
      * @param array  $methods The available methods
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      */
     protected function getAbstractMock($class, array $methods)
     {

--- a/tests/phpunit/unit/Mocks/LoripsumMock.php
+++ b/tests/phpunit/unit/Mocks/LoripsumMock.php
@@ -2,10 +2,12 @@
 
 namespace Bolt\Tests\Mocks;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Mock Builder for Doctrine objects
  */
-class LoripsumMock extends \PHPUnit_Framework_TestCase
+class LoripsumMock extends TestCase
 {
     public function get($request)
     {

--- a/tests/phpunit/unit/Nut/UserAddTest.php
+++ b/tests/phpunit/unit/Nut/UserAddTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserAdd;
+use Bolt\Storage\Entity;
 use Bolt\Tests\BoltUnitTest;
 use PasswordLib\PasswordLib;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -34,7 +35,7 @@ class UserAddTest extends BoltUnitTest
         $this->assertEquals('Successfully created user: test', trim($result));
 
         // Test that the saved value matches the hash
-        $repo = $app['storage']->getRepository('Bolt\Storage\Entity\Users');
+        $repo = $app['storage']->getRepository(Entity\Users::class);
         $userEntity = $repo->getUser('test');
         $userAuth = $repo->getUserAuthData($userEntity->getId());
         $crypt = new PasswordLib();

--- a/tests/phpunit/unit/Nut/UserRoleAddTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleAddTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserRoleAdd;
 use Bolt\Tests\BoltUnitTest;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -51,7 +52,7 @@ class UserRoleAddTest extends BoltUnitTest
 
     protected function getUserMockWithReturns($hasRole = false, $addRole = true)
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject $users */
+        /** @var MockObject $users */
         $users = $this->getMockUsers(['hasRole', 'addRole']);
         $users->expects($this->any())
             ->method('hasRole')

--- a/tests/phpunit/unit/Nut/UserRoleRemoveTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleRemoveTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\UserRoleRemove;
 use Bolt\Tests\BoltUnitTest;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -52,7 +53,7 @@ class UserRoleRemoveTest extends BoltUnitTest
 
     protected function getUserMockWithReturns($remove = false, $has = false)
     {
-        /** @var \PHPUnit_Framework_MockObject_MockObject $users */
+        /** @var MockObject $users */
         $users = $this->getMockUsers(['hasRole', 'removeRole']);
         $users->expects($this->any())
             ->method('removeRole')

--- a/tests/phpunit/unit/Pager/PagerManagerUnitTest.php
+++ b/tests/phpunit/unit/Pager/PagerManagerUnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Pager;
 
+use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -101,7 +102,7 @@ class PagerManagerUnitTest extends PagerManagerTestBase
         $expected = [];
         $expected['page_some'] = $this->createPager($base);
         $expected['page_some']->setManager($manager);
-        $this->assertEquals($expected, \PHPUnit_Framework_Assert::readAttribute($manager, 'pagers'));
+        $this->assertEquals($expected, Assert::readAttribute($manager, 'pagers'));
     }
 
     public function testOffsetGet()

--- a/tests/phpunit/unit/Provider/CacheServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/CacheServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Cache;
 use Bolt\Provider\CacheServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
@@ -17,7 +18,7 @@ class CacheServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new CacheServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Cache', $app['cache']);
+        $this->assertInstanceOf(Cache::class, $app['cache']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/CanonicalServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/CanonicalServiceProviderTest.php
@@ -2,8 +2,8 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Routing\Canonical;
 use Bolt\Provider\CanonicalServiceProvider;
+use Bolt\Routing\Canonical;
 use Bolt\Tests\BoltUnitTest;
 
 /**

--- a/tests/phpunit/unit/Provider/ConfigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ConfigServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Config;
 use Bolt\Provider\ConfigServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
@@ -17,7 +18,7 @@ class ConfigServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new ConfigServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Config', $app['config']);
+        $this->assertInstanceOf(Config::class, $app['config']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/CronServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/CronServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Cron;
 use Bolt\Provider\CronServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
@@ -17,7 +18,7 @@ class CronServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new CronServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Cron', $app['cron']);
+        $this->assertInstanceOf(Cron::class, $app['cron']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/DatabaseSchemaServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/DatabaseSchemaServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\DatabaseSchemaServiceProvider;
+use Bolt\Storage\Database\Schema;
 use Bolt\Tests\BoltUnitTest;
 
 /**
@@ -17,7 +18,7 @@ class DatabaseSchemaServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new DatabaseSchemaServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Storage\Database\Schema\Manager', $app['schema']);
+        $this->assertInstanceOf(Schema\Manager::class, $app['schema']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/ExtensionServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ExtensionServiceProviderTest.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Composer\Satis\StatService;
+use Bolt\Extension;
 use Bolt\Provider\ExtensionServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
@@ -17,8 +19,8 @@ class ExtensionServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new ExtensionServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Extensions', $app['extensions']);
-        $this->assertInstanceOf('Bolt\Composer\Satis\StatService', $app['extensions.stats']);
+        $this->assertInstanceOf(Extension\Manager::class, $app['extensions']);
+        $this->assertInstanceOf(StatService::class, $app['extensions.stats']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/FilePermissionsServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/FilePermissionsServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Filesystem\FilePermissions;
 use Bolt\Provider\FilePermissionsServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
@@ -17,7 +18,7 @@ class FilePermissionsServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new FilePermissionsServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Filesystem\FilePermissions', $app['filepermissions']);
+        $this->assertInstanceOf(FilePermissions::class, $app['filepermissions']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/FilesystemServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/FilesystemServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Filesystem;
 use Bolt\Provider\FilesystemServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
@@ -18,7 +19,7 @@ class FilesystemServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
 
         $app->register(new FilesystemServiceProvider());
-        $this->assertInstanceOf('Bolt\Filesystem\Manager', $app['filesystem']);
+        $this->assertInstanceOf(Filesystem\Manager::class, $app['filesystem']);
 
         $app->boot();
     }

--- a/tests/phpunit/unit/Provider/LoggerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/LoggerServiceProviderTest.php
@@ -2,8 +2,10 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Logger;
 use Bolt\Provider\LoggerServiceProvider;
 use Bolt\Tests\BoltUnitTest;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class to test src/Provider/NutServiceProvider.
@@ -17,10 +19,10 @@ class LoggerServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new LoggerServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Psr\Log\LoggerInterface', $app['logger.system']);
-        $this->assertInstanceOf('Psr\Log\LoggerInterface', $app['logger.change']);
-        $this->assertInstanceOf('Psr\Log\LoggerInterface', $app['logger.firebug']);
-        $this->assertInstanceOf('Bolt\Logger\Manager', $app['logger.manager']);
+        $this->assertInstanceOf(LoggerInterface::class, $app['logger.system']);
+        $this->assertInstanceOf(LoggerInterface::class, $app['logger.change']);
+        $this->assertInstanceOf(LoggerInterface::class, $app['logger.firebug']);
+        $this->assertInstanceOf(Logger\Manager::class, $app['logger.manager']);
 
         $app->boot();
     }

--- a/tests/phpunit/unit/Provider/MenuServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/MenuServiceProviderTest.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Menu\MenuBuilder;
+use Bolt\Menu\MenuEntry;
 use Bolt\Provider\MenuServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
@@ -17,8 +19,8 @@ class MenuServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new MenuServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Menu\MenuBuilder', $app['menu']);
-        $this->assertInstanceOf('Bolt\Menu\MenuEntry', $app['menu.admin']);
+        $this->assertInstanceOf(MenuBuilder::class, $app['menu']);
+        $this->assertInstanceOf(MenuEntry::class, $app['menu.admin']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/OmnisearchServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/OmnisearchServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Omnisearch;
 use Bolt\Provider\OmnisearchServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
@@ -17,6 +18,6 @@ class OmnisearchServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new OmnisearchServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Omnisearch', $app['omnisearch']);
+        $this->assertInstanceOf(Omnisearch::class, $app['omnisearch']);
     }
 }

--- a/tests/phpunit/unit/Provider/PagerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PagerServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Pager\PagerManager;
 use Bolt\Provider\PagerServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,7 +23,7 @@ class PagerServiceProviderTest extends BoltUnitTest
         $provider = new PagerServiceProvider($app);
         $app->register($provider);
 
-        $this->assertInstanceOf('Bolt\Pager\PagerManager', $app['pager']);
+        $this->assertInstanceOf(PagerManager::class, $app['pager']);
 
         $app->boot();
     }

--- a/tests/phpunit/unit/Provider/PathServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PathServiceProviderTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\PathServiceProvider;
 use Bolt\Tests\BoltUnitTest;
+use Eloquent\Pathogen\FileSystem\Factory\PlatformFileSystemPathFactory;
 
 /**
  * Class to test src/Provider/PathServiceProvider.
@@ -17,7 +18,7 @@ class PathServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new PathServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Eloquent\Pathogen\FileSystem\Factory\PlatformFileSystemPathFactory', $app['pathmanager']);
+        $this->assertInstanceOf(PlatformFileSystemPathFactory::class, $app['pathmanager']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/PermissionsServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PermissionsServiceProviderTest.php
@@ -18,7 +18,7 @@ class PermissionsServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new PermissionsServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\AccessControl\Permissions', $app['permissions']);
+        $this->assertInstanceOf(Permissions::class, $app['permissions']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/ProfilerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ProfilerServiceProviderTest.php
@@ -2,8 +2,11 @@
 
 namespace Bolt\Tests\Provider;
 
+use Bolt\Profiler\BoltDataCollector;
+use Bolt\Profiler\DatabaseDataCollector;
 use Bolt\Provider\ProfilerServiceProvider;
 use Bolt\Tests\BoltUnitTest;
+use Doctrine\DBAL\Logging\DebugStack;
 
 /**
  * Class to test src/Provider/DatabaseProfilerServiceProvider.
@@ -28,13 +31,13 @@ class ProfilerServiceProviderTest extends BoltUnitTest
         $collectors = $app['data_collectors'];
         $this->assertArrayHasKey('bolt', $collectors);
         $this->assertArrayHasKey('db', $collectors);
-        $this->assertInstanceOf('Bolt\Profiler\BoltDataCollector', $collectors['bolt']->__invoke($app));
-        $this->assertInstanceOf('Bolt\Profiler\DatabaseDataCollector', $collectors['db']->__invoke($app));
+        $this->assertInstanceOf(BoltDataCollector::class, $collectors['bolt']->__invoke($app));
+        $this->assertInstanceOf(DatabaseDataCollector::class, $collectors['db']->__invoke($app));
 
         $this->assertNotEmpty($app['twig.loader.bolt_filesystem']->getPaths('BoltProfiler'));
 
         $logger = $app['db.logger'];
-        $this->assertInstanceOf('Doctrine\DBAL\Logging\DebugStack', $logger);
+        $this->assertInstanceOf(DebugStack::class, $logger);
 
         $app->boot();
 

--- a/tests/phpunit/unit/Provider/RenderServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/RenderServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\RenderServiceProvider;
+use Bolt\Render;
 use Bolt\Tests\BoltUnitTest;
 
 /**
@@ -19,8 +20,8 @@ class RenderServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $app->register(new RenderServiceProvider());
 
-        $this->assertInstanceOf('Bolt\Render', $app['render']);
-        $this->assertInstanceOf('Bolt\Render', $app['safe_render']);
+        $this->assertInstanceOf(Render::class, $app['render']);
+        $this->assertInstanceOf(Render::class, $app['safe_render']);
 
         $app->boot();
     }

--- a/tests/phpunit/unit/Provider/SlugifyProviderTest.php
+++ b/tests/phpunit/unit/Provider/SlugifyProviderTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Tests\BoltUnitTest;
 use Cocur\Slugify\Bridge\Silex\SlugifyServiceProvider;
+use Cocur\Slugify\Slugify;
 
 /**
  * Class to test Cocur\Slugify\Bridge\Silex\SlugifyServiceProvider used in $app['slugify']
@@ -17,7 +18,7 @@ class SlugifyProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new SlugifyServiceProvider();
         $app->register($provider);
-        $this->assertInstanceOf('Cocur\Slugify\Slugify', $app['slugify']);
+        $this->assertInstanceOf(Slugify::class, $app['slugify']);
         $app->boot();
 
         $slug = 'This is a title';

--- a/tests/phpunit/unit/Provider/StackServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/StackServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\StackServiceProvider;
+use Bolt\Stack;
 use Bolt\Tests\BoltUnitTest;
 
 /**
@@ -17,7 +18,7 @@ class StackServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new StackServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\Stack', $app['stack']);
+        $this->assertInstanceOf(Stack::class, $app['stack']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/TemplateChooserServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TemplateChooserServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Provider\TemplateChooserServiceProvider;
+use Bolt\TemplateChooser;
 use Bolt\Tests\BoltUnitTest;
 
 /**
@@ -17,7 +18,7 @@ class TemplateChooserServiceProviderTest extends BoltUnitTest
         $app = $this->getApp();
         $provider = new TemplateChooserServiceProvider($app);
         $app->register($provider);
-        $this->assertInstanceOf('Bolt\TemplateChooser', $app['templatechooser']);
+        $this->assertInstanceOf(TemplateChooser::class, $app['templatechooser']);
         $app->boot();
     }
 }

--- a/tests/phpunit/unit/Routing/UrlGeneratorFragmentWrapperTest.php
+++ b/tests/phpunit/unit/Routing/UrlGeneratorFragmentWrapperTest.php
@@ -24,7 +24,7 @@ class UrlGeneratorFragmentWrapperTest extends BoltUnitTest
         $parent = new UrlGenerator($collection, new RequestContext());
         $generator = new UrlGeneratorFragmentWrapper($parent);
 
-        $this->assertInstanceOf('\Symfony\Component\Routing\Generator\UrlGeneratorInterface', $generator);
+        $this->assertInstanceOf(UrlGeneratorInterface::class, $generator);
 
         return $generator;
     }

--- a/tests/phpunit/unit/Session/OptionsBagTest.php
+++ b/tests/phpunit/unit/Session/OptionsBagTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Session;
 
 use Bolt\Session\OptionsBag;
 use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 /**
  * Class to test src/Session/OptionsBag.
@@ -15,7 +16,7 @@ class OptionsBagTest extends BoltUnitTest
     public function testInstanceOf()
     {
         $bag = new OptionsBag();
-        $this->assertInstanceOf('Symfony\Component\HttpFoundation\ParameterBag', $bag);
+        $this->assertInstanceOf(ParameterBag::class, $bag);
     }
 
     public function testGet()

--- a/tests/phpunit/unit/Stack/StackTest.php
+++ b/tests/phpunit/unit/Stack/StackTest.php
@@ -7,6 +7,7 @@ use Bolt\Filesystem\Handler\FileInterface;
 use Bolt\Stack;
 use Bolt\Tests\BoltUnitTest;
 use League\Flysystem\Memory\MemoryAdapter;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
@@ -22,7 +23,7 @@ class StackTest extends BoltUnitTest
     private $stack;
     /** @var Filesystem\FilesystemInterface */
     private $filesystem;
-    /** @var \Bolt\Users|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Bolt\Users|MockObject */
     private $users;
     /** @var SessionInterface */
     private $session;

--- a/tests/phpunit/unit/Stack/StackTest.php
+++ b/tests/phpunit/unit/Stack/StackTest.php
@@ -2,13 +2,10 @@
 
 namespace Bolt\Tests\Stack;
 
-use Bolt\Exception\FileNotStackableException;
 use Bolt\Filesystem;
-use Bolt\Filesystem\Exception\FileNotFoundException;
 use Bolt\Filesystem\Handler\FileInterface;
 use Bolt\Stack;
 use Bolt\Tests\BoltUnitTest;
-use Bolt\Users;
 use League\Flysystem\Memory\MemoryAdapter;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -260,21 +257,27 @@ class StackTest extends BoltUnitTest
         $this->assertNull($removed, 'Add methods removed parameter should be optional and null if no file was removed off stack');
     }
 
+    /**
+     * @expectedException \Bolt\Exception\FileNotStackableException
+     */
     public function testAddExistingFile()
     {
-        $this->setExpectedException(FileNotStackableException::class);
         $this->stack->add('d.doc');
     }
 
+    /**
+     * @expectedException \Bolt\Exception\FileNotStackableException
+     */
     public function testAddUnacceptableFile()
     {
-        $this->setExpectedException(FileNotStackableException::class);
         $this->stack->add('evil.exe');
     }
 
+    /**
+     * @expectedException \Bolt\Filesystem\Exception\FileNotFoundException
+     */
     public function testAddNonExistentFile()
     {
-        $this->setExpectedException(FileNotFoundException::class);
         $this->stack->add('non_existent_file');
     }
 

--- a/tests/phpunit/unit/Storage/EntityManagerTest.php
+++ b/tests/phpunit/unit/Storage/EntityManagerTest.php
@@ -58,10 +58,18 @@ class EntityManagerTest extends BoltUnitTest
         $app = $this->getApp();
         $em = $app['storage'];
         $repo = $em->getRepository('showcases');
+        $this->assertInstanceOf('Bolt\Storage\Repository\ContentRepository', $repo);
+    }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to handle unmapped data without a defaultRepositoryFactory set
+     */
+    public function testGetDefaultRepositoryFactoryNotSet()
+    {
+        $app = $this->getApp();
         // The first check should work, this one should fail because the factory has not been set.
-        $this->setExpectedException('RuntimeException');
         $em = new EntityManager($app['db'], $app['dispatcher'], $app['storage.metadata']);
-        $repo = $em->getRepository('showcases');
+        $em->getRepository('showcases');
     }
 }

--- a/tests/phpunit/unit/Storage/EntityManagerTest.php
+++ b/tests/phpunit/unit/Storage/EntityManagerTest.php
@@ -2,8 +2,12 @@
 
 namespace Bolt\Tests\Storage;
 
+use Bolt\Storage\Entity;
 use Bolt\Storage\EntityManager;
+use Bolt\Storage\Repository;
 use Bolt\Tests\BoltUnitTest;
+use Bolt\Tests\Storage\Mock\TestRepository;
+use Doctrine\DBAL\Query\QueryBuilder;
 use PHPUnit\Framework\Assert;
 
 /**
@@ -27,7 +31,7 @@ class EntityManagerTest extends BoltUnitTest
         $em = $app['storage'];
 
         $qb = $em->createQueryBuilder();
-        $this->assertInstanceOf('Doctrine\DBAL\Query\QueryBuilder', $qb);
+        $this->assertInstanceOf(QueryBuilder::class, $qb);
     }
 
     public function testGetRepository()
@@ -35,9 +39,9 @@ class EntityManagerTest extends BoltUnitTest
         $app = $this->getApp();
         $em = $app['storage'];
 
-        $repo = $em->getRepository('Bolt\Storage\Entity\Users');
+        $repo = $em->getRepository(Entity\Users::class);
 
-        $this->assertInstanceOf('Bolt\Storage\Repository', $repo);
+        $this->assertInstanceOf(Repository::class, $repo);
     }
 
     public function testGetRepositoryWithAliases()
@@ -45,13 +49,12 @@ class EntityManagerTest extends BoltUnitTest
         $app = $this->getApp();
         $em = $app['storage'];
 
-        $customRepoClass = 'Bolt\Tests\Storage\Mock\TestRepository';
-        $em->setRepository('Bolt\Storage\Entity\Users', $customRepoClass);
-        $em->addEntityAlias('test', 'Bolt\Storage\Entity\Users');
+        $em->setRepository(Entity\Users::class, TestRepository::class);
+        $em->addEntityAlias('test', Entity\Users::class);
 
         $repo = $em->getRepository('test');
 
-        $this->assertInstanceOf('Bolt\Tests\Storage\Mock\TestRepository', $repo);
+        $this->assertInstanceOf(TestRepository::class, $repo);
     }
 
     public function testGetDefaultRepositoryFactory()
@@ -59,7 +62,7 @@ class EntityManagerTest extends BoltUnitTest
         $app = $this->getApp();
         $em = $app['storage'];
         $repo = $em->getRepository('showcases');
-        $this->assertInstanceOf('Bolt\Storage\Repository\ContentRepository', $repo);
+        $this->assertInstanceOf(Repository\ContentRepository::class, $repo);
     }
 
     /**

--- a/tests/phpunit/unit/Storage/EntityManagerTest.php
+++ b/tests/phpunit/unit/Storage/EntityManagerTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Storage;
 
 use Bolt\Storage\EntityManager;
 use Bolt\Tests\BoltUnitTest;
+use PHPUnit\Framework\Assert;
 
 /**
  * Class to test src/Storage/EntityManager.
@@ -16,8 +17,8 @@ class EntityManagerTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $em = $app['storage'];
-        $this->assertSame($app['db'], \PHPUnit_Framework_Assert::readAttribute($em, 'conn'));
-        $this->assertSame($app['dispatcher'], \PHPUnit_Framework_Assert::readAttribute($em, 'eventManager'));
+        $this->assertSame($app['db'], Assert::readAttribute($em, 'conn'));
+        $this->assertSame($app['dispatcher'], Assert::readAttribute($em, 'eventManager'));
     }
 
     public function testCreateQueryBuilder()

--- a/tests/phpunit/unit/Storage/FieldLoadTest.php
+++ b/tests/phpunit/unit/Storage/FieldLoadTest.php
@@ -3,8 +3,10 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Legacy\Storage;
-use Bolt\Storage\Entity\FieldValue;
+use Bolt\Storage\Collection\Taxonomy;
+use Bolt\Storage\Entity;
 use Bolt\Storage\Field\Collection\FieldCollectionInterface;
+use Bolt\Storage\Field\Collection\RepeatingFieldCollection;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,8 +42,8 @@ class FieldLoadTest extends BoltUnitTest
         $repo = $em->getRepository('showcases');
 
         $record = $repo->find(1);
-        $this->assertInstanceOf('Bolt\Storage\Collection\Taxonomy', $record->taxonomy['categories']);
-        $this->assertInstanceOf('Bolt\Storage\Collection\Taxonomy', $record->taxonomy['tags']);
+        $this->assertInstanceOf(Taxonomy::class, $record->taxonomy['categories']);
+        $this->assertInstanceOf(Taxonomy::class, $record->taxonomy['tags']);
     }
 
     public function testRepeaterLoad()
@@ -51,12 +53,12 @@ class FieldLoadTest extends BoltUnitTest
         $this->addSomeFields();
         $repo = $em->getRepository('showcases');
         $record = $repo->find(1);
-        $this->assertInstanceOf('Bolt\Storage\Field\Collection\RepeatingFieldCollection', $record->repeater);
+        $this->assertInstanceOf(RepeatingFieldCollection::class, $record->repeater);
         $this->assertEquals(2, count($record->repeater));
         foreach ($record->repeater as $collection) {
             $this->assertInstanceOf(FieldCollectionInterface::class, $collection);
             foreach ($collection as $fieldValue) {
-                $this->assertInstanceOf(FieldValue::class, $fieldValue);
+                $this->assertInstanceOf(Entity\FieldValue::class, $fieldValue);
             }
         }
     }
@@ -67,13 +69,13 @@ class FieldLoadTest extends BoltUnitTest
         $em = $app['storage'];
         $repo = $em->getRepository('pages');
         $record = $repo->find(3);
-        $tax = $em->createCollection('Bolt\Storage\Entity\Taxonomy');
+        $tax = $em->createCollection(Entity\Taxonomy::class);
         $tax->setFromPost(['groups' => ['main']], $record);
         $record->setTaxonomy($tax);
         $repo->save($record);
         $recordSaved = $repo->find(3);
-        $this->assertInstanceOf('Bolt\Storage\Collection\Taxonomy', $recordSaved->taxonomy['groups']);
-        $this->assertInstanceOf('Bolt\Storage\Collection\Taxonomy', $recordSaved->getGroups());
+        $this->assertInstanceOf(Taxonomy::class, $recordSaved->taxonomy['groups']);
+        $this->assertInstanceOf(Taxonomy::class, $recordSaved->getGroups());
         $this->assertEquals(1, count($recordSaved->getGroups()));
     }
 

--- a/tests/phpunit/unit/Storage/FieldSaveTest.php
+++ b/tests/phpunit/unit/Storage/FieldSaveTest.php
@@ -3,6 +3,8 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Legacy\Storage;
+use Bolt\Storage\Collection\Taxonomy;
+use Bolt\Storage\Entity;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Mocks\LoripsumMock;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,7 +31,7 @@ class FieldSaveTest extends BoltUnitTest
             $this->assertNotEmpty($entry->slug);
         }
 
-        $newRels = $em->createCollection('Bolt\Storage\Entity\Relations');
+        $newRels = $em->createCollection(Entity\Relations::class);
         $record->setRelation($newRels);
         $em->save($record);
 
@@ -46,10 +48,10 @@ class FieldSaveTest extends BoltUnitTest
 
         $record = $repo->find(1);
 
-        $this->assertInstanceOf('Bolt\Storage\Collection\Taxonomy', $record->taxonomy['categories']);
-        $this->assertInstanceOf('Bolt\Storage\Collection\Taxonomy', $record->taxonomy['tags']);
+        $this->assertInstanceOf(Taxonomy::class, $record->taxonomy['categories']);
+        $this->assertInstanceOf(Taxonomy::class, $record->taxonomy['tags']);
 
-        $taxonomy = $em->createCollection('Bolt\Storage\Entity\Taxonomy');
+        $taxonomy = $em->createCollection(Entity\Taxonomy::class);
         $taxonomy->setFromPost(['categories' => []], $record);
         $record->setTaxonomy($taxonomy);
         $repo->save($record);
@@ -58,19 +60,19 @@ class FieldSaveTest extends BoltUnitTest
         $record1 = $repo->find(1);
         $this->assertEquals(0, count($record1->taxonomy['categories']));
     }
-    
+
     public function testEntityCreateTaxonomySave()
     {
         $app = $this->getApp();
         $em = $app['storage'];
         $repo = $em->getRepository('showcases');
-        
+
         $newEntity = $repo->create(['title' => 'Testing', 'slug' => 'testing', 'status' => 'published']);
-        $taxonomy = $em->createCollection('Bolt\Storage\Entity\Taxonomy');
+        $taxonomy = $em->createCollection(Entity\Taxonomy::class);
         $taxonomy->setFromPost(['categories' => ['news', 'events']], $newEntity);
         $newEntity->setTaxonomy($taxonomy);
         $repo->save($newEntity);
-        
+
         $savedEntity = $repo->find($newEntity->getId());
         $this->assertEquals(2, count($savedEntity->getCategories()));
     }

--- a/tests/phpunit/unit/Storage/Mapping/MetadataDriverTest.php
+++ b/tests/phpunit/unit/Storage/Mapping/MetadataDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Storage\Mapping;
 
+use Bolt\Storage\Entity;
 use Bolt\Storage\Mapping\MetadataDriver;
 use Bolt\Tests\BoltUnitTest;
 use PHPUnit\Framework\Assert;
@@ -25,7 +26,7 @@ class MetadataDriverTest extends BoltUnitTest
         $app = $this->getApp();
         $map = new MetadataDriver($app['schema'], $app['storage.config.contenttypes'], $app['storage.config.taxonomy'], $app['storage.typemap'], $app['storage.namingstrategy']);
         $map->initialize();
-        $metadata = $map->loadMetadataForClass('Bolt\Storage\Entity\Users');
+        $metadata = $map->loadMetadataForClass(Entity\Users::class);
         $this->assertNotNull($metadata);
         $this->assertEquals('bolt_users', $metadata->getTableName());
         $field = $metadata->getFieldMapping('id');

--- a/tests/phpunit/unit/Storage/Mapping/MetadataDriverTest.php
+++ b/tests/phpunit/unit/Storage/Mapping/MetadataDriverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bolt\Tests\Mapping;
+namespace Bolt\Tests\Storage\Mapping;
 
 use Bolt\Storage\Mapping\MetadataDriver;
 use Bolt\Tests\BoltUnitTest;

--- a/tests/phpunit/unit/Storage/Mapping/MetadataDriverTest.php
+++ b/tests/phpunit/unit/Storage/Mapping/MetadataDriverTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Storage\Mapping;
 
 use Bolt\Storage\Mapping\MetadataDriver;
 use Bolt\Tests\BoltUnitTest;
+use PHPUnit\Framework\Assert;
 
 /**
  * Class to test src/Mapping/MetadataDriver.
@@ -16,7 +17,7 @@ class MetadataDriverTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $map = new MetadataDriver($app['schema'], $app['storage.config.contenttypes'], $app['storage.config.taxonomy'], $app['storage.typemap']);
-        $this->assertSame($app['schema'], \PHPUnit_Framework_Assert::readAttribute($map, 'schemaManager'));
+        $this->assertSame($app['schema'], Assert::readAttribute($map, 'schemaManager'));
     }
 
     public function testInitialize()

--- a/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Storage\Query;
 
+use Bolt\Storage\Entity;
 use Bolt\Storage\Query\ContentQueryParser;
 use Bolt\Tests\BoltUnitTest;
 
@@ -153,7 +154,7 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb->setParameters(['returnsingle' => true]);
         $res = $qb->fetch();
 
-        $this->assertInstanceOf('Bolt\Storage\Entity\Content', $res);
+        $this->assertInstanceOf(Entity\Content::class, $res);
     }
 
     public function testFirstHandler()
@@ -280,6 +281,6 @@ class ContentQueryParserTest extends BoltUnitTest
 
         $this->expectOutputString('SELECT pages.* FROM bolt_pages pages WHERE pages.id = :id_1');
         $res = $qb->fetch();
-        $this->assertInstanceOf('Bolt\Storage\Entity\Content', $res);
+        $this->assertInstanceOf(Entity\Content::class, $res);
     }
 }

--- a/tests/phpunit/unit/Storage/Query/NativeSearchTest.php
+++ b/tests/phpunit/unit/Storage/Query/NativeSearchTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Storage\Query;
 
 use Bolt\Storage\Query\Adapter\PostgresSearch;
 use Bolt\Tests\BoltUnitTest;
+use Doctrine\DBAL\Query\Expression\CompositeExpression;
 
 /**
  * Class to test src/Storage/Query/QueryTest.
@@ -36,7 +37,7 @@ class NativeSearchTest extends BoltUnitTest
             ],
             $query->getQueryPart('from')
         );
-        $this->assertInstanceOf('Doctrine\DBAL\Query\Expression\CompositeExpression', $query->getQueryPart('where'));
+        $this->assertInstanceOf(CompositeExpression::class, $query->getQueryPart('where'));
         $this->assertEquals(['score DESC'], $query->getQueryPart('orderBy'));
     }
 }

--- a/tests/phpunit/unit/Storage/Query/QueryParameterParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/QueryParameterParserTest.php
@@ -77,10 +77,18 @@ class QueryParameterParserTest extends BoltUnitTest
         $filter = $p->getFilter('id', '>29 && <=37');
         $this->assertEquals('(id > :id_1) AND (id <= :id_2)', $filter->getExpression());
         $this->assertEquals(['id_1' => '29', 'id_2' => '37'], $filter->getParameters());
+    }
 
-        $this->setExpectedException('Bolt\Exception\QueryParseException');
+    /**
+     * @expectedException \Bolt\Exception\QueryParseException
+     */
+    public function testCompositeOrAndInvalid()
+    {
+        $app = $this->getApp();
+        $expr = $app['storage']->createExpressionBuilder();
+
         $p = new QueryParameterParser($expr);
-        $filter = $p->getFilter('ownerid', '>1||<4 && <56');
+        $p->getFilter('ownerid', '>1||<4 && <56');
     }
 
     public function testComplexOr()
@@ -99,11 +107,13 @@ class QueryParameterParserTest extends BoltUnitTest
         $this->assertEquals(['username_1' => 'tester', 'email_2' => 'faker'], $filter->getParameters());
     }
 
+    /**
+     * @expectedException \Bolt\Exception\QueryParseException
+     */
     public function testMissingBuilderError()
     {
         $p = new QueryParameterParser();
-        $this->setExpectedException('Bolt\Exception\QueryParseException');
-        $filter = $p->getFilter('username ||| email', 'tester');
+        $p->getFilter('username ||| email', 'tester');
     }
 
     public function testAddingCustomMatcher()

--- a/tests/phpunit/unit/Storage/Query/QueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/QueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Storage\Query;
 
+use Bolt\Storage\Query\QueryResultset;
 use Bolt\Storage\Query\QueryScopeInterface;
 use Bolt\Tests\BoltUnitTest;
 
@@ -19,10 +20,10 @@ class QueryTest extends BoltUnitTest
 
         $results = $app['query']->getContent('pages', ['id' => '<10']);
 
-        $this->assertInstanceOf('Bolt\Storage\Query\QueryResultset', $results);
+        $this->assertInstanceOf(QueryResultset::class, $results);
 
         $results = $app['query']->getContent('pages', ['datepublish' => '>now || !last week', 'datedepublish' => '<1 year ago']);
-        $this->assertInstanceOf('Bolt\Storage\Query\QueryResultset', $results);
+        $this->assertInstanceOf(QueryResultset::class, $results);
     }
 
     public function testGetContentReturnSingle()

--- a/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
@@ -64,23 +64,27 @@ class SearchQueryTest extends BoltUnitTest
         $this->assertEquals('%ipsum%', $params['groups_2']);
     }
 
+    /**
+     * @expectedException \Bolt\Exception\QueryParseException
+     */
     public function testContenttypeFailure()
     {
         $app = $this->getApp();
         $filter = 'main other';
         $query = $app['query.search'];
         $query->setContentType('blocks');
-        $this->setExpectedException('Bolt\Exception\QueryParseException');
         $query->setSearch($filter);
     }
 
+    /**
+     * @expectedException \Bolt\Exception\QueryParseException
+     */
     public function testMissingContenttypeFailure()
     {
         $app = $this->getApp();
         $filter = 'main other';
         $query = $app['query.search'];
         $query->setContentType('nonexistent');
-        $this->setExpectedException('Bolt\Exception\QueryParseException');
         $query->setSearch($filter);
     }
 }

--- a/tests/phpunit/unit/Storage/Repository/ContentRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/ContentRepositoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Tests\Storage\Repository;
 
-use Bolt\Storage\Entity\Content;
+use Bolt\Storage\Entity;
 use Bolt\Storage\Repository;
 use Bolt\Tests\BoltUnitTest;
 
@@ -20,7 +20,7 @@ class ContentRepositoryTest extends BoltUnitTest
         $em = $app['storage'];
         $repo = $em->getRepository('bolt_showcases');
 
-        $this->assertInstanceOf('Bolt\Storage\Repository\ContentRepository', $repo);
+        $this->assertInstanceOf(Repository\ContentRepository::class, $repo);
     }
 
     public function testCreate()
@@ -29,7 +29,7 @@ class ContentRepositoryTest extends BoltUnitTest
         $em = $app['storage'];
         $repo = $em->getRepository('showcases');
 
-        $showcase = new Content([
+        $showcase = new Entity\Content([
             'title'  => 'Test Showcase',
             'slug'   => 'test-showcase',
             'status' => 'published',
@@ -90,6 +90,6 @@ class ContentRepositoryTest extends BoltUnitTest
             'status' => 'published',
         ]);
 
-        $this->assertInstanceOf('Bolt\Storage\Entity\Content', $record);
+        $this->assertInstanceOf(Entity\Content::class, $record);
     }
 }

--- a/tests/phpunit/unit/Storage/RepositoryTest.php
+++ b/tests/phpunit/unit/Storage/RepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Tests\Storage;
 
 use Bolt\Tests\BoltUnitTest;
+use PHPUnit\Framework\Assert;
 
 /**
  * Class to test src/Storage/Repository.
@@ -21,7 +22,7 @@ class RepositoryTest extends BoltUnitTest
         $em = $app['storage'];
         $repo = $em->getRepository($entityName);
 
-        $this->assertSame($em, \PHPUnit_Framework_Assert::readAttribute($repo, 'em'));
+        $this->assertSame($em, Assert::readAttribute($repo, 'em'));
     }
 
     public function testGetTableName()

--- a/tests/phpunit/unit/Storage/RepositoryTest.php
+++ b/tests/phpunit/unit/Storage/RepositoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Bolt\Tests\Storage;
 
-use Bolt\Storage\Repository;
 use Bolt\Tests\BoltUnitTest;
 
 /**

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -37,7 +37,7 @@ class StorageTest extends BoltUnitTest
         $app = $this->getApp();
         $storage = new Storage($app);
         $content = $storage->getContentObject('pages');
-        $this->assertInstanceOf('Bolt\Legacy\Content', $content);
+        $this->assertInstanceOf(Content::class, $content);
 
         // Fake it until we make it… to the end of the test suite.
         $contentType = $app['config']->get('contenttypes/pages');
@@ -58,7 +58,7 @@ class StorageTest extends BoltUnitTest
         ;
         $content = $storage->getContentObject(['class' => 'Fakes', 'fields' => $fields]);
         $this->assertInstanceOf('Fakes', $content);
-        $this->assertInstanceOf('Bolt\Legacy\Content', $content);
+        $this->assertInstanceOf(Content::class, $content);
 
         // Test that a class not instanceof Bolt\Legacy\Content fails
         $mock = $this->getMockBuilder(\stdClass::class)
@@ -132,7 +132,7 @@ class StorageTest extends BoltUnitTest
         $app['request'] = Request::create('/');
         $storage = new Storage($app);
 
-        $content = $storage->getEmptyContent('showcases');;
+        $content = $storage->getEmptyContent('showcases');
         $content->setValues([
             'title'  => 'koala',
             'slug'   => 'Kenny',
@@ -203,7 +203,7 @@ class StorageTest extends BoltUnitTest
         $app = $this->getApp();
         $storage = new Storage($app);
         $showcase = $storage->getEmptyContent('showcase');
-        $this->assertInstanceOf('Bolt\Legacy\Content', $showcase);
+        $this->assertInstanceOf(Content::class, $showcase);
         $this->assertEquals('showcases', $showcase->contenttype['slug']);
     }
 

--- a/tests/phpunit/unit/Translation/TranslationFileTest.php
+++ b/tests/phpunit/unit/Translation/TranslationFileTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Translation;
 
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Translation\TranslationFile;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -17,7 +18,7 @@ class TranslationFileTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $tr = new TranslationFile($app, 'translations', 'en_GB');
-        $this->assertEquals('translations', \PHPUnit_Framework_Assert::readAttribute($tr, 'domain'));
+        $this->assertEquals('translations', Assert::readAttribute($tr, 'domain'));
     }
 
     public function testPath()

--- a/tests/phpunit/unit/Twig/Runtime/AdminRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/AdminRuntimeTest.php
@@ -6,6 +6,7 @@ use Bolt\Stack;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Runtime\AdminRuntime;
 use Monolog\Logger;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Class to test Bolt\Twig\Runtime\AdminRuntime
@@ -280,7 +281,7 @@ class AdminRuntimeTest extends BoltUnitTest
     }
 
     /**
-     * @return Stack|\PHPUnit_Framework_MockObject_MockObject
+     * @return Stack|MockObject
      */
     protected function getMockStack()
     {

--- a/tests/phpunit/unit/Twig/Runtime/DumpRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/DumpRuntimeTest.php
@@ -5,6 +5,7 @@ namespace Bolt\Tests\Twig\Runtime;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Runtime\DumpRuntime;
 use Bolt\Users;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
@@ -48,7 +49,7 @@ class DumpRuntimeTest extends BoltUnitTest
             ->method('getCurrentUser')
             ->willReturn($hasUser ? true : null);
 
-        /** @var DumpRuntime|\PHPUnit_Framework_MockObject_MockObject $runtime */
+        /** @var DumpRuntime|MockObject $runtime */
         $runtime = $this->getMock(DumpRuntime::class, ['dump'], [
             new VarCloner(),
             new HtmlDumper(),

--- a/tests/phpunit/unit/Twig/Runtime/TextRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/TextRuntimeTest.php
@@ -4,6 +4,7 @@ namespace Bolt\Tests\Twig\Runtime;
 
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Runtime\TextRuntime;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Class to test Bolt\Twig\Runtime\TextRuntime
@@ -12,7 +13,7 @@ use Bolt\Twig\Runtime\TextRuntime;
  */
 class TextRuntimeTest extends BoltUnitTest
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject */
     public $phpMock;
 
     public function setUp()

--- a/tests/phpunit/unit/Twig/Runtime/WidgetRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/WidgetRuntimeTest.php
@@ -43,6 +43,10 @@ class WidgetRuntimeTest extends BoltUnitTest
         $this->assertSame(0, $count);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage countwidgets() requires a location, none given
+     */
     public function testCountWidgetsNoLocationStrict()
     {
         $app = $this->getStrictVariablesApp(true);
@@ -53,7 +57,6 @@ class WidgetRuntimeTest extends BoltUnitTest
             ->setContent('<blink>Drop Bear Warning!</blink>')
         ;
 
-        $this->setExpectedException('InvalidArgumentException', 'countwidgets() requires a location, none given');
         $app['asset.queue.widget']->add($widget);
         $handler->countWidgets($app['twig']);
     }
@@ -107,6 +110,10 @@ class WidgetRuntimeTest extends BoltUnitTest
         $this->assertFalse($handler->hasWidgets($app['twig']));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage haswidgets() requires a location, none given
+     */
     public function testHasWidgetsNoLocationStrict()
     {
         $app = $this->getStrictVariablesApp(true);
@@ -117,7 +124,6 @@ class WidgetRuntimeTest extends BoltUnitTest
             ->setContent('<blink>Drop Bear Warning!</blink>')
         ;
 
-        $this->setExpectedException('InvalidArgumentException', 'haswidgets() requires a location, none given');
         $app['asset.queue.widget']->add($widget);
         $handler->hasWidgets($app['twig']);
     }
@@ -154,6 +160,10 @@ class WidgetRuntimeTest extends BoltUnitTest
         $this->assertNull($result);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage widgets() requires a location, none given
+     */
     public function testWidgetNoLocationStrict()
     {
         $app = $this->getStrictVariablesApp(true);
@@ -164,7 +174,6 @@ class WidgetRuntimeTest extends BoltUnitTest
             ->setContent('<blink>Drop Bear Warning!</blink>')
         ;
 
-        $this->setExpectedException('InvalidArgumentException', 'widgets() requires a location, none given');
         $app['asset.queue.widget']->add($widget);
         $handler->widgets($app['twig']);
     }

--- a/tests/phpunit/unit/Twig/Runtime/WidgetRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/WidgetRuntimeTest.php
@@ -75,7 +75,7 @@ class WidgetRuntimeTest extends BoltUnitTest
         $result = $handler->getWidgets();
         $this->assertCount(1, $result);
 
-        $this->assertInstanceOf('Bolt\Asset\Widget\Widget', reset($result));
+        $this->assertInstanceOf(Widget::class, reset($result));
     }
 
     public function testHasWidgets()

--- a/tests/phpunit/unit/Users/AuthenticationTest.php
+++ b/tests/phpunit/unit/Users/AuthenticationTest.php
@@ -18,9 +18,6 @@ class AuthenticationTest extends BoltUnitTest
      */
     private $user;
 
-    /**
-     * @see \PHPUnit_Framework_TestCase::setUp
-     */
     protected function setUp()
     {
         $this->resetDb();
@@ -34,7 +31,7 @@ class AuthenticationTest extends BoltUnitTest
     public function testLoginWithUsername()
     {
         // Setup test
-        $app = $this->getApp();
+        $this->getApp();
         $loginMock = $this->getMockLogin();
 
         $loginMock->expects($this->once())->method('login')->willReturn(true);

--- a/tests/phpunit/unit/Users/CreateUsersTest.php
+++ b/tests/phpunit/unit/Users/CreateUsersTest.php
@@ -11,9 +11,6 @@ use Bolt\Tests\BoltUnitTest;
  **/
 class CreateUsersTest extends BoltUnitTest
 {
-    /**
-     * @see \PHPUnit_Framework_TestCase::setUp
-     */
     protected function setUp()
     {
         $this->resetDb();

--- a/tests/phpunit/unit/Users/UsersTest.php
+++ b/tests/phpunit/unit/Users/UsersTest.php
@@ -3,7 +3,6 @@
 namespace Bolt\Tests\Users;
 
 use Bolt\Tests\BoltUnitTest;
-use Bolt\Users;
 
 /**
  * Class to test correct operation of src/Users.
@@ -17,9 +16,6 @@ class UsersTest extends BoltUnitTest
      */
     private $user;
 
-    /**
-     * @see \PHPUnit_Framework_TestCase::setUp
-     */
     protected function setUp()
     {
         $this->resetDb();
@@ -31,7 +27,7 @@ class UsersTest extends BoltUnitTest
     }
 
     /**
-     * @covers Bolt\Users::getUser
+     * @covers \Bolt\Users::getUser
      */
     public function testGetUserById()
     {
@@ -48,7 +44,7 @@ class UsersTest extends BoltUnitTest
     }
 
     /**
-     * @covers Bolt\Users::getUser
+     * @covers \Bolt\Users::getUser
      */
     public function testGetUserByUnknownId()
     {
@@ -63,7 +59,7 @@ class UsersTest extends BoltUnitTest
     }
 
     /**
-     * @covers Bolt\Users::getUser
+     * @covers \Bolt\Users::getUser
      */
     public function testGetUserByUsername()
     {
@@ -80,7 +76,7 @@ class UsersTest extends BoltUnitTest
     }
 
     /**
-     * @covers Bolt\Users::getUser
+     * @covers \Bolt\Users::getUser
      */
     public function testGetUserByUnknownUsername()
     {


### PR DESCRIPTION
* Move `setExpectedException*()` to annotations (deprecated in PHPUnit 5.5.2)
* Move FQCN PHPUnit class name use into imports with an `as` that matches the PHPUnit 6.x namespace
* Class name resolution OCD