### PR TITLE
[3.3][MySQL] Set database character set & collation as configured

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -856,7 +856,7 @@ class Config
         $validKeys = [
             'user', 'password', 'host', 'port', 'dbname', 'charset',      // common
             'path', 'memory',                                             // Qqlite
-            'unix_socket', 'driverOptions',                               // MySql
+            'unix_socket', 'driverOptions', 'collate',                    // MySql
             'sslmode',                                                    // PostgreSQL
             'servicename', 'service', 'pooled', 'instancename', 'server', // Oracle
             'persistent',                                                 // SQL Anywhere

--- a/src/Provider/DatabaseServiceProvider.php
+++ b/src/Provider/DatabaseServiceProvider.php
@@ -40,7 +40,7 @@ class DatabaseServiceProvider implements ServiceProviderInterface
 
         $app['db.doctrine_listener'] = $app->share(
             function ($app) {
-                return new DoctrineListener($app['logger.system']);
+                return new DoctrineListener($app['config'], $app['logger.system']);
             }
         );
 

--- a/tests/phpunit/database/Entity/AbstractEntityTest.php
+++ b/tests/phpunit/database/Entity/AbstractEntityTest.php
@@ -130,6 +130,8 @@ abstract class AbstractEntityTest extends BoltUnitTest
             $app['config']->set('general/database/dbname', 'bolt_unit_test');
             $app['config']->set('general/database/user', 'bolt_unit_test');
             $app['config']->set('general/database/password', 'bolt_unit_test');
+            $app['config']->set('general/database/charset', 'utf8');
+            $app['config']->set('general/database/collate', 'utf8_general_ci');
             $app->boot();
             $app['schema']->update();
 


### PR DESCRIPTION
Fixes #6430

We'll need to follow up with docs on `utf8mb4` "fun"