### PR TITLE
[3.2] Reset GROUP BY and JOIN parameters for count()

### DIFF
--- a/src/Storage/Repository.php
+++ b/src/Storage/Repository.php
@@ -97,6 +97,7 @@ class Repository implements ObjectRepository
     {
         $qb = $this->getLoadQuery()
             ->select('COUNT(' . $this->getAlias() . '.id) as count')
+            ->resetQueryParts(['groupBy', 'join'])
         ;
         $result = $qb->execute()->fetchColumn(0);
 


### PR DESCRIPTION
The `JOIN`s and `GROUP BY` can produce some _interesting_ results. So this just un-sets them in the pre-built query object.