### PR TITLE
Fix incorrect Regex escaping

### DIFF
--- a/app/src/js/widgets/fields/fieldBlock.js
+++ b/app/src/js/widgets/fields/fieldBlock.js
@@ -155,7 +155,7 @@
          * @memberof Bolt.fields.block
          */
         _renumber: function () {
-            var re = new RegExp('^([^\\\[]+\\\[)([#|\d]+)(\\\].*)$', 'gi');
+            var re = new RegExp('^([^\\\[]+\\\[)([#|\\\d]+)(\\\].*)$', 'gi');
 
             this._ui.slot.find('div.block-group').each(function (index, group) {
                 $(group).find('[name]').each(function () {


### PR DESCRIPTION
This is #1555 material but fixes the renumbering of named repeaters due to the regex not being escaped correctly.