### PR TITLE
Implement getValues in new Storage Entity

### DIFF
--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -322,12 +322,9 @@ class Content extends Entity
             return [];
         }
 
-        $fields = array_keys($contentType['fields']);
         $allValues = $this->toArray();
 
-        return array_filter($allValues, function ($key) use ($fields) {
-            return in_array($key, $fields);
-        }, ARRAY_FILTER_USE_KEY);
+        return array_intersect_key($allValues, ($contentType['fields']));
     }
 
     /**

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -312,6 +312,25 @@ class Content extends Entity
     }
 
     /**
+     * Helper to return an array of user-defined values from the Entity.
+     * This excludes meta fields set by Bolt.
+     */
+    public function getValues()
+    {
+        $contentType = $this->getContenttype();
+        if (!isset($contentType['fields'])) {
+            return [];
+        }
+
+        $fields = array_keys($contentType['fields']);
+        $allValues = $this->toArray();
+
+        return array_filter($allValues, function ($key) use ($fields) {
+            return in_array($key, $fields);
+        }, ARRAY_FILTER_USE_KEY);
+    }
+
+    /**
      * Getter for a record's 'title' field.
      *
      * If there is no field called 'title' then we just return the first text

--- a/tests/phpunit/unit/Storage/EntityTest.php
+++ b/tests/phpunit/unit/Storage/EntityTest.php
@@ -51,4 +51,17 @@ class EntityTest extends BoltUnitTest
         $this->assertSame($entity->getSlug(), 'kenny-koala');
         $this->assertSame($entity->getImage(), ['file' => 'koala.png']);
     }
+
+    public function testContentGetValues()
+    {
+        $app = $this->getApp();
+        $repo = $app['storage']->getRepository('pages');
+        $content = $repo->findOneBy(['id'=>1]);
+        $vals = $content->getValues();
+        $this->assertArrayNotHasKey('datepublish', $vals);
+        $this->assertArrayNotHasKey('datedepublish', $vals);
+        $this->assertArrayNotHasKey('id', $vals);
+        $this->assertArrayHasKey('slug', $vals);
+        $this->assertArrayHasKey('title', $vals);
+    }
 }


### PR DESCRIPTION
Fixes #6579

Implements the getValues method to work on the new storage entity in the same way the old Content object did.

Includes test.