### PR TITLE
[3.3] Commands to query views into system operations

### DIFF
--- a/src/Nut/DebugEvents.php
+++ b/src/Nut/DebugEvents.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut command to dump system listened events, and target callable.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class DebugEvents extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('debug:events')
+            ->setDescription('System events, and target callable debug dumper.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->displayListeners($output);
+    }
+
+    /**
+     * Output a table of listeners, and their callbacks.
+     *
+     * @param OutputInterface $output
+     */
+    private function displayListeners(OutputInterface $output)
+    {
+        $table = new Table($output);
+        $table->setHeaders(array(
+            'Event Name',
+            'Priority',
+            'Listener',
+        ));
+        $dispatcher = $this->app['dispatcher'];
+        $listeners = $dispatcher->getListeners();
+
+        foreach ($listeners as $eventName => $eventListeners) {
+            foreach ($eventListeners as $callable) {
+                $priority = $dispatcher->getListenerPriority($eventName, $callable);
+                if (is_array($callable)) {
+                    $table->addRow([
+                        $eventName,
+                        $priority,
+                        sprintf('%s::%s', get_class($callable[0]), $callable[1]),
+                    ]);
+                } else {
+                    $table->addRow([$eventName, $priority, get_class($callable)]);
+                }
+            }
+        }
+
+        $table->render();
+    }
+}

--- a/src/Nut/DebugRoutes.php
+++ b/src/Nut/DebugRoutes.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Silex\Route;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut command to dump system routes.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class DebugRoutes extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('debug:routes')
+            ->setDescription('System route debug dumper.')
+            ->addOption('sort-bind', null, InputOption::VALUE_NONE, 'Sort in order of bind name (default).')
+            ->addOption('sort-pattern', null, InputOption::VALUE_NONE, 'Sort in order of URI patterns.')
+            ->addOption('sort-methods', null, InputOption::VALUE_NONE, 'Sort in order of HTTP method grouping allowed.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $table = new Table($output);
+        $table->setHeaders([
+            'Bind name',
+            'Path matching parameter',
+            'Method(s)',
+        ]);
+        $routes = (array) $this->app['routes']->getIterator();
+
+        if ($input->getOption('sort-bind')) {
+            $routes = $this->sortBind($routes);
+        }
+        if ($input->getOption('sort-pattern')) {
+            $routes = $this->sortPattern($routes);
+        }
+        if ($input->getOption('sort-methods')) {
+            $routes = $this->sortMethods($routes);
+        }
+
+        foreach ($routes as $bindName => $route) {
+            $table->addRow([
+                $bindName,
+                $route->getPath(),
+                $this->getMethods($route),
+            ]);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * Sort routes by their binding name.
+     *
+     * @param Route[] $routes
+     *
+     * @return Route[]
+     */
+    private function sortBind(array $routes)
+    {
+        ksort($routes);
+
+        return $routes;
+    }
+
+    /**
+     * Sort routes by their URI pattern.
+     *
+     * @param Route[] $routes
+     *
+     * @return Route[]
+     */
+    private function sortPattern(array $routes)
+    {
+        uasort($routes, function (Route $a, Route $b) {
+            if ($a->getPath() === $b->getPath()) {
+                return 0;
+            }
+            $a = str_replace('{', '', str_replace('}', '', $a->getPath()));
+            $b = str_replace('{', '', str_replace('}', '', $b->getPath()));
+
+            return ($a < $b) ? -1 : 1;
+        });
+
+        return $routes;
+    }
+
+    /**
+     * Get a route's HTTP methods as a sorted string.
+     *
+     * @param Route $route
+     *
+     * @return string
+     */
+    private function getMethods(Route $route)
+    {
+        $methods = $route->getMethods();
+        sort($methods);
+
+        return implode('|', $methods) ?: 'ALL';
+    }
+
+    /**
+     * Sort routes by their allowed HTTP method(s).
+     *
+     * @param Route[] $routes
+     *
+     * @return Route[]
+     */
+    private function sortMethods(array $routes)
+    {
+        uasort($routes, function (Route $a, Route $b) {
+            if ($a->getMethods() === $b->getMethods()) {
+                return 0;
+            }
+
+            return ($a->getMethods() < $b->getMethods()) ? -1 : 1;
+        });
+
+        return $routes;
+    }
+}

--- a/src/Nut/DebugServiceRegistration.php
+++ b/src/Nut/DebugServiceRegistration.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Silex\Application;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Nut command to dump system service provider registration boot order.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class DebugServiceRegistration extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('debug:services')
+            ->setDescription('System service provider registration boot order debug dumper.')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->displayRegistration($output);
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    private function displayRegistration(OutputInterface $output)
+    {
+        $table = new Table($output);
+        $table->setHeaders([
+            '#',
+            'Provider',
+        ]);
+
+        $reflect = new \ReflectionProperty(Application::class, 'providers');
+        $reflect->setAccessible(true);
+        $registrations = $reflect->getValue($this->app);
+
+        $i = 1;
+        foreach ($registrations as $registration) {
+            $table->addRow([$i++, get_class($registration)]);
+        }
+
+        $table->render();
+    }
+}

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -60,6 +60,9 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\UserResetPassword($app),
                     new Nut\UserRoleAdd($app),
                     new Nut\UserRoleRemove($app),
+                    new Nut\DebugEvents($app),
+                    new Nut\DebugServiceRegistration($app),
+                    new Nut\DebugRoutes($app),
                 ];
             }
         );


### PR DESCRIPTION
This adds the following three ommands:
  * `debug:events` — System listened events, and target callable debug dumper.
  * `debug:routes` — System route debug dumper.
  * `debug:services` — System service provider registration boot order debug dumper.

