### PR TITLE
Improve relation and taxonomy normalisation

### DIFF
--- a/src/Storage/Field/Type/JoinTypeBase.php
+++ b/src/Storage/Field/Type/JoinTypeBase.php
@@ -101,8 +101,12 @@ abstract class JoinTypeBase extends FieldTypeBase
         $filter->setExpression($originalExpression);
     }
 
-    public function normalizeFromPost($outerCollection, $target, $entity, $field)
+    public function normalizeFromPost($entity, $target)
     {
+        $key = $this->mapping['fieldname'];
+        $accessor = 'get' . ucfirst($key);
+
+        $outerCollection = $entity->$accessor();
         if (!$outerCollection instanceof Collection) {
             $collection = $this->em->createCollection($target);
 
@@ -112,7 +116,7 @@ abstract class JoinTypeBase extends FieldTypeBase
 
             if (is_array($outerCollection)) {
                 $related = [
-                    $field => $outerCollection
+                    $key => $outerCollection
                 ];
                 $collection->setFromPost($related, $entity);
             }

--- a/src/Storage/Field/Type/JoinTypeBase.php
+++ b/src/Storage/Field/Type/JoinTypeBase.php
@@ -4,6 +4,7 @@ namespace Bolt\Storage\Field\Type;
 
 use Bolt\Storage\Query\Filter;
 use Bolt\Storage\Query\QueryInterface;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Traversable;
 use ReflectionProperty;
@@ -100,13 +101,13 @@ abstract class JoinTypeBase extends FieldTypeBase
         $filter->setExpression($originalExpression);
     }
 
-    public function normalizeFromPost($entity, $collection, $target)
+    public function normalizeFromPost($entity, $target)
     {
         $key = $this->mapping['fieldname'];
         $accessor = 'get' . ucfirst($key);
 
         $outerCollection = $entity->$accessor();
-        if (!$outerCollection instanceof $collection) {
+        if (!$outerCollection instanceof Collection) {
             $collection = $this->em->createCollection($target);
 
             if (is_string($outerCollection)) {

--- a/src/Storage/Field/Type/JoinTypeBase.php
+++ b/src/Storage/Field/Type/JoinTypeBase.php
@@ -101,12 +101,8 @@ abstract class JoinTypeBase extends FieldTypeBase
         $filter->setExpression($originalExpression);
     }
 
-    public function normalizeFromPost($entity, $target)
+    public function normalizeFromPost($outerCollection, $target, $entity, $field)
     {
-        $key = $this->mapping['fieldname'];
-        $accessor = 'get' . ucfirst($key);
-
-        $outerCollection = $entity->$accessor();
         if (!$outerCollection instanceof Collection) {
             $collection = $this->em->createCollection($target);
 
@@ -116,7 +112,7 @@ abstract class JoinTypeBase extends FieldTypeBase
 
             if (is_array($outerCollection)) {
                 $related = [
-                    $key => $outerCollection
+                    $field => $outerCollection
                 ];
                 $collection->setFromPost($related, $entity);
             }

--- a/src/Storage/Field/Type/JoinTypeBase.php
+++ b/src/Storage/Field/Type/JoinTypeBase.php
@@ -120,7 +120,7 @@ abstract class JoinTypeBase extends FieldTypeBase
                 $collection->setFromPost($related, $entity);
             }
 
-            $entity->setTaxonomy($collection);
+            return $collection;
         }
     }
 }

--- a/src/Storage/Field/Type/JoinTypeBase.php
+++ b/src/Storage/Field/Type/JoinTypeBase.php
@@ -99,4 +99,28 @@ abstract class JoinTypeBase extends FieldTypeBase
 
         $filter->setExpression($originalExpression);
     }
+
+    public function normalizeFromPost($entity, $collection, $target)
+    {
+        $key = $this->mapping['fieldname'];
+        $accessor = 'get' . ucfirst($key);
+
+        $outerCollection = $entity->$accessor();
+        if (!$outerCollection instanceof $collection) {
+            $collection = $this->em->createCollection($target);
+
+            if (is_string($outerCollection)) {
+                $outerCollection = [$outerCollection];
+            }
+
+            if (is_array($outerCollection)) {
+                $related = [
+                    $key => $outerCollection
+                ];
+                $collection->setFromPost($related, $entity);
+            }
+
+            $entity->setTaxonomy($collection);
+        }
+    }
 }

