### PR TITLE
replaced use of deprecated request object

### DIFF
--- a/app/theme_defaults/_sub_searchbox.twig
+++ b/app/theme_defaults/_sub_searchbox.twig
@@ -2,7 +2,7 @@
 
     <form method="get" action="/search" id="searchform" enctype="text/plain">
 
-        <input type="text" name="search" value="{{ app.request.get('search') }}" placeholder="{{ __('general.phrase.search-for-ellipsis') }}" >
+        <input type="text" name="search" value="{{ global.request.get('search') }}" placeholder="{{ __('general.phrase.search-for-ellipsis') }}" >
         <input type="submit" name="submit" value="{{ __('general.phrase.search') }}" >
 
     </form>

--- a/app/view/toolbar/db.html.twig
+++ b/app/view/toolbar/db.html.twig
@@ -1,4 +1,4 @@
-{% extends app.request.isXmlHttpRequest ? '@WebProfiler/Profiler/ajax_layout.html.twig' : '@WebProfiler/Profiler/layout.html.twig' %}
+{% extends global.request.isXmlHttpRequest ? '@WebProfiler/Profiler/ajax_layout.html.twig' : '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
 <style>

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -29,7 +29,7 @@
 extended:       not compact,
 has_groupname:  content.group.name is defined,
 nextgroup:      new_group|default(false),
-unordered:      request('order') == '',
+unordered:      global.request.get('order') == '',
 first:          loop.first,
 last:           loop.last
 }%}

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -76,7 +76,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
 {% if local.row_header %}
     {# Deprecated #}
     {% set params = {} %}
-    {% for key, val in app.request.query.all if key != 'order' %}
+    {% for key, val in global.request.query.all if key != 'order' %}
         {% set params = params|merge({(key): val}) %}
     {% endfor %}
     {% set link = '?' ~ params|url_encode ~ (params|length ? '&' : '') ~ 'order=' %}

--- a/app/view/twig/_base/_page-nav.twig
+++ b/app/view/twig/_base/_page-nav.twig
@@ -18,7 +18,7 @@
 {% block page_plain %}
     {{ data('omnisearch.placeholder', __('general.phrase.find')) }}
 
-    <div id="navpage-wrapper"{% if app.request.cookies.get('sidebar') %} class="nav-secondary-collapsed nav-secondary-collapsed-hoverable"{% endif %}>
+    <div id="navpage-wrapper"{% if global.request.cookies.get('sidebar') %} class="nav-secondary-collapsed nav-secondary-collapsed-hoverable"{% endif %}>
         <nav id="navpage-primary" class="navbar navbar-static-top navbar-inverse navbar-bolt">
             <div class="container-fluid">
                 {{ include('@bolt/_nav/_primary.twig') }}

--- a/app/view/twig/_base/_page.twig
+++ b/app/view/twig/_base/_page.twig
@@ -115,7 +115,7 @@
         },
     },
     stackAddUrl: path('stack/add'),
-    contentActionUrl: path('contentaction', app.request.query.all),
+    contentActionUrl: path('contentaction', global.request.query.all),
     google_api_key: config.get('general/google_api_key'),
 } %}
 <script src="{{ asset('js/bolt.js', 'bolt') }}" data-config="{{ bconfig|json_encode }}" data-jsdata="{{ app.jsdata|json_encode }}"></script>

--- a/app/view/twig/_buic/_listing.twig
+++ b/app/view/twig/_buic/_listing.twig
@@ -2,14 +2,14 @@
     {% set paramname = paramname|default('order') %}
 
     {% set params = {} %}
-    {% for key, val in app.request.query.all if key != paramname %}
+    {% for key, val in global.request.query.all if key != paramname %}
         {% set params = params|merge({(key): val}) %}
     {% endfor %}
 
-    {% if app.request.query.get(paramname) == id %}
+    {% if global.request.query.get(paramname) == id %}
         {% set class = 'order-asc' %}
         {% set params = params|merge({(paramname): '-' ~ id}) %}
-    {% elseif app.request.query.get(paramname) == '-' ~ id %}
+    {% elseif global.request.query.get(paramname) == '-' ~ id %}
         {% set class = 'order-desc' %}
     {% else %}
         {% set class = 'order-none' %}

--- a/app/view/twig/_nav/_footer.twig
+++ b/app/view/twig/_nav/_footer.twig
@@ -1,6 +1,6 @@
 {% if app.config.get('general/branding/provided_link') is not empty %}
 
