### PR TITLE
Clear 'exception' and 'translation' too.

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -76,9 +76,12 @@ class Cache extends FilesystemCache
             }
 
             // Clear our own cache folder.
+            $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/composer'));
             $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/development'));
+            $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/exception'));
             $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/production'));
             $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/profiler'));
+            $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/trans'));
 
             // Clear the thumbs folder.
             $this->flushDirectory($this->filesystem->getFilesystem('web')->getDir('/thumbs'));

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -76,7 +76,6 @@ class Cache extends FilesystemCache
             }
 
             // Clear our own cache folder.
-            $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/composer'));
             $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/development'));
             $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/exception'));
             $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/production'));


### PR DESCRIPTION
When clearing the cache using `app/nut`, some cruft stayed behind: 

```
[🐹::~/Sites/bolt-origin]$ du -h -d1 app/cache
4.0K	app/cache/.sessions
8.0K	app/cache/composer
  0B	app/cache/development
8.3M	app/cache/exception
  0B	app/cache/profiler
144K	app/cache/trans
8.5M	app/cache
```

This PR flushes those folders as well. 