### PR TITLE
Add option to only dump the SQL from the database:update command

### DIFF
--- a/tests/phpunit/unit/Nut/DatabaseRepairTest.php
+++ b/tests/phpunit/unit/Nut/DatabaseRepairTest.php
@@ -26,19 +26,25 @@ class DatabaseRepairTest extends BoltUnitTest
 
     public function testUpdateSchema()
     {
-        $tester = $this->executeChanged([]);
+        $tester = $this->getTester();
+        $tester->execute([]);
         $result = $tester->getDisplay();
         $this->assertRegExp('/Created table `bolt_newcontent`/', $result);
     }
 
     public function testUpdateSchemaDumpSql()
     {
-        $tester = $this->executeChanged(['--dump-sql']);
+        $this->resetDb();
+        $tester = $this->getTester();
+        $tester->execute(['--dump-sql' => true]);
         $result = $tester->getDisplay();
         $this->assertRegExp('/CREATE TABLE bolt_newcontent/', $result);
     }
 
-    private function executeChanged(array $arguments)
+    /**
+     * @return CommandTester
+     */
+    private function getTester()
     {
         $app = $this->getApp(false);
         $app['config']->set('contenttypes/newcontent', [

--- a/tests/phpunit/unit/Nut/DatabaseRepairTest.php
+++ b/tests/phpunit/unit/Nut/DatabaseRepairTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class DatabaseRepairTest extends BoltUnitTest
 {
-    public function testRunNormal()
+    public function testSchemaUpToDate()
     {
         $app = $this->getApp();
         $command = new DatabaseRepair($app);
@@ -24,7 +24,21 @@ class DatabaseRepairTest extends BoltUnitTest
         $this->assertEquals('Your database is already up to date.', trim($result));
     }
 
-    public function testRunChanged()
+    public function testUpdateSchema()
+    {
+        $tester = $this->executeChanged([]);
+        $result = $tester->getDisplay();
+        $this->assertRegExp('/Created table `bolt_newcontent`/', $result);
+    }
+
+    public function testUpdateSchemaDumpSql()
+    {
+        $tester = $this->executeChanged(['--dump-sql']);
+        $result = $tester->getDisplay();
+        $this->assertRegExp('/CREATE TABLE bolt_newcontent/', $result);
+    }
+
+    private function executeChanged(array $arguments)
     {
         $app = $this->getApp(false);
         $app['config']->set('contenttypes/newcontent', [
@@ -44,8 +58,6 @@ class DatabaseRepairTest extends BoltUnitTest
         $command = new DatabaseRepair($app);
         $tester = new CommandTester($command);
 
-        $tester->execute([]);
-        $result = $tester->getDisplay();
-        $this->assertRegExp('/Created table `bolt_newcontent`/', $result);
+        return $tester;
     }
 }


### PR DESCRIPTION
This PR adds a `dump-sql` option to the `database:update` command.

Using this option will dump a list of SQL statements *instead* of performing the update on the database.

This is useful when generating migrations.

```
$ app/nut database:update --dump-sql                                                                                                                                                                   
ALTER TABLE bolt_field_value ADD value_boolean TINYINT(1) DEFAULT '0' NOT NULL
DROP INDEX IDX_4C524BC3EA112943 ON bolt_relations
DROP INDEX IDX_4C524BC378CED90B ON bolt_relations
DROP INDEX IDX_4C524BC35ACD2645 ON bolt_relations
DROP INDEX IDX_4C524BC330354A65 ON bolt_relations
CREATE INDEX IDX_4C524BC3EA11294378CED90B ON bolt_relations (from_contenttype, from_id)
CREATE INDEX IDX_4C524BC35ACD264530354A65 ON bolt_relations (to_contenttype, to_id)
CREATE INDEX IDX_ABAA1200989D9B62 ON bolt_taxonomy (slug)
...
```

If this is OK I will add the test :)