### PR TITLE
[RFC] Makes deleting saved thumbnails when clearing cache optional

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -199,6 +199,8 @@ changelog:
 #                     the requested dimensions.
 # browser_cache_time: Sets the amount of seconds that the browser will cache
 #                     images for. Set it to activate browser caching.
+# clear_with_cache:   Used alongside save_files. Setting to false prevents
+#                     deletion of saved thumbs when clearing bolt cache.
 #
 # Note: If you change these values, you might need to clear the cache before
 #       they show up.
@@ -213,6 +215,7 @@ thumbnails:
     allow_upscale: false
     exif_orientation: true
     only_aliases: false
+    clear_with_cache: true
 #    browser_cache_time: 2592000
 
 # Define the HTML tags and attributes that are allowed in 'cleaned' HTML. This

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -27,6 +27,9 @@ class Cache extends FilesystemCache
     /** @var AggregateFilesystemInterface */
     private $filesystem;
 
+    /** @var bool */
+    private $clearThumbs;
+
     /**
      * Cache constructor.
      *
@@ -34,11 +37,13 @@ class Cache extends FilesystemCache
      * @param string                       $extension
      * @param int                          $umask
      * @param AggregateFilesystemInterface $filesystem
+     * @param bool                         $clearThumbs
      */
-    public function __construct($directory, $extension = self::EXTENSION, $umask = 0002, AggregateFilesystemInterface $filesystem = null)
+    public function __construct($directory, $extension = self::EXTENSION, $umask = 0002, AggregateFilesystemInterface $filesystem = null, $clearThumbs = true)
     {
         parent::__construct($directory, $extension, $umask);
         $this->filesystem = $filesystem;
+        $this->clearThumbs = $clearThumbs;
     }
 
     /**
@@ -85,8 +90,10 @@ class Cache extends FilesystemCache
             $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/profiler'));
             $this->flushDirectory($this->filesystem->getFilesystem('cache')->getDir('/trans'));
 
-            // Clear the thumbs folder.
-            $this->flushDirectory($this->filesystem->getFilesystem('web')->getDir('/thumbs'));
+            if ($this->clearThumbs) {
+                // Clear the thumbs folder.
+                $this->flushDirectory($this->filesystem->getFilesystem('web')->getDir('/thumbs'));
+            }
         }
 
         return $result;

--- a/src/Config.php
+++ b/src/Config.php
@@ -1127,6 +1127,7 @@ class Config
                 'notfound_image'    => 'bolt_assets://img/default_notfound.png',
                 'error_image'       => 'bolt_assets://img/default_error.png',
                 'only_aliases'      => false,
+                'clear_with_cache'  => true,
             ],
             'accept_file_types'           => explode(',', 'twig,html,js,css,scss,gif,jpg,jpeg,png,ico,zip,tgz,txt,md,doc,docx,pdf,epub,xls,xlsx,csv,ppt,pptx,mp3,ogg,wav,m4a,mp4,m4v,ogv,wmv,avi,webm,svg'),
             'hash_strength'               => 10,

--- a/src/Provider/CacheServiceProvider.php
+++ b/src/Provider/CacheServiceProvider.php
@@ -17,7 +17,8 @@ class CacheServiceProvider implements ServiceProviderInterface
                         $app['path_resolver']->resolve('%cache%/' . $app['environment'] . '/data'),
                         Cache::EXTENSION,
                         0002,
-                        $app['filesystem']
+                        $app['filesystem'],
+                        $app['config']->get('general/thumbnails/clear_with_cache')
                     );
                 } catch (\Exception $e) {
                     $app['logger.system']->critical($e->getMessage(), ['event' => 'exception', 'exception' => $e]);


### PR DESCRIPTION
This adds an option to config.yml which allows disabling the clearing of the saved thumbs folder when cache is cleared.


Details
-------

While in many cases it's okay and perhaps desired to clear saved thumbnails along with other caches, there are some cases where keeping them around may be better.  Product/photo galleries for example may get quite large, and when looking to not restrict the uploader, full images from cameras can get quite hefty in size where the required processing needed to scale them would increase proportionally.  A low powered VPS instance, which may otherwise be suitable for hosting such a gallery, may not be as up to the task of rescaling listing pages full of images on demand if they're cleared.  This change keeps the current default of clearing the saved images, while allowing a developer to disable this behavior if desired.