### PR TITLE
Tweaked Error/Exception Handler Configuration

### DIFF
--- a/src/Provider/DebugServiceProvider.php
+++ b/src/Provider/DebugServiceProvider.php
@@ -108,20 +108,6 @@ class DebugServiceProvider implements ServiceProviderInterface
         // To fix this do `$handler->setDefaultLogger(new NullLogger(), null, true)` after the event listener
         // below runs its configure method.
 
-        // Listener to register logger with error handler and set real exception handler
-        $app['debug.handlers_listener'] = $app->share(
-            function ($app) {
-                return new DebugHandlersListener(
-                    null, // null to use HttpKernel or Console App exception handler
-                    $app['logger'],
-                    $app['debug.error_handler.log_at'],
-                    null, // Throw at is already applied.
-                    true, // Log silenced errors
-                    $app['code.file_link_format']
-                );
-            }
-        );
-
         // Enable handlers for web and cli, but not test runners since they have their own.
         $app['debug.error_handler.enabled'] =
         $app['debug.exception_handler.enabled'] =
@@ -178,6 +164,20 @@ class DebugServiceProvider implements ServiceProviderInterface
 
             return $handler;
         };
+
+        // Listener to register logger with error handler and set real exception handler
+        $app['debug.handlers_listener'] = $app->share(
+            function ($app) {
+                return new DebugHandlersListener(
+                    null, // null to use HttpKernel or Console App exception handler
+                    $app['logger'],
+                    $app['debug.error_handler.log_at'],
+                    null, // Throw at is already applied.
+                    true, // Log silenced errors
+                    $app['code.file_link_format']
+                );
+            }
+        );
 
         $app['debug.class_loader.enabled'] = function ($app) {
             return $app['debug'];

--- a/src/Provider/DebugServiceProvider.php
+++ b/src/Provider/DebugServiceProvider.php
@@ -208,6 +208,11 @@ class DebugServiceProvider implements ServiceProviderInterface
         $app['debug.class_loader.enabled'] = function ($app) {
             return $app['debug'];
         };
+
+        // Added by WebProviderServiceProvider
+        if (!isset($app['code.file_link_format'])) {
+            $app['code.file_link_format'] = null;
+        }
     }
 
     /**

--- a/src/Provider/DebugServiceProvider.php
+++ b/src/Provider/DebugServiceProvider.php
@@ -93,17 +93,15 @@ class DebugServiceProvider implements ServiceProviderInterface
             });
         }
 
-        // Thrown errors in an integer bit field of E_* constants
-        $app['error_handler.throw_at'] = function ($app) {
+        // Thrown and logged errors in an integer bit field of E_* constants
+        $app['error_handler.throw_at'] =
+        $app['error_handler.log_at'] = function ($app) {
             if ($app['debug']) {
                 return $app['config']->get('general/debug_error_level', E_ALL);
             } else {
                 return $app['config']->get('general/production_error_level', 0);
             }
         };
-
-        // Logged errors in an integer bit field of E_* constants.
-        $app['error_handler.log_at'] = E_ALL; // TODO Should this be the same as throw_at? Previously it was via config env_error_level.
 
         $app['error_handler.logger'] = function ($app) {
             return $app['logger'];

--- a/src/Provider/DebugServiceProvider.php
+++ b/src/Provider/DebugServiceProvider.php
@@ -216,8 +216,6 @@ class DebugServiceProvider implements ServiceProviderInterface
     public function boot(Application $app)
     {
         if ($this->firstPhase) {
-            $app['dispatcher']->addSubscriber($app['debug.handlers_listener']);
-
             $level = $app['debug.error_handler.reporting_level'];
             if ($level !== null) {
                 error_reporting($level);
@@ -227,6 +225,10 @@ class DebugServiceProvider implements ServiceProviderInterface
             $this->registerHandlers($app);
         } else {
             $app['debug.initialized'] = true;
+
+            // Can be subscribed regardless of enabled, because it won't do anything
+            // if there is no error handler or exception handler registered.
+            $app['dispatcher']->addSubscriber($app['debug.handlers_listener']);
 
             // Register again which will make changes to handlers if parameters have changed.
             $this->registerHandlers($app);


### PR DESCRIPTION
See commit messages for details.

:koala: edit:
  * Moved invoking/subscribing handler listener to second phase, so it gets the correct parameters from Config
  * Replaced `display_errors` and `reporting_level` with `throw_at` and `log_at` DI parameters
    * ErrorHandler's "displayErrors" logic is deprecated and we are instructed to use "throw at" logic instead.
      This is also better because instead of a boolean we can specify which errors we want thrown (aka displayed to user).
    * Additionally, PHP has `display_errors` ini setting which is similar but not the same as ErrorHandler's "display errors" logic.
      This is now automatically disabled (if error handler is enabled) since it is not helpful to users.
You can see the error with the logger you've configured and optionally see it inline as an exception message.
    * PHP's `reporting_level` is automatically configured to report all errors (if error handler is enabled).
This is because Symfony's ErrorHandler has its own logic for configuring how errors are handled: "throw at" and "log_at".
  * Reorder listener code below handlers to visual represent it is executed later
  * Remove debug. prefix from error_handler and exception_handler keys since they are separate from debugging.
  * Move logger out into its own service so it can be configured separately.
    * Set the logger ourselves so we can tell the handler to not log levels we don't want logged.
    * This removes the bootstrap BufferLogger which could cause a memory leak for long running processes.