### PR TITLE
[3.3][Deprecation] Use Form::isSubmitted() before Form::isValid()

### DIFF
--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -235,7 +235,7 @@ class General extends BackendBase
             ->getForm();
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             if ($response = $this->saveTranslationFile($data['contents'], $tr)) {
                 return $response;

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -294,23 +294,19 @@ class Users extends BackendBase
         /** @var \Symfony\Component\Form\Form */
         $form = $form->getForm();
 
-        // Check if the form was POST-ed, and valid. If so, store the user.
-        if ($request->isMethod('POST')) {
-            $form->submit($request->get($form->getName()));
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->app['logger.system']->info(Trans::__('page.edit-users.log.user-updated', ['%user%' => $user->getDisplayname()]), ['event' => 'security']);
 
-            if ($form->isValid()) {
-                $this->app['logger.system']->info(Trans::__('page.edit-users.log.user-updated', ['%user%' => $user->getDisplayname()]), ['event' => 'security']);
-
-                $user = new Entity\Users($form->getData());
-                if ($this->getRepository(Entity\Users::class)->save($user)) {
-                    $this->flashes()->success(Trans::__('page.edit-users.message.user-saved', ['%user%' => $user->getDisplayname()]));
-                } else {
-                    $this->flashes()->error(Trans::__('page.edit-users.message.saving-user', ['%user%' => $user->getDisplayname()]));
-                }
-
-                return $this->redirectToRoute('profile');
+            $user = new Entity\Users($form->getData());
+            if ($this->getRepository(Entity\Users::class)->save($user)) {
+                $this->flashes()->success(Trans::__('page.edit-users.message.user-saved', ['%user%' => $user->getDisplayname()]));
+            } else {
+                $this->flashes()->error(Trans::__('page.edit-users.message.saving-user', ['%user%' => $user->getDisplayname()]));
             }
-        }
+
+            return $this->redirectToRoute('profile');
+        };
 
         $context = [
             'kind'        => 'profile',


### PR DESCRIPTION
Might was well stay ahead of the game …
```
    Form::isValid() with an unsubmitted form is deprecated since version 3.2
    and will throw an exception in 4.0.
```