### PR TITLE
[3.3] Keep order number consistent to class when using --sort-listener

### DIFF
--- a/src/Nut/DebugEvents.php
+++ b/src/Nut/DebugEvents.php
@@ -66,22 +66,22 @@ class DebugEvents extends BaseCommand
                 $output->section('"' . $eventName . '" event');
             }
 
-            $i = 1;
             $table = $this->getTable($output);
-            foreach ($eventListeners as $callable) {
+            foreach ($eventListeners as $order => $callable) {
+                $order++;
                 $priority = $dispatcher->getListenerPriority($eventName, $callable);
                 if (is_array($callable)) {
                     $table->addRow([
-                        '#' . $i++,
+                        '#' . $order,
                         sprintf('%s::%s()', get_class($callable[0]), $callable[1]),
                         $priority,
                     ]);
                 } elseif ($callable instanceof Closure) {
                     $r = new ReflectionFunction($callable);
                     $originClass = $r->getClosureScopeClass()->getName() . ' ' . $r->getShortName();
-                    $table->addRow(['#' .  $i++, $originClass, $priority]);
+                    $table->addRow(['#' .  $order, $originClass, $priority]);
                 } else {
-                    $table->addRow(['#' .  $i++, get_class($callable), $priority]);
+                    $table->addRow(['#' .  $order, get_class($callable), $priority]);
                 }
             }
             $table->render();


### PR DESCRIPTION
Calling `./app/nut debug:events kernel.response --sort-listener` would correctly sort the columns by the callable name, but leave the order column linear.

Now:
```
$ ./app/nut debug:events kernel.response --sort-listener

Registered Listeners for "kernel.response" Event
================================================

+-------+----------------------------------------------------------------------------------+----------+
| Order | Callable                                                                         | Priority |
+-------+----------------------------------------------------------------------------------+----------+
|    #1 | Bolt\EventListener\FlashLoggerListener::onEvent()                                |     1000 |
|   #12 | Bolt\EventListener\FlashLoggerListener::onEvent()                                |     1000 |
|    #7 | Bolt\EventListener\GeneralListener::onResponse()                                 |        0 |
|    #9 | Bolt\EventListener\RedirectListener::onResponse()                                |        0 |
|    #8 | Bolt\EventListener\SnippetListener::onResponse()                                 |        0 |
|   #11 | Bolt\Session\SessionListener::onResponse()                                       |     -128 |
|    #4 | Silex\Application {closure}                                                      |        0 |
|    #5 | Silex\EventListener\LogListener::onKernelResponse()                              |        0 |
|    #2 | Silex\EventListener\MiddlewareListener::onKernelResponse()                       |      128 |
|   #10 | Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelResponse()  |     -100 |
|    #3 | Symfony\Component\HttpKernel\EventListener\ResponseListener::onKernelResponse()  |        0 |
|    #6 | Symfony\Component\HttpKernel\EventListener\SurrogateListener::onKernelResponse() |        0 |
+-------+----------------------------------------------------------------------------------+----------+
``