### PR TITLE
Fix content changelog field handling

### DIFF
--- a/src/Storage/Entity/LogChange.php
+++ b/src/Storage/Entity/LogChange.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Storage\Entity;
 
+use Bolt\Storage\Mapping\ClassMetadata;
+
 /**
  * Entity for change logs.
  */
@@ -25,6 +27,8 @@ class LogChange extends Entity
     protected $diff;
     /** @var string */
     protected $comment;
+    /** @var ClassMetadata */
+    protected $contentTypeMeta;
 
     /**
      * @return int
@@ -171,6 +175,16 @@ class LogChange extends Entity
     }
 
     /**
+     * Allows injecting the metadata configuration into the record so output can be built based on variable types.
+     *
+     * @param ClassMetadata $config
+     */
+    public function setContentTypeMeta(ClassMetadata $config)
+    {
+        $this->contentTypeMeta = $config;
+    }
+
+    /**
      * Get changed fields.
      *
      * @return array
@@ -184,7 +198,10 @@ class LogChange extends Entity
         }
 
         // Get the contenttype that we're dealing with
-        $fields = $this->contentTypeMeta['fields'];
+        if ($this->contentTypeMeta) {
+            $fields = $this->contentTypeMeta->getFieldMappings();
+        }
+
         $hash = [
             'html'        => 'fieldText',
             'markdown'    => 'fieldText',
@@ -198,6 +215,9 @@ class LogChange extends Entity
         ];
 
         foreach ($this->diff as $key => $value) {
+            if (!isset($fields[$key])) {
+                continue;
+            }
             $changedfields[$key] = [
                 'type'   => 'normal',
                 'label'  => empty($fields[$key]['label']) ? $key : $fields[$key]['label'],

--- a/src/Storage/Repository/LogChangeRepository.php
+++ b/src/Storage/Repository/LogChangeRepository.php
@@ -173,7 +173,13 @@ class LogChangeRepository extends BaseLogRepository
 
         $query = $this->getChangeLogEntryQuery($contenttype, $contentid, $id, $cmpOp);
 
-        return $this->findOneWith($query);
+        $record = $this->findOneWith($query);
+        if ($record) {
+            $repo = $this->getEntityManager()->getRepository($record->getContentType());
+            $record->setContentTypeMeta($repo->getClassMetadata());
+        }
+
+        return $record;
     }
 
     /**


### PR DESCRIPTION
I'm not sure exactly where the bug starts manifesting itself but sometimes the changelog will record a diff for relation and taxonomy fields, even if there are no taxonomy or relations set on a contenttype.

The root cause of this was that the metadata for the field was not set on the LogChange entity although it was expecting the property to be available.

This fixes that issue by injecting the metadata into the entity object after it has been fetched in the Repository.

If the field is not then set, the transformation will be skipped.

I've tested this on 3.3 and 3.4 and this seems to work.