--- a/src/Storage/Field/Type/JoinTypeBase.php
+++ b/src/Storage/Field/Type/JoinTypeBase.php
@@ -107,6 +107,9 @@ abstract class JoinTypeBase extends FieldTypeBase
         $accessor = 'get' . ucfirst($key);
 
         $outerCollection = $entity->$accessor();
+        if ($outerCollection === null) {
+            return;
+        }
         if (!$outerCollection instanceof Collection) {
             $collection = $this->em->createCollection($target);
 

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -247,9 +247,11 @@ class RelationType extends JoinTypeBase
      *
      * @param Entity\Content $entity
      */
-    protected function normalize($entity)
+    public function normalize($entity)
     {
         $collection = $this->normalizeFromPost($entity, Relations::class, Entity\Relations::class);
-        $entity->setRelation($collection);
+        if ($collection) {
+            $entity->setRelation($collection);
+        }
     }
 }

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -245,11 +245,11 @@ class RelationType extends JoinTypeBase
      *
      *   `$entity->setRelation(['pages'=>['1', '2']]);`
      *
-     * @param $entity
+     * @param Entity\Content $entity
      */
     protected function normalize($entity)
     {
-        $this->normalizeFromPost($entity, Relations::class, Entity\Relations::class);
-
+        $collection = $this->normalizeFromPost($entity, Relations::class, Entity\Relations::class);
+        $entity->setRelation($collection);
     }
 }

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -249,7 +249,9 @@ class RelationType extends JoinTypeBase
      */
     public function normalize($entity)
     {
-        $collection = $this->normalizeFromPost($entity, Entity\Relations::class);
+        $field = $this->mapping['fieldname'];
+        $relations = $entity->getRelation()->getField($field);
+        $collection = $this->normalizeFromPost($relations, Entity\Relations::class, $entity, $field);
         if ($collection) {
             $entity->setRelation($collection);
         }

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -249,7 +249,7 @@ class RelationType extends JoinTypeBase
      */
     public function normalize($entity)
     {
-        $collection = $this->normalizeFromPost($entity, Relations::class, Entity\Relations::class);
+        $collection = $this->normalizeFromPost($entity, Entity\Relations::class);
         if ($collection) {
             $entity->setRelation($collection);
         }

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -253,7 +253,11 @@ class RelationType extends JoinTypeBase
 
         $outerCollection = $entity->$accessor();
         if (!$outerCollection instanceof Relations) {
-            $collection = new Relations([], $this->em);
+            $collection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
+
+            if (is_string($outerCollection)) {
+                $outerCollection = [$outerCollection];
+            }
 
             if (is_array($outerCollection)) {
                 $related = [

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -3,6 +3,7 @@
 namespace Bolt\Storage\Field\Type;
 
 use Bolt\Exception\StorageException;
+use Bolt\Storage\Collection\Relations;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Mapping\ClassMetadata;
 use Bolt\Storage\Query\QueryInterface;
@@ -248,25 +249,7 @@ class RelationType extends JoinTypeBase
      */
     protected function normalize($entity)
     {
-        $key = $this->mapping['fieldname'];
-        $accessor = 'get' . ucfirst($key);
+        $this->normalizeFromPost($entity, Relations::class, Entity\Relations::class);
 
-        $outerCollection = $entity->$accessor();
-        if (!$outerCollection instanceof Relations) {
-            $collection = $this->em->createCollection('Bolt\Storage\Entity\Relations');
-
-            if (is_string($outerCollection)) {
-                $outerCollection = [$outerCollection];
-            }
-
-            if (is_array($outerCollection)) {
-                $related = [
-                    $key => $outerCollection
-                ];
-                $collection->setFromPost($related, $entity);
-            }
-
-            $entity->setRelation($collection);
-        }
     }
 }

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -249,9 +249,7 @@ class RelationType extends JoinTypeBase
      */
     public function normalize($entity)
     {
-        $field = $this->mapping['fieldname'];
-        $relations = $entity->getRelation()->getField($field);
-        $collection = $this->normalizeFromPost($relations, Entity\Relations::class, $entity, $field);
+        $collection = $this->normalizeFromPost($entity, Entity\Relations::class);
         if ($collection) {
             $entity->setRelation($collection);
         }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -262,6 +262,7 @@ class TaxonomyType extends JoinTypeBase
      */
     public function normalize($entity)
     {
-        $this->normalizeFromPost($entity, Collection\Taxonomy::class, Entity\Taxonomy::class);
+        $collection = $this->normalizeFromPost($entity, Collection\Taxonomy::class, Entity\Taxonomy::class);
+        $entity->setTaxonomy($collection);
     }
 }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -262,25 +262,6 @@ class TaxonomyType extends JoinTypeBase
      */
     public function normalize($entity)
     {
-        $key = $this->mapping['fieldname'];
-        $accessor = 'get' . ucfirst($key);
-
-        $outerCollection = $entity->$accessor();
-        if (!$outerCollection instanceof Taxonomy) {
-            $collection = $this->em->createCollection(Entity\Taxonomy::class);
-
-            if (is_string($outerCollection)) {
-                $outerCollection = [$outerCollection];
-            }
-
-            if (is_array($outerCollection)) {
-                $taxonomy = [
-                    $key => $outerCollection
-                ];
-                $collection->setFromPost($taxonomy, $entity);
-            }
-
-            $entity->setTaxonomy($collection);
-        }
+        $this->normalizeFromPost($entity, Collection\Taxonomy::class, Entity\Taxonomy::class);
     }
 }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -263,7 +263,7 @@ class TaxonomyType extends JoinTypeBase
      */
     public function normalize($entity)
     {
-        $collection = $this->normalizeFromPost($entity, Collection\Taxonomy::class, Entity\Taxonomy::class);
+        $collection = $this->normalizeFromPost($entity, Entity\Taxonomy::class);
         if ($collection) {
             $entity->setTaxonomy($collection);
         }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -121,6 +121,7 @@ class TaxonomyType extends JoinTypeBase
      */
     public function persist(QuerySet $queries, $entity)
     {
+        $this->normalize($entity);
         $field = $this->mapping['fieldname'];
         $taxonomy = $entity->getTaxonomy()
             ->getField($field);
@@ -263,6 +264,8 @@ class TaxonomyType extends JoinTypeBase
     public function normalize($entity)
     {
         $collection = $this->normalizeFromPost($entity, Collection\Taxonomy::class, Entity\Taxonomy::class);
-        $entity->setTaxonomy($collection);
+        if ($collection) {
+            $entity->setTaxonomy($collection);
+        }
     }
 }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -263,9 +263,7 @@ class TaxonomyType extends JoinTypeBase
      */
     public function normalize($entity)
     {
-        $field = $this->mapping['fieldname'];
-        $taxonomy = $entity->getTaxonomy()->getField($field);
-        $collection = $this->normalizeFromPost($taxonomy, Entity\Taxonomy::class, $entity, $field);
+        $collection = $this->normalizeFromPost($entity, Entity\Taxonomy::class);
         if ($collection) {
             $entity->setTaxonomy($collection);
         }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -263,7 +263,9 @@ class TaxonomyType extends JoinTypeBase
      */
     public function normalize($entity)
     {
-        $collection = $this->normalizeFromPost($entity, Entity\Taxonomy::class);
+        $field = $this->mapping['fieldname'];
+        $taxonomy = $entity->getTaxonomy()->getField($field);
+        $collection = $this->normalizeFromPost($taxonomy, Entity\Taxonomy::class, $entity, $field);
         if ($collection) {
             $entity->setTaxonomy($collection);
         }


### PR DESCRIPTION
This is just a tidy up to standardise the interface for collection normalisation. For both taxonomies and categories if the value is set to either a string or an integer the values get passed through the `setFromPost` method in the same way that the other Collection fields do.

It will also sort out https://github.com/bolt/boltforms/issues/139 over on boltforms too.