### PR TITLE
[3.4][Deprecation] Add migration for Twig_Simple

### DIFF
--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -4,6 +4,9 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFilter as TwigFilter;
+use Twig_SimpleFunction as TwigFunction;
+use Twig_SimpleTest as TwigTest;
 
 /**
  * Admin (back-end) functionality Twig extension.
@@ -24,14 +27,14 @@ class AdminExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('__',                 [Runtime\AdminRuntime::class, 'trans'], $safe),
-            new \Twig_SimpleFunction('buid',               [Runtime\AdminRuntime::class, 'buid'], $safe),
-            new \Twig_SimpleFunction('data',               [Runtime\AdminRuntime::class, 'addData']),
-            new \Twig_SimpleFunction('hattr',              [Runtime\AdminRuntime::class, 'hattr'], $safe),
-            new \Twig_SimpleFunction('hclass',             [Runtime\AdminRuntime::class, 'hclass'], $safe),
-            new \Twig_SimpleFunction('ischangelogenabled', [Runtime\AdminRuntime::class, 'isChangelogEnabled'], $deprecated),
-            new \Twig_SimpleFunction('randomquote',        [Runtime\AdminRuntime::class, 'randomQuote'], $safe),
-            new \Twig_SimpleFunction('stack',              [Runtime\AdminRuntime::class, 'stack']),
+            new TwigFunction('__',                 [Runtime\AdminRuntime::class, 'trans'], $safe),
+            new TwigFunction('buid',               [Runtime\AdminRuntime::class, 'buid'], $safe),
+            new TwigFunction('data',               [Runtime\AdminRuntime::class, 'addData']),
+            new TwigFunction('hattr',              [Runtime\AdminRuntime::class, 'hattr'], $safe),
+            new TwigFunction('hclass',             [Runtime\AdminRuntime::class, 'hclass'], $safe),
+            new TwigFunction('ischangelogenabled', [Runtime\AdminRuntime::class, 'isChangelogEnabled'], $deprecated),
+            new TwigFunction('randomquote',        [Runtime\AdminRuntime::class, 'randomQuote'], $safe),
+            new TwigFunction('stack',              [Runtime\AdminRuntime::class, 'stack']),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -45,9 +48,9 @@ class AdminExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFilter('__',       [Runtime\AdminRuntime::class, 'trans']),
-            new \Twig_SimpleFilter('loglevel', [Runtime\AdminRuntime::class, 'logLevel']),
-            new \Twig_SimpleFilter('ymllink',  [Runtime\AdminRuntime::class, 'ymllink'], $safe),
+            new TwigFilter('__',       [Runtime\AdminRuntime::class, 'trans']),
+            new TwigFilter('loglevel', [Runtime\AdminRuntime::class, 'logLevel']),
+            new TwigFilter('ymllink',  [Runtime\AdminRuntime::class, 'ymllink'], $safe),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -58,7 +61,7 @@ class AdminExtension extends Extension
     public function getTests()
     {
         return [
-            new \Twig_SimpleTest('stackable', [Runtime\AdminRuntime::class, 'testStackable']),
+            new TwigTest('stackable', [Runtime\AdminRuntime::class, 'testStackable']),
         ];
     }
 }

--- a/src/Twig/Extension/ArrayExtension.php
+++ b/src/Twig/Extension/ArrayExtension.php
@@ -3,6 +3,8 @@
 namespace Bolt\Twig\Extension;
 
 use Twig_Extension as Extension;
+use Twig_SimpleFilter as TwigFilter;
+use Twig_SimpleFunction as TwigFunction;
 
 /**
  * Bolt specific Twig functions and filters that provide array manipulation
@@ -25,7 +27,7 @@ class ArrayExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('unique', [$this, 'unique'], $safe),
+            new TwigFunction('unique', [$this, 'unique'], $safe),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -37,8 +39,8 @@ class ArrayExtension extends Extension
     {
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFilter('order',   [$this, 'order']),
-            new \Twig_SimpleFilter('shuffle', [$this, 'shuffle']),
+            new TwigFilter('order',   [$this, 'order']),
+            new TwigFilter('shuffle', [$this, 'shuffle']),
             // @codingStandardsIgnoreEnd
         ];
     }

--- a/src/Twig/Extension/BoltExtension.php
+++ b/src/Twig/Extension/BoltExtension.php
@@ -8,11 +8,15 @@ use Bolt\Configuration\PathsProxy;
 use Bolt\Storage\EntityManagerInterface;
 use Bolt\Twig\SetcontentTokenParser;
 use Bolt\Twig\SwitchTokenParser;
+use Twig_Extension as Extension;
+use Twig_SimpleFilter as TwigFilter;
+use Twig_SimpleFunction as TwigFunction;
+use Twig_Extension_GlobalsInterface as GlobalsInterface;
 
 /**
  * Bolt base Twig functionality and definitions.
  */