e.g.

## Events
```
+-----------------------+----------+-------------------------------------------------------------------------------------+
| Event Name            | Priority | Listener                                                                            |
+-----------------------+----------+-------------------------------------------------------------------------------------+
| kernel.request        | 2048     | Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure         |
| kernel.request        | 1024     | Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelRequest        |
| kernel.request        | 512      | Bolt\EventListener\ConfigListener::onRequestEarly                                   |
| kernel.request        | 128      | Bolt\Session\SessionListener::onRequest                                             |
| kernel.request        | 127      | Bolt\EventListener\FlashLoggerListener::onRequest                                   |
| kernel.request        | 126      | Bolt\Profiler\DebugToolbarEnabler::onRequest                                        |
| kernel.request        | 48       | Symfony\Component\HttpKernel\EventListener\FragmentListener::onKernelRequest        |
| kernel.request        | 34       | Bolt\Configuration\ConfigurationValueProxy::onKernelRequest                         |
| kernel.request        | 34       | Bolt\Configuration\ConfigurationValueProxy::onKernelRequest                         |
| kernel.request        | 33       | Bolt\EventListener\ConfigListener::onRequest                                        |
| kernel.request        | 32       | Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest          |
| kernel.request        | 31       | Bolt\EventListener\StorageEventListener::onKernelRequest                            |
| kernel.request        | 31       | Bolt\EventListener\ZoneGuesser::onKernelRequest                                     |
| kernel.request        | 31       | Bolt\Routing\Canonical::onRequest                                                   |
| kernel.request        | 16       | Silex\EventListener\LocaleListener::onKernelRequest                                 |
| kernel.request        | 8        | Symfony\Component\Security\Http\Firewall::onKernelRequest                           |
| kernel.request        | 0        | Closure                                                                             |
| kernel.request        | 0        | Silex\EventListener\LogListener::onKernelRequest                                    |
| kernel.request        | 0        | Bolt\EventListener\PagerListener::onRequest                                         |
| kernel.request        | -1024    | Silex\EventListener\MiddlewareListener::onKernelRequest                             |
| kernel.request        | -1024    | Bolt\EventListener\FlashLoggerListener::onEvent                                     |
| kernel.finish_request | 0        | Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelFinishRequest    |
| kernel.finish_request | 0        | Silex\EventListener\LocaleListener::onKernelFinishRequest                           |
| kernel.finish_request | 0        | Symfony\Component\Security\Http\Firewall::onKernelFinishRequest                     |
| kernel.finish_request | 0        | Bolt\Routing\Canonical::onFinishRequest                                             |
| kernel.exception      | 0        | Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelException      |
```
… and so on

## Routes 

```
+-----------------------+---------------------------------------------------+-----------+
| Bind name             | Path matching parameter                           | Method(s) |
+-----------------------+---------------------------------------------------+-----------+
| thumb                 | /thumbs/{width}x{height}{action}/{file}           | GET       |
| thumb_alias           | /thumbs/{alias}/{file}                            | GET       |
| login                 | /bolt/login                                       | GET       |
| postLogin             | /bolt/login                                       | POST      |
| logout                | /bolt/logout                                      | ALL       |
| resetpassword         | /bolt/resetpassword                               | GET       |
| dbcheck               | /bolt/dbcheck                                     | GET       |
| dbupdate              | /bolt/dbupdate                                    | POST      |
| dbupdate_result       | /bolt/dbupdate_result                             | GET       |
| fileedit              | /bolt/file/edit/{namespace}/{file}                | ALL       |
| files                 | /bolt/files/{namespace}/{path}                    | ALL       |
| about                 | /bolt/about                                       | GET       |
| checks                | /bolt/checks                                      | GET       |
| clearcache            | /bolt/clearcache                                  | GET       |
| dashboard             | /bolt                                             | GET       |
| omnisearch-results    | /bolt/omnisearch                                  | GET       |
| prefill               | /bolt/prefill                                     | ALL       |
| translation           | /bolt/tr/{domain}/{tr_locale}                     | ALL       |
| changelog             | /bolt/changelog                                   | GET       |
| changelogrecordsingle | /bolt/changelog/{contenttype}/{contentid}/{id}    | GET       |
| changelogrecordall    | /bolt/changelog/{contenttype}/{contentid}         | GET       |
| systemlog             | /bolt/systemlog                                   | GET       |
| editcontent           | /bolt/editcontent/{contenttypeslug}/{id}          | GET|POST  |
```
… and so on

## Service Providers
```
+----+---------------------------------------------------+
| #  | Provider                                          |
+----+---------------------------------------------------+
| 1  | Bolt\Provider\DebugServiceProvider                |
| 2  | Bolt\Provider\ExtensionServiceProvider            |
| 3  | Bolt\Provider\DebugServiceProvider                |
| 4  | Bolt\Provider\ExtensionServiceProvider            |
| 5  | Bolt\Provider\PathServiceProvider                 |
| 6  | Bolt\Provider\FilesystemServiceProvider           |
| 7  | Bolt\Provider\DatabaseSchemaServiceProvider       |
| 8  | Bolt\Provider\ConfigServiceProvider               |
| 9  | Bolt\Provider\LoggerServiceProvider               |
| 10 | Silex\Provider\MonologServiceProvider             |
| 11 | Bolt\Provider\SessionServiceProvider              |
| 12 | Bolt\Provider\TranslationServiceProvider          |
| 13 | Silex\Provider\TranslationServiceProvider         |
| 14 | Bolt\Provider\TwigServiceProvider                 |
| 15 | Silex\Provider\TwigServiceProvider                |
```
… and so on