### PR TITLE
Bag and ImmutableBag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "symfony/intl": "^2.8",
         "symfony/monolog-bridge": "^2.8",
         "symfony/options-resolver": "^2.8",
+        "symfony/polyfill-php71": "^1.3",
         "symfony/process": "^2.8",
         "symfony/property-access": "^2.8",
         "symfony/routing": "^2.8",

--- a/src/Collection/Bag.php
+++ b/src/Collection/Bag.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Bolt\Collection;
+
+use Bolt\Helpers\Arr;
+
+/**
+ * This is an OO implementation of almost all of PHP's array functionality.
+ *
+ * Generally only methods dealing with a single item mutate the current bag,
+ * all others return a new bag.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Bag extends ImmutableBag
+{
+    /**
+     * Returns an immutable bag with the items from this bag.
+     *
+     * @return ImmutableBag
+     */
+    public function immutable()
+    {
+        return new ImmutableBag($this->items);
+    }
+
+    // region Mutating Methods
+
+    /**
+     * Adds an item to the end of this bag.
+     *
+     * @param mixed $item The item to append.
+     */
+    public function add($item)
+    {
+        $this->items[] = $item;
+    }
+
+    /**
+     * Adds an item to the beginning of this bag.
+     *
+     * @param mixed $item The item to prepend.
+     */
+    public function prepend($item)
+    {
+        array_unshift($this->items, $item);
+    }
+
+    /**
+     * Sets a item by key.
+     *
+     * @param string $key   The key
+     * @param mixed  $value The value
+     */
+    public function set($key, $value)
+    {
+        $this->items[$key] = $value;
+    }
+
+    /**
+     * Sets a value at the path given.
+     * Keys will be created as needed to set the value.
+     *
+     * This function does not support keys that contain "/" or "[]" characters
+     * because these are special tokens used when traversing the data structure.
+     * A value may be appended to an existing array by using "[]" as the final
+     * key of a path.
+     *
+     *     // Set an item at a nested structure.
+     *     setPath('foo/bar', 'color');
+     *
+     *     // Append to a list in a nested structure.
+     *     setPath('foo/baz/[]', 'a');
+     *     setPath('foo/baz/[]', 'b');
+     *     getPath('foo/baz'); // returns ['a', 'b']
+     *
+     * Note: To set values not directly under ArrayAccess objects their
+     * offsetGet() method needs to be defined as return by reference.
+     *
+     *     public function &offsetGet($offset) {}
+     *
+     * @param string $path  The path to traverse and set the value at
+     * @param mixed  $value The value to set
+     */
+    public function setPath($path, $value)
+    {
+        Arr::set($this->items, $path, $value);
+    }
+
+    /**
+     * Remove all items from bag.
+     */
+    public function clear()
+    {
+        $this->items = [];
+    }
+
+    /**
+     * Removes and returns the item at the specified key from the bag.
+     *
+     * @param string|integer $key     The kex of the item to remove.
+     * @param mixed|null     $default The default value to return if the key is not found.
+     *
+     * @return mixed The removed item or default, if the bag did not contain the item.
+     */
+    public function remove($key, $default = null)
+    {
+        if (!$this->has($key)) {
+            return $default;
+        }
+
+        $removed = $this->items[$key];
+        unset($this->items[$key]);
+
+        return $removed;
+    }
+
+    /**
+     * Removes the given item from the bag if it is found.
+     *
+     * @param mixed $item
+     */
+    public function removeItem($item)
+    {
+        $key = array_search($item, $this->items, true);
+
+        if ($key !== false) {
+            unset($this->items[$key]);
+        }
+    }
+
+    /**
+     * Removes and returns the first item in the list.
+     *
+     * @return mixed|null
+     */
+    public function removeFirst()
+    {
+        return array_shift($this->items);
+    }
+
+    /**
+     * Removes and returns the last item in the list.
+     *
+     * @return mixed|null
+     */
+    public function removeLast()
+    {
+        return array_pop($this->items);
+    }
+
+    // endregion
+
+    // region Internal Methods
+
+    /**
+     * Don't call directly. Used for ArrayAccess.
+     *
+     * @internal
+     *
+     * @inheritdoc
+     */
+    public function &offsetGet($offset)
+    {
+        $result = null;
+        if (isset($this->items[$offset])) {
+            $result = &$this->items[$offset];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Don't call directly. Used for ArrayAccess.
+     *
+     * @internal
+     *
+     * @inheritdoc
+     */
+    public function offsetSet($offset, $value)
+    {
+        if ($offset === null) {
+            $this->add($value);
+        } else {
+            $this->set($offset, $value);
+        }
+    }
+
+    /**
+     * Don't call directly. Used for ArrayAccess.
+     *
+     * @internal
+     *
+     * @inheritdoc
+     */
+    public function offsetUnset($offset)
+    {
+        $this->remove($offset);
+    }
+
+    // endregion
+}

--- a/src/Collection/ImmutableBag.php
+++ b/src/Collection/ImmutableBag.php
@@ -1,0 +1,781 @@
+<?php
+
+namespace Bolt\Collection;
+
+use ArrayAccess;
+use BadMethodCallException;
+use Bolt\Helpers\Arr;
+use Countable;
+use InvalidArgumentException;
+use IteratorAggregate;
+use RuntimeException;
+use stdClass;
+use Traversable;
+
+/**
+ * This is an OO implementation of almost all of PHP's array functionality.
+ *
+ * But there are no methods that allow the object to be mutated. All methods return a new bag.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class ImmutableBag implements ArrayAccess, Countable, IteratorAggregate
+{
+    /** @var array */
+    protected $items;
+
+    // region Creation / Unwrapping Methods
+
+    /**
+     * Constructor.
+     *
+     * @param array $items
+     */
+    public function __construct(array $items = [])
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * Create a bag from a variety of collections.
+     *
+     * @param Traversable|array|stdClass|mixed|null $collection
+     *
+     * @return static
+     */
+    public static function from($collection)
+    {
+        return new static(static::normalize($collection));
+    }
+
+    /**
+     * Takes the items and recursively converts them to Bags.
+     *
+     * @param Traversable|array|stdClass|mixed|null $collection
+     *
+     * @return static
+     */
+    public static function fromRecursive($collection = [])
+    {
+        return static::convertToCollection($collection);
+    }
+
+    /**
+     * Creates a bag by using one collection for keys and another for its values.
+     *
+     * @param Traversable|array $keys
+     * @param Traversable|array $values
+     *
+     * @return static
+     */
+    public static function combine($keys, $values)
+    {
+        $keys = static::normalize($keys);
+        $values = static::normalize($values);
+        if (count($keys) !== count($values)) {
+            throw new InvalidArgumentException('The size of keys and values needs to be the same.');
+        } elseif (count($keys) === 0) {
+            return new static();
+        }
+
+        return new static(array_combine($keys, $values));
+    }
+
+    /**
+     * Returns the array of items.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Returns the items recursively converting them to arrays.
+     *
+     * @return array
+     */
+    public function toArrayRecursive()
+    {
+        return static::convertToCollection($this->items, false);
+    }
+
+    /**
+     * Creates a new instance from the specified items.
+     *
+     * This method is provided for derived classes to specify how a new
+     * instance should be created when constructor semantics have changed.
+     *
+     * @param array $items
+     *
+     * @return static
+     */
+    protected function createFrom(array $items)
+    {
+        return new static($items);
+    }
+
+    /**
+     * Normalize input to an array
+     *
+     * @param Traversable|array|stdClass $collection
+     *
+     * @return array
+     */
+    protected static function normalize($collection)
+    {
+        if ($collection instanceof static) {
+            return $collection->toArray();
+        } elseif ($collection instanceof Traversable) {
+            return iterator_to_array($collection, true);
+        } elseif ($collection === null) {
+            return [];
+        } elseif ($collection instanceof stdClass) {
+            return get_object_vars($collection);
+        } elseif (is_array($collection)) {
+            return $collection;
+        } else {
+            return [$collection];
+        }
+    }
+
+    /**
+     * Recursively converts $data to an array or a bag.
+     *
+     * @param Traversable|array|stdClass $data The collection to convert
+     * @param bool                       $bag  Whether to return a bag or an array
+     *
+     * @return static|array
+     */
+    protected static function convertToCollection($data, $bag = true)
+    {
+        $collection = [];
+        foreach ($data as $key => $value) {
+            if ($value instanceof stdClass || is_iterable($value)) {
+                $value = static::convertToCollection($value, $bag);
+            }
+            $collection[$key] = $value;
+        }
+
+        if (!$bag) {
+            /** @noinspection PhpIncompatibleReturnTypeInspection */
+            return $collection;
+        }
+        return new static($collection);
+    }
+
+    // endregion
+
+    // region Methods returning a single value
+
+    /**
+     * Returns whether an item exists for the given key.
+     *
+     * @param string $key The key
+     *
+     * @return bool
+     */
+    public function has($key)
+    {
+        return isset($this->items[$key]) || array_key_exists($key, $this->items);
+    }
+
+    /**
+     * Returns whether an item exists for the key defined by the given path.
+     *
+     *     hasPath('foo/bar/baz') // true
+     *
+     * This method does not allow for keys that contain "/".
+     *
+     * @param string $path The path to traverse and check keys from
+     *
+     * @return bool
+     */
+    public function hasPath($path)
+    {
+        return Arr::has($this->items, $path);
+    }
+
+    /**
+     * Returns true if the item is in the bag.
+     *
+     * @param mixed $item
+     *
+     * @return bool
+     */
+    public function hasItem($item)
+    {
+        return in_array($item, $this->items, true);
+    }
+
+    /**
+     * Returns an item by its key.
+     *
+     * @param string $key     The key
+     * @param mixed  $default The default value if the key does not exist
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        return (isset($this->items[$key]) || array_key_exists($key, $this->items)) ? $this->items[$key] : $default;
+    }
+
+    /**
+     * Returns an item using a path syntax to retrieve nested data.
+     *
+     *     getPath('foo/bar/baz') // baz item
+     *
+     * This method does not allow for keys that contain "/".
+     *
+     * @param string $path    The path to traverse and retrieve an item from
+     * @param mixed  $default The default value if the key does not exist
+     *
+     * @return mixed
+     */
+    public function getPath($path, $default = null)
+    {
+        return Arr::get($this->items, $path, $default);
+    }
+
+    /**
+     * Returns the number of items in this bag.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->items);
+    }
+
+    /**
+     * Checks whether the bag is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return !$this->items;
+    }
+
+    /**
+     * Gets the index/key of a given item. The comparison of two items is strict,
+     * that means not only the value but also the type must match.
+     * For objects this means reference equality.
+     *
+     * @param mixed $item The item to search for.
+     *
+     * @return int|string|false The index or key of the item or false if the item was not found.
+     */
+    public function indexOf($item)
+    {
+        return array_search($item, $this->items, true);
+    }
+
+    /**
+     * Returns the first item in the list.
+     *
+     * @return mixed
+     */
+    public function first()
+    {
+        return reset($this->items);
+    }
+
+    /**
+     * Returns the last item in the list.
+     *
+     * @return mixed
+     */
+    public function last()
+    {
+        return end($this->items);
+    }
+
+    /**
+     * Joins the list to a string.
+     *
+     * @param string $separator The term to join on
+     *
+     * @return string A string representation of all the items with the separator between them.
+     */
+    public function join($separator)
+    {
+        return implode($separator, $this->items);
+    }
+
+    /**
+     * Returns the sum of the values in this list.
+     *
+     * @return number
+     */
+    public function sum()
+    {
+        return array_sum($this->items);
+    }
+
+    /**
+     * Returns the product of the values in this list.
+     *
+     * @return number
+     */
+    public function product()
+    {
+        return array_product($this->items);
+    }
+
+    /**
+     * Returns whether the items in this bag are key/value pairs.
+     *
+     * Note: Empty bags are not.
+     *
+     * @return bool
+     */
+    public function isAssociative()
+    {
+        return Arr::isAssociative($this->items);
+    }
+
+    /**
+     * Returns whether the items in this bag are zero indexed and sequential.
+     *
+     * Note: Empty bags are.
+     *
+     * @return bool
+     */
+    public function isIndexed()
+    {
+        return !$this->isAssociative();
+    }
+
+    // endregion
+
+    // region Methods returning a new bag
+
+    /**
+     * Returns a mutable bag with the items from this bag.
+     *
+     * @return Bag
+     */
+    public function mutable()
+    {
+        return new Bag($this->items);
+    }
+
+    /**
+     * Returns a bag with all the keys of the items.
+     *
+     * @return static
+     */
+    public function keys()
+    {
+        return $this->createFrom(array_keys($this->items));
+    }
+
+    /**
+     * Returns a bag with all the values of the items.
+     *
+     * Useful for reindexing a list.
+     *
+     * @return static
+     */
+    public function values()
+    {
+        return $this->createFrom(array_values($this->items));
+    }
+
+    /**
+     * Applies the given function to each item in the bag and returns
+     * a new bag with the items returned by the function.
+     *
+     * Note: This differs from array_map in that the callback is passed $key first, then $value.
+     *
+     * @param callable $callback Function is passed (key, value).
+     *
+     * @return static
+     */
+    public function map(callable $callback)
+    {
+        $items = [];
+
+        foreach ($this->items as $key => $value) {
+            $items[$key] = $callback($key, $value);
+        }
+
+        return $this->createFrom($items);
+    }
+
+    /**
+     * Applies the given function to each _key_ in the bag and returns
+     * a new bag with the keys returned by the function and their values.
+     *
+     * @param callable $callback Function is passed (key, value).
+     *
+     * @return static
+     */
+    public function mapKeys(callable $callback)
+    {
+        $items = [];
+
+        foreach ($this->items as $key => $value) {
+            $items[$callback($key, $value)] = $value;
+        }
+
+        return $this->createFrom($items);
+    }
+
+    /**
+     * Returns a bag with the items that satisfy the predicate $callback.
+     *
+     * Keys are preserved, so lists could need to be re-indexed.
+     *
+     * Note: This differs from array_filter in that the callback is passed $key first, then $value.
+     *
+     * @param callable $callback The predicate used for filtering. Function is passed (key, value).
+     *
+     * @return static
+     */
+    public function filter(callable $callback)
+    {
+        $items = [];
+
+        foreach ($this->items as $key => $value) {
+            if ($callback($key, $value)) {
+                $items[$key] = $value;
+            }
+        }
+
+        return $this->createFrom($items);
+    }
+
+    /**
+     * Returns a bag with falsely values filtered out.
+     *
+     * @return static
+     */
+    public function clean()
+    {
+        return $this->createFrom(array_filter($this->items));
+    }
+
+    /**
+     * Replaces items in this bag from the given collection by comparing keys and returns the result.
+     *
+     * @param Traversable|array $collection The collection from which items will be extracted.
+     *
+     * @return static
+     */
+    public function replace($collection)
+    {
+        return $this->createFrom(array_replace($this->items, static::normalize($collection)));
+    }
+
+    /**
+     * Returns a bag with the items replaced recursively from the given collection.
+     *
+     * This differs from {@see array_replace_recursive} in a couple ways:
+     *  - Lists (zero indexed and sequential items) from given collection completely replace lists in this Bag.
+     *  - Null values from given collection do not replace lists or associative arrays in this Bag
+     *    (they do still replace scalar values).
+     *
+     * @param Traversable|array $collection The collection from which items will be extracted.
+     *
+     * @return static
+     */
+    public function replaceRecursive($collection)
+    {
+        return $this->createFrom(Arr::replaceRecursive($this->items, static::normalize($collection)));
+    }
+
+    /**
+     * Returns a bag with the items from the given collection added to the items in this bag
+     * if they do not already exist by comparing keys. The opposite of replace().
+     *
+     * @param Traversable|array $collection The collection from which items will be extracted.
+     *
+     * @return static
+     */
+    public function defaults($collection)
+    {
+        return $this->createFrom(array_replace(static::normalize($collection), $this->items));
+    }
+
+    /**
+     * Returns a bag with the items from the given collection recursively added to the items in this bag
+     * if they do not already exist by comparing keys. The opposite of replaceRecursive().
+     *
+     * @param Traversable|array $collection The collection from which items will be extracted.
+     *
+     * @return static
+     */
+    public function defaultsRecursive($collection)
+    {
+        return $this->createFrom(Arr::replaceRecursive(static::normalize($collection), $this->items));
+    }
+
+    /**
+     * Returns a bag with the items merged with the given list.
+     *
+     * Note: This should only be used for lists (zero indexed and sequential items).
+     * For associative arrays, use replace instead.
+     *
+     * @param Traversable|array $list The list of items to merge.
+     *
+     * @return static
+     */
+    public function merge($list)
+    {
+        return $this->createFrom(array_merge($this->items, static::normalize($list)));
+    }
+
+    /**
+     * Returns a bag with a slice of $length items starting at position $offset extracted from this bag.
+     *
+     * @param int      $offset       If positive, the offset to start from.
+     *                               If negative, the bag will start that far from the end of the list.
+     * @param int|null $length       If positive, the maximum number of items to return.
+     *                               If negative, the bag will stop that far from the end of the list.
+     *                               If null, the bag will have everything from the $offset to the end of the list.
+     * @param bool     $preserveKeys Whether to preserve keys in the resulting bag or not.
+     *
+     * @return static
+     */
+    public function slice($offset, $length = null, $preserveKeys = false)
+    {
+        return $this->createFrom(array_slice($this->items, $offset, $length, $preserveKeys));
+    }
+
+    /**
+     * Partitions the items into two bags according to the callback function.
+     * Keys are preserved in the resulting bags.
+     *
+     *     [$trueItems, $falseItems] = $bag->partition(function ($key, $item) {
+     *         return true; // whatever logic
+     *     });
+     *
+     * @param callable $callback The function is passed (key, value) and should return a boolean.
+     *
+     * @return static[] [true bag, false bag]
+     */
+    public function partition(callable $callback)
+    {
+        $coll1 = $coll2 = [];
+
+        foreach ($this->items as $key => $item) {
+            if ($callback($key, $item)) {
+                $coll1[$key] = $item;
+            } else {
+                $coll2[$key] = $item;
+            }
+        }
+
+        return [$this->createFrom($coll1), $this->createFrom($coll2)];
+    }
+
+    /**
+     * Returns a bag with the values from a single column, identified by the $columnKey.
+     *
+     * Optionally, an $indexKey may be provided to index the values in the
+     * returned Bag by the values from the $indexKey column.
+     *
+     * @param string      $columnKey Column of values to return.
+     * @param string|null $indexKey  Column to use as the index/keys for the returned items.
+     *
+     * @return static
+     */
+    public function column($columnKey, $indexKey = null)
+    {
+        return $this->createFrom(Arr::column($this->items, $columnKey, $indexKey));
+    }
+
+    /**
+     * Returns a bag with all keys exchanged with their associated values.
+     *
+     * If a value has several occurrences, the latest key will be used as its value, and all others will be lost.
+     *
+     * @return static
+     *
+     * @throws RuntimeException when flip fails
+     */
+    public function flip()
+    {
+        $arr = array_flip($this->items);
+        if (!$arr) {
+            throw new RuntimeException('Failed to flip the items.');
+        }
+
+        return $this->createFrom($arr);
+    }
+
+    /**
+     * Iteratively reduce the items to a single value using a callback function.
+     *
+     * @param callable $callback Function is passed $carry (previous or initial value)
+     *                           and $item (value of the current iteration).
+     * @param mixed    $initial  Initial value
+     *
+     * @return mixed The resulting value or the initial value if list is empty.
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        return array_reduce($this->items, $callback, $initial);
+    }
+
+    /**
+     * Returns a bag with duplicate values removed.
+     *
+     * @return static
+     */
+    public function unique()
+    {
+        $items = [];
+
+        foreach ($this->items as $item) {
+            if (array_search($item, $items, true) === false) {
+                $items[] = $item;
+            }
+        }
+
+        return $this->createFrom($items);
+    }
+
+    /**
+     * Returns a bag with the items split into chunks.
+     *
+     * The last chunk may contain less items.
+     *
+     *     $bag = new Bag([1, 2, 3, 4, 5]);
+     *     $bag->chunk(2); // returns [[1, 2], [3, 4], [5]] but as bags not arrays.
+     *
+     * @param int  $size         The size of each chunk
+     * @param bool $preserveKeys When set to TRUE keys will be preserved. Default is FALSE which will reindex
+     *                           the chunk numerically.
+     *
+     * @return static|static[] Returns a multidimensional bag, with each dimension containing $size items
+     */
+    public function chunk($size, $preserveKeys = false)
+    {
+        $create = function ($items) {
+            return $this->createFrom($items);
+        };
+        return $this->createFrom(array_map($create, array_chunk($this->items, $size, $preserveKeys)));
+    }
+
+    // endregion
+
+    // region Sorting Methods
+
+    /**
+     * Returns a bag with the items reversed.
+     *
+     * @param bool $preserveKeys If true numeric keys are preserved. Non-numeric keys are always preserved.
+     *
+     * @return static
+     */
+    public function reverse($preserveKeys = false)
+    {
+        return $this->createFrom(array_reverse($this->items, $preserveKeys));
+    }
+
+    /**
+     * Returns a bag with the items shuffled.
+     *
+     * @return static
+     */
+    public function shuffle()
+    {
+        $items = $this->items;
+
+        shuffle($items);
+
+        return $this->createFrom($items);
+    }
+
+    //endregion
+
+    // region Internal Methods
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->items);
+    }
+
+    /**
+     * Don't call directly. Used for ArrayAccess.
+     *
+     * @internal
+     *
+     * @inheritdoc
+     */
+    public function offsetExists($offset)
+    {
+        return $this->has($offset);
+    }
+
+    /**
+     * Don't call directly. Used for ArrayAccess.
+     *
+     * @internal
+     *
+     * @inheritdoc
+     */
+    public function offsetGet($offset)
+    {
+        return $this->get($offset);
+    }
+
+    /**
+     * Don't call directly. Used for ArrayAccess.
+     *
+     * @internal
+     *
+     * @inheritdoc
+     */
+    public function offsetSet($offset, $value)
+    {
+        throw new BadMethodCallException('Cannot modify items on an ' . __CLASS__);
+    }
+
+    /**
+     * Don't call directly. Used for ArrayAccess.
+     *
+     * @internal
+     *
+     * @inheritdoc
+     */
+    public function offsetUnset($offset)
+    {
+        throw new BadMethodCallException('Cannot remove items from an ' . __CLASS__);
+    }
+
+    /**
+     * Don't call directly. Used for debugging.
+     *
+     * @internal
+     */
+    public function __debugInfo()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Don't call directly. Used for debugging.
+     *
+     * xdebug needs this to be able to display nested items properly.
+     * For example: We say this bag has a "foo" key, so xdebug does `$this->foo`.
+     *
+     * @internal
+     *
+     * @inheritdoc
+     */
+    public function __get($key)
+    {
+        return $this->get($key);
+    }
+
+    // endregion
+}

