### PR TITLE
[3.3] Deprecate and replace use of {{ link() }}

### DIFF
--- a/src/Twig/Extension/HtmlExtension.php
+++ b/src/Twig/Extension/HtmlExtension.php
@@ -21,10 +21,11 @@ class HtmlExtension extends Extension
     {
         $safe = ['is_safe' => ['html']];
         $env  = ['needs_environment' => true];
+        $deprecated = ['deprecated' => true];
 
         return [
             // @codingStandardsIgnoreStart
-            new \Twig_SimpleFunction('link',           [Runtime\HtmlRuntime::class, 'link'], $safe),
+            new \Twig_SimpleFunction('link',           [Runtime\HtmlRuntime::class, 'link'], $safe + $deprecated),
             new \Twig_SimpleFunction('markdown',       [Runtime\HtmlRuntime::class, 'markdown'], $safe),
             new \Twig_SimpleFunction('menu',           [Runtime\HtmlRuntime::class, 'menu'], $env + $safe),
             // @codingStandardsIgnoreEnd

--- a/theme/base-2016/partials/_aside.twig
+++ b/theme/base-2016/partials/_aside.twig
@@ -21,10 +21,16 @@
                 <h5>{{ block.title }}</h5>
                 {{ block.content }}
 
-                {% if link(block.contentlink) or block.editlink() %}
+                {% set edit_link = block.editlink() %}
+                {% set content_link = block.contentlink %}
+                {% if content_link or edit_link %}
                     <p>
-                        {{ link(block.contentlink, __('general.phrase.read-more')) }} /
-                        <a href="{{ block.editlink() }}">{{ __('general.phrase.edit') }}</a>
+                    {%- if content_link %}
+                        <a href="{{ relative_path(content_link|e) }}">{{ __('general.phrase.read-more') }}</a>
+                    {% endif -%}
+                    {%- if edit_link %}
+                        / <a href="{{ edit_link }}">{{ __('general.phrase.edit') }}</a>
+                    {% endif -%}
                     </p>
                 {% endif %}
 


### PR DESCRIPTION
A per last night's meeting, and [upstream changes](http://symfony.com/blog/new-in-symfony-3-3-weblink-component).