### PR TITLE
[3.3] Avoid Nut BC derp

### DIFF
--- a/src/Nut/AbstractConfig.php
+++ b/src/Nut/AbstractConfig.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\OutputStyle;
 use Symfony\Component\Yaml\Exception\ParseException;
 
 /**
@@ -36,6 +37,8 @@ abstract class AbstractConfig extends BaseCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @param OutputStyle $output
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -52,12 +55,12 @@ abstract class AbstractConfig extends BaseCommand
             $this->doExecute($updater, $input, $output);
         } catch (Exception $e) {
             if ($e instanceof FileNotFoundException) {
-                $this->io->error($e->getMessage());
-                $this->io->error("Can't read file: $fileName.");
+                $output->error($e->getMessage());
+                $output->error("Can't read file: $fileName.");
             } elseif ($e instanceof ParseException) {
-                $this->io->error(sprintf('Invalid YAML in file: %s.', $this->file->getFullPath()));
+                $output->error(sprintf('Invalid YAML in file: %s.', $this->file->getFullPath()));
             } elseif ($e instanceof InvalidArgumentException) {
-                $this->io->error($e->getMessage());
+                $output->error($e->getMessage());
             } else {
                 throw $e;
             }

--- a/src/Nut/BaseCommand.php
+++ b/src/Nut/BaseCommand.php
@@ -4,9 +4,6 @@ namespace Bolt\Nut;
 
 use Silex\Application;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -16,8 +13,6 @@ abstract class BaseCommand extends Command
 {
     /** @var Application */
     protected $app;
-    /** @var SymfonyStyle */
-    protected $io;
 
     /**
      * @param \Silex\Application $app
@@ -27,14 +22,6 @@ abstract class BaseCommand extends Command
     {
         parent::__construct();
         $this->app = $app;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function initialize(InputInterface $input, OutputInterface $output)
-    {
-        $this->io = new SymfonyStyle($input, $output);
     }
 
     /**

--- a/src/Nut/ConfigGet.php
+++ b/src/Nut/ConfigGet.php
@@ -5,6 +5,7 @@ namespace Bolt\Nut;
 use Bolt\Configuration\YamlUpdater;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\OutputStyle;
 
 /**
  * Nut command to get a parameter value from a YAML configuration file.
@@ -23,6 +24,11 @@ class ConfigGet extends AbstractConfig
         ;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param OutputStyle $output
+     */
     protected function doExecute(YamlUpdater $updater, InputInterface $input, OutputInterface $output)
     {
         $key = $input->getArgument('key');
@@ -32,7 +38,7 @@ class ConfigGet extends AbstractConfig
             $value = $value ? 'true' : 'false';
         }
 
-        $this->io->title(sprintf("Configuration setting in file %s", $this->file->getFullPath()));
-        $this->io->text([sprintf('%s: %s', $key, $value), '']);
+        $output->title(sprintf("Configuration setting in file %s", $this->file->getFullPath()));
+        $output->text([sprintf('%s: %s', $key, $value), '']);
     }
 }

--- a/src/Nut/ConfigSet.php
+++ b/src/Nut/ConfigSet.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\OutputStyle;
 
 /**
  * Nut command to set parameter value in a YAML configuration file
@@ -27,6 +28,11 @@ class ConfigSet extends AbstractConfig
         ;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param OutputStyle $output
+     */
     protected function doExecute(YamlUpdater $updater, InputInterface $input, OutputInterface $output)
     {
         $key = $input->getArgument('key');
@@ -38,8 +44,8 @@ class ConfigSet extends AbstractConfig
             $value = $value ? 'true' : 'false';
         }
 
