### PR TITLE
Fix News widget on dashboard

### DIFF
--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -122,6 +122,7 @@ class General extends AsyncBase
         // but Alerts can't.
         $context = [
             'alert'       => empty($news['alert']) ? null : $news['alert'],
+            'news'        => empty($news['news']) ? null : $news['news'],
             'information' => empty($news['information']) ? null : $news['information'],
             'error'       => empty($news['error']) ? null : $news['error'],
             'disable'     => $this->getOption('general/backend/news/disable'),


### PR DESCRIPTION
After dd6b99ce25975408ae26d05301c3ecf230a449d0, news items did no longer fall back to 'information', but they remained in the array as 'news'. This PR passes that one into the rendering function too. 