### PR TITLE
[3.2 only] Fix issue with sortable selects not retaining ordering

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -34,6 +34,19 @@
     {% set selection = [ selection ] %}
 {% endif %}
 
+{# if we have (sorted) options present already, make sure their order is
+   maintained. We do this by first selecting the current values, and then
+   merging that with the entire array of values. See #6332. #}
+{% if option.sortable %}
+    {% set leadingvalues = [] %}
+    {% for key, sel in selection %}
+        {% for value_key, value_sel in values if value_key == sel %}
+            {% set leadingvalues = leadingvalues|merge({ (value_key): value_sel}) %}
+        {% endfor %}
+    {% endfor %}
+    {% set values = unique(leadingvalues, values) %}
+{% endif %}
+
 {# If the current selection contains an existing id, we must use _only_ the id, and not accept a fallback. #}
 {% set onlyids = selection|first in values|keys %}
 


### PR DESCRIPTION
This fixes the bug on the 3.2 branch. It's looking as though the regular breakages may well be due to competing bugs, so once this one is in, I'm going to try a few more permutations... I think it stems from the fact that we use select fields for lots of varying data formats.