### PR TITLE
Allow overriding `description: ` in `contenttypes.yml`.

### DIFF
--- a/app/view/twig/overview/_panel-actions_overview.twig
+++ b/app/view/twig/overview/_panel-actions_overview.twig
@@ -54,8 +54,10 @@
 
     </form>
 
-
-    {% set description = __(['contenttypes', context.contenttype.slug, 'description'], {DEFAULT: context.contenttype.description|default()}) %}
+    {# Use the `description:` from contenttypes.yml if set, otherwise fall back
+       to the (localized) default descriptions that are available for the
+       built-in contenttupes like 'pages' and 'blocks'. #}
+    {% set description = context.contenttype.description|default(__(['contenttypes', context.contenttype.slug, 'description'], {DEFAULT: ''})) %}  
     <div class="description">
         {% if description %}
             {{ description|markdown }}


### PR DESCRIPTION
As pointed out by @eduardomart today, you can set the `description:` for custom contenttypes, but if you have created your own `pages:` for example, it will _always_ use the baked-in description, without allowing you to override it. This PR changes the order: Use the description in contenttypes.yml, and fall back to the baked-in one if it wasn't set. 


