### PR TITLE
[3.3] Disable the class loader if not specifically enabled during boot

### DIFF
--- a/src/Provider/DebugServiceProvider.php
+++ b/src/Provider/DebugServiceProvider.php
@@ -237,6 +237,8 @@ class DebugServiceProvider implements ServiceProviderInterface
     {
         if ($app['debug.class_loader.enabled']) {
             DebugClassLoader::enable();
+        } else {
+            DebugClassLoader::disable();
         }
 
         if ($app['debug.error_handler.enabled']) {


### PR DESCRIPTION
This saves about 350ms in a basic front-end with debugging **disabled**

… and #1555 