--- a/src/Config.php
+++ b/src/Config.php
@@ -178,27 +178,7 @@ class Config
      */
     public function set($path, $value)
     {
-        $path = explode('/', $path);
-
-        // Only do something if we get at least one key.
-        if (empty($path[0])) {
-            $logline = "Config: can't set empty path to '" . (string) $value . "'";
-            $this->app['logger.system']->critical($logline, ['event' => 'config']);
-
-            return false;
-        }
-
-        $part = & $this->data;
-
-        foreach ($path as $key) {
-            if (!isset($part[$key])) {
-                $part[$key] = [];
-            }
-
-            $part = & $part[$key];
-        }
-
-        $part = $value;
+        Arr::set($this->data, $path, $value);
 
         return true;
     }
@@ -216,30 +196,7 @@ class Config
      */
     public function get($path, $default = null)
     {
-        $path = explode('/', $path);
-
-        // Only do something if we get at least one key.
-        if (empty($path[0]) || !isset($this->data[$path[0]])) {
-            return false;
-        }
-
-        $part = & $this->data;
-        $value = null;
-
-        foreach ($path as $key) {
-            if (!isset($part[$key])) {
-                $value = null;
-                break;
-            }
-
-            $value = $part[$key];
-            $part = & $part[$key];
-        }
-        if ($value !== null) {
-            return $value;
-        }
-
-        return $default;
+        return Arr::get($this->data, $path, $default);
     }
 
     /**

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -5,6 +5,7 @@ namespace Bolt\Helpers;
 use ArrayAccess;
 use InvalidArgumentException;
 use RuntimeException;
+use Traversable;
 use Webmozart\Assert\Assert;
 
 class Arr
@@ -44,13 +45,13 @@ class Arr
      *
      * Note: Empty arrays are.
      *
-     * @param array $array
+     * @param Traversable|array $array
      *
      * @return bool
      */
     public static function isIndexed($array)
     {
-        if (!is_array($array)) {
+        if (!is_iterable($array)) {
             return false;
         }
 
@@ -62,12 +63,15 @@ class Arr
      *
      * Note: Empty arrays are not.
      *
-     * @param array $array
+     * @param Traversable|array  $array
      *
      * @return bool
      */
     public static function isAssociative($array)
     {
+        if ($array instanceof Traversable) {
+            $array = iterator_to_array($array);
+        }
         if (!is_array($array) || $array === []) {
             return false;
         }

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -2,6 +2,11 @@
 
 namespace Bolt\Helpers;
 
+use ArrayAccess;
+use InvalidArgumentException;
+use RuntimeException;
+use Webmozart\Assert\Assert;
+
 class Arr
 {
     /**
@@ -68,6 +73,175 @@ class Arr
         }
 
         return array_keys($array) !== range(0, count($array) - 1);
+    }
+
+    /**
+     * Returns whether a key exists from an array (or ArrayAccess object) using a path syntax to retrieve nested data.
+     *
+     * This method does not allow for keys that contain "/". You must traverse
+     * the array manually or using something more advanced like JMESPath to
+     * work with keys that contain "/".
+     *
+     *     // Check if the the bar key of a set of nested arrays exists.
+     *     // This is equivalent to isset($data['foo']['baz']['bar']) but won't
+     *     // throw warnings for missing keys.
+     *     has($data, 'foo/baz/bar');
+     *
+     * Note: isset() with nested data, `isset($data['a']['b'])`, won't call offsetExists for 'a'.
+     * It calls offsetGet('a') and if 'a' doesn't exist and an isset isn't done in offsetGet, a warning is thrown.
+     * It could be argued that that ArrayAccess object should fix its implementation of offsetGet, and I would agree.
+     * But I think this can have nicer syntax.
+     *
+     * @param array|ArrayAccess $data Data to check values from
+     * @param string            $path Path to traverse and check keys from
+     *
+     * @return bool
+     */
+    public static function has($data, $path)
+    {
+        static::assertArrayAccessible($data);
+        Assert::stringNotEmpty($path);
+
+        $path = explode('/', $path);
+
+        while (null !== ($part = array_shift($path))) {
+            if (!($data instanceof ArrayAccess) && !is_array($data)) {
+                return false;
+            }
+            if (!(isset($data[$part]) || array_key_exists($part, $data))) {
+                return false;
+            }
+            $data = $data[$part];
+        }
+
+        return true;
+    }
+
+    /**
+     * Gets a value from an array (or ArrayAccess object) using a path syntax to retrieve nested data.
+     *
+     * This method does not allow for keys that contain "/". You must traverse
+     * the array manually or using something more advanced like JMESPath to
+     * work with keys that contain "/".
+     *
+     *     // Get the bar key of a set of nested arrays.
+     *     // This is equivalent to $data['foo']['baz']['bar'] but won't
+     *     // throw warnings for missing keys.
+     *     get($data, 'foo/baz/bar');
+     *
+     * This code is adapted from Michael Dowling in his Guzzle library.
+     *
+     * @param array|ArrayAccess $data    Data to retrieve values from
+     * @param string            $path    Path to traverse and retrieve a value from
+     * @param mixed|null        $default Default value to return if key does not exist
+     *
+     * @return mixed|null
+     */
+    public static function get($data, $path, $default = null)
+    {
+        static::assertArrayAccessible($data);
+        Assert::stringNotEmpty($path);
+
+        $path = explode('/', $path);
+
+        while (null !== ($part = array_shift($path))) {
+            if ((!is_array($data) && !($data instanceof ArrayAccess)) || !isset($data[$part])) {
+                return $default;
+            }
+            $data = $data[$part];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Set a value in a nested array (or ArrayAccess object) key.
+     * Keys will be created as needed to set the value.
+     *
+     * This function does not support keys that contain "/" or "[]" characters
+     * because these are special tokens used when traversing the data structure.
+     * A value may be appended to an existing array by using "[]" as the final
+     * key of a path.
+     *
+     *     get($data, 'foo/baz'); // null
+     *     set($data, 'foo/baz/[]', 'a');
+     *     set($data, 'foo/baz/[]', 'b');
+     *     get($data, 'foo/baz');
+     *     // Returns ['a', 'b']
+     *
+     * Note: To set values not directly under ArrayAccess objects their
+     * offsetGet() method needs to be defined as return by reference.
+     *
+     *     public function &offsetGet($offset) {}
+     *
+     * This code is adapted from Michael Dowling in his Guzzle library.
+     *
+     * @param array|ArrayAccess $data  Data to modify by reference
+     * @param string            $path  Path to set
+     * @param mixed             $value Value to set at the key
+     *
+     * @throws \RuntimeException when trying to set using a nested path
+     *     that travels through a scalar value or an object whose
+     *     offsetGet method isn't marked as return by reference.
+     */
+    public static function set(&$data, $path, $value)
+    {
+        static::assertArrayAccessible($data);
+        Assert::stringNotEmpty($path);
+
+        $queue = explode('/', $path);
+        // Optimization for simple sets.
+        if (count($queue) === 1) {
+            if ($path === '[]') {
+                $data[] = $value;
+            } else {
+                $data[$path] = $value;
+            }
+            return;
+        }
+
+        $invalidKey = []; // array so it can be modified after being passed by reference to error handler closure.
+        $prev = set_error_handler('var_dump');
+        restore_error_handler();
+        set_error_handler(function ($type, $message, $file, $line) use ($prev, $path, &$invalidKey) {
+            $regex = '/Indirect modification of overloaded element of ([\w\\\\]+) has no effect/';
+            if (preg_match($regex, $message, $matches)) {
+                throw new RuntimeException(
+                    "Cannot to set \"$path\", because \"{$invalidKey['key']}\" is an {$matches[1]} which has not " .
+                    "defined its offsetGet() method as return by reference."
+                );
+            } elseif ($prev) {
+                return call_user_func($prev, $type, $message, $file, $line);
+            } else {
+                // return false to let PHP handle error
+                return false;
+            }
+        });
+        try {
+            $current =& $data;
+            while (null !== ($key = array_shift($queue))) {
+                if (!is_array($current) && !($current instanceof ArrayAccess)) {
+                    throw new RuntimeException(
+                        "Cannot set \"$path\", because \"{$invalidKey['key']}\" is already set and not an array " .
+                        "or an object implementing ArrayAccess."
+                    );
+                } elseif (!$queue) {
+                    if ($key === '[]') {
+                        $current[] = $value;
+                    } else {
+                        $current[$key] = $value;
+                    }
+                } elseif (isset($current[$key])) {
+                    $current =& $current[$key];
+                } else {
+                    $current[$key] = [];
+                    $current =& $current[$key];
+                }
+                $invalidKey['key'] = $key;
+            }
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**
@@ -165,6 +339,16 @@ class Arr
         }
 
         return $result;
+    }
+
+    protected static function assertArrayAccessible($value)
+    {
+        if (!is_array($value) && !($value instanceof ArrayAccess)) {
+            throw new InvalidArgumentException(
+                'Expected an array or an object implementing ArrayAccess. Got: ' .
+                (is_object($value) ? get_class($value) : gettype($value))
+            );
+        }
     }
 
     /**

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -18,19 +18,37 @@ class Arr
      *  - Null values from second array do not replace lists or associative arrays in first
      *    (they do still replace scalar values).
      *
-     * @param array $array1
-     * @param array $array2
+     * This method converts all traversable objects at any level to arrays in the return value.
+     *
+     * @param Traversable|array $array1
+     * @param Traversable|array $array2
      *
      * @return array The combined array
      */
-    public static function replaceRecursive(array $array1, array $array2)
+    public static function replaceRecursive($array1, $array2)
     {
+        Assert::allIsTraversable([$array1, $array2]);
+
+        if ($array1 instanceof Traversable) {
+            $array1 = iterator_to_array($array1);
+        }
+        if ($array2 instanceof Traversable) {
+            $array2 = iterator_to_array($array2);
+        }
+
         $merged = $array1;
 
         foreach ($array2 as $key => $value) {
-            if (is_array($value) && static::isAssociative($value) && isset($merged[$key]) && is_array($merged[$key])) {
+            if ($value instanceof Traversable) {
+                $value = iterator_to_array($value);
+            }
+            if (is_array($value) && static::isAssociative($value) && isset($merged[$key]) && is_iterable($merged[$key])) {
                 $merged[$key] = static::replaceRecursive($merged[$key], $value);
-            } elseif ($value === null && isset($merged[$key]) && is_array($merged[$key])) {
+            } elseif ($value === null && isset($merged[$key]) && is_iterable($merged[$key])) {
+                // Convert iterable to array to be consistent.
+                if ($merged[$key] instanceof Traversable) {
+                    $merged[$key] = iterator_to_array($merged[$key]);
+                }
                 continue;
             } else {
                 $merged[$key] = $value;

--- a/tests/phpunit/unit/Collection/BagTest.php
+++ b/tests/phpunit/unit/Collection/BagTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Bolt\Tests\Collection;
+
+use ArrayObject;
+use Bolt\Collection\Bag;
+use Bolt\Collection\ImmutableBag;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class BagTest extends TestCase
+{
+    public function testImmutable()
+    {
+        $bag = new Bag(['foo', 'bar']);
+
+        $immutable = $bag->immutable();
+
+        $this->assertNotSame($bag, $immutable);
+        $this->assertInstanceOf(ImmutableBag::class, $immutable);
+        $this->assertEquals(['foo', 'bar'], $immutable->toArray());
+    }
+
+    public function testAdd()
+    {
+        $bag = new Bag();
+
+        $bag->add('foo');
+        $bag->add('bar');
+
+        $this->assertEquals(['foo', 'bar'], $bag->toArray());
+    }
+
+    public function testPrepend()
+    {
+        $bag = new Bag();
+
+        $bag->prepend('foo');
+        $bag->prepend('bar');
+
+        $this->assertEquals(['bar', 'foo'], $bag->toArray());
+    }
+
+    public function testSet()
+    {
+        $bag = new Bag();
+
+        $bag->set('foo', 'bar');
+
+        $this->assertEquals(['foo' => 'bar'], $bag->toArray());
+    }
+
+    public function testSetPath()
+    {
+        $bag = new Bag([
+            'items' => new ArrayObject([
+                'foo' => 'bar',
+            ]),
+        ]);
+
+        $bag->setPath('items/hello', 'world');
+        $bag->setPath('items/colors/[]', 'red');
+        $bag->setPath('items/colors/[]', 'blue');
+
+        $this->assertEquals('world', $bag->getPath('items/hello'));
+
+        $this->assertEquals(['red', 'blue'], $bag->getPath('items/colors'));
+    }
+
+    public function testClear()
+    {
+        $bag = new Bag(['foo', 'bar']);
+
+        $bag->clear();
+
+        $this->assertTrue($bag->isEmpty());
+    }
+
+    public function testRemove()
+    {
+        $bag = new Bag(['foo' => 'bar']);
+
+        $this->assertEquals('bar', $bag->remove('foo'));
+        $this->assertFalse($bag->has('foo'));
+
+        $this->assertNull($bag->remove('derp'));
+        $this->assertEquals('default', $bag->remove('derp', 'default'));
+    }
+
+    public function testRemoveItem()
+    {
+        $bag = new Bag(['foo', 'bar']);
+
+        $bag->removeItem('bar');
+
+        $this->assertFalse($bag->hasItem('bar'));
+    }
+
+    public function testRemoveFirst()
+    {
+        $bag = new Bag(['foo', 'bar']);
+
+        $this->assertEquals('foo', $bag->removeFirst());
+        $this->assertEquals('bar', $bag->removeFirst());
+        $this->assertNull($bag->removeFirst());
+        $this->assertTrue($bag->isEmpty());
+    }
+
+    public function testRemoveLast()
+    {
+        $bag = new Bag(['foo', 'bar']);
+
+        $this->assertEquals('bar', $bag->removeLast());
+        $this->assertEquals('foo', $bag->removeLast());
+        $this->assertNull($bag->removeFirst());
+        $this->assertTrue($bag->isEmpty());
+    }
+
+    // region Internal Methods
+
+    public function testOffsetGet()
+    {
+        $bag = new Bag(['foo' => 'bar']);
+
+        $this->assertEquals('bar', $bag['foo']);
+        $this->assertNull($bag['nope']);
+    }
+
+    public function testOffsetGetModifyByReference()
+    {
+        $bag = new Bag(['arr' => ['1']]);
+
+        // Assert arrays are not able to be modified by reference.
+        $errors = new \ArrayObject();
+        set_error_handler(function ($type, $message) use ($errors) {
+            $errors[] = [$type, $message];
+        });
+
+        $arr = &$bag['arr'];
+        $arr[] = '2';
+
+        restore_error_handler();
+        $this->assertEmpty($errors->getArrayCopy());
+
+        $this->assertEquals(['1', '2'], $bag['arr']);
+    }
+
+    public function testOffsetSet()
+    {
+        $bag = new Bag();
+
+        $bag['foo'] = 'bar';
+        $bag[] = 'hello';
+        $bag[] = 'world';
+
+        $this->assertEquals('bar', $bag['foo']);
+        $this->assertEquals('hello', $bag[0]);
+        $this->assertEquals('world', $bag[1]);
+    }
+
+    public function testOffsetUnset()
+    {
+        $bag = new Bag(['foo' => 'bar']);
+
+        unset($bag['foo']);
+
+        $this->assertFalse($bag->has('foo'));
+    }
+
+    // endregion
+}

--- a/tests/phpunit/unit/Collection/ImmutableBagTest.php
+++ b/tests/phpunit/unit/Collection/ImmutableBagTest.php
@@ -1,0 +1,643 @@
+<?php
+
+namespace Bolt\Tests\Collection;
+
+use ArrayObject;
+use Bolt\Collection\Bag;
+use Bolt\Collection\ImmutableBag;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ImmutableBagTest extends TestCase
+{
+    // region Creation / Unwrapping Methods
+
+    public function provideFromAndToArray()
+    {
+        return [
+            'bag'         => [new ImmutableBag(['foo' => 'bar'])],
+            'traversable' => [new ArrayObject(['foo' => 'bar'])],
+            'null'        => [null, []],
+            'stdClass'    => [json_decode(json_encode(['foo' => 'bar']))],
+            'array'       => [['foo' => 'bar']],
+            'mixed'       => ['derp', ['derp']],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFromAndToArray
+     *
+     * @param mixed $input
+     * @param array $output
+     */
+    public function testFromAndToArray($input, $output = ['foo' => 'bar'])
+    {
+        $actual = ImmutableBag::from($input)->toArray();
+        $this->assertSame($output, $actual);
+    }
+
+    public function testFromRecursive()
+    {
+        $a = [
+            'foo' => 'bar',
+            'items' => new ArrayObject(['hello' => 'world']),
+            'std class' => json_decode(json_encode([
+                'why use' => 'these',
+            ])),
+        ];
+
+        $bag = ImmutableBag::fromRecursive($a);
+
+        $bagArr = $bag->toArray();
+        $this->assertEquals('bar', $bagArr['foo']);
+
+        $this->assertInstanceOf(ImmutableBag::class, $bagArr['items']);
+        /** @var ImmutableBag $items */
+        $items = $bagArr['items'];
+        $this->assertEquals(['hello' => 'world'], $items->toArray());
+
+        $this->assertInstanceOf(ImmutableBag::class, $bagArr['std class']);
+        /** @var ImmutableBag $stdClass */
+        $stdClass = $bagArr['std class'];
+        $this->assertEquals(['why use' => 'these'], $stdClass->toArray());
+    }
+
+    public function testToArrayRecursive()
+    {
+        $bag = new ImmutableBag([
+            'foo' => 'bar',
+            'colors' => new ImmutableBag(['red', 'blue']),
+            'array' => ['hello', 'world'],
+        ]);
+        $expected = [
+            'foo' => 'bar',
+            'colors' => ['red', 'blue'],
+            'array' => ['hello', 'world'],
+        ];
+
+        $arr = $bag->toArrayRecursive();
+
+        $this->assertEquals($expected, $arr);
+    }
+
+    public function testCombine()
+    {
+        $actual = ImmutableBag::combine(['red', 'green'], ['bad', 'good'])->toArray();
+        $expected = [
+            'red' => 'bad',
+            'green' => 'good',
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testCombineEmpty()
+    {
+        $actual = ImmutableBag::combine([], [])->toArray();
+
+        $this->assertEquals([], $actual);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCombineDifferentSizes()
+    {
+        ImmutableBag::combine(['derp'], ['wait', 'wut']);
+    }
+
+    // endregion
+
+    // region Methods returning a single value
+
+    public function testHas()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar', 'null' => null]);
+
+        $this->assertTrue($bag->has('foo'));
+        $this->assertTrue($bag->has('null'));
+
+        $this->assertFalse($bag->has('derp'));
+    }
+
+    public function testHasPath()
+    {
+        $bag = new ImmutableBag([
+            'items' => new ArrayObject([
+                'foo' => 'bar',
+            ]),
+        ]);
+
+        $this->assertTrue($bag->hasPath('items/foo'));
+
+        $this->assertFalse($bag->hasPath('items/derp'));
+        $this->assertFalse($bag->hasPath('derp'));
+    }
+
+    public function testHasItem()
+    {
+        $foo = new ArrayObject();
+        $bag = new ImmutableBag([
+            'foo' => 'bar',
+            'items' => $foo,
+        ]);
+
+        $this->assertTrue($bag->hasItem('bar'));
+        $this->assertTrue($bag->hasItem($foo));
+
+        $this->assertFalse($bag->hasItem('derp'));
+    }
+
+    public function testGet()
+    {
+        $bag = new ImmutableBag([
+            'foo' => 'bar',
+            'null' => null,
+        ]);
+
+        $this->assertEquals('bar', $bag->get('foo'));
+        $this->assertNull($bag->get('null', 'default'));
+        $this->assertEquals('default', $bag->get('derp', 'default'));
+    }
+
+    public function testGetPath()
+    {
+        $bag = new ImmutableBag([
+            'items' => new ArrayObject([
+                'foo' => 'bar',
+            ]),
+        ]);
+
+        $this->assertEquals('bar', $bag->getPath('items/foo'));
+
+        $this->assertNull($bag->getPath('derp/derp'));
+        $this->assertEquals('default', $bag->getPath('derp/derp', 'default'));
+    }
+
+    public function testCount()
+    {
+        $bag = new ImmutableBag(['foo', 'bar']);
+
+        $this->assertEquals(2, count($bag));
+    }
+
+    public function testEmpty()
+    {
+        $bag = new ImmutableBag(['foo', 'bar']);
+        $this->assertFalse($bag->isEmpty());
+
+        $empty = new ImmutableBag();
+        $this->assertTrue($empty->isEmpty());
+    }
+
+    public function testFirst()
+    {
+        $bag = new ImmutableBag(['first', 'second']);
+        $this->assertEquals('first', $bag->first());
+
+        $empty = new ImmutableBag();
+        $this->assertFalse($empty->first());
+    }
+
+    public function testLast()
+    {
+        $bag = new ImmutableBag(['first', 'second']);
+        $this->assertEquals('second', $bag->last());
+
+        $empty = new ImmutableBag();
+        $this->assertFalse($empty->last());
+    }
+
+    public function testJoin()
+    {
+        $bag = new ImmutableBag(['first', 'second', 'third']);
+        $this->assertEquals('first, second, third', $bag->join(', '));
+
+        $empty = new ImmutableBag();
+        $this->assertEquals('', $empty->join(', '));
+    }
+
+    public function testSum()
+    {
+        $bag = new ImmutableBag([3, 4]);
+        $this->assertEquals(7, $bag->sum());
+
+        $empty = new ImmutableBag();
+        $this->assertEquals(0, $empty->sum());
+
+        $dumb = new ImmutableBag(['wut']);
+        $this->assertEquals(0, $dumb->sum());
+    }
+
+    public function testProduct()
+    {
+        $bag = new ImmutableBag([3, 4]);
+        $this->assertEquals(12, $bag->product());
+
+        $empty = new ImmutableBag();
+        $this->assertEquals(1, $empty->product());
+
+        $dumb = new ImmutableBag(['wut']);
+        $this->assertEquals(0, $dumb->product());
+    }
+
+    /**
+     * @dataProvider \Bolt\Tests\Helper\ArrTest::isIndexedProvider
+     *
+     * @param array $data
+     * @param bool  $isIndexed
+     */
+    public function testIsAssociativeAndIndexed($data, $isIndexed)
+    {
+        $bag = new ImmutableBag($data);
+
+        $this->assertEquals($isIndexed, $bag->isIndexed());
+        $this->assertEquals(!$isIndexed, $bag->isAssociative());
+    }
+
+    // endregion
+
+    // region Methods returning a new bag
+
+    public function testMutable()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar']);
+
+        $mutable = $bag->mutable();
+
+        $this->assertNotSame($bag, $mutable);
+        $this->assertInstanceOf(Bag::class, $mutable);
+        $this->assertEquals(['foo' => 'bar'], $mutable->toArray());
+    }
+
+    public function testKeys()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+
+        $keys = $bag->keys();
+
+        $this->assertBagResult(['foo', 'hello'], $bag, $keys);
+    }
+
+    public function testValues()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+
+        $values = $bag->values();
+
+        $this->assertBagResult(['bar', 'world'], $bag, $values);
+    }
+
+    public function testMap()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+
+        $actual = $bag->map(function ($key, $item) {
+            return $key . '.' . $item;
+        });
+
+        $this->assertBagResult(['foo' => 'foo.bar', 'hello' => 'hello.world'], $bag, $actual);
+    }
+
+    public function testMapKeys()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+
+        $actual = $bag->mapKeys(function ($key, $item) {
+            return $key . '.' . $item;
+        });
+
+        $this->assertBagResult(['foo.bar' => 'bar', 'hello.world' => 'world'], $bag, $actual);
+    }
+
+    public function testFilter()
+    {
+        $bag = new ImmutableBag(['foo', 'bar', 'hello', 'world']);
+
+        $actual = $bag->filter(function ($key, $item) {
+            return $item !== 'bar' && $key !== 2;
+        });
+
+        $this->assertBagResult([0 => 'foo', 3 => 'world'], $bag, $actual);
+    }
+
+    public function testClean()
+    {
+        $bag = new ImmutableBag([null, '', 'foo', false, 0, true, [], ['bar']]);
+
+        $actual = $bag->clean();
+
+        $this->assertBagResult([2 => 'foo', 5 => true, 7 => ['bar']], $bag, $actual);
+    }
+
+    public function testReplace()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar']);
+
+        $actual = $bag->replace(['foo' => 'baz', 'hello' => 'world']);
+
+        $this->assertBagResult(['foo' => 'baz', 'hello' => 'world'], $bag, $actual);
+    }
+
+    /**
+     * @dataProvider \Bolt\Tests\Helper\ArrTest::replaceRecursiveProvider
+     *
+     * @param array $array1
+     * @param array $array2
+     * @param array $expected
+     */
+    public function testReplaceRecursive($array1, $array2, $expected)
+    {
+        $bag = ImmutableBag::from($array1);
+
+        $actual = $bag->replaceRecursive($array2);
+
+        $this->assertBagResult($expected, $bag, $actual);
+    }
+
+    public function testDefaults()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar']);
+
+        $actual = $bag->defaults(['foo' => 'baz', 'hello' => 'world']);
+
+        $this->assertBagResult(['foo' => 'bar', 'hello' => 'world'], $bag, $actual);
+    }
+
+    /**
+     * @dataProvider \Bolt\Tests\Helper\ArrTest::replaceRecursiveProvider
+     *
+     * @param array $array1
+     * @param array $array2
+     * @param array $expected
+     */
+    public function testDefaultsRecursive($array1, $array2, $expected)
+    {
+        $bag = ImmutableBag::from($array2);
+
+        $actual = $bag->defaultsRecursive($array1);
+
+        $this->assertBagResult($expected, $bag, $actual);
+    }
+
+    public function testMerge()
+    {
+        $bag = new ImmutableBag(['foo', 'bar']);
+
+        $actual = $bag->merge(['hello', 'world']);
+
+        $this->assertBagResult(['foo', 'bar', 'hello', 'world'], $bag, $actual);
+    }
+
+    public function provideSlice()
+    {
+        return [
+            [ 0, null, false, ['foo', 'bar', 'hello', 'world']],
+            [ 1, null, false, [       'bar', 'hello', 'world']],
+            [ 1,    2, false, [       'bar', 'hello'         ]],
+            [-2, null, false, [              'hello', 'world']],
+            [ 1,   -1, false, [       'bar', 'hello'         ]],
+            [-2,   -1, false, [              'hello'         ]],
+            [ 1,    2,  true, [1 => 'bar', 2 => 'hello']],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSlice
+     *
+     * @param int      $offset
+     * @param int|null $length
+     * @param bool     $preserveKeys
+     * @param array    $expected
+     */
+    public function testSlice($offset, $length, $preserveKeys, $expected)
+    {
+        $bag = new ImmutableBag(['foo', 'bar', 'hello', 'world']);
+
+        $actual = $bag->slice($offset, $length, $preserveKeys);
+
+        $this->assertBagResult($expected, $bag, $actual);
+    }
+
+    public function testPartition()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world']);
+
+        $actual = $bag->partition(function ($key, $item) {
+            return strpos($item, 'a') !== false;
+        });
+
+        $this->assertTrue(is_array($actual));
+        $this->assertCount(2, $actual);
+
+        list($trueBag, $falseBag) = $actual;
+        $this->assertBagResult(['foo' => 'bar'], $bag, $trueBag);
+        $this->assertBagResult(['hello' => 'world'], $bag, $falseBag);
+    }
+
+    public function testColumn()
+    {
+        $bag = new ImmutableBag([
+            ['id' => 'foo', 'value' => 'bar'],
+            ['id' => 'hello', 'value' => 'world'],
+        ]);
+
+        $actual = $bag->column('id');
+        $this->assertBagResult(['foo', 'hello'], $bag, $actual);
+
+        $actual = $bag->column('value', 'id');
+        $this->assertBagResult(['foo' => 'bar', 'hello' => 'world'], $bag, $actual);
+    }
+
+    public function testFlip()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar', 'hello' => 'world', 'second' => 'world']);
+
+        $actual = $bag->flip();
+
+        $this->assertBagResult(['bar' => 'foo', 'world' => 'second'], $bag, $actual);
+    }
+
+    public function testReduce()
+    {
+        $bag = new ImmutableBag([1, 2, 3, 4]);
+
+        $product = $bag->reduce(
+            function ($carry, $item) {
+                return $carry * $item;
+            },
+            1
+        );
+
+        $this->assertEquals(24, $product);
+    }
+
+    public function testUnique()
+    {
+        $bag = new ImmutableBag(['foo', 'bar', 'foo', 3, '3', '3a', '3']);
+        $actual = $bag->unique();
+        $this->assertBagResult(['foo', 'bar', 3 , '3', '3a'], $bag, $actual);
+
+        $first = new ImmutableBag();
+        $second = new ImmutableBag();
+        $bag = new ImmutableBag([$first, $second, $first]);
+        $actual = $bag->unique();
+        $this->assertBagResult([$first, $second], $bag, $actual);
+    }
+
+    public function testChunk()
+    {
+        $bag = new ImmutableBag(['a', 'b', 'c', 'd', 'e']);
+
+        $chunked = $bag->chunk(2);
+
+        $this->assertInstanceOf(ImmutableBag::class, $chunked);
+        $this->assertNotSame($bag, $chunked);
+        $this->assertCount(3, $chunked);
+
+        $this->assertBagResult(['a', 'b'], $bag, $chunked->get(0));
+        $this->assertBagResult(['c', 'd'], $bag, $chunked->get(1));
+        $this->assertBagResult(['e'], $bag, $chunked->get(2));
+    }
+
+    public function testChunkPreserveKeys()
+    {
+        $bag = new ImmutableBag(['a', 'b', 'c', 'd', 'e']);
+
+        $chunked = $bag->chunk(2, true);
+
+        $this->assertInstanceOf(ImmutableBag::class, $chunked);
+        $this->assertNotSame($bag, $chunked);
+        $this->assertCount(3, $chunked);
+
+        $this->assertBagResult(['a', 'b'], $bag, $chunked->get(0));
+        $this->assertBagResult([2 => 'c', 3 => 'd'], $bag, $chunked->get(1));
+        $this->assertBagResult([4 => 'e'], $bag, $chunked->get(2));
+    }
+
+    // endregion
+
+    // region Sorting Methods
+
+    public function testReverse()
+    {
+        $bag = new ImmutableBag(['a', 'b', 'c', 'd']);
+
+        $actual = $bag->reverse();
+
+        $this->assertBagResult(['d', 'c', 'b', 'a'], $bag, $actual);
+    }
+
+    public function testReversePreserveKeys()
+    {
+        $bag = new ImmutableBag(['a', 'b', 'c', 'd']);
+
+        $actual = $bag->reverse(true);
+
+        $this->assertBagResult([3 => 'd', 2 => 'c', 1 => 'b', 0 => 'a'], $bag, $actual);
+    }
+
+    public function testShuffle()
+    {
+        $bag = new ImmutableBag(['a', 'b', 'c', 'd']);
+
+        $actual = $bag->shuffle();
+
+        $this->assertInstanceOf(ImmutableBag::class, $actual);
+        $this->assertNotSame($bag, $actual);
+        $this->assertNotEquals($bag->toArray(), $actual->toArray());
+
+        $sorted = $actual->toArray();
+        sort($sorted);
+        $this->assertEquals($bag->toArray(), $sorted);
+    }
+
+    // endregion
+
+    // region Internal Methods
+
+    public function testIterator()
+    {
+        $bag = new ImmutableBag(['a', 'b', 'c', 'd']);
+
+        $this->assertEquals(['a', 'b', 'c', 'd'], iterator_to_array($bag));
+    }
+
+    public function testOffsetExists()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar']);
+
+        $this->assertTrue(isset($bag['foo']));
+        $this->assertFalse(isset($bag['derp']));
+    }
+
+    public function testOffsetGet()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar']);
+
+        $this->assertEquals('bar', $bag['foo']);
+        $this->assertNull($bag['nope']);
+    }
+
+    public function testOffsetGetByReference()
+    {
+        $bag = new ImmutableBag(['arr' => ['1']]);
+
+        // Assert arrays are not able to be modified by reference.
+        $errors = new \ArrayObject();
+        set_error_handler(function ($type, $message) use ($errors) {
+            $errors[] = [$type, $message];
+        });
+
+        $arr = &$bag['arr'];
+
+        restore_error_handler();
+
+        $this->assertEquals([[E_NOTICE, 'Indirect modification of overloaded element of Bolt\Collection\ImmutableBag has no effect']], $errors->getArrayCopy());
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Cannot modify items on an Bolt\Collection\ImmutableBag
+     */
+    public function testOffsetSet()
+    {
+        $bag = new ImmutableBag();
+
+        $bag['foo'] = 'bar';
+    }
+
+    /**
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage Cannot remove items from an Bolt\Collection\ImmutableBag
+     */
+    public function testOffsetUnset()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar']);
+
+        unset($bag['foo']);
+    }
+
+    public function testDebugInfo()
+    {
+        $bag = new ImmutableBag(['foo' => 'bar']);
+
+        $this->assertEquals($bag->toArray(), $bag->__debugInfo());
+        $this->assertEquals('bar', $bag->foo);
+    }
+
+    // endregion
+
+    /**
+     * Assert $actualBag is an ImmutableBag that's a different instance from $initialBag and its items equal $expected.
+     *
+     * @param array        $expected
+     * @param ImmutableBag $initialBag
+     * @param ImmutableBag $actualBag
+     */
+    protected function assertBagResult($expected, $initialBag, $actualBag)
+    {
+        $this->assertInstanceOf(ImmutableBag::class, $actualBag);
+        $this->assertNotSame($initialBag, $actualBag);
+        $this->assertEquals($expected, $actualBag->toArray());
+    }
+}

--- a/tests/phpunit/unit/Helper/ArrTest.php
+++ b/tests/phpunit/unit/Helper/ArrTest.php
@@ -127,6 +127,10 @@ class ArrTest extends BoltUnitTest
     {
         $this->assertEquals($indexed, Arr::isIndexed($array));
         $this->assertEquals(!$indexed, Arr::isAssociative($array));
+
+        $traversable = new \ArrayObject($array);
+        $this->assertEquals($indexed, Arr::isIndexed($traversable));
+        $this->assertEquals(!$indexed, Arr::isAssociative($traversable));
     }
 
     public function testNonArraysAreNotIndexedOrAssociative()

--- a/tests/phpunit/unit/Helper/ArrTest.php
+++ b/tests/phpunit/unit/Helper/ArrTest.php
@@ -89,6 +89,28 @@ class ArrTest extends BoltUnitTest
                 ['a' => 'derp'],
                 ['a' => 'derp'],
             ],
+            'traversable'                             => [
+                new \ArrayObject([
+                    'a' => new \ArrayObject([
+                        'foo' => 'bar',
+                        'hello' => 'world',
+                        'dont override' => new \ArrayObject(['for reals']),
+                    ])
+                ]),
+                new \ArrayObject([
+                    'a' => new \ArrayObject([
+                        'foo' => 'baz',
+                        'dont override' => null
+                    ])
+                ]),
+                [
+                    'a' => [
+                        'foo' => 'baz', // replaced value
+                        'hello' => 'world', // untouched pair
+                        'dont override' => ['for reals'] // null didn't overwrite list
+                    ]
+                ],
+            ],
         ];
     }
 

--- a/tests/phpunit/unit/Helper/ArrTest.php
+++ b/tests/phpunit/unit/Helper/ArrTest.php
@@ -135,6 +135,212 @@ class ArrTest extends BoltUnitTest
         $this->assertFalse(Arr::isAssociative('derp'));
     }
 
+    public function provideGetSetHasInvalidArgs()
+    {
+        return [
+            'data not accessible' => [new \EmptyIterator(), 'foo'],
+            'path not string' => [[], false],
+            'empty path' => [[], ''],
+        ];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @dataProvider provideGetSetHasInvalidArgs
+     *
+     * @param mixed $data
+     * @param mixed $path
+     */
+    public function testHasInvalidArgs($data, $path)
+    {
+        Arr::has($data, $path);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @dataProvider provideGetSetHasInvalidArgs
+     *
+     * @param mixed $data
+     * @param mixed $path
+     */
+    public function testGetInvalidArgs($data, $path)
+    {
+        Arr::get($data, $path);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @dataProvider provideGetSetHasInvalidArgs
+     *
+     * @param mixed $data
+     * @param mixed $path
+     */
+    public function testSetInvalidArgs($data, $path)
+    {
+        Arr::set($data, $path, 'mixed');
+    }
+
+    public function provideGetSetHas()
+    {
+        return [
+            'array' => [[
+                'foo' => 'bar',
+                'items' => [
+                    'nested' => [
+                        'hello' => 'world',
+                    ],
+                ],
+            ]],
+
+            'array access' => [new \ArrayObject([
+                'foo' => 'bar',
+                'items' => new \ArrayObject([
+                    'nested' => new \ArrayObject([
+                        'hello' => 'world',
+                    ]),
+                ]),
+            ])],
+
+            'user array access' => [new TestArrayLike([
+                'foo' => 'bar',
+                'items' => new TestArrayLike([
+                    'nested' => new TestArrayLike([
+                        'hello' => 'world',
+                    ]),
+                ]),
+            ])],
+
+            'mixed' => [[
+                'foo' => 'bar',
+                'items' => new \ArrayObject([
+                    'nested' => [
+                        'hello' => 'world',
+                    ],
+                ]),
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetSetHas
+     *
+     * @param array|\ArrayAccess $data
+     */
+    public function testHas($data)
+    {
+        $this->assertTrue(Arr::has($data, 'foo'));
+        $this->assertTrue(Arr::has($data, 'items'));
+        $this->assertTrue(Arr::has($data, 'items/nested/hello'));
+
+        $this->assertFalse(Arr::has($data, 'derp'));
+        $this->assertFalse(Arr::has($data, 'items/nope/bad'));
+    }
+
+    /**
+     * @dataProvider provideGetSetHas
+     *
+     * @param array|\ArrayAccess $data
+     */
+    public function testGet($data)
+    {
+        $this->assertEquals('bar', Arr::get($data, 'foo'));
+        $this->assertEquals('world', Arr::get($data, 'items/nested/hello'));
+
+        $this->assertEquals('default', Arr::get($data, 'derp', 'default'));
+        $this->assertEquals('default', Arr::get($data, 'items/derp', 'default'));
+        $this->assertEquals('default', Arr::get($data, 'derp/nope/whoops', 'default'));
+    }
+
+    /**
+     * @dataProvider provideGetSetHas
+     *
+     * @param array|\ArrayAccess $data
+     */
+    public function testSet($data)
+    {
+        Arr::set($data, 'color', 'red');
+        $this->assertEquals('red', $data['color']);
+
+        Arr::set($data, '[]', 'first');
+        $this->assertEquals('first', $data[0]);
+        Arr::set($data, '[]', 'second');
+        $this->assertEquals('second', $data[1]);
+
+        Arr::set($data, 'items/nested/color', 'blue');
+        $this->assertEquals('blue', $data['items']['nested']['color']);
+
+        Arr::set($data, 'items/nested/new/point', 'bolt');
+        $this->assertEquals('bolt', $data['items']['nested']['new']['point']);
+
+        Arr::set($data, 'items/nested/list/[]', 'first');
+        $this->assertEquals('first', $data['items']['nested']['list'][0]);
+        Arr::set($data, 'items/nested/list/[]', 'second');
+        $this->assertEquals('second', $data['items']['nested']['list'][1]);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Cannot set "a/foo", because "a" is already set and not an array or an object implementing ArrayAccess.
+     */
+    public function testSetNestedInaccessibleObject()
+    {
+        $data = [
+            'a' => new \EmptyIterator(),
+        ];
+
+        Arr::set($data, 'a/foo', 'bar');
+    }
+
+    /**
+     * Test that Arr::set throws exception when trying to indirectly modify an ArrayAccess object.
+     * This happens when one tries to set a value on a sub array/object of an AA object.
+     * Ex: A/B/C where A is an object. B can be anything.
+     */
+    public function testSetNestedIndirectModificationError()
+    {
+        $data = [
+            'a' => new TestBadArrayLike(),
+        ];
+
+        $prevReporting = error_reporting(E_ALL);
+        $expectedErrorHandler = set_error_handler('var_dump');
+        restore_error_handler();
+
+        $errors = new \ArrayObject();
+        set_error_handler(function ($type, $message) use ($errors) {
+            $errors[] = [$type, $message];
+        });
+
+        $e = null;
+        try {
+            Arr::set($data, 'a/foo/bar', 'baz');
+        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+        }
+        error_reporting($prevReporting);
+        restore_error_handler();
+
+        $actualErrorHandler = set_error_handler('var_dump');
+        restore_error_handler();
+
+        $message = 'Arr::set did not restore previous error handler';
+        if (is_array($expectedErrorHandler)) {
+            $this->assertTrue(is_array($actualErrorHandler), $message);
+            $this->assertSame($expectedErrorHandler[0], $actualErrorHandler[0], $message);
+            $this->assertSame($expectedErrorHandler[1], $actualErrorHandler[1], $message);
+        } else {
+            $this->assertSame($expectedErrorHandler, $actualErrorHandler, $message);
+        }
+
+        $this->assertEquals([[E_USER_NOTICE, 'Some notice']], $errors->getArrayCopy(), 'Arr::set did not call previous error handler for non indirect modification errors');
+
+        if ($e instanceof \RuntimeException) {
+            $this->assertEquals('Cannot to set "a/foo/bar", because "a" is an Bolt\Tests\Helper\TestBadArrayLike which has not defined its offsetGet() method as return by reference.', $e->getMessage());
+        } else {
+            $this->fail("Arr::set should've thrown a RuntimeException");
+        }
+    }
+
     public function testColumn()
     {
         $data = [
@@ -213,6 +419,50 @@ class ArrTest extends BoltUnitTest
                 ],
             ],
         ];
+    }
+}
+
+class TestArrayLike implements \ArrayAccess
+{
+    protected $items = [];
+
+    public function __construct(array $items = [])
+    {
+        $this->items = $items;
+    }
+
+    public function offsetExists($offset)
+    {
+        @trigger_error('Some notice', E_USER_NOTICE);
+
+        return isset($this->items[$offset]);
+    }
+
+    public function &offsetGet($offset) // Note "&"
+    {
+        return $this->items[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if ($offset === null) {
+            $this->items[] = $value;
+        } else {
+            $this->items[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->items[$offset]);
+    }
+}
+
+class TestBadArrayLike extends TestArrayLike
+{
+    public function offsetGet($offset) // Note no "&"
+    {
+        return $this->items[$offset];
     }
 }
 


### PR DESCRIPTION
This is something I've been wanting to do for about a year and a half now. We all know working with arrays in PHP is not the best experience. `isset` checks are annoying and `array_*` methods make code hard to read. 

Introducing the solution™:
# `Bag` and `ImmutableBag`

These are OO implementations of arrays. The goal of these classes:
- Provide functionality on par with built-in array methods
- Provide useful functionality lacking from built-in array methods
- Provide a fluent-like experience
- Make implementing code more readable

Examples:
```php
$arr = [
    'debug' => true,
    'color' => 'blue',
    'db' => [
        'driver' => 'sqlite',
    ],
];

$bag = Bag::from($arr)
    ->defaults([
        'debug' => false,
        'color' => 'green',
    ])
    ->replace([
        'color' => 'red',
    ])
;
$bag->get('debug'); // true
$bag->getPath('db/driver'); // "sqlite"
$bag->keys()->join(', '); // "debug, color, db"
$bag->isAssociative(); // true
```
```php
$colors = Bag::from(['red', 'blue', 'yellow'])
    ->merge(['green', 'orange'])
;
$colors->isIndexed(); // true
$colors->indexOf('yellow'); // 2
$colors[2]; // "yellow"

$colors->prepend('purple');
$colors[] = 'pink';

$colors->first(); // "purple"
$colors->last(); // "pink"

$colors->shuffle()->first(); // one of the colors

$colors->chunk(2); // Bags represented as arrays:
// [ ['purple', 'red'], ['blue', 'yellow'], ['green, 'orange'], ['pink'] ]

$colors->removeFirst(); // "purple"
$colors->removeFirst(); // "red"
```
These examples only cover half of the functionality.

All methods asking for a collection will accept other `Bags`, `arrays`, `stdClass`, and `Traversable` objects. This makes it very easy work with any collection-like object. `Nulls` and `mixed` values are also supported which are converted to empty arrays and an array with one item respectively.

The methods are clearly documented in code but here's a summary 
<details>
<summary>Methods</summary>

```php
static from(mixed $collection): Bag
static fromRecursive(mixed $collection): Bag
static combine(array|Traversable $keys, array|Traversable $values): Bag
toArray(): array
toArrayRecursive(): array
mutable(): Bag
immutable(): ImmutableBag
has(int|string $key): bool
hasPath(string $path): bool
hasItem(mixed $item): bool
get(int|string $key, mixed $default): mixed
getPath(string $path, mixed $default): mixed
count(): int
isEmpty(): bool
indexOf(mixed $item): int|string|false
first(): mixed|null
last(): mixed|null
join(string $separator): string
sum(): number
product(): number
isAssociative(): bool
isIndexed(): bool
keys(): Bag
values(): Bag
map((int|string $key, mixed $value) => mixed): Bag
mapKeys((int|string $key, mixed $value) => mixed): Bag
filter((int|string $key, mixed $value) => bool): Bag
clean(): Bag
replace(array|Traversable $collection): Bag
replaceRecursive(array|Traversable $collection): Bag
defaults(array|Traversable $collection): Bag
defaultsRecursive(array|Traversable $collection): Bag
merge(array|Traversable $list): Bag
slice(int $offset, int $length = null, bool $preserveKeys = false): Bag
partition((int|string $key, mixed $value) => bool): [Bag, Bag]
column(string $columnKey, string $indexKey = null): Bag
flip(): Bag
reduce((mixed $carry, mixed $item) => mixed, mixed $initial): mixed
unique(): Bag
chunk(int $size, bool $preserveKeys = false): Bag[]
reverse(bool $preserveKeys = false): Bag
shuffle(): Bag
add(mixed $item): void
prepend(mixed $item): void
set(int|string $key, mixed $value): void
setPath(string $path, mixed $value): void
clear(): void
remove(int|string $key, mixed $default = null): mixed
removeItem(mixed $item): mixed
removeFirst(): mixed|null
removeLast(): mixed|null
```
</details>

### Also I know this looks like a lot of code, but there's only 115 lines of logical source code. 
<details>

```
phploc 3.0.1 by Sebastian Bergmann.

Size
  Lines of Code (LOC)                              983
  Comment Lines of Code (CLOC)                     517 (52.59%)
  Non-Comment Lines of Code (NCLOC)                466 (47.41%)
  Logical Lines of Code (LLOC)                     115 (11.70%)
```
</details>

## What's `ImmutableBag` for?

All of the methods in `ImmutableBag` are queries of the current state or return a _new_ modified Bag. Thus an `ImmutableBag` cannot be mutated...no duh. `Bag` extends `ImmutableBag` and provides methods to add, modify, and remove items. 

In PHP, arrays are always passed/returned by value, but objects are passed/returned by reference. 
Let's look at an example:
```php
class Foo
{
    /** @var array */
    private $items;

    public function getItems()
    {
        return $this->items;
    }
}

$foo = new Foo();
$items = $foo->getItems();
$items[] = 'hello';
```
Since `Foo::$items` is an array, the `$items` returned from `getItems()` is a different array. Thus appending "hello" to the array does not modify `Foo::$items`.

Now pretend `Foo::$items` is a `Bag`. Since it is an object, the `$items` returned from `getItems()` is the same object as `Foo::$items`. This means you can modify `Foo`'s internal state externally. `Foo` may not want this, so it can return an `ImmutableBag` instead. 

It could be argued that a clone of the Bag could be returned from the method instead. This is true, but it would lead to more processing for each query of the bag, and could lead to WTF's if the user is trying to modify the clone and it's not applying to the object.

## Hasn't this been done already?
Obviously others think PHP arrays suck as well and have attempted to resolve this. Symfony's `ParamaterBag` is a good basic _map_ (associative arrays) container but is lacking when it comes to mutating the items around and working with lists. Doctrine's `ArrayCollection` is also another, more robust, option. It works well for maps and lists, but still has limited functionality due to needing to interface with a database collection. It also has some annoyances, like `getKeys()` returns an `array` instead of another `ArrayCollection` instance.

# `Arr` updates

`Arr` now has:
```php
has(array|ArrayAccess $data, string $path): bool
get(array|ArrayAccess $data, string $path, mixed $default = null): mixed
set(array|ArrayAccess $data, string $path, mixed $value): void
```
These methods work with "paths" to provide access to nested objects. This is the same as how `Config::get/set` works and it has even been updated to just use these `Arr` methods.
`Bag::hasPath/getPath/setPath` are powered by these functions as well.

Also `replaceRecursive/isIndexed/isAssociative` have been updated to support `Traversable` objects.