### PR TITLE
[3.3][Tests] Silex2 deprecations

### DIFF
--- a/src/Provider/DatabaseSchemaServiceProvider.php
+++ b/src/Provider/DatabaseSchemaServiceProvider.php
@@ -4,6 +4,7 @@ namespace Bolt\Provider;
 
 use Bolt\Helpers\Deprecated;
 use Bolt\Storage\Database\Schema\Builder;
+use Bolt\Storage\Database\Schema\Comparison;
 use Bolt\Storage\Database\Schema\LazySchemaManager;
 use Bolt\Storage\Database\Schema\Manager;
 use Bolt\Storage\Database\Schema\Table;
@@ -209,9 +210,9 @@ class DatabaseSchemaServiceProvider implements ServiceProviderInterface
         $app['schema.comparator.factory'] = $app->protect(
             function () use ($app) {
                 $platforms = [
-                    'mysql'      => '\\Bolt\\Storage\\Database\\Schema\\Comparison\\MySql',
-                    'postgresql' => '\\Bolt\\Storage\\Database\\Schema\\Comparison\\PostgreSql',
-                    'sqlite'     => '\\Bolt\\Storage\\Database\\Schema\\Comparison\\Sqlite',
+                    'mysql'      => Comparison\MySql::class,
+                    'postgresql' => Comparison\PostgreSql::class,
+                    'sqlite'     => Comparison\Sqlite::class,
                 ];
                 $platformName = $app['db']->getDatabasePlatform()->getName();
 

--- a/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
+++ b/tests/phpunit/unit/AccessControl/AccessCheckerTest.php
@@ -108,7 +108,7 @@ class AccessCheckerTest extends BoltUnitTest
             ->method('info')
             ->with($this->equalTo('You have been logged out.'))
         ;
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $userEntity = new Entity\Users();
         $tokenEntity = new Entity\Authtoken();

--- a/tests/phpunit/unit/AccessControl/LoginTest.php
+++ b/tests/phpunit/unit/AccessControl/LoginTest.php
@@ -38,7 +38,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Login function called with empty username/password combination, or no authentication token.'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $login = new Login($app);
         $login->login(null, null, new AccessControlEvent(new Request()));
@@ -54,7 +54,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Username or password not correct. Please check your input.'));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $login = new Login($app);
 
@@ -72,13 +72,13 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('alert')
             ->with($this->equalTo("Attempt to login with disabled account by 'admin'"));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $logger = $this->getMockFlashLogger();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Your account is disabled. Sorry about that.'));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         /** @var UsersRepository $repo */
         $repo = $app['storage']->getRepository(Entity\Users::class);
@@ -103,7 +103,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Your account is disabled. Sorry about that.'));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $login = new Login($app);
 
@@ -120,13 +120,13 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('info')
             ->with($this->equalTo("Failed login attempt for 'Admin'."));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $logger = $this->getMockFlashLogger();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Username or password not correct. Please check your input.'));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $app['request_stack']->push(new Request());
 
@@ -148,7 +148,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->at(1))
             ->method('debug')
             ->with($this->matchesRegularExpression('#Saving new login token#'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $request = Request::createFromGlobals();
         $request->server->set('HTTP_USER_AGENT', 'Bolt PHPUnit tests');
@@ -169,7 +169,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Invalid login parameters.'));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $request = Request::createFromGlobals();
         $request->server->set('REMOTE_ADDR', '1.2.3.4');
@@ -191,7 +191,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Invalid login parameters.'));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $repo = $app['storage']->getRepository(Entity\Authtoken::class);
         $entityAuthtoken = new Entity\Authtoken();
@@ -228,7 +228,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('debug')
             ->with($this->matchesRegularExpression('#Generating authentication cookie#'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $repo = $app['storage']->getRepository(Entity\Authtoken::class);
         $entityAuthtoken = new Entity\Authtoken();
@@ -265,7 +265,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->at(1))
             ->method('debug')
             ->with($this->matchesRegularExpression('#Saving new login token#'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $logger = $this->getMockFlashLogger();
         $logger->expects($this->at(0))
@@ -274,7 +274,7 @@ class LoginTest extends BoltUnitTest
         $logger->expects($this->at(1))
             ->method('success')
             ->with($this->equalTo("You've been logged on successfully."));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $userName = 'admin';
         $salt = 'vinagre';

--- a/tests/phpunit/unit/AccessControl/PasswordTest.php
+++ b/tests/phpunit/unit/AccessControl/PasswordTest.php
@@ -34,7 +34,7 @@ class PasswordTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('info')
             ->with($this->equalTo("Password for user 'admin' was reset via Nut."));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $password = new Password($app);
         $newPass = $password->setRandomPassword('admin');
@@ -91,7 +91,7 @@ class PasswordTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Somebody tried to reset a password with an invalid token.'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $shadowToken = $app['randomgenerator']->generateString(32);
         $shadowTokenHash = md5($shadowToken . '-' . str_replace('.', '-', '8.8.8.8'));
@@ -120,7 +120,7 @@ class PasswordTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Somebody tried to reset a password with an invalid token.'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $shadowToken = $app['randomgenerator']->generateString(32);
         $shadowTokenHash = md5($shadowToken . '-' . str_replace('.', '-', '8.8.8.8'));
@@ -149,7 +149,7 @@ class PasswordTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Somebody tried to reset a password with an invalid token.'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $shadowToken = $app['randomgenerator']->generateString(32);
 
@@ -175,7 +175,7 @@ class PasswordTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('info')
             ->with($this->equalTo("A password reset link has been sent to 'sneakykoala'."));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $event = new AccessControlEvent(Request::createFromGlobals());
         $password = new Password($app);
@@ -194,13 +194,13 @@ class PasswordTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('danger')
             ->with($this->equalTo("The email configuration setting 'mailoptions' hasn't been set. Bolt may be unable to send password reset."));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $mailer = $this->getMockSwiftMailer();
         $mailer->expects($this->atLeastOnce())
             ->method('send')
             ->will($this->returnValue(true));
-        $app['mailer'] = $mailer;
+        $this->setService('mailer', $mailer);
 
         $event = new AccessControlEvent(Request::createFromGlobals());
         $password = new Password($app);
@@ -219,13 +219,13 @@ class PasswordTest extends BoltUnitTest
         $logger->expects($this->never())
             ->method('error')
             ->with($this->equalTo("A password reset link has been sent to 'sneakykoala'."));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $mailer = $this->getMockSwiftMailer();
         $mailer->expects($this->atLeastOnce())
             ->method('send')
             ->will($this->returnValue(true));
-        $app['mailer'] = $mailer;
+        $this->setService('mailer', $mailer);
 
         $event = new AccessControlEvent(Request::createFromGlobals());
         $password = new Password($app);
@@ -244,19 +244,19 @@ class PasswordTest extends BoltUnitTest
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo('Failed to send password request. Please check the email settings.'));
-        $app['logger.flash'] = $logger;
+        $this->setService('logger.flash', $logger);
 
         $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
             ->method('error')
             ->with($this->equalTo("Failed to send password request sent to 'Admin'."));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
 
         $mailer = $this->getMockSwiftMailer();
         $mailer->expects($this->atLeastOnce())
             ->method('send')
             ->will($this->returnValue(false));
-        $app['mailer'] = $mailer;
+        $this->setService('mailer', $mailer);
 
         $event = new AccessControlEvent(Request::createFromGlobals());
         $password = new Password($app);

--- a/tests/phpunit/unit/Asset/AssetsProviderTest.php
+++ b/tests/phpunit/unit/Asset/AssetsProviderTest.php
@@ -215,13 +215,6 @@ HTML;
     public function testBadExtensionSnippets()
     {
         $app = $this->getApp();
-        $app['asset.queue.snippet'] = new \Bolt\Asset\Snippet\Queue(
-            $app['asset.injector'],
-            $app['cache'],
-            $app['config'],
-            $app['resources'],
-            $app['request_stack']
-        );
         new Mock\BadExtensionSnippets($app);
         $response = new Response($this->template);
 

--- a/tests/phpunit/unit/BoltUnitTest.php
+++ b/tests/phpunit/unit/BoltUnitTest.php
@@ -178,7 +178,7 @@ abstract class BoltUnitTest extends TestCase
         $users->expects($this->any())
             ->method('isEnabled')
             ->will($this->returnValue(true));
-        $app['users'] = $users;
+        $this->setService('users', $users);
 
         $permissions = $this->getMockPermissions(['isAllowed']);
         $permissions->expects($this->any())
@@ -191,7 +191,7 @@ abstract class BoltUnitTest extends TestCase
             ->method('isValidSession')
             ->will($this->returnValue(true));
 
-        $app['access_control'] = $auth;
+        $this->setService('access_control', $auth);
     }
 
     protected function removeCSRF($app)
@@ -206,7 +206,7 @@ abstract class BoltUnitTest extends TestCase
             ->method('getToken')
             ->will($this->returnValue('xyz'));
 
-        $app['form.csrf_provider'] = $csrf;
+        $this->setService('form.csrf_provider', $csrf);
     }
 
     protected function addSomeContent()
@@ -214,8 +214,7 @@ abstract class BoltUnitTest extends TestCase
         $app = $this->getApp();
         $this->addDefaultUser($app);
         $app['config']->set('taxonomy/categories/options', ['news']);
-        $prefillMock = new LoripsumMock();
-        $app['prefill'] = $prefillMock;
+        $this->setService('prefill', new LoripsumMock());
 
         $storage = new Storage($app);
         $storage->prefill(['showcases', 'pages']);
@@ -227,6 +226,9 @@ abstract class BoltUnitTest extends TestCase
      */
     protected function setService($key, $value)
     {
+        // In Pimple v3+ you can't re-set a container value,
+        // this just keeps us working forward with tests.
+        $this->getApp()->offsetUnset($key);
         $this->getApp()->offsetSet($key, $value);
     }
 
@@ -394,7 +396,7 @@ abstract class BoltUnitTest extends TestCase
     {
         return $this->getMockBuilder(Swift_Mailer::class)
             ->setMethods($methods)
-            ->setConstructorArgs([$this->app['swiftmailer.transport']])
+            ->disableOriginalConstructor()
             ->getMock()
         ;
     }

--- a/tests/phpunit/unit/Controller/Async/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Async/GeneralTest.php
@@ -71,13 +71,13 @@ class GeneralTest extends ControllerUnitTest
         $requestInterface = $this->createMock(RequestInterface::class);
         $testGuzzle->expects($this->at(0))->method('get')->will($this->throwException(new RequestException('Mock Fail', $requestInterface)));
 
-        $app['guzzle.client'] = $testGuzzle;
+        $this->setService('guzzle.client', $testGuzzle);
 
         $logger = $this->getMockLoggerManager();
         $logger->expects($this->at(1))
             ->method('error')
             ->with($this->stringContains('Error occurred'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
         $this->controller()->dashboardNews($this->getRequest());
     }
 
@@ -91,13 +91,13 @@ class GeneralTest extends ControllerUnitTest
         $testGuzzle->expects($this->any())
                     ->method('get')
                     ->will($this->returnValue($testRequest));
-        $app['guzzle.client'] = $testGuzzle;
+        $this->setService('guzzle.client', $testGuzzle);
 
         $logger = $this->getMockLoggerManager();
         $logger->expects($this->at(1))
             ->method('error')
             ->with($this->stringContains('Invalid JSON'));
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
         $this->controller()->dashboardNews($this->getRequest());
     }
 
@@ -117,7 +117,7 @@ class GeneralTest extends ControllerUnitTest
         $testGuzzle->expects($this->any())
                     ->method('get')
                     ->will($this->returnValue($requestInterface));
-        $app['guzzle.client'] = $testGuzzle;
+        $this->setService('guzzle.client', $testGuzzle);
 
         $response = $this->controller()->dashboardNews($this->getRequest());
 

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -68,7 +68,7 @@ class GeneralTest extends ControllerUnitTest
         /** @var Application $app */
         $app = $this->getApp();
         $flashes = $this->createMock(FlashLogger::class);
-        $app['logger.flash'] = $flashes;
+        $this->setService('logger.flash', $flashes);
 
         $flashes->expects($this->once())
             ->method('error');

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -164,7 +164,7 @@ class FrontendTest extends ControllerUnitTest
     {
         /** @var \Silex\Application $app */
         $app = $this->getApp();
-        $app['twig.runtime.bolt_html'] = $this->getHtmlRuntime();
+        $this->setService('twig.runtime.bolt_html', $this->getHtmlRuntime());
 
         $this->setRequest(Request::create('/pages/5'));
         $app['request_context']->fromRequest($this->getRequest());
@@ -175,7 +175,7 @@ class FrontendTest extends ControllerUnitTest
         $content1['slug'] = 'foo';
 
         $storage = $this->getMockStorage(['getContent']);
-        $app['storage'] = $storage;
+        $this->setService('storage', $storage);
 
         $storage->expects($this->at(0))
             ->method('getContent')
@@ -199,7 +199,7 @@ class FrontendTest extends ControllerUnitTest
     {
         /** @var \Silex\Application $app */
         $app = $this->getApp();
-        $app['twig.runtime.bolt_html'] = $this->getHtmlRuntime();
+        $this->setService('twig.runtime.bolt_html', $this->getHtmlRuntime());
 
         $this->setRequest(Request::create('/pages/', 'GET', ['id' => 5]));
         $contentType = $this->getService('storage')->getContentType('pages');

--- a/tests/phpunit/unit/Events/CronEventTest.php
+++ b/tests/phpunit/unit/Events/CronEventTest.php
@@ -19,16 +19,18 @@ class CronEventTest extends BoltUnitTest
     {
         $app = $this->getApp();
 
-        $app['cache'] = $this->getMockCache();
-        $app['cache']
+        $cache = $this->getMockCache();
+        $cache
             ->expects($this->exactly(1))
             ->method('flushAll')
         ;
+        $this->setService('cache', $cache);
 
-        $app['logger.manager'] = $this->getMockLoggerManager();
-        $app['logger.manager']
+        $logger = $this->getMockLoggerManager();
+        $logger
             ->expects($this->exactly(2))
             ->method('trim');
+        $this->setService('logger.manager', $logger);
 
         $output = new BufferedOutput();
 

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -97,7 +97,7 @@ class AssetTraitTest extends BoltUnitTest
             'theme' => new Filesystem(new Memory()),
             'web' => new Filesystem(new Memory()),
         ]);
-        $app['filesystem'] = $filesystem;
+        $this->setService('filesystem', $filesystem);
 
         $ext = new AssetExtension();
         $ext->setAssets([new JavaScript('js/test.js')]);
@@ -125,7 +125,7 @@ class AssetTraitTest extends BoltUnitTest
             'theme' => new Filesystem(new Memory()),
             'web' => new Filesystem(new Memory()),
         ]);
-        $app['filesystem'] = $filesystem;
+        $this->setService('filesystem', $filesystem);
 
         $filesystem->put('theme://js/test.js', '');
 

--- a/tests/phpunit/unit/Extension/TwigTraitTest.php
+++ b/tests/phpunit/unit/Extension/TwigTraitTest.php
@@ -94,7 +94,7 @@ TWIG;
             ->method('addDir')
             ->with($koala)
         ;
-        $app['twig.loader.bolt_filesystem'] = $boltLoaderMock;
+        $this->setService('twig.loader.bolt_filesystem', $boltLoaderMock);
 
         $app['twig']->getExtensions();
     }

--- a/tests/phpunit/unit/Logger/LogManagerTest.php
+++ b/tests/phpunit/unit/Logger/LogManagerTest.php
@@ -36,7 +36,7 @@ class LogManagerTest extends BoltUnitTest
             ->method('executeUpdate')
             ->with($this->equalTo('DELETE FROM bolt_log_system WHERE date < :date'));
 
-        $app['db'] = $db;
+        $this->setService('db', $db);
         $log = $this->getLogManager($app);
         $log->trim('system');
     }
@@ -50,7 +50,7 @@ class LogManagerTest extends BoltUnitTest
             ->method('executeUpdate')
             ->with($this->equalTo('DELETE FROM bolt_log_change WHERE date < :date'));
 
-        $app['db'] = $db;
+        $this->setService('db', $db);
         $log = $this->getLogManager($app);
         $log->trim('change');
     }
