### PR TITLE
[3.3] Add debug:twig & lint:twig commands from symfony/twig-bridge

### DIFF
--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -9,6 +9,7 @@ use LogicException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Bridge;
 
 class NutServiceProvider implements ServiceProviderInterface
 {
@@ -28,6 +29,9 @@ class NutServiceProvider implements ServiceProviderInterface
                 return $console;
             }
         );
+
+        $app['nut.command.twig_debug'] = $app->share(function () { return new Bridge\Twig\Command\DebugCommand(); });
+        $app['nut.command.twig_lint'] = $app->share(function () { return new Bridge\Twig\Command\LintCommand(); });
 
         $app['nut.commands'] = $app->share(
             function ($app) {
@@ -63,6 +67,8 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\DebugEvents($app),
                     new Nut\DebugServiceProviders($app),
                     new Nut\DebugRoutes($app),
+                    $app['nut.command.twig_debug'],
+                    $app['nut.command.twig_lint']
                 ];
             }
         );
@@ -120,5 +126,7 @@ class NutServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
+        $app['nut.command.twig_debug']->setTwigEnvironment($app['twig']);
+        $app['nut.command.twig_lint']->setTwigEnvironment($app['twig']);
     }
 }


### PR DESCRIPTION
Some more tools to help give insight to certain levels of front-enders

![lint twig](https://cloud.githubusercontent.com/assets/1427081/24948924/36142f8a-1f6c-11e7-8ec6-2a397699ab80.png)

```
$ ./app/nut debug:twig 

Functions
---------

 * asset(path, packageName = null, absolute = false, version = null)
 * url(name, parameters = [], schemeRelative = false)
 * widgets(location = null, zone = "frontend", wrapper = "widgetwrapper.twig")
 * … etc

Filters
-------

 * capitalize
 * current
 * date(format = null, timezone = null)
 * markdown
 * … etc

Tests
-----

 * constant
 * defined
 * … etc

Globals
-------

 * global = object(Symfony\Bridge\Twig\AppVariable)
 *  … etc
```