### PR TITLE
[3.3] Enable breaking events up into single events

### DIFF
--- a/src/Nut/DebugEvents.php
+++ b/src/Nut/DebugEvents.php
@@ -4,9 +4,11 @@ namespace Bolt\Nut;
 
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableStyle;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Nut command to dump system listened events, and target callable.
@@ -23,6 +25,7 @@ class DebugEvents extends BaseCommand
         $this
             ->setName('debug:events')
             ->setDescription('Dumps event listeners.')
+            ->addArgument('event', InputArgument::OPTIONAL, 'An event name')
             ->addOption('sort-listener', null, InputOption::VALUE_NONE, 'Sort events in order of callable name.')
         ;
     }
@@ -32,17 +35,17 @@ class DebugEvents extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $table = new Table($output);
-        $rightAligned = new TableStyle();
-        $rightAligned->setPadType(STR_PAD_LEFT);
-        $table->setHeaders([
-            ['Event Name', 'Listener', 'Priority'],
-        ]);
-        $table->setColumnStyle(2, $rightAligned);
         $dispatcher = $this->app['dispatcher'];
         $listeners = $dispatcher->getListeners();
+        $eventArg = $input->getArgument('event');
+
+        $io = new SymfonyStyle($input, $output);
 
         foreach ($listeners as $eventName => $eventListeners) {
+            if ($eventArg && $eventName !== $eventArg) {
+                continue;
+            }
+
             if ($input->getOption('sort-listener')) {
                 uasort($eventListeners, function ($a, $b) {
                     $a = is_array($a) ? get_class($a[0]) : get_class($a);
@@ -54,20 +57,56 @@ class DebugEvents extends BaseCommand
                     return ($a < $b) ? -1 : 1;
                 });
             }
+
+            if ($eventArg) {
+                $io->title('Registered Listeners for "' . $eventName . '" Event');
+            } else {
+                $io->section('"' . $eventName . '" event');
+            }
+
+            $i = 1;
+            $table = $this->getTable($output);
             foreach ($eventListeners as $callable) {
                 $priority = $dispatcher->getListenerPriority($eventName, $callable);
                 if (is_array($callable)) {
                     $table->addRow([
-                        $eventName,
+                        '#' .  $i++,
                         sprintf('%s::%s()', get_class($callable[0]), $callable[1]),
                         $priority,
                     ]);
                 } else {
-                    $table->addRow([$eventName, get_class($callable), $priority]);
+                    $table->addRow(['#' .  $i++, get_class($callable), $priority]);
                 }
             }
+            $table->render();
+            $output->writeln('');
         }
 
-        $table->render();
+        return 0;
+    }
+
+    /**
+     * @param OutputInterface $output
+     *
+     * @return Table
+     */
+    protected function getTable(OutputInterface $output)
+    {
+        $table = new Table($output);
+
+
+        $leftAligned = new TableStyle();
+        $leftAligned->setPadType(STR_PAD_LEFT);
+        $table->setColumnStyle(0, $leftAligned);
+
+        $rightAligned = new TableStyle();
+        $rightAligned->setPadType(STR_PAD_LEFT);
+        $table->setColumnStyle(2, $rightAligned);
+
+        $table->setHeaders([
+            ['Order', 'Callable', 'Priority'],
+        ]);
+
+        return $table;
     }
 }

--- a/tests/phpunit/unit/Nut/DebugEventsTest.php
+++ b/tests/phpunit/unit/Nut/DebugEventsTest.php
@@ -15,7 +15,7 @@ class DebugEventsTest extends BoltUnitTest
 {
     use TableHelperTrait;
 
-    protected $regexExpectedA = '/(kernel\.request).+(Symfony.Component.HttpKernel.EventListener.RouterListener::onKernelRequest).+(32)/';
+    protected $regexExpectedA = '/(#\d+).+(Symfony.Component.HttpKernel.EventListener.RouterListener::onKernelRequest).+(32)/';
     protected $regexExpectedB = '/(Bolt.Routing.Canonical::onRequest).+(31)/';
 
     public function testRunNormal()


### PR DESCRIPTION
* Follow upstream use of columns
* Allow a single request by name to be dumped

```
$ ./app/nut debug:events kernel.request

Registered Listeners for "kernel.request" Event
===============================================

+-------+--------------------------------------------------------------------------------+----------+
| Order | Callable                                                                       | Priority |
+-------+--------------------------------------------------------------------------------+----------+
|    #1 | Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure()  |     2048 |
|    #2 | Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelRequest() |     1024 |
|    #3 | Bolt\EventListener\ConfigListener::onRequestEarly()                            |      512 |
|    #4 | Bolt\Session\SessionListener::onRequest()                                      |      128 |
|    #5 | Bolt\EventListener\FlashLoggerListener::onRequest()                            |      127 |
|    #6 | Bolt\Profiler\DebugToolbarEnabler::onRequest()                                 |      126 |
|    #7 | Symfony\Component\HttpKernel\EventListener\FragmentListener::onKernelRequest() |       48 |
|    #8 | Bolt\Configuration\ConfigurationValueProxy::onKernelRequest()                  |       34 |
|    #9 | Bolt\Configuration\ConfigurationValueProxy::onKernelRequest()                  |       34 |
|   #10 | Bolt\EventListener\ConfigListener::onRequest()                                 |       33 |
|   #11 | Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest()   |       32 |
|   #12 | Bolt\EventListener\StorageEventListener::onKernelRequest()                     |       31 |
|   #13 | Bolt\EventListener\ZoneGuesser::onKernelRequest()                              |       31 |
|   #14 | Bolt\Routing\Canonical::onRequest()                                            |       31 |
|   #15 | Silex\EventListener\LocaleListener::onKernelRequest()                          |       16 |
|   #16 | Symfony\Component\Security\Http\Firewall::onKernelRequest()                    |        8 |
|   #17 | Closure                                                                        |        0 |
|   #18 | Silex\EventListener\LogListener::onKernelRequest()                             |        0 |
|   #19 | Bolt\EventListener\PagerListener::onRequest()                                  |        0 |
|   #20 | Silex\EventListener\MiddlewareListener::onKernelRequest()                      |    -1024 |
|   #21 | Bolt\EventListener\FlashLoggerListener::onEvent()                              |    -1024 |
+-------+--------------------------------------------------------------------------------+----------+
```