### PR TITLE
[3.3 ] Remove requirement on (optional) gmp PHP extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "ext-exif": "*",
         "ext-fileinfo": "*",
         "ext-gd": "*",
-        "ext-gmp": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/src/Configuration/Check/PhpExtensions.php
+++ b/src/Configuration/Check/PhpExtensions.php
@@ -18,7 +18,6 @@ class PhpExtensions extends BaseCheck implements ConfigurationCheckInterface
             'exif',
             'gd',
             'gettext',
-            'gmp',
             'hash',
             'iconv',
             'intl',


### PR DESCRIPTION
It is (optionally) used by ircmaxell/security-lib and PasswordLib/PasswordLib, but neither package require it

Related: https://github.com/bolt/docs/pull/708