-        $this->io->title(sprintf("Updating configuration setting in file %s", $this->file->getFullPath()));
-        $this->io->success([
+        $output->title(sprintf("Updating configuration setting in file %s", $this->file->getFullPath()));
+        $output->success([
             'Setting updated to:',
             sprintf('%s: %s', $key, $value),
         ]);

--- a/src/Nut/DebugEvents.php
+++ b/src/Nut/DebugEvents.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Style\OutputStyle;
 
 /**
  * Nut command to dump system listened events, and target callable.
@@ -32,14 +32,14 @@ class DebugEvents extends BaseCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @param OutputStyle $output
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dispatcher = $this->app['dispatcher'];
         $listeners = $dispatcher->getListeners();
         $eventArg = $input->getArgument('event');
-
-        $io = new SymfonyStyle($input, $output);
 
         foreach ($listeners as $eventName => $eventListeners) {
             if ($eventArg && $eventName !== $eventArg) {
@@ -59,9 +59,9 @@ class DebugEvents extends BaseCommand
             }
 
             if ($eventArg) {
-                $io->title('Registered Listeners for "' . $eventName . '" Event');
+                $output->title('Registered Listeners for "' . $eventName . '" Event');
             } else {
-                $io->section('"' . $eventName . '" event');
+                $output->section('"' . $eventName . '" event');
             }
 
             $i = 1;

--- a/src/Nut/NutApplication.php
+++ b/src/Nut/NutApplication.php
@@ -4,7 +4,11 @@ namespace Bolt\Nut;
 
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand;
 use Symfony\Component\Console\Application as ConsoleApplication;
-use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Nut application.
@@ -14,9 +18,22 @@ use Symfony\Component\Console\Command\Command;
 class NutApplication extends ConsoleApplication
 {
     /**
-     * Gets the default commands that should always be available.
-     *
-     * @return Command[] An array of default Command instances
+     * {@inheritdoc}
+     */
+    public function run(InputInterface $input = null, OutputInterface $output = null)
+    {
+        if (null === $input) {
+            $input = new ArgvInput();
+        }
+        if (null === $output) {
+            $output = new SymfonyStyle($input, new ConsoleOutput());
+        }
+
+        return parent::run($input, $output);
+    }
+
+    /**
+     * {@inheritdoc}
      */
     protected function getDefaultCommands()
     {

--- a/src/Nut/RouterMatch.php
+++ b/src/Nut/RouterMatch.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Style\OutputStyle;
 use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
@@ -63,11 +63,12 @@ EOF
 
     /**
      * {@inheritdoc}
+     *
+     * @param OutputStyle $output
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->app->flush();
-        $io = new SymfonyStyle($input, $output);
 
         /** @var RouteCollection $router */
         $router = $this->app['routes'];
@@ -86,26 +87,26 @@ EOF
 
         $traces = $matcher->getTraces($input->getArgument('path_info'));
 
-        $io->newLine();
+        $output->newLine();
 
         $matches = false;
         foreach ($traces as $trace) {
             if (TraceableUrlMatcher::ROUTE_ALMOST_MATCHES == $trace['level']) {
-                $io->text(sprintf('Route <info>"%s"</> almost matches but %s', $trace['name'], lcfirst($trace['log'])));
+                $output->text(sprintf('Route <info>"%s"</> almost matches but %s', $trace['name'], lcfirst($trace['log'])));
             } elseif (TraceableUrlMatcher::ROUTE_MATCHES == $trace['level']) {
-                $io->success(sprintf('Route "%s" matches', $trace['name']));
+                $output->success(sprintf('Route "%s" matches', $trace['name']));
 
                 $routerDebugCommand = $this->getApplication()->find('debug:router');
                 $routerDebugCommand->run(new ArrayInput(['name' => $trace['name']]), $output);
 
                 $matches = true;
             } elseif ($input->getOption('verbose')) {
-                $io->text(sprintf('Route "%s" does not match: %s', $trace['name'], $trace['log']));
+                $output->text(sprintf('Route "%s" does not match: %s', $trace['name'], $trace['log']));
             }
         }
 
         if (!$matches) {
-            $io->error(sprintf('None of the routes match the path "%s"', $input->getArgument('path_info')));
+            $output->error(sprintf('None of the routes match the path "%s"', $input->getArgument('path_info')));
 
             return 1;
         }

--- a/src/Nut/ServerRun.php
+++ b/src/Nut/ServerRun.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Style\OutputStyle;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
 
@@ -34,18 +34,18 @@ class ServerRun extends BaseCommand
 
     /**
      * {@inheritdoc}
+     *
+     * @param OutputStyle $output
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $io = new SymfonyStyle($input, $output);
-
         $address = $input->getArgument('address');
         if (strpos($address, ':') === false) {
             $address .= ':' . $input->getOption('port');
         }
 
         if ($this->isOtherServerProcessRunning($address)) {
-            $io->error(sprintf('A process is already listening on http://%s', $address));
+            $output->error(sprintf('A process is already listening on http://%s', $address));
 
             return 1;
         }
@@ -53,8 +53,8 @@ class ServerRun extends BaseCommand
         $webDir = $this->app['path_resolver']->resolve('web');
         $router = $webDir . '/index.php';
 
-        $io->success(sprintf('Server running on http://%s', $address));
-        $io->comment('Quit the server with CONTROL-C.');
+        $output->success(sprintf('Server running on http://%s', $address));
+        $output->comment('Quit the server with CONTROL-C.');
 
         if (($process = $this->createServerProcess($io, $address, $webDir, $router)) === null) {
             return 1;
@@ -78,14 +78,14 @@ class ServerRun extends BaseCommand
     }
 
     /**
-     * @param SymfonyStyle $io
-     * @param string       $address
-     * @param string       $webDir
-     * @param string       $router
+     * @param OutputStyle $io
+     * @param string      $address
+     * @param string      $webDir
+     * @param string      $router
      *
      * @return null|\Symfony\Component\Process\Process
      */
-    protected function createServerProcess(SymfonyStyle $io, $address, $webDir, $router)
+    protected function createServerProcess(OutputStyle $io, $address, $webDir, $router)
     {
         if (!file_exists($router)) {
             $io->error(sprintf('The router script "%s" does not exist', $router));

--- a/tests/phpunit/unit/Nut/ConfigGetTest.php
+++ b/tests/phpunit/unit/Nut/ConfigGetTest.php
@@ -6,7 +6,6 @@ use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Nut\ConfigGet;
 use Bolt\Tests\BoltUnitTest;
-use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * Class to test src/Nut/ConfigGet.
@@ -22,12 +21,12 @@ class ConfigGetTest extends BoltUnitTest
         $app['filesystem']->mountFilesystem('config', $filesystem);
 
         $command = new ConfigGet($app);
-        $tester = new CommandTester($command);
+        $tester = new NutCommandTester($command);
         $tester->execute(['key' => 'sitename', '--file' => 'config.yml']);
         $this->assertRegExp('/sitename: A sample site/', $tester->getDisplay());
 
         // test invalid
-        $tester = new CommandTester($command);
+        $tester = new NutCommandTester($command);
         $tester->execute(['key' => 'nonexistent', '--file' => 'config.yml']);
         $this->assertRegExp("/The key 'nonexistent' was not found in config:\/\/config.yml/", $tester->getDisplay());
     }
@@ -39,7 +38,7 @@ class ConfigGetTest extends BoltUnitTest
         $app['filesystem']->mountFilesystem('config', $filesystem);
 
         $command = new ConfigGet($app);
-        $tester = new CommandTester($command);
+        $tester = new NutCommandTester($command);
         $tester->execute(['key' => 'sitename']);
         $this->assertRegExp('/sitename: A sample site/', $tester->getDisplay());
     }

--- a/tests/phpunit/unit/Nut/ConfigSetTest.php
+++ b/tests/phpunit/unit/Nut/ConfigSetTest.php
@@ -6,7 +6,6 @@ use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Nut\ConfigSet;
 use Bolt\Tests\BoltUnitTest;
-use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * Class to test src/Nut/ConfigSet.
@@ -22,7 +21,7 @@ class ConfigSetTest extends BoltUnitTest
         $app['filesystem']->mountFilesystem('config', $filesystem);
 
         $command = new ConfigSet($app);
-        $tester = new CommandTester($command);
+        $tester = new NutCommandTester($command);
 
         // Test successful update
         $tester->execute(['key' => 'sitename', 'value' => 'my test', '--file' => 'config.yml']);
@@ -41,7 +40,7 @@ class ConfigSetTest extends BoltUnitTest
         $app['filesystem']->mountFilesystem('config', $filesystem);
 
         $command = new ConfigSet($app);
-        $tester = new CommandTester($command);
+        $tester = new NutCommandTester($command);
         $tester->execute(['key' => 'nonexistent', 'value' => 'test']);
         $this->assertRegExp("/The key 'nonexistent' was not found in config:\/\/config.yml/", $tester->getDisplay());
     }

--- a/tests/phpunit/unit/Nut/DebugEventsTest.php
+++ b/tests/phpunit/unit/Nut/DebugEventsTest.php
@@ -4,7 +4,6 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Nut\DebugEvents;
 use Bolt\Tests\BoltUnitTest;
-use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * Test for \Bolt\Nut\DebugEvents
@@ -47,13 +46,13 @@ class DebugEventsTest extends BoltUnitTest
     }
 
     /**
-     * @return CommandTester
+     * @return NutCommandTester
      */
     protected function getCommandTester()
     {
         $app = $this->getApp();
         $command = new DebugEvents($app);
 
-        return new CommandTester($command);
+        return new NutCommandTester($command);
     }
 }