-    <footer id="bolt-footer" class="hidden-xs {% if app.request.cookies.get('sidebar') %}bolt-footer-hidden{% endif %}">
+    <footer id="bolt-footer" class="hidden-xs {% if global.request.cookies.get('sidebar') %}bolt-footer-hidden{% endif %}">
         {{ __('general.phrase.provided-by-colon') }}
         {{ app.config.get('general/branding/provided_link')|raw }} &ndash;
         <i class="fa fa-cog"></i> <b>Bolt {{ bolt_version }}</b>:
@@ -10,7 +10,7 @@
 
 {% else %}
 
-    <footer id="bolt-footer" class="hidden-xs bolt-footer-mini {% if app.request.cookies.get('sidebar') %}bolt-footer-hidden{% endif %}">
+    <footer id="bolt-footer" class="hidden-xs bolt-footer-mini {% if global.request.cookies.get('sidebar') %}bolt-footer-hidden{% endif %}">
         <i class="fa fa-cog"></i> <a href="http://bolt.cm" target="_blank">Bolt {{ bolt_version|replace({'alpha': 'α', ' beta ': 'β'}) }}</a> &ndash;
         <i class="fa fa-heart"></i > <a href="{{ path('about') }}">{{ __('general.about') }}</a>
     </footer>

--- a/app/view/twig/custom/listing/pages.twig.dist
+++ b/app/view/twig/custom/listing/pages.twig.dist
@@ -13,18 +13,18 @@
 {# The header line #}
 {% block listing_header %}
     <th style="width:50%">
-        <a href="{{ link }}title {% if request('order') == "title ASC" %}DESC{% else %}ASC{% endif %}">{{ __('Title') }}</a>
+        <a href="{{ link }}title {% if global.request.get('order') == "title ASC" %}DESC{% else %}ASC{% endif %}">{{ __('Title') }}</a>
     </th>
 
     <th>
-        <a href="{{ link }}slug {% if request('order') == "slug ASC" %}DESC{% else %}ASC{% endif %}">{{ __('Slug') }}</a>
+        <a href="{{ link }}slug {% if global.request.get('order') == "slug ASC" %}DESC{% else %}ASC{% endif %}">{{ __('Slug') }}</a>
     </th>
 
     <th>
-        <a href="{{ link }}image {% if request('order') == "image ASC" %}DESC{% else %}ASC{% endif %}">{{ __('Image') }}</a>
+        <a href="{{ link }}image {% if global.request.get('order') == "image ASC" %}DESC{% else %}ASC{% endif %}">{{ __('Image') }}</a>
     </th>
 
-    <th class="username hidden-xs"><a href="{{ link }}datecreated {% if request('order') == "datecreated ASC" %}DESC{% else %}ASC{% endif %}">{{ __('general.phrase.meta') }}</a></th>
+    <th class="username hidden-xs"><a href="{{ link }}datecreated {% if global.request.get('order') == "datecreated ASC" %}DESC{% else %}ASC{% endif %}">{{ __('general.phrase.meta') }}</a></th>
 
     <th><a href="?">{{ __('general.phrase.action-plural') }}</a></th>
 {% endblock %}

--- a/app/view/twig/editcontent/fields/_relationship.twig
+++ b/app/view/twig/editcontent/fields/_relationship.twig
@@ -18,8 +18,8 @@
 {% set options = [] %}
 
 {% for item in context.relations_list[relcontenttype] %}
-    {% set selectedbyrelation = relcontenttype == app.request.get('relation') and
-                                item.id == app.request.get('relationid') %}
+    {% set selectedbyrelation = relcontenttype == global.request.get('relation') and
+                                item.id == global.request.get('relationid') %}
 
     {% set options = options|merge([{
         value:    item.id,

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -200,6 +200,6 @@
     {{ data('extend.text.updated',            __('page.extend.message.updated')) }}
 
     {{ data('extend.siteurl',             context.site) }}
-    {{ data('extend.baseurl',             app.request.basePath ~ '/' ~ app['controller.backend.extend.mount_prefix']|trim('/') ~ '/') }}
+    {{ data('extend.baseurl',             global.request.basePath ~ '/' ~ app['controller.backend.extend.mount_prefix']|trim('/') ~ '/') }}
 
 {% endblock page_main %}

--- a/app/view/twig/files_ck/files_ck.twig
+++ b/app/view/twig/files_ck/files_ck.twig
@@ -18,9 +18,9 @@
     <h1{{ macro.attr({_bind: ['ckfileselect']}) }} style="display: none;"></h1>
 
     {% set pathoptions = {
-        'CKEditor': app.request.query.get('CKEditor'),
-        'CKEditorFuncNum': app.request.query.get('CKEditorFuncNum'),
-        'langCode': app.request.query.get('langCode')
+        'CKEditor': global.request.query.get('CKEditor'),
+        'CKEditorFuncNum': global.request.query.get('CKEditorFuncNum'),
+        'langCode': global.request.query.get('langCode')
     } %}
 
     {{ files_path(context.directory, pathoptions) }}

--- a/app/view/twig/overview/_panel-actions_overview.twig
+++ b/app/view/twig/overview/_panel-actions_overview.twig
@@ -25,7 +25,7 @@
         <div class="form-group">
         {% for taxonomy in context.contenttype.taxonomy|default([]) %}
             {% if app.config.get('taxonomy/' ~ taxonomy ~ '/options') is iterable %}
-                {% set tax_query = app.request.query.get('taxonomy-' ~ taxonomy ) %}
+                {% set tax_query = global.request.query.get('taxonomy-' ~ taxonomy ) %}
                 {% if tax_query %}
                     {% set taxonomyfilter = true %}
                 {% endif %}
@@ -42,8 +42,8 @@
                 {{ __('general.phrase.or') }}
             {% endif %}
         {% endfor %}
-        {% set filter_query = app.request.query.get('filter') %}
-        {% set order_query = app.request.query.get('order') %}
+        {% set filter_query = global.request.query.get('filter') %}
+        {% set order_query = global.request.query.get('order') %}
             <input type="text" class="form-control" value="{{ filter_query }}" name="filter" style="width: 110px;" placeholder="{{ __('general.phrase.keyword-ellipsis') }}">
         </div>
 

--- a/app/view/twig/relatedto/_panel-actions_relatedto.twig
+++ b/app/view/twig/relatedto/_panel-actions_relatedto.twig
@@ -24,15 +24,15 @@
     {% endif %}
 
     {# TODO: add filtering
-    {% if app.request.query.get('filter') or app.request.query.get('order') %}
+    {% if global.request.query.get('filter') or global.request.query.get('order') %}
         <a class="btn" href="?">{{ __('general.phrase.clear-filter-sort') }}</a>
     {% endif %}
 
     <form class="form-inline" style="margin-top:15px;">
-        <input type="hidden" value="{{ app.request.query.get('show') }}" name="show">
-        <input type="text" class="form-control" value="{{ app.request.query.get('filter') }}" name="filter" style="width: 110px;" placeholder="{{ __('general.phrase.filtering') }}">
+        <input type="hidden" value="{{ global.request.query.get('show') }}" name="show">
+        <input type="text" class="form-control" value="{{ global.request.query.get('filter') }}" name="filter" style="width: 110px;" placeholder="{{ __('general.phrase.filtering') }}">
         <button type="submit" class="btn">{{ __('general.phrase.filter') }}</button>
-        {% if app.request.query.get('filter') %}<p><a href="?">{{ __('general.phrase.clear-filter') }}</a></p>{% endif %}
+        {% if global.request.query.get('filter') %}<p><a href="?">{{ __('general.phrase.clear-filter') }}</a></p>{% endif %}
     </form>
     #}
 

--- a/theme/base-2016/notfound.twig
+++ b/theme/base-2016/notfound.twig
@@ -11,7 +11,7 @@
         <div class="large-12 columns">
 
         {# special case: See if we actually want the Styleguide. #}
-        {% if app.request.server.get('REQUEST_URI') == '/styleguide' %}
+        {% if global.request.server.get('REQUEST_URI') == '/styleguide' %}
             {{ include('styleguide.twig') }}
         {% else %}
             <h1>{{ record.title|default('404 not found') }}</h1>

--- a/theme/base-2016/partials/_fresh_install.twig
+++ b/theme/base-2016/partials/_fresh_install.twig
@@ -4,7 +4,7 @@
         <p>This is a bland theme, with a modular structure. It is well suited to build your own theme's on top of.</p>
         <ul>
             <li>Check the <a href='https://github.com/bobdenotter/bolt-foundation-theme/blob/master/readme.md'>readme.md</a> for instructions on how to customize this theme.</li>
-            <li>View the <a href='{{ app.request.basePath }}/styleguide'>Styleguide</a> for this theme.</li>
+            <li>View the <a href='{{ global.request.basePath }}/styleguide'>Styleguide</a> for this theme.</li>
             <li>Read the <a href='http://foundation.zurb.com/sites/docs/'>Foundation for Sites</a> documentation.</li>
             <li><a href='{{ path('fileedit', {'namespace': 'theme', 'file': 'index.twig'}) }}'>Edit this template</a>, to get rid of this 'callout'.</li>
         </ul>


### PR DESCRIPTION
The template used the now deprecated global `request('foo')` object, which causes a twig exception when rendering. This exception can not be overridden if happening while rendering a widgets template, causing a crash in the backend.

Replaced (as specified by @CarsonF) with `global.request.get('foo')`.

*Note*: There are other occurrences which use `app.request.query.get('foo')`. Should probably use same new method?