@@ -83,7 +83,7 @@ class LogManagerTest extends BoltUnitTest
             ->method('executeQuery')
             ->with($this->equalTo('TRUNCATE bolt_log_change'));
 
-        $app['db'] = $db;
+        $this->setService('db', $db);
         $log = $this->getLogManager($app);
         $log->clear('system');
         $log->clear('change');
@@ -108,7 +108,7 @@ class LogManagerTest extends BoltUnitTest
                 }
             ));
 
-        $app['db'] = $db;
+        $this->setService('db', $db);
         $app['request'] = Request::createFromGlobals();
 
         $log = $this->getLogManager($app);
@@ -132,7 +132,7 @@ class LogManagerTest extends BoltUnitTest
                 }
             ));
 
-        $app['db'] = $db;
+        $this->setService('db', $db);
         $app['request'] = Request::createFromGlobals();
 
         $log = $this->getLogManager($app);
@@ -167,7 +167,7 @@ class LogManagerTest extends BoltUnitTest
                 }
             ));
 
-        $app['db'] = $db;
+        $this->setService('db', $db);
         $app['request'] = Request::createFromGlobals();
 
         $log = $this->getLogManager($app);

--- a/tests/phpunit/unit/Logger/RecordChangeHandlerTest.php
+++ b/tests/phpunit/unit/Logger/RecordChangeHandlerTest.php
@@ -25,7 +25,7 @@ class RecordChangeHandlerTest extends BoltUnitTest
 
         $mocker = new DoctrineMockBuilder();
         $db = $mocker->getConnectionMock();
