### PR TITLE
Allow Canonical Url to be overridden

### DIFF
--- a/src/Provider/CanonicalServiceProvider.php
+++ b/src/Provider/CanonicalServiceProvider.php
@@ -18,9 +18,8 @@ class CanonicalServiceProvider implements ServiceProviderInterface
         $app['canonical'] = $app->share(
             function ($app) {
                 return new Canonical(
-                    $app['request_stack'],
-                    $app['request_context'],
                     $app['url_generator'],
+                    $app['config']->get('general/force_ssl'),
                     $app['config']->get('general/canonical')
                 );
             }

--- a/src/Routing/Canonical.php
+++ b/src/Routing/Canonical.php
@@ -2,51 +2,49 @@
 
 namespace Bolt\Routing;
 
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\RequestContext;
+use Webmozart\Assert\Assert;
 
 /**
  * This class has two purposes.
- * - Provide a getter to get the canonical url for the current request.
+ * - Provide a getter (and override setter) to get the canonical url for the current request.
  * - Update the RequestContext with the scheme/host override from the config.
- *
- * Note: Updating the RequestContext also applies to the UrlGenerator.
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
 class Canonical implements EventSubscriberInterface
 {
-    /** @var RequestStack */
-    protected $requestStack;
-    /** @var RequestContext */
-    protected $requestContext;
     /** @var UrlGeneratorInterface */
     private $urlGenerator;
-    /** @var string|null An optional scheme/host override. */
+    /** @var UriInterface|null An optional scheme/host override. */
+    private $globalOverride;
+    /** @var bool */
+    private $forceSsl;
+
+    /** @var UriInterface|null An optional override for current request to use instead of the UrlGenerator */
     private $override;
+    /** @var Request|null The current request. */
+    private $request;
 
     /**
      * Constructor.
      *
-     * @param RequestStack          $requestStack
-     * @param RequestContext        $requestContext
-     * @param UrlGeneratorInterface $urlGenerator
-     * @param string|null           $override       An optional scheme/host override.
+     * @param UrlGeneratorInterface    $urlGenerator   The url generator.
+     * @param bool                     $forceSsl       Whether to force SSL on relative override urls (generated urls get this applied elsewhere).
+     * @param UriInterface|string|null $globalOverride An optional scheme and/or host override to apply to all urls.
      */
-    public function __construct(
-        RequestStack $requestStack,
-        RequestContext $requestContext,
-        UrlGeneratorInterface $urlGenerator,
-        $override = null
-    ) {
-        $this->requestStack = $requestStack;
-        $this->requestContext = $requestContext;
+    public function __construct(UrlGeneratorInterface $urlGenerator, $forceSsl = false, $globalOverride = null)
+    {
         $this->urlGenerator = $urlGenerator;
-        $this->override = $override;
+        $this->forceSsl = $forceSsl;
+        $this->setGlobalOverride($globalOverride);
     }
 
     /**
@@ -58,6 +56,43 @@ class Canonical implements EventSubscriberInterface
     }
 
     /**
+     * This overrides the scheme and host for all urls generated including the canonical one.
+     *
+     * @param UriInterface|string|null $uri
+     */
+    public function setGlobalOverride($uri)
+    {
+        if (is_string($uri)) {
+            // Prepend scheme if not included so parse_url doesn't choke.
+            if (strpos($uri, 'http') !== 0) {
+                $uri = 'http://' . $uri;
+            }
+            $uri = new Uri($uri);
+        }
+        Assert::nullOrIsInstanceOf($uri, UriInterface::class, 'Expected a string, UriInterface, or null. Got: %s');
+
+        $this->globalOverride = $uri;
+    }
+
+    /**
+     * This overrides the the canonical url. It will be resolved against the current request.
+     *
+     * Note: This only applies to the current request, so it will need to be called again for the next one.
+     *
+     * @param UriInterface|string|null $uri
+     */
+    public function setOverride($uri)
+    {
+        if (is_string($uri)) {
+            $uri = new Uri($uri);
+        }
+
+        Assert::nullOrIsInstanceOf($uri, UriInterface::class, 'Expected a string, UriInterface, or null. Got: %s');
+
+        $this->override = $uri;
+    }
+
+    /**
      * Returns the canonical url for the current request,
      * or null if called outside of the request cycle.
      *
@@ -65,50 +100,49 @@ class Canonical implements EventSubscriberInterface
      */
     public function getUrl()
     {
-        if (($request = $this->requestStack->getCurrentRequest()) === null) {
-            return null;
-        }
-        if (!$request->attributes->get('_route')) {
+        // Ensure in request cycle (even for override).
+        if ($this->request === null) {
             return null;
         }
 
+        // Ensure request has been matched
+        if (!$this->request->attributes->get('_route')) {
+            return null;
+        }
+
+        if ($this->override) {
+            $this->resolveCurrentOverride();
+
+            return (string) $this->override;
+        }
+
         return $this->urlGenerator->generate(
-            $request->attributes->get('_route'),
-            $request->attributes->get('_route_params'),
+            $this->request->attributes->get('_route'),
+            $this->request->attributes->get('_route_params'),
             UrlGeneratorInterface::ABSOLUTE_URL
         );
     }
 
     /**
-     * Sets the scheme and host overrides (if any) on the RequestContext.
-     *
-     * This needs to happen after RouterListener as that sets the scheme
-     * and host from the request. To override we need to be after that.
+     * Stores the current request and applies the global override.
      *
      * @param GetResponseEvent $event
      */
     public function onRequest(GetResponseEvent $event)
     {
-        if (!$this->override) {
-            return;
-        }
+        $this->setRequest($event->getRequest());
 
-        $override = $this->override;
+        $this->applyGlobalOverride();
+    }
 
-        // Prepend scheme if not included so parse_url doesn't choke.
-        if (strpos($override, 'http') !== 0) {
-            $override = 'http://' . $override;
-        }
-        $parts = parse_url($override);
-
-        // Only override scheme if it's an upgrade to https.
-        // i.e Don't do: https -> http
-        if (isset($parts['scheme']) && $parts['scheme'] === 'https') {
-            $this->requestContext->setScheme($parts['scheme']);
-        }
-        if (isset($parts['host'])) {
-            $this->requestContext->setHost($parts['host']);
-        }
+    /**
+     * Clear the current request and override.
+     *
+     * @param FinishRequestEvent $event
+     */
+    public function onFinishRequest(FinishRequestEvent $event)
+    {
+        $this->setRequest(null);
     }
 
     /**
@@ -118,6 +152,67 @@ class Canonical implements EventSubscriberInterface
     {
         return [
             KernelEvents::REQUEST => ['onRequest', 31], // Right after RouterListener
+            KernelEvents::FINISH_REQUEST => 'onFinishRequest',
         ];
+    }
+
+    /**
+     * Set the current request and reset the current override.
+     *
+     * @param Request|null $request
+     */
+    private function setRequest(Request $request = null)
+    {
+        $this->request = $request;
+        $this->override = null;
+    }
+
+    /**
+     * Sets the scheme and host overrides (if any) on the UrlGenerator's RequestContext.
+     *
+     * This needs to happen after RouterListener as that sets the scheme
+     * and host from the request. To override we need to be after that.
+     */
+    private function applyGlobalOverride()
+    {
+        if (!$this->globalOverride) {
+            return;
+        }
+
+        $context = $this->urlGenerator->getContext();
+
+        // Only override scheme if it's an upgrade to https.
+        // i.e Don't do: https -> http
+        if ($this->globalOverride->getScheme() === 'https') {
+            $context->setScheme('https');
+        }
+        if ($host = $this->globalOverride->getHost()) {
+            $context->setHost($host);
+        }
+    }
+
+    /**
+     * If there is a current override, resolve it to an absolute url based on current request.
+     */
+    private function resolveCurrentOverride()
+    {
+        // Absolute url or network path
+        if ($this->override->getHost() !== '') {
+            return;
+        }
+
+        $context = $this->urlGenerator->getContext();
+
+        if (Uri::isRelativePathReference($this->override)) {
+            $this->override = $this->override->withPath($context->getPathInfo() . '/' . $this->override->getPath());
+        }
+
+        $scheme = $this->forceSsl ? 'https' : $context->getScheme();
+        $this->override = $this->override
+            ->withScheme($scheme)
+            ->withHost($context->getHost())
+            ->withPort($scheme === 'http' ? $context->getHttpPort() : $context->getHttpsPort())
+            ->withPath($context->getBaseUrl() . $this->override->getPath())
+        ;
     }
 }

--- a/src/Routing/Canonical.php
+++ b/src/Routing/Canonical.php
@@ -25,7 +25,7 @@ class Canonical implements EventSubscriberInterface
     /** @var RequestContext */
     protected $requestContext;
     /** @var UrlGeneratorInterface */
-    protected $urlGenerator;
+    private $urlGenerator;
     /** @var string|null An optional scheme/host override. */
     private $override;
 
@@ -47,6 +47,14 @@ class Canonical implements EventSubscriberInterface
         $this->requestContext = $requestContext;
         $this->urlGenerator = $urlGenerator;
         $this->override = $override;
+    }
+
+    /**
+     * @param UrlGeneratorInterface $urlGenerator
+     */
+    public function setUrlGenerator(UrlGeneratorInterface $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
     }
 
     /**

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -139,6 +139,10 @@ class FrontendTest extends ControllerUnitTest
         $this->setRequest(Request::create($expected));
         $app['request_context']->fromRequest($this->getRequest());
 
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new GetResponseEvent($kernel, $this->getRequest(), HttpKernelInterface::MASTER_REQUEST);
+        $app['canonical']->onRequest($event);
+
         $templates = $this->getMockBuilder(TemplateChooser::class)
             ->setMethods(['record'])
             ->setConstructorArgs([$app['config']])
@@ -179,6 +183,10 @@ class FrontendTest extends ControllerUnitTest
         $storage->expects($this->at(1))
             ->method('getContent')
             ->will($this->returnValue($content1));
+
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new GetResponseEvent($kernel, $this->getRequest(), HttpKernelInterface::MASTER_REQUEST);
+        $app['canonical']->onRequest($event);
 
         // Route for /page/5 instead of /page/foo
         $this->controller()->record($this->getRequest(), 'pages', 5);

--- a/tests/phpunit/unit/Routing/CanonicalTest.php
+++ b/tests/phpunit/unit/Routing/CanonicalTest.php
@@ -2,8 +2,13 @@
 
 namespace Bolt\Tests\Routing;
 
-use Bolt\Tests\BoltUnitTest;
+use Bolt\Routing\Canonical;
+use PHPUnit\Framework\TestCase;
+use Silex\Application;
+use Silex\Provider\UrlGeneratorServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Test for Canonical class.
@@ -11,50 +16,157 @@ use Symfony\Component\HttpFoundation\Request;
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
  */
-class CanonicalTest extends BoltUnitTest
+class CanonicalTest extends TestCase
 {
-    public function provider()
+    public function urlProvider()
     {
         return [
-            'default'                  => [null, '/drop/bear', 'http://localhost/drop/bear'],
-            'override host'            => ['koala.org.au', '/drop/bear', 'http://koala.org.au/drop/bear'],
-            'override host and https'  => ['https://koala.org.au', '/drop/bear', 'https://koala.org.au/drop/bear'],
-            'https does not downgrade' => ['koala.org.au', 'https://koala.org.au/drop/bear', 'https://koala.org.au/drop/bear'],
+            'http'  => ['/foo', 'http://localhost/foo'],
+            'https' => ['https://localhost/foo', 'https://localhost/foo'],
         ];
     }
 
     /**
-     * @dataProvider provider
+     * @dataProvider urlProvider
      */
-    public function testCanonical($override, $uri, $expected)
+    public function testUrl($uri, $expected)
     {
-        $app = $this->getApp(false);
-        $app->match('/drop/bear', function () {
-            return '<html><head></head><body>Koala!</body></html>';
-        });
-        if ($override !== null) {
-            $app['config']->set('general/canonical', $override);
-        }
-        $request = Request::create($uri);
+        $app = $this->createAppWithCanonical();
 
-        $url = null;
-        $app->after(function () use (&$url, $app) {
-            $url = $app['canonical']->getUrl();
-        });
-
-        $app->handle($request);
-
-        $this->assertEquals($expected, $url);
+        $this->assertCanonicalUrlInKernel($app, $uri, $expected);
     }
 
-    public function testNullForUnmatchedRoute()
+    public function globalOverrideProvider()
     {
-        $app = $this->getApp(false);
+        return [
+            'only host (http)'       => ['/foo', 'http://bar.com/foo', 'bar.com'],
+            'only host (https)'      => ['https://localhost/foo', 'https://bar.com/foo', 'bar.com'],
 
-        $app['request_stack']->push(Request::create('/_nope/_no_route'));
+            'only host and http scheme (http)'  => ['/foo', 'http://bar.com/foo', 'http://bar.com'],
+            'only host and http scheme (https)' => ['https://localhost/foo', 'https://bar.com/foo', 'http://bar.com'],
+
+            'only host and https scheme (http)'  => ['/foo', 'https://bar.com/foo', 'https://bar.com'],
+            'only host and https scheme (https)' => ['https://localhost/foo', 'https://bar.com/foo', 'https://bar.com'],
+        ];
+    }
+
+    /**
+     * @dataProvider globalOverrideProvider
+     */
+    public function testGlobalOverrideWithConstructor($uri, $expected, $globalOverride)
+    {
+        $app = $this->createAppWithCanonical($globalOverride);
+
+        $this->assertCanonicalUrlInKernel($app, $uri, $expected);
+    }
+
+    /**
+     * @dataProvider globalOverrideProvider
+     */
+    public function testGlobalOverrideWithSetter($uri, $expected, $globalOverride)
+    {
+        $app = $this->createAppWithCanonical(null);
+        $app['canonical']->setGlobalOverride($globalOverride);
+
+        $this->assertCanonicalUrlInKernel($app, $uri, $expected);
+    }
+
+    public function overrideProvider()
+    {
+        return [
+            'absolute url' => ['http://foo.com/bar', null, false, 'http://foo.com/bar'],
+            'absolute url (force ssl does not apply)' => ['http://foo.com/bar', null, true, 'http://foo.com/bar'],
+            'absolute url (global override does not apply)' => ['http://foo.com/bar', 'baz.com', false, 'http://foo.com/bar'],
+
+            'network url' => ['//foo.com/bar', null, false, '//foo.com/bar'],
+            'network url (force ssl does not apply)' => ['//foo.com/bar', null, true, '//foo.com/bar'],
+            'network url (global override does not apply)' => ['//foo.com/bar', 'baz.com', false, '//foo.com/bar'],
+
+            'absolute path' => ['/bar', null, false, 'http://localhost/base/bar'],
+            'absolute path (force ssl applies)' => ['/bar', null, true, 'https://localhost/base/bar'],
+            'absolute path (global override applies)' => ['/bar', 'baz.com', false, 'http://baz.com/base/bar'],
+
+            'relative path' => ['bar', null, false, 'http://localhost/base/foo/bar'],
+            'relative path (force ssl applies)' => ['bar', null, true, 'https://localhost/base/foo/bar'],
+            'relative path (global override applies)' => ['bar', 'baz.com', false, 'http://baz.com/base/foo/bar'],
+        ];
+    }
+
+    /**
+     * @dataProvider overrideProvider
+     */
+    public function testOverride($override, $globalOverride, $forceSsl, $expected)
+    {
+        $app = $this->createAppWithCanonical($globalOverride, $forceSsl);
+
+        $app->after(function () use ($app, $override) {
+            $app['canonical']->setOverride($override);
+        });
+
+        $request = Request::create('/base/foo', 'GET', [], [], [], [
+            'PHP_SELF'        => '/base/index.php',
+            'SCRIPT_FILENAME' => '/base/index.php',
+        ]);
+
+        $this->assertCanonicalUrlInKernel($app, $request, $expected);
+    }
+
+    public function testNullOutsideRequestCycle()
+    {
+        $app = $this->createAppWithCanonical();
 
         $url = $app['canonical']->getUrl();
 
         $this->assertNull($url);
+    }
+
+    public function testNullForUnmatchedRoute()
+    {
+        $app = $this->createAppWithCanonical();
+
+        $app['dispatcher']->addListener(KernelEvents::REQUEST, function (GetResponseEvent $event) use ($app) {
+            $app['canonical']->onRequest($event);
+            $event->stopPropagation();
+        }, 1000);
+
+        $this->assertCanonicalUrlInKernel($app, '/unmatched', null);
+    }
+
+    protected function createAppWithCanonical($globalOverride = null, $forceSsl = false)
+    {
+        $app = new Application();
+        $app->register(new UrlGeneratorServiceProvider());
+        $app->match('/foo');
+
+        $canonical = new Canonical($app['url_generator'], $forceSsl, $globalOverride);
+        $canonical->setUrlGenerator($app['url_generator']);
+        $app['canonical'] = $canonical;
+
+        $app['dispatcher']->addSubscriber($canonical);
+
+        return $app;
+    }
+
+    /**
+     * @param Application    $app
+     * @param string|Request $uri
+     * @param string         $expected
+     */
+    protected function assertCanonicalUrlInKernel(Application $app, $uri, $expected)
+    {
+        $url = null;
+        $app->after(
+            function () use (&$url, $app) {
+                $url = $app['canonical']->getUrl();
+            }
+        );
+
+        $request = $uri instanceof Request ? $uri : Request::create($uri);
+
+        $app->handle($request);
+
+        $this->assertEquals($expected, $url);
+
+        $this->assertNull($app['canonical']->getUrl(), 'Canonical url from previous request should be reset.');
     }
 }


### PR DESCRIPTION
`Canonical::setOverride` can now be used _during_ the request cycle to change the canonical url. Absolute and relative paths are resolved with the current request.

It was also refactored to not depend on `RequestStack` and `RequestContext`.

Test coverage is 100%.