### PR TITLE
Add disabled attribute support to buic select options

### DIFF
--- a/app/view/twig/_buic/_select.twig
+++ b/app/view/twig/_buic/_select.twig
@@ -88,6 +88,7 @@
                             {% set optattr = {
                                 'value!':   option.value,
                                 'selected': option.selected|default(false),
+                                'disabled': option.disabled|default(false),
                                 'label':    option.value == '' and opttext == '' ? '–' : false,
                             } %}
                             <option{{ hattr(optattr) }}>{{ opttext }}</option>

--- a/app/view/twig/_buic/_select.twig
+++ b/app/view/twig/_buic/_select.twig
@@ -85,6 +85,7 @@
 
                             {# option #}
                             {% set opttext = option.text|default(option.value)|striptags %}
+                            {# for details on why 'disabled' is in here, see https://github.com/bolt/bolt/pull/6590 #}
                             {% set optattr = {
                                 'value!':   option.value,
                                 'selected': option.selected|default(false),


### PR DESCRIPTION
_This adds support for the disabled attribute to Bolt's select2 field, this is not a bug fix for any particular issue_

It's not currently possible to set options to disabled, adding the disabled attribute to the `optattr` array allows you to pass `disabled:true` in the `conf.options`.

## Use case
The disabled attribute is **not** useful from the `contenttypes.yml` config. For example - why would you have `values: [ A, B, C ]` and then set `B` to be disabled. It would be disabled on **all** instances of the field and never selectable. 

The disabled attribute is however useful for extension development - where the values array is being dynamically generated. For example, a field that has options you can only use once. If `Page 1` has selected option `B` then on `Page 2` option `B` can be defined as disabled. 