-        $app['db'] = $db;
+        $this->setService('db', $db);
 
         $log->pushHandler($handler);
         $log->addRecord(
@@ -64,7 +64,7 @@ class RecordChangeHandlerTest extends BoltUnitTest
                 )
             );
 
-        $app['db'] = $db;
+        $this->setService('db', $db);
 
         $log->pushHandler($handler);
         $log->addRecord(

--- a/tests/phpunit/unit/Logger/SystemHandlerTest.php
+++ b/tests/phpunit/unit/Logger/SystemHandlerTest.php
@@ -25,7 +25,7 @@ class SystemHandlerTest extends BoltUnitTest
 
         $mocker = new DoctrineMockBuilder();
         $db = $mocker->getConnectionMock();
-        $app['db'] = $db;
+        $this->setService('db', $db);
 
         $log->pushHandler($handler);
         $log->addRecord(Logger::DEBUG, 'test', ['id' => 5, 'title' => 'test']);
@@ -44,7 +44,7 @@ class SystemHandlerTest extends BoltUnitTest
         $db->expects($this->any())
             ->method('insert')
             ->with($this->equalTo('bolt_log_system'));
-        $app['db'] = $db;
+        $this->setService('db', $db);
 
         $log->addRecord(Logger::DEBUG, 'test', ['id' => 5, 'title' => 'test']);
     }