-class BoltExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+class BoltExtension extends Extension implements GlobalsInterface
 {
     /** @var EntityManagerInterface */
     private $em;
@@ -63,8 +67,8 @@ class BoltExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('first', 'twig_first', $env + $deprecated),
-            new \Twig_SimpleFunction('last',  'twig_last', $env + $deprecated),
+            new TwigFunction('first', 'twig_first', $env + $deprecated),
+            new TwigFunction('last',  'twig_last', $env + $deprecated),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -78,7 +82,7 @@ class BoltExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
         $deprecated = ['deprecated' => true];
 
         return [
-            new \Twig_SimpleFilter('ucfirst', 'twig_capitalize_string_filter', $env + $deprecated + ['alternative' => 'capitalize']),
+            new TwigFilter('ucfirst', 'twig_capitalize_string_filter', $env + $deprecated + ['alternative' => 'capitalize']),
         ];
     }
 

--- a/src/Twig/Extension/DumpExtension.php
+++ b/src/Twig/Extension/DumpExtension.php
@@ -4,6 +4,8 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime\DumpRuntime;
 use Symfony\Bridge\Twig\TokenParser\DumpTokenParser;
+use Twig_SimpleFunction as TwigFunction;
+use Twig_Extension as Extension;
 
 /**
  * Modified version of Twig Bridge's DumpExtension to use runtime loading.
@@ -11,16 +13,18 @@ use Symfony\Bridge\Twig\TokenParser\DumpTokenParser;
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
-class DumpExtension extends \Twig_Extension
+class DumpExtension extends Extension
 {
     public function getFunctions()
     {
         $options = ['is_safe' => ['html'], 'needs_context' => true, 'needs_environment' => true];
 
         return [
-            new \Twig_SimpleFunction('backtrace', [DumpRuntime::class, 'dumpBacktrace'], $options),
-            new \Twig_SimpleFunction('dump', [DumpRuntime::class, 'dump'], $options),
-            new \Twig_SimpleFunction('print', [DumpRuntime::class, 'dump'], $options + ['deprecated' => true, 'alternative' => 'dump']),
+            // @codingStandardsIgnoreStart
+            new TwigFunction('backtrace', [DumpRuntime::class, 'dumpBacktrace'], $options),
+            new TwigFunction('dump',      [DumpRuntime::class, 'dump'], $options),
+            new TwigFunction('print',     [DumpRuntime::class, 'dump'], $options + ['deprecated' => true, 'alternative' => 'dump']),
+            // @codingStandardsIgnoreEnd
         ];
     }
 

--- a/src/Twig/Extension/HtmlExtension.php
+++ b/src/Twig/Extension/HtmlExtension.php
@@ -4,6 +4,8 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFilter as TwigFilter;
+use Twig_SimpleFunction as TwigFunction;
 
 /**
  * HTML functionality Twig extension.
@@ -24,9 +26,9 @@ class HtmlExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('link',           [Runtime\HtmlRuntime::class, 'link'], $safe),
-            new \Twig_SimpleFunction('markdown',       [Runtime\HtmlRuntime::class, 'markdown'], $safe),
-            new \Twig_SimpleFunction('menu',           [Runtime\HtmlRuntime::class, 'menu'], $env + $safe),
+            new TwigFunction('link',     [Runtime\HtmlRuntime::class, 'link'], $safe),
+            new TwigFunction('markdown', [Runtime\HtmlRuntime::class, 'markdown'], $safe),
+            new TwigFunction('menu',     [Runtime\HtmlRuntime::class, 'menu'], $env + $safe),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -40,11 +42,11 @@ class HtmlExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFilter('editable', [Runtime\HtmlRuntime::class, 'editable'], $safe),
-            new \Twig_SimpleFilter('markdown', [Runtime\HtmlRuntime::class, 'markdown'], $safe),
-            new \Twig_SimpleFilter('shy',      [Runtime\HtmlRuntime::class, 'shy'], $safe),
-            new \Twig_SimpleFilter('tt',       [Runtime\HtmlRuntime::class, 'decorateTT'], $safe),
-            new \Twig_SimpleFilter('twig',     [Runtime\HtmlRuntime::class, 'twig'], ['needs_environment' => true] + $safe),
+            new TwigFilter('editable', [Runtime\HtmlRuntime::class, 'editable'], $safe),
+            new TwigFilter('markdown', [Runtime\HtmlRuntime::class, 'markdown'], $safe),
+            new TwigFilter('shy',      [Runtime\HtmlRuntime::class, 'shy'], $safe),
+            new TwigFilter('tt',       [Runtime\HtmlRuntime::class, 'decorateTT'], $safe),
+            new TwigFilter('twig',     [Runtime\HtmlRuntime::class, 'twig'], ['needs_environment' => true] + $safe),
             // @codingStandardsIgnoreEnd
         ];
     }

--- a/src/Twig/Extension/ImageExtension.php
+++ b/src/Twig/Extension/ImageExtension.php
@@ -4,6 +4,8 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFilter as TwigFilter;
+use Twig_SimpleFunction as TwigFunction;
 
 /**
  * Image functionality Twig extension.
@@ -24,12 +26,12 @@ class ImageExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('fancybox',  [Runtime\ImageRuntime::class, 'popup'], $safe + $deprecated + ['alternative' => 'popup']),
-            new \Twig_SimpleFunction('image',     [Runtime\ImageRuntime::class, 'image']),
-            new \Twig_SimpleFunction('imageinfo', [Runtime\ImageRuntime::class, 'imageInfo']),
-            new \Twig_SimpleFunction('popup',     [Runtime\ImageRuntime::class, 'popup'], $safe),
-            new \Twig_SimpleFunction('showimage', [Runtime\ImageRuntime::class, 'showImage'], $safe),
-            new \Twig_SimpleFunction('thumbnail', [Runtime\ImageRuntime::class, 'thumbnail']),
+            new TwigFunction('fancybox',  [Runtime\ImageRuntime::class, 'popup'], $safe + $deprecated + ['alternative' => 'popup']),
+            new TwigFunction('image',     [Runtime\ImageRuntime::class, 'image']),
+            new TwigFunction('imageinfo', [Runtime\ImageRuntime::class, 'imageInfo']),
+            new TwigFunction('popup',     [Runtime\ImageRuntime::class, 'popup'], $safe),
+            new TwigFunction('showimage', [Runtime\ImageRuntime::class, 'showImage'], $safe),
+            new TwigFunction('thumbnail', [Runtime\ImageRuntime::class, 'thumbnail']),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -44,12 +46,12 @@ class ImageExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFilter('fancybox',  [Runtime\ImageRuntime::class, 'popup'], $safe + $deprecated + ['alternative' => 'popup']),
-            new \Twig_SimpleFilter('image',     [Runtime\ImageRuntime::class, 'image']),
-            new \Twig_SimpleFilter('imageinfo', [Runtime\ImageRuntime::class, 'imageInfo']),
-            new \Twig_SimpleFilter('popup',     [Runtime\ImageRuntime::class, 'popup'], $safe),
-            new \Twig_SimpleFilter('showimage', [Runtime\ImageRuntime::class, 'showImage'], $safe),
-            new \Twig_SimpleFilter('thumbnail', [Runtime\ImageRuntime::class, 'thumbnail']),
+            new TwigFilter('fancybox',  [Runtime\ImageRuntime::class, 'popup'], $safe + $deprecated + ['alternative' => 'popup']),
+            new TwigFilter('image',     [Runtime\ImageRuntime::class, 'image']),
+            new TwigFilter('imageinfo', [Runtime\ImageRuntime::class, 'imageInfo']),
+            new TwigFilter('popup',     [Runtime\ImageRuntime::class, 'popup'], $safe),
+            new TwigFilter('showimage', [Runtime\ImageRuntime::class, 'showImage'], $safe),
+            new TwigFilter('thumbnail', [Runtime\ImageRuntime::class, 'thumbnail']),
             // @codingStandardsIgnoreEnd
         ];
     }

--- a/src/Twig/Extension/RecordExtension.php
+++ b/src/Twig/Extension/RecordExtension.php
@@ -4,6 +4,8 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFilter as TwigFilter;
+use Twig_SimpleFunction as TwigFunction;
 
 /**
  * Content record functionality Twig extension.
@@ -25,12 +27,12 @@ class RecordExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('current',            [Runtime\RecordRuntime::class, 'current']),
-            new \Twig_SimpleFunction('excerpt',            [Runtime\RecordRuntime::class, 'excerpt'], $safe),
-            new \Twig_SimpleFunction('fields',             [Runtime\RecordRuntime::class, 'fields'], $env + $safe),
-            new \Twig_SimpleFunction('listtemplates',      [Runtime\RecordRuntime::class, 'listTemplates']),
-            new \Twig_SimpleFunction('pager',              [Runtime\RecordRuntime::class, 'pager'], $env + $safe),
-            new \Twig_SimpleFunction('trimtext',           [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
+            new TwigFunction('current',       [Runtime\RecordRuntime::class, 'current']),
+            new TwigFunction('excerpt',       [Runtime\RecordRuntime::class, 'excerpt'], $safe),
+            new TwigFunction('fields',        [Runtime\RecordRuntime::class, 'fields'], $env + $safe),
+            new TwigFunction('listtemplates', [Runtime\RecordRuntime::class, 'listTemplates']),
+            new TwigFunction('pager',         [Runtime\RecordRuntime::class, 'pager'], $env + $safe),
+            new TwigFunction('trimtext',      [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -45,10 +47,10 @@ class RecordExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFilter('current',        [Runtime\RecordRuntime::class, 'current']),
-            new \Twig_SimpleFilter('excerpt',        [Runtime\RecordRuntime::class, 'excerpt'], $safe),
-            new \Twig_SimpleFilter('selectfield',    [Runtime\RecordRuntime::class, 'selectField']),
-            new \Twig_SimpleFilter('trimtext',       [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
+            new TwigFilter('current',     [Runtime\RecordRuntime::class, 'current']),
+            new TwigFilter('excerpt',     [Runtime\RecordRuntime::class, 'excerpt'], $safe),
+            new TwigFilter('selectfield', [Runtime\RecordRuntime::class, 'selectField']),
+            new TwigFilter('trimtext',    [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
             // @codingStandardsIgnoreEnd
         ];
     }

--- a/src/Twig/Extension/RoutingExtension.php
+++ b/src/Twig/Extension/RoutingExtension.php
@@ -4,6 +4,7 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFunction as TwigFunction;
 
 /**
  * Routing functionality Twig extension.
@@ -21,11 +22,11 @@ class RoutingExtension extends Extension
     {
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('canonical',      [Runtime\RoutingRuntime::class, 'canonical']),
-            new \Twig_SimpleFunction('htmllang',       [Runtime\RoutingRuntime::class, 'htmlLang']),
-            new \Twig_SimpleFunction('ismobileclient', [Runtime\RoutingRuntime::class, 'isMobileClient']),
-            new \Twig_SimpleFunction('redirect',       [Runtime\RoutingRuntime::class, 'redirect'], ['deprecated' => true]),
-            new \Twig_SimpleFunction('request',        [Runtime\RoutingRuntime::class, 'request'], ['deprecated' => true]),
+            new TwigFunction('canonical',      [Runtime\RoutingRuntime::class, 'canonical']),
+            new TwigFunction('htmllang',       [Runtime\RoutingRuntime::class, 'htmlLang']),
+            new TwigFunction('ismobileclient', [Runtime\RoutingRuntime::class, 'isMobileClient']),
+            new TwigFunction('redirect',       [Runtime\RoutingRuntime::class, 'redirect'], ['deprecated' => true]),
+            new TwigFunction('request',        [Runtime\RoutingRuntime::class, 'request'], ['deprecated' => true]),
             // @codingStandardsIgnoreEnd
         ];
     }

--- a/src/Twig/Extension/TextExtension.php
+++ b/src/Twig/Extension/TextExtension.php
@@ -4,6 +4,8 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFilter as TwigFilter;
+use Twig_SimpleTest as TwigTest;
 
 /**
  * Text functionality Twig extension.
@@ -32,12 +34,12 @@ class TextExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFilter('json_decode',    [Runtime\TextRuntime::class, 'jsonDecode']),
-            new \Twig_SimpleFilter('localdate',      [Runtime\TextRuntime::class, 'localeDateTime'], $safe + $deprecated + ['alternative' => 'localedatetime']),
-            new \Twig_SimpleFilter('localedatetime', [Runtime\TextRuntime::class, 'localeDateTime'], $safe),
-            new \Twig_SimpleFilter('preg_replace',   [Runtime\TextRuntime::class, 'pregReplace']),
-            new \Twig_SimpleFilter('safestring',     [Runtime\TextRuntime::class, 'safeString'], $safe),
-            new \Twig_SimpleFilter('slug',           [Runtime\TextRuntime::class, 'slug']),
+            new TwigFilter('json_decode',    [Runtime\TextRuntime::class, 'jsonDecode']),
+            new TwigFilter('localdate',      [Runtime\TextRuntime::class, 'localeDateTime'], $safe + $deprecated + ['alternative' => 'localedatetime']),
+            new TwigFilter('localedatetime', [Runtime\TextRuntime::class, 'localeDateTime'], $safe),
+            new TwigFilter('preg_replace',   [Runtime\TextRuntime::class, 'pregReplace']),
+            new TwigFilter('safestring',     [Runtime\TextRuntime::class, 'safeString'], $safe),
+            new TwigFilter('slug',           [Runtime\TextRuntime::class, 'slug']),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -48,7 +50,7 @@ class TextExtension extends Extension
     public function getTests()
     {
         return [
-            new \Twig_SimpleTest('json', [Runtime\TextRuntime::class, 'testJson']),
+            new TwigTest('json', [Runtime\TextRuntime::class, 'testJson']),
         ];
     }
 }

--- a/src/Twig/Extension/UserExtension.php
+++ b/src/Twig/Extension/UserExtension.php
@@ -4,6 +4,7 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFunction as TwigFunction;
 
 /**
  * User functionality Twig extension.
@@ -23,10 +24,10 @@ class UserExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('getuser',   [Runtime\UserRuntime::class, 'getUser']),
-            new \Twig_SimpleFunction('getuserid', [Runtime\UserRuntime::class, 'getUserId']),
-            new \Twig_SimpleFunction('isallowed', [Runtime\UserRuntime::class, 'isAllowed']),
-            new \Twig_SimpleFunction('token',     [Runtime\UserRuntime::class, 'token'], $deprecated + ['alternative' => 'csrf_token']),
+            new TwigFunction('getuser',   [Runtime\UserRuntime::class, 'getUser']),
+            new TwigFunction('getuserid', [Runtime\UserRuntime::class, 'getUserId']),
+            new TwigFunction('isallowed', [Runtime\UserRuntime::class, 'isAllowed']),
+            new TwigFunction('token',     [Runtime\UserRuntime::class, 'token'], $deprecated + ['alternative' => 'csrf_token']),
             // @codingStandardsIgnoreEnd
         ];
     }

--- a/src/Twig/Extension/UtilsExtension.php
+++ b/src/Twig/Extension/UtilsExtension.php
@@ -4,6 +4,7 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFunction as TwigFunction;
 
 /**
  * General-purpose utility functionality Twig extension.
@@ -23,8 +24,8 @@ class UtilsExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('file_exists', [Runtime\UtilsRuntime::class, 'fileExists'], $deprecated),
-            new \Twig_SimpleFunction('firebug',     [Runtime\UtilsRuntime::class, 'printFirebug']),
+            new TwigFunction('file_exists', [Runtime\UtilsRuntime::class, 'fileExists'], $deprecated),
+            new TwigFunction('firebug',     [Runtime\UtilsRuntime::class, 'printFirebug']),
             // @codingStandardsIgnoreEnd
         ];
     }

--- a/src/Twig/Extension/WidgetExtension.php
+++ b/src/Twig/Extension/WidgetExtension.php
@@ -4,6 +4,7 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
 use Twig_Extension as Extension;
+use Twig_SimpleFunction as TwigFunction;
 
 /**
  * Widget functionality Twig extension.
@@ -24,10 +25,10 @@ class WidgetExtension extends Extension
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('countwidgets', [Runtime\WidgetRuntime::class, 'countWidgets'], $safe + $env),
-            new \Twig_SimpleFunction('getwidgets',   [Runtime\WidgetRuntime::class, 'getWidgets'], $safe),
-            new \Twig_SimpleFunction('haswidgets',   [Runtime\WidgetRuntime::class, 'hasWidgets'], $safe + $env),
-            new \Twig_SimpleFunction('widgets',      [Runtime\WidgetRuntime::class, 'widgets'], $safe + $env),
+            new TwigFunction('countwidgets', [Runtime\WidgetRuntime::class, 'countWidgets'], $safe + $env),
+            new TwigFunction('getwidgets',   [Runtime\WidgetRuntime::class, 'getWidgets'], $safe),
+            new TwigFunction('haswidgets',   [Runtime\WidgetRuntime::class, 'hasWidgets'], $safe + $env),
+            new TwigFunction('widgets',      [Runtime\WidgetRuntime::class, 'widgets'], $safe + $env),
             // @codingStandardsIgnoreEnd
         ];
     }


### PR DESCRIPTION
In Twig 2.x, Twig_Simple* classes are deprecated for 3.x, and replaced with a name minus "Simple"
 * Twig_SimpleFunction -> Twig_Function
 * Twig_SimpleFilter -> Twig_Filter
 * Twig_SimpleTest -> Twig_Test

This PR will hopefully create less related merge conflict as 3.x changes cascade down to `master`