### PR TITLE
Multiple extends tags are forbidden

### DIFF
--- a/app/theme_defaults/_sub_pager.twig
+++ b/app/theme_defaults/_sub_pager.twig
@@ -1,5 +1,3 @@
-{% if class|default == 'narrow' %}
-    {% extends 'pager/narrow.twig' %}
-{% else %}
-    {% extends 'pager/default.twig' %}
-{% endif %}
+{% extends class|default() == 'narrow'
+    ? 'pager/narrow.twig'
+    : 'pager/default.twig' %}


### PR DESCRIPTION
When using `{{ pager() }}` without a template, and falling back to default, I'm now getting 
```
Twig_Error_Syntax in Extends.php line 33:
Multiple extends tags are forbidden in "_sub_pager.twig" at line 4.
```
Works fine on =< 3.3