### PR TITLE
[3.3] Nut debug — Phase III

### DIFF
--- a/src/Nut/DebugRouter.php
+++ b/src/Nut/DebugRouter.php
@@ -2,11 +2,14 @@
 
 namespace Bolt\Nut;
 
+use ArrayObject;
 use Silex\Route;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Nut command to dump system routes.
@@ -23,6 +26,7 @@ class DebugRouter extends BaseCommand
         $this
             ->setName('debug:router')
             ->setDescription('System route debug dumper.')
+            ->addArgument('name', InputArgument::OPTIONAL, 'A route name')
             ->addOption('sort-route', null, InputOption::VALUE_NONE, 'Sort in order of route name (default).')
             ->addOption('sort-pattern', null, InputOption::VALUE_NONE, 'Sort in order of URI patterns.')
             ->addOption('sort-method', null, InputOption::VALUE_NONE, 'Sort in order of HTTP method grouping allowed.')
@@ -35,6 +39,57 @@ class DebugRouter extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->app->flush();
+        $name = $input->getArgument('name');
+        if ($name === null) {
+            return $this->executeAll($input, $output);
+        }
+
+        $table = new Table($output);
+        $table->setHeaders([
+            [
+                'Property',
+                'Value',
+            ]
+        ]);
+
+        $routes = $this->app['routes'];
+        $route = $routes->get($name);
+
+        $table->addRows([
+            [ 'Route Name', $name],
+            [ 'Path', $route->getPath()],
+            [ 'Host', $route->getHost() ?: 'ANY'],
+            [ 'Scheme', implode('|', $route->getSchemes()) ?: 'ANY'],
+            [ 'Method(s)', $this->getMethods($route)],
+            [ 'Requirements', $this->formatArrayAsYaml($route->getRequirements()) ?: 'NO CUSTOM'],
+            [ 'Defaults', $this->formatArrayAsYaml($route->getDefaults())],
+            [ 'Options', $this->formatArrayAsYaml($route->getOptions())],
+        ]);
+
+        $table->render();
+    }
+
+    /**
+     * @param mixed $array
+     *
+     * @return string
+     */
+    protected function formatArrayAsYaml($array)
+    {
+        if (!(is_array($array) || !$array instanceof ArrayObject)) {
+            return $array;
+        }
+        array_walk_recursive($array, function (&$item) {
+            $item = is_object($item) ? get_class($item) : $item;
+        });
+
+        $yaml = Yaml::dump($array, 4, 2);
+
+        return trim($yaml);
+    }
+
+    protected function executeAll(InputInterface $input, OutputInterface $output)
+    {
         $table = new Table($output);
         $table->setHeaders([
             [

--- a/src/Nut/DebugRouter.php
+++ b/src/Nut/DebugRouter.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class DebugRoutes extends BaseCommand
+class DebugRouter extends BaseCommand
 {
     /**
      * {@inheritdoc}
@@ -21,7 +21,7 @@ class DebugRoutes extends BaseCommand
     protected function configure()
     {
         $this
-            ->setName('debug:routes')
+            ->setName('debug:router')
             ->setDescription('System route debug dumper.')
             ->addOption('sort-route', null, InputOption::VALUE_NONE, 'Sort in order of route name (default).')
             ->addOption('sort-pattern', null, InputOption::VALUE_NONE, 'Sort in order of URI patterns.')
@@ -37,12 +37,18 @@ class DebugRoutes extends BaseCommand
         $this->app->flush();
         $table = new Table($output);
         $table->setHeaders([
-            ['Route Name', 'Path', 'Method(s)']
+            [
+                'Route Name',
+                'Method(s)',
+                'Scheme',
+                'Host',
+                'Path',
+            ]
         ]);
         $routes = (array) $this->app['routes']->getIterator();
 
         if ($input->getOption('sort-route')) {
-            $routes = $this->sortRotues($routes);
+            $routes = $this->sortRoutes($routes);
         }
         if ($input->getOption('sort-pattern')) {
             $routes = $this->sortPattern($routes);
@@ -54,8 +60,10 @@ class DebugRoutes extends BaseCommand
         foreach ($routes as $bindName => $route) {
             $table->addRow([
                 $bindName,
-                $route->getPath(),
                 $this->getMethods($route),
+                implode('|', $route->getSchemes()) ?: ' ANY',
+                $route->getHost() ?: ' ANY',
+                $route->getPath(),
             ]);
         }
 
@@ -69,7 +77,7 @@ class DebugRoutes extends BaseCommand
      *
      * @return Route[]
      */
-    private function sortRotues(array $routes)
+    private function sortRoutes(array $routes)
     {
         ksort($routes);
 
@@ -110,7 +118,7 @@ class DebugRoutes extends BaseCommand
         $methods = $route->getMethods();
         sort($methods);
 
-        return implode('|', $methods) ?: 'ALL';
+        return implode('|', $methods) ?: 'ANY';
     }
 
     /**

--- a/src/Nut/DebugRoutes.php
+++ b/src/Nut/DebugRoutes.php
@@ -34,6 +34,7 @@ class DebugRoutes extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->app->flush();
         $table = new Table($output);
         $table->setHeaders([
             ['Route Name', 'Path', 'Method(s)']

--- a/src/Nut/RouterMatch.php
+++ b/src/Nut/RouterMatch.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * A console command to test route matching.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class RouterMatch extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled()
+    {
+        if (!isset($this->app['routes'])) {
+            return false;
+        }
+        $router = $this->app['routes'];
+        if (!$router instanceof RouteCollection) {
+            return false;
+        }
+
+        return parent::isEnabled();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('router:match')
+            ->setDescription('Helps debug routes by simulating a URI path match')
+            ->addArgument('path_info', InputArgument::REQUIRED, 'A relative URI path')
+            ->addOption('method', null, InputOption::VALUE_REQUIRED, 'Sets the HTTP method')
+            ->addOption('scheme', null, InputOption::VALUE_REQUIRED, 'Sets the URI scheme (usually http or https)')
+            ->addOption('host', null, InputOption::VALUE_REQUIRED, 'Sets the URI host')
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> shows which routes match a given request and which don't and for what reason:
+
+  <info>php %command.full_name% /foo</info>
+
+or
+
+  <info>php %command.full_name% /foo --method POST --scheme https --host bolt.cm --verbose</info>
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->app->flush();
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var RouteCollection $router */
+        $router = $this->app['routes'];
+        $context = new RequestContext($input->getArgument('path_info'));
+        if (null !== $method = $input->getOption('method')) {
+            $context->setMethod($method);
+        }
+        if (null !== $scheme = $input->getOption('scheme')) {
+            $context->setScheme($scheme);
+        }
+        if (null !== $host = $input->getOption('host')) {
+            $context->setHost($host);
+        }
+
+        $matcher = new TraceableUrlMatcher($router, $context);
+
+        $traces = $matcher->getTraces($input->getArgument('path_info'));
+
+        $io->newLine();
+
+        $matches = false;
+        foreach ($traces as $trace) {
+            if (TraceableUrlMatcher::ROUTE_ALMOST_MATCHES == $trace['level']) {
+                $io->text(sprintf('Route <info>"%s"</> almost matches but %s', $trace['name'], lcfirst($trace['log'])));
+            } elseif (TraceableUrlMatcher::ROUTE_MATCHES == $trace['level']) {
+                $io->success(sprintf('Route "%s" matches', $trace['name']));
+
+                $routerDebugCommand = $this->getApplication()->find('debug:router');
+                $routerDebugCommand->run(new ArrayInput(['name' => $trace['name']]), $output);
+
+                $matches = true;
+            } elseif ($input->getOption('verbose')) {
+                $io->text(sprintf('Route "%s" does not match: %s', $trace['name'], $trace['log']));
+            }
+        }
+
+        if (!$matches) {
+            $io->error(sprintf('None of the routes match the path "%s"', $input->getArgument('path_info')));
+
+            return 1;
+        }
+    }
+}

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -8,8 +8,8 @@ use Bolt\Nut\NutApplication;
 use LogicException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Bridge;
+use Symfony\Component\Console\Command\Command;
 
 class NutServiceProvider implements ServiceProviderInterface
 {
@@ -67,6 +67,7 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\DebugEvents($app),
                     new Nut\DebugServiceProviders($app),
                     new Nut\DebugRouter($app),
+                    new Nut\RouterMatch($app),
                     $app['nut.command.twig_debug'],
                     $app['nut.command.twig_lint']
                 ];

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -66,7 +66,7 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\UserRoleRemove($app),
                     new Nut\DebugEvents($app),
                     new Nut\DebugServiceProviders($app),
-                    new Nut\DebugRoutes($app),
+                    new Nut\DebugRouter($app),
                     $app['nut.command.twig_debug'],
                     $app['nut.command.twig_lint']
                 ];

--- a/tests/phpunit/unit/Nut/DebugRouterTest.php
+++ b/tests/phpunit/unit/Nut/DebugRouterTest.php
@@ -33,6 +33,38 @@ class DebugRouterTest extends BoltUnitTest
         $this->assertLessThan($expectedA, $expectedB);
     }
 
+    public function providerRunNamed()
+    {
+        return [
+            [
+                'preview',
+                '/(Route Name).+(preview)/',
+                '/(Path).+(\/preview\/{contenttypeslug})/',
+            ],
+            [
+                'contentaction',
+                '/(Route Name).+(contentaction)/',
+                '/(Path).+(\/async\/content\/action)/',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerRunNamed
+     */
+    public function testRunNamed($name, $routeNamePattern, $pathPattern)
+    {
+        $tester = $this->getCommandTester();
+
+        $tester->execute(['name' => $name]);
+        $result = $tester->getDisplay();
+
+        $this->assertRegExp($routeNamePattern, $result);
+        $this->assertRegExp($pathPattern, $result);
+        $this->assertNotRegExp($this->regexExpectedA, $result);
+        $this->assertNotRegExp($this->regexExpectedB, $result);
+    }
+
     public function testSortRoute()
     {
         $tester = $this->getCommandTester();

--- a/tests/phpunit/unit/Nut/DebugRouterTest.php
+++ b/tests/phpunit/unit/Nut/DebugRouterTest.php
@@ -2,21 +2,21 @@
 
 namespace Bolt\Tests\Nut;
 
-use Bolt\Nut\DebugRoutes;
+use Bolt\Nut\DebugRouter;
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
- * Tests for \Bolt\Nut\DebugRoutes
+ * Tests for \Bolt\Nut\DebugRouter
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class DebugRoutesTest extends BoltUnitTest
+class DebugRouterTest extends BoltUnitTest
 {
     use TableHelperTrait;
 
-    protected $regexExpectedA = '/(preview).+(\/{contenttypeslug}).+(ALL)/';
-    protected $regexExpectedB = '/(contentaction).+(\/async\/content\/action).+(POST)/';
+    protected $regexExpectedA = '/(preview).+(ANY).+(ANY).+(ANY).+(\/{contenttypeslug})/';
+    protected $regexExpectedB = '/(contentaction).+(POST).+(ANY).+(ANY).+(\/async\/content\/action)/';
 
     public function testRunNormal()
     {
@@ -72,7 +72,7 @@ class DebugRoutesTest extends BoltUnitTest
     protected function getCommandTester()
     {
         $app = $this->getApp();
-        $command = new DebugRoutes($app);
+        $command = new DebugRouter($app);
 
         return new CommandTester($command);
     }

--- a/tests/phpunit/unit/Nut/RouterMatchTest.php
+++ b/tests/phpunit/unit/Nut/RouterMatchTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Bolt\Tests\Nut;
+
+use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Tests for \Bolt\Nut\RouterMatch
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class RouterMatchTest extends BoltUnitTest
+{
+    /**
+     * @expectedException \Symfony\Component\Console\Exception\RuntimeException
+     * @expectedExceptionMessage Not enough arguments (missing: "path_info").
+     */
+    public function testRunNormal()
+    {
+        $tester = $this->getCommandTester();
+
+        $tester->execute([]);
+        $result = $tester->getDisplay();
+
+        $this->assertRegExp('/Not enough arguments/', $result);
+    }
+
+    public function providerRunPaths()
+    {
+        return [
+            [
+                '/',
+                '/Route \"homepage\" matches/',
+                '/(Route Name).+(homepage)/',
+                '/(Path).+(\/)/',
+            ],
+            [
+                '/bolt/editcontent/pages/42',
+                '/Route \"editcontent\" matches/',
+                '/(Route Name).+(editcontent)/',
+                '/(Path).+(\/bolt\/editcontent\/{contenttypeslug}\/{id})/',
+            ],
+            [
+                '/pages/koalas',
+                '/Route \"contentlink\" matches/',
+                '/(Route Name).+(contentlink)/',
+                '/(Path).+(\/{contenttypeslug}\/{slug})/',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerRunPaths
+     */
+    public function testRunPaths($uri, $confirmation, $routeName, $path)
+    {
+        $tester = $this->getCommandTester();
+
+        $tester->execute(['path_info' => $uri]);
+        $result = $tester->getDisplay();
+        ConsoleCommandEvent::RETURN_CODE_DISABLED;
+
+        $this->assertRegExp($confirmation, $result);
+        $this->assertRegExp($routeName, $result);
+        $this->assertRegExp($path, $result);
+
+    }
+
+    /**
+     * @return CommandTester
+     */
+    protected function getCommandTester()
+    {
+        $app = $this->getApp();
+        $command = $app['nut']->get('router:match');
+
+        return new CommandTester($command);
+    }
+}


### PR DESCRIPTION
* Rename `debug:routes` to `debug:router` to match Symfony's
* Added single route information option to match Symfony's
* Ported `router:match` from Symfony full-stack

```
$ ./app/nut router:match /

 [OK] Route "homepage" matches

+--------------+---------------------------------------------------------+
| Property     | Value                                                   |
+--------------+---------------------------------------------------------+
| Route Name   | homepage                                                |
| Path         | /                                                       |
| Host         | ANY                                                     |
| Scheme       | ANY                                                     |
| Method(s)    | ANY                                                     |
| Requirements | {  }                                                    |
| Defaults     | zone: frontend                                          |
|              | _controller: 'controller.frontend:homepage'             |
| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler |
|              | _before_middlewares:                                    |
|              |   - Closure                                             |
|              | _after_middlewares:                                     |
|              |   - Closure                                             |
+--------------+---------------------------------------------------------+
```

```
$ ./app/nut router:match /bolt/editcontent/pages/42

 [OK] Route "editcontent" matches

+--------------+---------------------------------------------------------+
| Property     | Value                                                   |
+--------------+---------------------------------------------------------+
| Route Name   | editcontent                                             |
| Path         | /bolt/editcontent/{contenttypeslug}/{id}                |
| Host         | ANY                                                     |
| Scheme       | ANY                                                     |
| Method(s)    | GET|POST                                                |
| Requirements | _method: GET|POST                                       |
|              | id: '\d*'                                               |
| Defaults     | _controller:                                            |
|              |   - Bolt\Controller\Backend\Records                     |
|              |   - edit                                                |
|              | id: ''                                                  |
|              | zone: backend                                           |
| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler |
|              | _before_middlewares:                                    |
|              |   -                                                     |
|              |     - Bolt\Controller\Backend\Records                   |
|              |     - before                                            |
+--------------+---------------------------------------------------------+
```

```
$ ./app/nut router:match /pages/koalas
                                                                                                                        
 [OK] Route "contentlink" matches

+--------------+---------------------------------------------------------------------------+
| Property     | Value                                                                     |
+--------------+---------------------------------------------------------------------------+
| Route Name   | contentlink                                                               |
| Path         | /{contenttypeslug}/{slug}                                                 |
| Host         | ANY                                                                       |
| Scheme       | ANY                                                                       |
| Method(s)    | ANY                                                                       |
| Requirements | contenttypeslug: pages|page|entries|entry|showcases|showcase|blocks|block |
| Defaults     | zone: frontend                                                            |
|              | _controller: 'controller.frontend:record'                                 |
| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler                   |
|              | _before_middlewares:                                                      |
|              |   - Closure                                                               |
|              | _after_middlewares:                                                       |
|              |   - Closure                                                               |
+--------------+---------------------------------------------------------------------------+
```