### PR TITLE
[3.3] Nut pimple:dump consistency & tests

### DIFF
--- a/src/Nut/PimpleDump.php
+++ b/src/Nut/PimpleDump.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @author Carson Full <carsonfull@gmail.com>
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class PimpleDumpCommand extends BaseCommand
+class PimpleDump extends BaseCommand
 {
     /**
      * {@inheritdoc}

--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -8,8 +8,8 @@ use Bolt\Nut\NutApplication;
 use LogicException;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Bridge;
+use Symfony\Component\Console\Command\Command;
 
 class NutServiceProvider implements ServiceProviderInterface
 {
@@ -55,7 +55,7 @@ class NutServiceProvider implements ServiceProviderInterface
                     new Nut\Init($app),
                     new Nut\LogClear($app),
                     new Nut\LogTrim($app),
-                    new Nut\PimpleDumpCommand($app),
+                    new Nut\PimpleDump($app),
                     new Nut\ServerRun($app),
                     new Nut\SetupSync($app),
                     new Nut\TestRunner($app),

--- a/tests/phpunit/unit/Nut/PimpleDumpTest.php
+++ b/tests/phpunit/unit/Nut/PimpleDumpTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bolt\Tests\Nut;
+
+use Bolt\Nut\PimpleDump;
+use Bolt\Tests\BoltUnitTest;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @covers \Bolt\Nut\PimpleDump
+ * @group slow
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class PimpleDumpTest extends BoltUnitTest
+{
+    public function testRun()
+    {
+        $app = $this->getApp();
+        $app['pimpledump.output_dir'] = PHPUNIT_WEBROOT;
+        $command = new PimpleDump($app);
+
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertFileExists(PHPUNIT_WEBROOT . '/pimple.json');
+    }
+
+    public function tearDown()
+    {
+        @unlink(PHPUNIT_WEBROOT . '/pimple.json');
+    }
+}


### PR DESCRIPTION
`PimpleDumpCommand` was the only Nut class to use the "Command" suffix, and my C.D.O. couldn't cope :stuck_out_tongue_winking_eye: 

Also added test coverage.