--- a/tests/phpunit/unit/Nut/NutCommandTester.php
+++ b/tests/phpunit/unit/Nut/NutCommandTester.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Bolt\Tests\Nut;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Eases the testing of console commands.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class NutCommandTester
+{
+    /** @var Command */
+    private $command;
+    /** @var InputInterface */
+    private $input;
+    /** @var SymfonyStyle */
+    private $output;
+    /** @var StreamOutput */
+    private $stream;
+    /** @var int */
+    private $statusCode;
+
+    /**
+     * Constructor.
+     *
+     * @param Command $command A Command instance to test
+     */
+    public function __construct(Command $command)
+    {
+        $this->command = $command;
+    }
+
+    /**
+     * Executes the command.
+     *
+     * Available execution options:
+     *
+     *  * interactive: Sets the input interactive flag
+     *  * decorated:   Sets the output decorated flag
+     *  * verbosity:   Sets the output verbosity flag
+     *
+     * @param array $input   An array of command arguments and options
+     * @param array $options An array of execution options
+     *
+     * @return int The command exit code
+     */
+    public function execute(array $input, array $options = array())
+    {
+        // set the command name automatically if the application requires
+        // this argument and no command name was passed
+        if (!isset($input['command'])
+            && (null !== $application = $this->command->getApplication())
+            && $application->getDefinition()->hasArgument('command')
+        ) {
+            $input = array_merge(array('command' => $this->command->getName()), $input);
+        }
+
+        $this->input = new ArrayInput($input);
+        if (isset($options['interactive'])) {
+            $this->input->setInteractive($options['interactive']);
+        }
+
+        $this->stream = new StreamOutput(fopen('php://memory', 'w', false));
+        $this->output = new SymfonyStyle($this->input, $this->stream);
+        $this->output->setDecorated(isset($options['decorated']) ? $options['decorated'] : false);
+        if (isset($options['verbosity'])) {
+            $this->output->setVerbosity($options['verbosity']);
+        }
+
+        return $this->statusCode = $this->command->run($this->input, $this->output);
+    }
+
+    /**
+     * Gets the display returned by the last execution of the command.
+     *
+     * @param bool $normalize Whether to normalize end of lines to \n or not
+     *
+     * @return string The display
+     */
+    public function getDisplay($normalize = false)
+    {
+        rewind($this->stream->getStream());
+
+        $display = stream_get_contents($this->stream->getStream());
+
+        if ($normalize) {
+            $display = str_replace(PHP_EOL, "\n", $display);
+        }
+
+        return $display;
+    }
+
+    /**
+     * Gets the input instance used by the last execution of the command.
+     *
+     * @return InputInterface The current input instance
+     */
+    public function getInput()
+    {
+        return $this->input;
+    }
+
+    /**
+     * Gets the output instance used by the last execution of the command.
+     *
+     * @return OutputInterface The current output instance
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    /**
+     * Gets the status code returned by the last execution of the application.
+     *
+     * @return int The status code
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+}

--- a/tests/phpunit/unit/Nut/RouterMatchTest.php
+++ b/tests/phpunit/unit/Nut/RouterMatchTest.php
@@ -4,7 +4,6 @@ namespace Bolt\Tests\Nut;
 
 use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * Tests for \Bolt\Nut\RouterMatch
@@ -69,13 +68,13 @@ class RouterMatchTest extends BoltUnitTest
     }
 
     /**
-     * @return CommandTester
+     * @return NutCommandTester
      */
     protected function getCommandTester()
     {
         $app = $this->getApp();
         $command = $app['nut']->get('router:match');
 
-        return new CommandTester($command);
+        return new NutCommandTester($command);
     }
 }


### PR DESCRIPTION
So, when Carson and I split the config commands into a base class, I meant to override the `initialize()` in that abstract, instead I put it into `BaseCommand` … :man_facepalming: 

Anyway, as we're using `OutputStyle` (`SymfonyStyle`) in quite a few places, and I'd guess mroe to come :wink: 

… and it would be good to have consistently formatted output that is logical for the programmer to write, so I am setting a `null` `$output` to a `ConsoleOutput` (normal) wrapped in a `SymfonyStyle`