### PR TITLE
Fix bug in repeater buttons

### DIFF
--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -246,10 +246,10 @@
 
             if (this._count >= this.options.maximum) {
                 this._ui.add.addClass('disabled');
-                this.element.find('.duplicate-button').addClass('disabled');
+                this._ui.add.prop('disabled', 'disabled');
             } else {
                 this._ui.add.removeClass('disabled');
-                this.element.find('.duplicate-button').removeClass('disabled');
+                this._ui.add.prop('disabled', false);
             }
 
             if (this._count <= this.options.minimum) {

--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -247,15 +247,21 @@
             if (this._count >= this.options.maximum) {
                 this._ui.add.addClass('disabled');
                 this._ui.add.prop('disabled', 'disabled');
+                this.element.find('.duplicate-button').addClass('disabled');
+                this.element.find('.duplicate-button').prop('disabled', 'disabled');
             } else {
                 this._ui.add.removeClass('disabled');
                 this._ui.add.prop('disabled', false);
+                this.element.find('.duplicate-button').removeClass('disabled');
+                this.element.find('.duplicate-button').prop('disabled', false);
             }
 
             if (this._count <= this.options.minimum) {
                 this.element.find('.delete-button').addClass('disabled');
+                this.element.find('.delete-button').prop('disabled', 'disabled');
             } else {
                 this.element.find('.delete-button').removeClass('disabled');
+                this.element.find('.delete-button').prop('disabled', false);
             }
         }
     });


### PR DESCRIPTION
Problem:
Currently, when reaching the `limit` set in a repeater definition, the *[Add new Repeater set]* button gets grayed out but clicking it still adds a new repeater set, and the *[Duplicate set]* button gets wrongly grayed out.

Fix:
The `.disabled` class was being applied to the *[Duplicate set]* buttons, instead of adding the `“disabled”` property to the *[Add new Repeater set]* button.