### PR TITLE
Enable no, partial, or full Q&A on Nut user:add

### DIFF
--- a/src/Nut/AbstractUser.php
+++ b/src/Nut/AbstractUser.php
@@ -63,7 +63,7 @@ abstract class AbstractUser extends BaseCommand
      */
     protected function askRole(InputInterface $input)
     {
-        $roles = $input->getArgument('role');
+        $roles = (array) $input->getArgument('role');
         $choices = [];
 
         $allRoles = Bag::from($this->app['config']->get('permissions/roles'));
@@ -71,7 +71,7 @@ abstract class AbstractUser extends BaseCommand
         foreach ($allRoles->keys() as $role) {
             $choices[$role] = $allRoles->getPath("$role/label", $role);
         }
-        $defaults = empty($roles) ? null : implode(', ', (array) $roles);
+        $defaults = empty($roles) ? null : implode(', ', $roles);
 
         $question = new ChoiceQuestion('Roles (comma separated)', $choices, $defaults);
         $question->setMultiselect(true);

--- a/src/Nut/AbstractUser.php
+++ b/src/Nut/AbstractUser.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Bolt\Nut;
+
+use Bolt\Collection\Bag;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * User command base class.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+abstract class AbstractUser extends BaseCommand
+{
+    /**
+     * @param InputInterface $input
+     */
+    protected function askUserName(InputInterface $input)
+    {
+        $userName = $input->getArgument('username');
+        $question = new Question('User name', $userName);
+        $userName = $this->io->askQuestion($question);
+        $input->setArgument('username', $userName);
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function askDisplayName(InputInterface $input)
+    {
+        $displayName = $input->getArgument('displayname');
+        $question = new Question('Display name', $displayName);
+        $displayName = $this->io->askQuestion($question);
+        $input->setArgument('displayname', $displayName);
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function askEmail(InputInterface $input)
+    {
+        $emailAddress = $input->getArgument('email');
+        $question = new Question('Email address', $emailAddress);
+        $emailAddress = $this->io->askQuestion($question);
+        $input->setArgument('email', $emailAddress);
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function askPassword(InputInterface $input)
+    {
+        $question = new Question('Password');
+        $question->setHidden(true);
+        $password = $this->io->askQuestion($question);
+        $input->setArgument('password', $password);
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    protected function askRole(InputInterface $input)
+    {
+        $roles = $input->getArgument('role');
+        $choices = [];
+
+        $allRoles = Bag::from($this->app['config']->get('permissions/roles'));
+        $allRoles->setPath('root/label', 'Root');
+        foreach ($allRoles->keys() as $role) {
+            $choices[$role] = $allRoles->getPath("$role/label", $role);
+        }
+        $defaults = empty($roles) ? null : implode(', ', (array) $roles);
+
+        $question = new ChoiceQuestion('Roles (comma separated)', $choices, $defaults);
+        $question->setMultiselect(true);
+        $roles = $this->io->askQuestion($question);
+        $input->setArgument('role', $roles);
+    }
+}

--- a/src/Nut/UserAdd.php
+++ b/src/Nut/UserAdd.php
@@ -2,17 +2,20 @@
 
 namespace Bolt\Nut;
 
+use Bolt\Form\FormType;
 use Bolt\Storage\Entity;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Form\FormInterface;
 
 /**
  * Nut command to add a user to the system
  */
-class UserAdd extends BaseCommand
+class UserAdd extends AbstractUser
 {
     /**
      * {@inheritdoc}
@@ -22,13 +25,29 @@ class UserAdd extends BaseCommand
         $this
             ->setName('user:add')
             ->setDescription('Add a new user.')
-            ->addArgument('username', InputArgument::REQUIRED, 'The user name (login name) for the new user.')
-            ->addArgument('displayname', InputArgument::REQUIRED, 'The display name for the new user.')
-            ->addArgument('email', InputArgument::REQUIRED, 'The email address for the new user.')
-            ->addArgument('password', InputArgument::REQUIRED, 'The password for the new user.')
-            ->addArgument('role', InputArgument::REQUIRED, 'The role you wish to give them.')
-            ->addOption('enable', 'e', InputOption::VALUE_NONE, 'Enable the new user.')
+            ->addArgument('username', InputArgument::REQUIRED, 'User (login) name for the new user')
+            ->addArgument('displayname', InputArgument::REQUIRED, 'Display name for the new user')
+            ->addArgument('email', InputArgument::REQUIRED, 'Email address for the new user')
+            ->addArgument('password', InputArgument::REQUIRED, 'Password for the new user')
+            ->addArgument('role', InputArgument::REQUIRED ^ InputArgument::IS_ARRAY, 'Role(s) you wish to give them')
+            ->addOption('enable', 'e', InputOption::VALUE_NONE, 'Enable the new user upon creation')
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $input->validate();
+        } catch (RuntimeException $e) {
+            $this->askUserName($input);
+            $this->askDisplayName($input);
+            $this->askEmail($input);
+            $this->askPassword($input);
+            $this->askRole($input);
+        }
     }
 
     /**
@@ -38,7 +57,7 @@ class UserAdd extends BaseCommand
     {
         /** @var \Bolt\Storage\Repository\UsersRepository $repo */
         $repo = $this->app['storage']->getRepository(Entity\Users::class);
-        $user = new Entity\Users([
+        $userEntity = new Entity\Users([
             'username'    => $input->getArgument('username'),
             'password'    => $input->getArgument('password'),
             'email'       => $input->getArgument('email'),
@@ -47,35 +66,56 @@ class UserAdd extends BaseCommand
             'enabled'     => (bool) $input->getOption('enable'),
         ]);
 
-        $message = [];
-        $valid = true;
-        if ($repo->getUser($user->getEmail())) {
-            $valid = false;
-            $message[] = "    * Email address '{$user->getEmail()}' already exists";
-        }
-        if ($repo->getUser($user->getUsername())) {
-            $valid = false;
-            $message[] = "    * User name '{$user->getUsername()}' already exists";
-        }
-        if ($valid === false) {
-            $message[] = 'Error creating user:';
-            $this->io->error(array_reverse($message));
+        $messages = $this->validate($userEntity);
+        if ($messages !== null) {
+            $messages[] = 'Error creating user:';
+            $this->io->error(array_reverse($messages));
 
             return 1;
         }
 
         // Boot all service providers manually as, we're not handling a request
         $this->app->boot();
-        $this->app['storage']->getRepository(Entity\Users::class)->save($user);
-        $this->auditLog(__CLASS__, "User created: {$user->getUsername()}");
+        $repo->save($userEntity);
+        $this->auditLog(__CLASS__, "User created: {$userEntity->getUsername()}");
 
         $userCommand = $this->getApplication()->find('user:manage');
         $userCommand->run(new ArrayInput([
             'login'  => $input->getArgument('username'),
             '--list' => true,
         ]), $output);
-        $this->io->success("Successfully created user: {$user->getUsername()}");
+        $this->io->success("Successfully created user: {$userEntity->getUsername()}");
 
         return 0;
+    }
+
+    /**
+     * @param Entity\Users $userEntity
+     *
+     * @return array|null
+     */
+    private function validate(Entity\Users $userEntity)
+    {
+        $options = [
+            'allow_extra_fields' => true,
+            'csrf_protection'    => false,
+        ];
+
+        /** @var FormInterface $form */
+        $form = $this->app['form.factory']->createBuilder(FormType\UserNewType::class, $userEntity, $options)
+            ->getForm()
+            ->submit($userEntity->toArray())
+        ;
+        $errors = $form->getErrors(true);
+        if ($errors->count() === 0) {
+            return null;
+        }
+
+        $messages = [];
+        foreach ($errors as $error) {
+            $messages[] = $error->getMessage();
+        }
+
+        return $messages;
     }
 }

--- a/src/Nut/UserManage.php
+++ b/src/Nut/UserManage.php
@@ -70,12 +70,15 @@ class UserManage extends BaseCommand
         if ($input->getOption('list')) {
             $this->io->title("Account details for '$userLogin'");
             $headers = ['User name', 'Email', 'Display Name', 'Roles', 'Enabled'];
+            $roles = array_filter($userEntity->getRoles(), function ($var) {
+                return $var !== 'everyone';
+            });
             $rows = [
                 [
                     $userEntity->getUsername(),
                     $userEntity->getEmail(),
                     $userEntity->getDisplayname(),
-                    implode(', ', $userEntity->getRoles()),
+                    implode(', ', $roles),
                     json_encode($userEntity->getEnabled()),
                 ],
             ];

--- a/tests/phpunit/unit/Nut/UserAddTest.php
+++ b/tests/phpunit/unit/Nut/UserAddTest.php
@@ -63,7 +63,8 @@ class UserAddTest extends BoltUnitTest
         );
         $result = $tester->getDisplay();
         $this->assertRegExp('#Error creating user:#', $result);
-        $this->assertRegExp("#    \* User name 'test' already exists#", $result);
-        $this->assertRegExp("#    \* Email address 'test@example.com' already exists#", $result);
+        $this->assertRegExp("#username is already in use#", $result);
+        $this->assertRegExp("#displayname is already in use#", $result);
+        $this->assertRegExp("#email address is already in use#", $result);
     }
 }

--- a/tests/phpunit/unit/Nut/UserRoleAddTest.php
+++ b/tests/phpunit/unit/Nut/UserRoleAddTest.php
@@ -21,7 +21,7 @@ class UserRoleAddTest extends BoltUnitTest
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 
-        $tester->execute(['username' => 'test', 'role' => 'admin']);
+        $tester->execute(['username' => 'test', 'role' => ['admin']]);
         $result = $tester->getDisplay();
         $this->assertRegExp("/User 'test' now has role 'admin'/", $result);
     }
@@ -33,7 +33,7 @@ class UserRoleAddTest extends BoltUnitTest
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 
-        $tester->execute(['username' => 'test', 'role' => 'admin']);
+        $tester->execute(['username' => 'test', 'role' => ['admin']]);
         $result = $tester->getDisplay();
         $this->assertRegExp('/already has role/', $result);
     }
@@ -45,7 +45,7 @@ class UserRoleAddTest extends BoltUnitTest
         $command = new UserRoleAdd($app);
         $tester = new CommandTester($command);
 
-        $tester->execute(['username' => 'test', 'role' => 'admin']);
+        $tester->execute(['username' => 'test', 'role' => ['admin']]);
         $result = $tester->getDisplay();
         $this->assertRegExp('/Could not add role/', $result);
     }


### PR DESCRIPTION
You can still run the command will all the options (even multiple roles)

```bash
$ ./app/nut user:add kenneth "Kenny Koala" kenny@koala.com.au T0pSecret editor admin

Account details for 'kenneth'
=============================

 ----------- -------------------- -------------- --------------- ---------
  User name   Email                Display Name   Roles           Enabled 
 ----------- -------------------- -------------- --------------- --------- 
  kenneth     kenny@koala.com.au   Kenny Koala    editor, admin   false
 ----------- -------------------- -------------- --------------- --------- 

 [OK] Successfully created user: kenneth
``` 

Or, if you omit some, or all parameters — 'cause you know _passwords in your command history_ and all — you will be prompted for all options, but with the ones you provided already on the command line as default:

```bash
$ ./app/nut user:add kenneth "Kenny Koala" kenny@koala.com.au

 User name [kenneth]:
 > 

 Display name [Kenny Koala]:
 > 

 Email address [kenny@koala.com.au]:
 > kenny@dropbear.com.au

 Password:
 > 

 Roles (comma separated):
  [editor      ] Editor
  [chief-editor] Chief Editor
  [admin       ] Administrator
  [developer   ] Developer
  [guest       ] Guest Editor
 > editor, chief-editor

Account details for 'kenneth'
=============================

 ----------- ----------------------- -------------- ---------------------- --------- 
  User name   Email                   Display Name   Roles                  Enabled  
 ----------- ----------------------- -------------- ---------------------- --------- 
  kenneth     kenny@dropbear.com.au   Kenny Koala    editor, chief-editor   false 
 ----------- ----------------------- -------------- ---------------------- --------- 

 [OK] Successfully created user: kenneth
```