### PR TITLE
[3.3] Don't boot disabled extensions

### DIFF
--- a/src/Extension/Manager.php
+++ b/src/Extension/Manager.php
@@ -236,6 +236,9 @@ class Manager
 
         // Boot all extension loaders that are also service providers
         foreach ($this->extensions as $extension) {
+            if ($extension->isEnabled() !== true) {
+                continue;
+            }
             foreach ($extension->getInnerExtension()->getServiceProviders() as $provider) {
                 $provider->boot($app);
             }


### PR DESCRIPTION
This is the same check we make above in `register()` … this one was driving me mental on a broken extension I wanted to disable. :laughing: 