@@ -61,7 +61,7 @@ class SystemHandlerTest extends BoltUnitTest
         $db->expects($this->any())
             ->method('insert')
             ->with($this->equalTo('bolt_log_system'));
-        $app['db'] = $db;
+        $this->setService('db', $db);
 
         $log->addRecord(Logger::DEBUG, 'test', ['event' => '', 'exception' => new \Exception()]);
     }

--- a/tests/phpunit/unit/Menu/MenuBuilderTest.php
+++ b/tests/phpunit/unit/Menu/MenuBuilderTest.php
@@ -217,7 +217,7 @@ class MenuBuilderTest extends BoltUnitTest
             ->method('getContent')
             ->will($this->returnValue($contentMock));
 
-        $app['storage'] = $storage;
+        $this->setService('storage', $storage);
 
         $mb = new MenuBuilder($app);
         $method = new \ReflectionMethod(

--- a/tests/phpunit/unit/Nut/CacheClearTest.php
+++ b/tests/phpunit/unit/Nut/CacheClearTest.php
@@ -16,7 +16,7 @@ class CacheClearTest extends BoltUnitTest
     public function testSuccessfulClear()
     {
         $app = $this->getApp();
-        $app['cache'] = $this->getMockCache();
+        $this->setService('cache', $this->getMockCache());
         $command = new CacheClear($app);
         $tester = new CommandTester($command);
         $tester->execute([]);
@@ -27,7 +27,7 @@ class CacheClearTest extends BoltUnitTest
     public function testWithFailures()
     {
         $app = $this->getApp();
-        $app['cache'] = $this->getMockCache(false);
+        $this->setService('cache', $this->getMockCache(false));
         $command = new CacheClear($app);
         $tester = new CommandTester($command);
 

--- a/tests/phpunit/unit/Nut/ExtensionsDumpAutoloadTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsDumpAutoloadTest.php
@@ -28,7 +28,7 @@ class ExtensionsDumpAutoloadTest extends BoltUnitTest
             ->method('dumpAuoloader')
             ->will($this->returnValue(0));
 
-        $app['extend.manager'] = $runner;
+        $this->setService('extend.manager', $runner);
 
         $command = new ExtensionsDumpAutoload($app);
         $tester = new CommandTester($command);

--- a/tests/phpunit/unit/Nut/ExtensionsInstallTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsInstallTest.php
@@ -28,7 +28,7 @@ class ExtensionsInstallTest extends BoltUnitTest
             ->method('requirePackage')
             ->will($this->returnValue(0));
 
-        $app['extend.manager'] = $runner;
+        $this->setService('extend.manager', $runner);
 
         $command = new ExtensionsInstall($app);
         $tester = new CommandTester($command);
@@ -51,7 +51,7 @@ class ExtensionsInstallTest extends BoltUnitTest
             ->method('requirePackage')
             ->will($this->returnValue(1));
 
-        $app['extend.manager'] = $runner;
+        $this->setService('extend.manager', $runner);
 
         $command = new ExtensionsInstall($app);
         $tester = new CommandTester($command);

--- a/tests/phpunit/unit/Nut/ExtensionsTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsTest.php
@@ -32,7 +32,7 @@ class ExtensionsTest extends BoltUnitTest
             ->method('showPackage')
             ->will($this->returnValue(['test' => ['package' => $testPackage]]));
 
-        $app['extend.manager'] = $runner;
+        $this->setService('extend.manager', $runner);
 
         $command = new Extensions($app);
         $tester = new CommandTester($command);

--- a/tests/phpunit/unit/Nut/ExtensionsUninstallTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsUninstallTest.php
@@ -28,7 +28,7 @@ class ExtensionsUninstallTest extends BoltUnitTest
             ->method('removePackage')
             ->will($this->returnValue(0));
 
-        $app['extend.manager'] = $runner;
+        $this->setService('extend.manager', $runner);
 
         $command = new ExtensionsUninstall($app);
         $tester = new CommandTester($command);
@@ -54,7 +54,7 @@ class ExtensionsUninstallTest extends BoltUnitTest
             ->method('removePackage')
             ->will($this->returnValue(1));
 
-        $app['extend.manager'] = $runner;
+        $this->setService('extend.manager', $runner);
 
         $command = new ExtensionsUninstall($app);
         $tester = new CommandTester($command);

--- a/tests/phpunit/unit/Nut/UserRoleAddTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleAddTest.php
@@ -17,7 +17,7 @@ class UserRoleAddTest extends BoltUnitTest
     public function testAdd()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMockWithReturns();
+        $this->setService('users', $this->getUserMockWithReturns());
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 
@@ -29,7 +29,7 @@ class UserRoleAddTest extends BoltUnitTest
     public function testRoleExists()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMockWithReturns(true);
+        $this->setService('users', $this->getUserMockWithReturns(true));
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 
@@ -41,7 +41,7 @@ class UserRoleAddTest extends BoltUnitTest
     public function testRoleFails()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMockWithReturns(false, false);
+        $this->setService('users', $this->getUserMockWithReturns(false, false));
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 

--- a/tests/phpunit/unit/Nut/UserRoleRemoveTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleRemoveTest.php
@@ -17,7 +17,7 @@ class UserRoleRemoveTest extends BoltUnitTest
     public function testRemove()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMockWithReturns(true, true);
+        $this->setService('users', $this->getUserMockWithReturns(true, true));
         $command = new UserRoleRemove($app);
         $tester = new CommandTester($command);
 
@@ -30,7 +30,7 @@ class UserRoleRemoveTest extends BoltUnitTest
     public function testRemoveFail()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMockWithReturns(false, true);
+        $this->setService('users', $this->getUserMockWithReturns(false, true));
         $command = new UserRoleRemove($app);
         $tester = new CommandTester($command);
 
@@ -42,7 +42,7 @@ class UserRoleRemoveTest extends BoltUnitTest
     public function testRemoveNonexisting()
     {
         $app = $this->getApp();
-        $app['users'] = $this->getUserMockWithReturns(true, false);
+        $this->setService('users', $this->getUserMockWithReturns(true, false));
         $command = new UserRoleRemove($app);
         $tester = new CommandTester($command);
 

--- a/tests/phpunit/unit/Pager/PagerManagerTestBase.php
+++ b/tests/phpunit/unit/Pager/PagerManagerTestBase.php
@@ -26,7 +26,7 @@ abstract class PagerManagerTestBase extends BoltUnitTest
     {
         $app = $this->getApp();
         $app['request'] = $request;
-        $app['request_stack'] = new RequestStack();
+        $this->setService('request_stack', new RequestStack());
 
         if ($request) {
             $app['request_stack']->push($request);

--- a/tests/phpunit/unit/Provider/CacheServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/CacheServiceProviderTest.php
@@ -3,11 +3,10 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Cache;
-use Bolt\Provider\CacheServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/CacheServiceProvider.
+ * @covers \Bolt\Provider\CacheServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class CacheServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new CacheServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Cache::class, $app['cache']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/CanonicalServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/CanonicalServiceProviderTest.php
@@ -2,12 +2,11 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\CanonicalServiceProvider;
 use Bolt\Routing\Canonical;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/CanonicalServiceProvider.
+ * @covers \Bolt\Provider\CanonicalServiceProvider
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
@@ -16,9 +15,6 @@ class CanonicalServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new CanonicalServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Canonical::class, $app['canonical']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/ConfigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ConfigServiceProviderTest.php
@@ -3,11 +3,10 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Config;
-use Bolt\Provider\ConfigServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/ConfigServiceProvider.
+ * @covers \Bolt\Provider\ConfigServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class ConfigServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new ConfigServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Config::class, $app['config']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/CronServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/CronServiceProviderTest.php
@@ -3,11 +3,10 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Cron;
-use Bolt\Provider\CronServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/CronServiceProvider.
+ * @covers \Bolt\Provider\CronServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class CronServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new CronServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Cron::class, $app['cron']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/DatabaseSchemaServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/DatabaseSchemaServiceProviderTest.php
@@ -2,12 +2,11 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\DatabaseSchemaServiceProvider;
 use Bolt\Storage\Database\Schema;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/DatabaseSchemaServiceProvider.
+ * @covers \Bolt\Provider\DatabaseSchemaServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class DatabaseSchemaServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new DatabaseSchemaServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Schema\Manager::class, $app['schema']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/ExtensionServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ExtensionServiceProviderTest.php
@@ -4,11 +4,10 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Composer\Satis\StatService;
 use Bolt\Extension;
-use Bolt\Provider\ExtensionServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/ExtensionServiceProvider.
+ * @covers \Bolt\Provider\ExtensionServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -17,10 +16,7 @@ class ExtensionServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new ExtensionServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Extension\Manager::class, $app['extensions']);
         $this->assertInstanceOf(StatService::class, $app['extensions.stats']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/FilePermissionsServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/FilePermissionsServiceProviderTest.php
@@ -3,11 +3,10 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Filesystem\FilePermissions;
-use Bolt\Provider\FilePermissionsServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/FilePermissionsServiceProvider.
+ * @covers \Bolt\Provider\FilePermissionsServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class FilePermissionsServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new FilePermissionsServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(FilePermissions::class, $app['filepermissions']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/FilesystemServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/FilesystemServiceProviderTest.php
@@ -3,11 +3,10 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Filesystem;
-use Bolt\Provider\FilesystemServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test Bolt\Provider\FilesystemServiceProvider.
+ * @covers \Bolt\Provider\FilesystemServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
@@ -17,10 +16,6 @@ class FilesystemServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-
-        $app->register(new FilesystemServiceProvider());
         $this->assertInstanceOf(Filesystem\Manager::class, $app['filesystem']);
-
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/LoggerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/LoggerServiceProviderTest.php
@@ -3,12 +3,11 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Logger;
-use Bolt\Provider\LoggerServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 use Psr\Log\LoggerInterface;
 
 /**
- * Class to test src/Provider/NutServiceProvider.
+ * @covers \Bolt\Provider\LoggerServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -17,13 +16,9 @@ class LoggerServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new LoggerServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(LoggerInterface::class, $app['logger.system']);
         $this->assertInstanceOf(LoggerInterface::class, $app['logger.change']);
         $this->assertInstanceOf(LoggerInterface::class, $app['logger.firebug']);
         $this->assertInstanceOf(Logger\Manager::class, $app['logger.manager']);
-
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/MenuServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/MenuServiceProviderTest.php
@@ -4,11 +4,10 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Menu\MenuBuilder;
 use Bolt\Menu\MenuEntry;
-use Bolt\Provider\MenuServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/MenuServiceProvider
+ * @covers \Bolt\Provider\MenuServiceProvider
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
@@ -17,10 +16,7 @@ class MenuServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new MenuServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(MenuBuilder::class, $app['menu']);
         $this->assertInstanceOf(MenuEntry::class, $app['menu.admin']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/NutServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/NutServiceProviderTest.php
@@ -2,13 +2,12 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\NutServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Console;
 use Symfony\Component\Console\Command\Command;
 
 /**
- * Class to test src/Provider/NutServiceProvider.
+ * @covers \Bolt\Provider\NutServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
@@ -18,9 +17,6 @@ class NutServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $app->register(new NutServiceProvider());
-        $app->boot();
-
         $this->assertInstanceOf(Console\Application::class, $app['nut']);
         $this->assertTrue(is_array($app['nut.commands']));
     }
@@ -28,8 +24,6 @@ class NutServiceProviderTest extends BoltUnitTest
     public function testAddCommandCallableSingle()
     {
         $app = $this->getApp();
-        $app->register(new NutServiceProvider());
-
         $app['nut.commands.add'](function ($app) {
             return new Command('command1');
         });
@@ -40,8 +34,6 @@ class NutServiceProviderTest extends BoltUnitTest
     public function testAddCommandCallableMultiple()
     {
         $app = $this->getApp();
-        $app->register(new NutServiceProvider());
-
         $app['nut.commands.add'](function ($app) {
             return [
                 new Command('command1'),
@@ -56,8 +48,6 @@ class NutServiceProviderTest extends BoltUnitTest
     public function testAddCommandSingle()
     {
         $app = $this->getApp();
-        $app->register(new NutServiceProvider());
-
         $command1 = new Command('command1');
         $app['nut.commands.add']($command1);
 
@@ -67,8 +57,6 @@ class NutServiceProviderTest extends BoltUnitTest
     public function testAddCommandMultiple()
     {
         $app = $this->getApp();
-        $app->register(new NutServiceProvider());
-
         $command1 = new Command('command1');
         $command2 = new Command('command2');
         $app['nut.commands.add']([$command1, $command2]);

--- a/tests/phpunit/unit/Provider/OmnisearchServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/OmnisearchServiceProviderTest.php
@@ -3,11 +3,10 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Omnisearch;
-use Bolt\Provider\OmnisearchServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/OmnisearchServiceProvider.
+ * @covers \Bolt\Provider\OmnisearchServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,8 +15,6 @@ class OmnisearchServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new OmnisearchServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Omnisearch::class, $app['omnisearch']);
     }
 }

--- a/tests/phpunit/unit/Provider/PagerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PagerServiceProviderTest.php
@@ -3,14 +3,10 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Pager\PagerManager;
-use Bolt\Provider\PagerServiceProvider;
 use Bolt\Tests\BoltUnitTest;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class PagerServiceProviderTest
- *
- * @package Bolt\Tests\Provider
+ * @covers \Bolt\Provider\PagerServiceProvider
  *
  * @author Rix Beck <rix@neologik.hu>
  */
@@ -19,12 +15,6 @@ class PagerServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $app['request'] = Request::create('/');
-        $provider = new PagerServiceProvider($app);
-        $app->register($provider);
-
         $this->assertInstanceOf(PagerManager::class, $app['pager']);
-
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/PathServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PathServiceProviderTest.php
@@ -2,12 +2,11 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\PathServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 use Eloquent\Pathogen\FileSystem\Factory\PlatformFileSystemPathFactory;
 
 /**
- * Class to test src/Provider/PathServiceProvider.
+ * @covers \Bolt\Provider\PathServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class PathServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new PathServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(PlatformFileSystemPathFactory::class, $app['pathmanager']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/PermissionsServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/PermissionsServiceProviderTest.php
@@ -3,11 +3,10 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\AccessControl\Permissions;
-use Bolt\Provider\PermissionsServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/PermissionsServiceProvider.
+ * @covers \Bolt\Provider\PermissionsServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class PermissionsServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new PermissionsServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Permissions::class, $app['permissions']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/ProfilerServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/ProfilerServiceProviderTest.php
@@ -4,12 +4,11 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Profiler\BoltDataCollector;
 use Bolt\Profiler\DatabaseDataCollector;
-use Bolt\Provider\ProfilerServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 use Doctrine\DBAL\Logging\DebugStack;
 
 /**
- * Class to test src/Provider/DatabaseProfilerServiceProvider.
+ * @covers \Bolt\Provider\ProfilerServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
@@ -20,8 +19,6 @@ class ProfilerServiceProviderTest extends BoltUnitTest
     {
         $app = $this->getApp(false);
         $app['debug'] = true;
-
-        $app->register(new ProfilerServiceProvider());
 
         $templates = $app['data_collector.templates'];
         $this->assertSame('bolt', $templates[0][0]);

--- a/tests/phpunit/unit/Provider/RenderServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/RenderServiceProviderTest.php
@@ -2,12 +2,11 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\RenderServiceProvider;
 use Bolt\Render;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/RenderServiceProvider.
+ * @covers \Bolt\Provider\RenderServiceProvider
  *
  * @group legacy
  *
@@ -18,11 +17,7 @@ class RenderServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $app->register(new RenderServiceProvider());
-
         $this->assertInstanceOf(Render::class, $app['render']);
         $this->assertInstanceOf(Render::class, $app['safe_render']);
-
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/SessionServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/SessionServiceProviderTest.php
@@ -2,7 +2,6 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\SessionServiceProvider;
 use Bolt\Session\Generator\GeneratorInterface;
 use Bolt\Session\Serializer\SerializerInterface;
 use Bolt\Tests\BoltUnitTest;
@@ -14,7 +13,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
 
 /**
- * Class to test src/Provider/SessionServiceProvider.
+ * @covers \Bolt\Provider\SessionServiceProvider
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
@@ -24,7 +23,6 @@ class SessionServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $app->register(new SessionServiceProvider());
 
         $this->assertInstanceOf(AttributeBagInterface::class, $app['session.bag.attribute']);
         $this->assertInstanceOf(FlashBagInterface::class, $app['session.bag.flash']);
@@ -42,7 +40,5 @@ class SessionServiceProviderTest extends BoltUnitTest
         $this->assertArrayHasKey('cookie_domain', $app['session.options']);
         $this->assertArrayHasKey('cookie_secure', $app['session.options']);
         $this->assertArrayHasKey('cookie_httponly', $app['session.options']);
-
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/SlugifyProviderTest.php
+++ b/tests/phpunit/unit/Provider/SlugifyProviderTest.php
@@ -3,7 +3,6 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Tests\BoltUnitTest;
-use Cocur\Slugify\Bridge\Silex\SlugifyServiceProvider;
 use Cocur\Slugify\Slugify;
 
 /**
@@ -16,10 +15,7 @@ class SlugifyProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new SlugifyServiceProvider();
-        $app->register($provider);
         $this->assertInstanceOf(Slugify::class, $app['slugify']);
-        $app->boot();
 
         $slug = 'This is a title';
         $this->assertEquals('this-is-a-title', $app['slugify']->slugify($slug));

--- a/tests/phpunit/unit/Provider/StackServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/StackServiceProviderTest.php
@@ -2,12 +2,11 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\StackServiceProvider;
 use Bolt\Stack;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/StackServiceProvider.
+ * @covers \Bolt\Provider\StackServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class StackServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new StackServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(Stack::class, $app['stack']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/StorageServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/StorageServiceProviderTest.php
@@ -3,12 +3,11 @@
 namespace Bolt\Tests\Provider;
 
 use Bolt\Legacy\Storage;
-use Bolt\Provider\StorageServiceProvider;
 use Bolt\Storage\EntityManager;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/StorageServiceProvider.
+ * @covers \Bolt\Provider\StorageServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -17,10 +16,7 @@ class StorageServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new StorageServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(EntityManager::class, $app['storage']);
         $this->assertInstanceOf(Storage::class, $app['storage.legacy']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/TemplateChooserServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TemplateChooserServiceProviderTest.php
@@ -2,12 +2,11 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\TemplateChooserServiceProvider;
 use Bolt\TemplateChooser;
 use Bolt\Tests\BoltUnitTest;
 
 /**
- * Class to test src/Provider/TemplateChooserServiceProvider.
+ * @covers \Bolt\Provider\TemplateChooserServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -16,9 +15,6 @@ class TemplateChooserServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new TemplateChooserServiceProvider($app);
-        $app->register($provider);
         $this->assertInstanceOf(TemplateChooser::class, $app['templatechooser']);
-        $app->boot();
     }
 }

--- a/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TranslationServiceProviderTest.php
@@ -4,12 +4,11 @@ namespace Bolt\Tests\Provider;
 
 use Bolt\Application;
 use Bolt\Configuration\PathResolver;
-use Bolt\Provider\TranslationServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Class to test src/Provider/TranslationServiceProvider.
+ * @covers \Bolt\Provider\TranslationServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
@@ -18,17 +17,12 @@ class TranslationServiceProviderTest extends BoltUnitTest
     public function testProvider()
     {
         $app = $this->getApp();
-        $provider = new TranslationServiceProvider($app);
-        $app->register($provider);
-        $app->boot();
         $this->assertNotNull($app['translator']->getLocale());
     }
 
     public function testLocaleChange()
     {
         $app = $this->getApp();
-        $provider = new TranslationServiceProvider($app);
-        $app->register($provider);
         $app['locale'] = 'de_XX';
         $this->assertEquals('de_XX', $app['translator']->getLocale());
     }

--- a/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
@@ -2,14 +2,13 @@
 
 namespace Bolt\Tests\Provider;
 
-use Bolt\Provider\TwigServiceProvider;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Extension\BoltExtension;
 use Bolt\Twig\SafeEnvironment;
 use Twig_Environment;
 
 /**
- * Class to test src/Provider/TwigServiceProvider.
+ * @covers \Bolt\Provider\TwigServiceProvider
  *
  * @author Ross Riley <riley.ross@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
@@ -37,10 +36,8 @@ class TwigServiceProviderTest extends BoltUnitTest
 
     public function testConfigCacheDisabled()
     {
-        $app = $this->getApp();
-
+        $app = $this->getApp(false);
         $app['config']->set('general/caching/templates', false);
-        $app->register(new TwigServiceProvider());
         $this->assertArrayNotHasKey('cache', $app['twig.options']);
     }
 }

--- a/tests/phpunit/unit/Storage/FieldLoadTest.php
+++ b/tests/phpunit/unit/Storage/FieldLoadTest.php
@@ -85,7 +85,7 @@ class FieldLoadTest extends BoltUnitTest
         $app['request'] = Request::create('/');
         $app['config']->set('taxonomy/categories/options', ['news']);
         $prefillMock = new LoripsumMock();
-        $app['prefill'] = $prefillMock;
+        $this->setService('prefill', $prefillMock);
 
         $storage = new Storage($app);
         $storage->prefill(['showcases', 'entries', 'pages']);

--- a/tests/phpunit/unit/Storage/FieldSaveTest.php
+++ b/tests/phpunit/unit/Storage/FieldSaveTest.php
@@ -84,7 +84,7 @@ class FieldSaveTest extends BoltUnitTest
         $app['request'] = Request::create('/');
         $app['config']->set('taxonomy/categories/options', ['news']);
         $prefillMock = new LoripsumMock();
-        $app['prefill'] = $prefillMock;
+        $this->setService('prefill', $prefillMock);
 
         $storage = new Storage($app);
         $storage->prefill(['showcases', 'entries', 'pages']);

--- a/tests/phpunit/unit/Storage/PrefillTest.php
+++ b/tests/phpunit/unit/Storage/PrefillTest.php
@@ -33,7 +33,7 @@ class PrefillTest extends BoltUnitTest
             ->with('http://loripsum.net/api/1/veryshort')
             ->will($this->returnValue($request));
 
-        $app['guzzle.client'] = $guzzle;
+        $this->setService('guzzle.client', $guzzle);
         $app['prefill']->get('/1/veryshort');
     }
 }

--- a/tests/phpunit/unit/Storage/Query/QueryFieldDelegationTest.php
+++ b/tests/phpunit/unit/Storage/Query/QueryFieldDelegationTest.php
@@ -50,7 +50,7 @@ class QueryFieldDelegationTest extends BoltUnitTest
         $app['request'] = Request::create('/');
         $app['config']->set('taxonomy/categories/options', ['news']);
         $prefillMock = new LoripsumMock();
-        $app['prefill'] = $prefillMock;
+        $this->setService('prefill', $prefillMock);
 
         $storage = new Storage($app);
         $storage->prefill(['showcases', 'entries', 'pages']);

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -75,7 +75,7 @@ class StorageTest extends BoltUnitTest
         $app = $this->getApp();
         $this->addDefaultUser($app);
         $prefillMock = new LoripsumMock();
-        $app['prefill'] = $prefillMock;
+        $this->setService('prefill', $prefillMock);
 
         $app['config']->set('general/changelog/enabled', true);
         $storage = new Storage($app);
@@ -261,7 +261,7 @@ class StorageTest extends BoltUnitTest
         $db = $this->getDbMockBuilder($app['db'])
             ->setMethods(['fetchAll'])
             ->getMock();
-        $app['db'] = $db;
+        $this->setService('db', $db);
         $db->expects($this->any())
             ->method('fetchAll')
             ->willReturn([]);
@@ -280,7 +280,7 @@ class StorageTest extends BoltUnitTest
         $db = $this->getDbMockBuilder($app['db'])
             ->setMethods(['fetchAll'])
             ->getMock();
-        $app['db'] = $db;
+        $this->setService('db', $db);
         $db->expects($this->any())
             ->method('fetchAll')
             ->willReturn([]);

--- a/tests/phpunit/unit/Twig/BoltExtensionTest.php
+++ b/tests/phpunit/unit/Twig/BoltExtensionTest.php
@@ -76,7 +76,7 @@ class BoltExtensionTest extends BoltUnitTest
             ->expects($this->atLeastOnce())
             ->method('getCurrentUser')
             ->will($this->throwException(new \Exception()));
-        $app['users'] = $users;
+        $this->setService('users', $users);
         $request = Request::createFromGlobals();
         $app['request'] = $request;
         $app['request_stack']->push($request);

--- a/tests/phpunit/unit/Twig/Runtime/AdminRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/AdminRuntimeTest.php
@@ -66,7 +66,7 @@ class AdminRuntimeTest extends BoltUnitTest
             ->expects($this->once())
             ->method('isStackable')
         ;
-        $app['stack'] = $stack;
+        $this->setService('stack', $stack);
 
         $handler = $this->getAdminRuntime();
 
@@ -87,7 +87,7 @@ class AdminRuntimeTest extends BoltUnitTest
                 [[]]
             )
         ;
-        $app['stack'] = $stack;
+        $this->setService('stack', $stack);
 
         $handler = $this->getAdminRuntime();
 
@@ -186,7 +186,7 @@ class AdminRuntimeTest extends BoltUnitTest
             ->method('trans')
             ->will($this->returnValue('Page löschen'))
         ;
-        $app['translator'] = $trans;
+        $this->setService('translator', $trans);
 
         $handler = $this->getAdminRuntime();
 

--- a/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
@@ -465,7 +465,7 @@ GRINGALET;
             ->method('isEmptyPager')
             ->will($this->returnValue(true))
         ;
-        $app['pager'] = $pager;
+        $this->setService('pager', $pager);
 
         $handler = $this->getRecordRuntime();
         $env = $app['twig'];
@@ -502,7 +502,7 @@ GRINGALET;
             ->method('getPager')
             ->will($this->returnValue($pager))
         ;
-        $app['pager'] = $manager;
+        $this->setService('pager', $manager);
 
         $handler = $this->getRecordRuntime();
         $env = $app['twig'];

--- a/tests/phpunit/unit/Twig/Runtime/TextRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/TextRuntimeTest.php
@@ -73,7 +73,7 @@ class TextRuntimeTest extends BoltUnitTest
             ->expects($this->once())
             ->method('error')
         ;
-        $app['logger.system'] = $logger;
+        $this->setService('logger.system', $logger);
         $handler = new TextRuntime($app['logger.system'], $app['slugify']);
 
         $result = $handler->localeDateTime('2012-06-14 09:07:55', '%B %e, %Y %H:%M');

--- a/tests/phpunit/unit/Twig/Runtime/UserRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/UserRuntimeTest.php
@@ -103,7 +103,7 @@ class UserRuntimeTest extends BoltUnitTest
             ->method('isAllowed')
             ->will($this->returnValue(true))
         ;
-        $app['users'] = $users;
+        $this->setService('users', $users);
         $handler = new UserRuntime($app['users'], $app['csrf']);
 
         $content = new \Bolt\Legacy\Content($app, []);
@@ -120,7 +120,7 @@ class UserRuntimeTest extends BoltUnitTest
             ->method('isAllowed')
             ->will($this->returnValue(true))
         ;
-        $app['users'] = $users;
+        $this->setService('users', $users);
         $handler = new UserRuntime($app['users'], $app['csrf']);
 
         $result = $handler->isAllowed('koala', []);
@@ -136,7 +136,7 @@ class UserRuntimeTest extends BoltUnitTest
             ->method('isAllowed')
             ->will($this->returnValue(true))
         ;
-        $app['users'] = $users;
+        $this->setService('users', $users);
         $handler = new UserRuntime($app['users'], $app['csrf']);
 
         $result = $handler->isAllowed('koala', 'clippy');
@@ -147,7 +147,7 @@ class UserRuntimeTest extends BoltUnitTest
     {
         $app = $this->getApp();
         $tokenManager = new CsrfTokenManager(null, new SessionTokenStorage(new Session(new MockArraySessionStorage())));
-        $app['csrf'] = $tokenManager;
+        $this->setService('csrf', $tokenManager);
         $handler = new UserRuntime($app['users'], $app['csrf']);
         $token = $tokenManager->refreshToken('bolt');
 

--- a/tests/phpunit/unit/Twig/Runtime/UtilsRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/UtilsRuntimeTest.php
@@ -58,7 +58,7 @@ class UtilsRuntimeTest extends BoltUnitTest
         $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
         ->method('info');
-        $app['logger.firebug'] = $logger;
+        $this->setService('logger.firebug', $logger);
 
         $handler = $this->getHandler();
 
@@ -74,7 +74,7 @@ class UtilsRuntimeTest extends BoltUnitTest
         $logger = $this->getMockMonolog();
         $logger->expects($this->atLeastOnce())
             ->method('info');
-        $app['logger.firebug'] = $logger;
+        $this->setService('logger.firebug', $logger);
 
         $handler = $this->getHandler();
 
@@ -89,7 +89,7 @@ class UtilsRuntimeTest extends BoltUnitTest
         $logger = $this->getMockMonolog();
         $logger->expects($this->never())
             ->method('info');
-        $app['logger.firebug'] = $logger;
+        $this->setService('logger.firebug', $logger);
 
         $handler = $this->getHandler();
 


### PR DESCRIPTION
In Pimple v3, once the container element has been accessed, it is "frozen" to change

e.g.
```php
$app = new \Pimple\Container();

$app['koala'] = 'drop bear';
$value = $app['koala'];

// This will now throw an exception
$app['koala'] = 'kenny';
```

This is _Phase I_ of getting tests in order :wink: 