### PR TITLE
Clarify error message for missing assets in extensions.

### DIFF
--- a/src/Extension/AssetTrait.php
+++ b/src/Extension/AssetTrait.php
@@ -196,7 +196,8 @@ trait AssetTrait
         }
 
         $message = sprintf(
-            "Couldn't add file asset '%s': File does not exist in either %s or %s directories. Make sure the file exists in either of these locations, by placing the file there manually (for Bundled Extensions) or by uninstalling / installing te extension again (for Managed Extensions).",
+            "Couldn't add file asset '%s': File does not exist in either %s or %s directories. Make sure the file exists in either of these locations, by ".
+            "placing the file there manually (for Bundled Extensions) or by uninstalling / installing the extension again (for Managed Extensions).",
             $path,
             $this->getWebDirectory()->getFullPath(),
             $themeFile->getFullPath()

--- a/src/Extension/AssetTrait.php
+++ b/src/Extension/AssetTrait.php
@@ -196,7 +196,7 @@ trait AssetTrait
         }
 
         $message = sprintf(
-            "Couldn't add file asset '%s': File does not exist in either %s or %s directories.",
+            "Couldn't add file asset '%s': File does not exist in either %s or %s directories. Make sure the file exists in either of these locations, either by Syncing assets or by placing the file there manually.",
             $path,
             $this->getWebDirectory()->getFullPath(),
             $themeFile->getFullPath()

--- a/src/Extension/AssetTrait.php
+++ b/src/Extension/AssetTrait.php
@@ -196,7 +196,7 @@ trait AssetTrait
         }
 
         $message = sprintf(
-            "Couldn't add file asset '%s': File does not exist in either %s or %s directories. Make sure the file exists in either of these locations, either by Syncing assets or by placing the file there manually.",
+            "Couldn't add file asset '%s': File does not exist in either %s or %s directories. Make sure the file exists in either of these locations, by placing the file there manually (for Bundled Extensions) or by uninstalling / installing te extension again (for Managed Extensions).",
             $path,
             $this->getWebDirectory()->getFullPath(),
             $themeFile->getFullPath()


### PR DESCRIPTION
We assume that the action to take is evident, but in practice it needs pointing out quite often. 