### PR TITLE
[3.2] Report a boolean value as "true" or "false"

### DIFF
--- a/src/Nut/ConfigGet.php
+++ b/src/Nut/ConfigGet.php
@@ -47,6 +47,9 @@ class ConfigGet extends BaseCommand
             $match = $yaml->get($key);
 
             if (null !== $match) {
+                if (is_bool($match)) {
+                    $match = $match ? 'true' : 'false';
+                }
                 $result = sprintf('%s: %s', $key, $match);
             } else {
                 $result = sprintf("<error>The key '%s' was not found in %s.</error>", $key, $file);


### PR DESCRIPTION
Classifying this as bug-fix, as booleans are currently cast to the string-integer in the UI, and the set command takes `true` and `false` as valid boolean inputs … so "confusement" 