### PR TITLE
Use `path()` for ajaxy uploads instead of `url()`.

### DIFF
--- a/app/view/twig/components/panel-stack.twig
+++ b/app/view/twig/components/panel-stack.twig
@@ -40,7 +40,7 @@
                         <input id="fileupload-stack"
                                type="file"
                                name="files[]"
-                               data-url="{{ url('upload', { namespace: context.namespace }, true) }}"
+                               data-url="{{ path('upload', { namespace: context.namespace }) }}"
                                accept=".{{ context.filetypes|join(',.') }}">
                     </span>
                 </div>

--- a/app/view/twig/editcontent/fields/_file.twig
+++ b/app/view/twig/editcontent/fields/_file.twig
@@ -23,7 +23,7 @@
 
     upload: {
         accept:       option.extensions ? '.' ~ option.extensions|join(',.') : '',
-        data_url:     url('upload', { 'handler': option.upload }, true),
+        data_url:     path('upload', { 'handler': option.upload }),
         id:           'fileupload-' ~ key,
         name:         'files[]',
         type:         'file',

--- a/app/view/twig/editcontent/fields/_filelist.twig
+++ b/app/view/twig/editcontent/fields/_filelist.twig
@@ -13,7 +13,7 @@
 {% set attributes = {
     fileupload: {
         accept:       option.extensions ? '.' ~ option.extensions|join(',.') : '',
-        data_url:     url('upload', { 'handler': option.upload }, true),
+        data_url:     path('upload', { 'handler': option.upload }),
         id:           'fileupload-' ~ key,
         multiple:     true,
         name:         'files[]',

--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -37,7 +37,7 @@
 
     upload: {
         'accept':       option.extensions ? '.' ~ option.extensions|join(',.') : '',
-        'data-url':     url('upload', { 'handler': option.upload }, true),
+        'data-url':     path('upload', { 'handler': option.upload }),
         'id':           'fileupload-' ~ key,
         'name':         'files[]',
         'type':         'file',


### PR DESCRIPTION
Fixes #6514 