### PR TITLE
Make thrown SecurityPolicy in Twig-in-content show Exception, instead of outputting HTML on page. 

### DIFF
--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -226,16 +226,9 @@ class Content implements \ArrayAccess
 
         $snippet = html_entity_decode($snippet, ENT_QUOTES, 'UTF-8');
 
-        try {
-            $template = $this->app['twig']->createTemplate((string) $snippet);
+        $template = $this->app['twig']->createTemplate((string) $snippet);
 
-            return twig_include($this->app['twig'], $this->getTemplateContext(), $template, [], true, false, true);
-        } catch (\Twig_Error $e) {
-            $message = sprintf('Rendering a record Twig snippet failed: %s', $e->getRawMessage());
-            $this->app['logger.system']->critical($message, ['event' => 'exception', 'exception' => $e]);
-
-            return $message;
-        }
+        return twig_include($this->app['twig'], $this->getTemplateContext(), $template, [], true, false, true);
     }
 
     public function getTemplateContext()

--- a/src/Twig/SecurityPolicy.php
+++ b/src/Twig/SecurityPolicy.php
@@ -155,19 +155,19 @@ class SecurityPolicy implements SecurityPolicyInterface
     {
         foreach ($tags as $tag) {
             if (!in_array($tag, $this->allowedTags)) {
-                throw new SecurityNotAllowedTagError(sprintf('Tag "%s" is not allowed.', $tag), $tag);
+                throw new SecurityNotAllowedTagError(sprintf("Tag '%s' is not allowed.", $tag), $tag);
             }
         }
 
         foreach ($filters as $filter) {
             if (!in_array($filter, $this->allowedFilters)) {
-                throw new SecurityNotAllowedFilterError(sprintf('Filter "%s" is not allowed.', $filter), $filter);
+                throw new SecurityNotAllowedFilterError(sprintf("Filter '%s' is not allowed.", $filter), $filter);
             }
         }
 
         foreach ($functions as $function) {
             if (!in_array($function, $this->allowedFunctions)) {
-                throw new SecurityNotAllowedFunctionError(sprintf('Function "%s" is not allowed.', $function), $function);
+                throw new SecurityNotAllowedFunctionError(sprintf("Function '%s' is not allowed.", $function), $function);
             }
         }
     }
@@ -202,7 +202,7 @@ class SecurityPolicy implements SecurityPolicyInterface
         }
 
         if (!$allowed) {
-            throw new SecurityError(sprintf('Calling "%s" method on a "%s" object is not allowed.', $method, $objClass));
+            throw new SecurityError(sprintf("Calling '%s' method on a '%s' object is not allowed.", $method, $objClass));
         }
     }
 
@@ -231,7 +231,7 @@ class SecurityPolicy implements SecurityPolicyInterface
         }
 
         if (!$allowed) {
-            throw new SecurityError(sprintf('Calling "%s" property on a "%s" object is not allowed.', $property, $objClass));
+            throw new SecurityError(sprintf("Calling '%s' property on a '%s' object is not allowed.", $property, $objClass));
         }
     }
 


### PR DESCRIPTION
Instead of outputting a SecurityPolicy error for Twig-in-content inline in the HTML, we now throw an exception.