### PR TITLE
Force saving of repeaters, even when empty

### DIFF
--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -23,6 +23,9 @@
         </div>
     {% endif %}
 
+    {# This ensures that an empty value is always submitted even if there are no subsequent repeater sets #}
+    <input type="hidden" name="{{ name }}[]">
+
     <div class="repeater-slot">
         <script type="text/template">
             {% set index = '#' %}


### PR DESCRIPTION
Fixes #6086

This adds an empty hidden value to repeater fields which ensures that a value is always posted even if there are no other sets posted.

Fixes a bug where deleting all the sets did not work because the field was not present.