### PR TITLE
[3.2] Version compare PHPDoc OCD-off

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -32,11 +32,29 @@ final class Version
     }
 
     /**
-     * Compares a version to Bolt's version.
+     * Compares a semantic version (x.y.z) against Bolt's version, given a
+     * specified comparison operator.
      *
-     * Note: Be sure to include the `.z` number in the version given, as omitting it can give inconsistent results.
-     * For example, if the current version is `3.3.0`, `compare('3.3', '>=')` returns false. In reality you want
-     * the check to return true for this case, and `compare('3.3.0', '>=')` _does_ return true.
+     * Note 1:
+     * Be sure to include the `.z` number in the version given, as
+     * omitting it can give inconsistent results.
+     *
+     * e.g. If the version of Bolt was '3.2.0' (or greater), then:
+     *     `Version::compare('3.2', '>=');`
+     * is NOT equal to, or greater than, Bolt's version.
+     *
+     * Note 2:
+     * Pre-release versions, such as 3.2.0-beta1, are considered lower
+     * than their final release counterparts (like 2.3.0). As you may notice,
+     * the difference being that Bolt '3.2.0-beta1' is considered LOWER than
+     * the `compare($version)` value of '3.2.0'.
+     *
+     * e.g. If the version of Bolt was '3.2.0 beta 1', then:
+     *     `Version::compare('3.2.0', '>=');`
+     * is equal to, or greater than, Bolt's version.
+     *
+     * @see http://semver.org/ For an explanation on semantic versioning.
+     * @see http://php.net/manual/en/function.version-compare.php#refsect1-function.version-compare-notes Notes on version_compare
      *
      * @param string $version  The version to compare.
      * @param string $operator The comparison operator: <, <=, >, >=, ==, !=


### PR DESCRIPTION
The discussion just didn't sit with me, so test case:

```php
<?php

namespace Koala;

use Symfony\Component\Console\Helper\Table;
use Symfony\Component\Console\Output\ConsoleOutput;

include_once __DIR__ . '/vendor/autoload.php';

final class Version
{
    //const VERSION = '3.2.0';
    const VERSION = '3.2.0 beta 9';

    public static function compare($version, $operator)
    {
        $currentVersion = str_replace(' ', '', strtolower(static::VERSION));
        $version = str_replace(' ', '', strtolower($version));

        return version_compare($version, $currentVersion, $operator);
    }
}
$operators = [
    //'<',
    //'>',
    //'<=',
    '>=',
];
$versions = [
    '3.1',
    '3.1.0',
    '3.2',
    '3.2.0-beta8',
    '3.2.0-beta9',
    '3.2.0',
    '3.2.1',
    '3.3',
    '3.3.0',
];
$output = new ConsoleOutput();
$output->writeln('');
$output->writeln(sprintf('Bolt version: "%s"', Version::VERSION));
foreach ($operators as $operator) {
    $table = new Table($output);
    $table->setHeaders(['Compared Version', '', 'Result']);

    foreach ($versions as $version) {
        $table->addRow([
            $version,
            $operator,
            Version::compare($version, $operator) ? 'true' : 'false'
        ]);
    }

    $table->render();
}

```
… plus updated PHPDoc :rofl: 