### PR TITLE
Remove outdated requirement on ext-posix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-pdo": "*",
-        "ext-posix": "*",
         "ext-xml": "*",
         "ext-zip": "*",
         "filp/whoops": "^2.0",


### PR DESCRIPTION
c.f. https://github.com/bolt/bolt/commit/2c6ac078e0fcd4a18c265d4f4da38d7195105a45#commitcomment-21963034

This was a 2.2 thing, and no [Windows support](http://php.net/manual/en/intro.posix.php) …

Introduced in #6490
