### PR TITLE
Fix frontend taxonomy lookups where key is different to slug

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2381,7 +2381,7 @@ class Storage
         }
 
         // Get the contenttype from first $content
-        $first = $content[util::array_first_key($content)];
+        $first = reset($content);
         $config = $first->contenttype;
         $contenttype = (isset($config['key'])) ? $config['key'] : $config['slug'];
 

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -2381,7 +2381,9 @@ class Storage
         }
 
         // Get the contenttype from first $content
-        $contenttype = $content[util::array_first_key($content)]->contenttype['slug'];
+        $first = $content[util::array_first_key($content)];
+        $config = $first->contenttype;
+        $contenttype = (isset($config['key'])) ? $config['key'] : $config['slug'];
 
         $taxonomytypes = $this->app['config']->get('taxonomy');
 


### PR DESCRIPTION
Fixes #6228 

Adds a check to see if the key is different to the slug when deciding how to lookup taxonomy joins.

Note this will need to be reworked slightly for 3.3 as the implementation has changed slightly (dropping util:: functions ) so it may need a separate PR.