### PR TITLE
[3.3] Use "is defined" to check if a block exists

### DIFF
--- a/app/view/twig/_base/_fieldset.twig
+++ b/app/view/twig/_base/_fieldset.twig
@@ -22,7 +22,7 @@
     for:    block('fieldset_label_for'),
 } %}
 
-{% if block('fieldset_label_info') %}
+{% if block('fieldset_label_info') is defined %}
     {% set field_info = buic_info(block('fieldset_label_text'), block('fieldset_label_info')) %}
 {% endif %}
 


### PR DESCRIPTION
Deprecation:

```
Silent display of undefined block "fieldset_label_info" in template
"@bolt/_base/_fieldset.twig" is deprecated since version 1.29 and will
throw an exception in 2.0.

Use the "block('fieldset_label_info') is defined" expression to test for
block existence
```