### PR TITLE
[3.2] Fix incompatible extensions showing

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -31,7 +31,7 @@ theme: base-2016
 # locales, ensure the first is a standard locale.
 locale: en_GB
 
-# Set the timezone to be used on the website. For a list of valid timezone 
+# Set the timezone to be used on the website. For a list of valid timezone
 # settings, see: http://php.net/manual/en/timezones.php
 # timezone: UTC
 
@@ -407,10 +407,11 @@ hash_strength: 10
 #         prefer-stable: true            # Prefer stable releases over development ones
 #         prefer-dist: true              # Forces installation from package dist even for dev versions.
 #         prefer-source: false           # Forces installation from package sources when possible, including VCS information.
-#         optimize-autoloader: false     # Optimize autoloader during autoloader dump.
-#         classmap-authoritative: false  # Autoload classes from the classmap only. Implicitly enables `optimize-autoloader`.
+#         options:
+#             optimize-autoloader: false     # Optimize autoloader during autoloader dump.
+#             classmap-authoritative: false  # Autoload classes from the classmap only. Implicitly enables `optimize-autoloader`.
 
-# Enforcing the use of SSL. If set, all pages will enforce an SSL connection, 
+# Enforcing the use of SSL. If set, all pages will enforce an SSL connection,
 # and redirect to HTTPS if you attempt to visit plain HTTP pages.
 # enforce_ssl: true
 

--- a/app/src/js/modules/extend.js
+++ b/app/src/js/modules/extend.js
@@ -738,7 +738,7 @@
                 $.ajax({
                     url: bolt.data('extend.siteurl') + 'list.json',
                     dataType: 'jsonp',
-                    data: {'name': searchVal}
+                    data: {'name': searchVal, 'bolt': bolt.data('extend.sitever')}
                 })
                     .success(function (data) {
                         if (data.packages.length) {

--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -167,6 +167,7 @@
     {{ data('extend.text.updating',           __('page.extend.message.updating')) }}
     {{ data('extend.text.updated',            __('page.extend.message.updated')) }}
 
+    {{ data('extend.sitever',             context.extendVersion) }}
     {{ data('extend.siteurl',             context.site) }}
     {{ data('extend.baseurl',             app['resources'].url('bolt') ~ 'extend'|trim('/') ~ '/') }}
     {{ data('extend.rootpath',            paths.rootpath) }}

--- a/src/Composer/JsonManager.php
+++ b/src/Composer/JsonManager.php
@@ -101,15 +101,23 @@ class JsonManager
      */
     private function setJsonDefaults(array $json)
     {
-        $rootPath = $this->app['resources']->getPath('root');
-        $extensionsPath = $this->app['resources']->getPath('extensions');
-        $srcPath = $this->app['resources']->getPath('src');
-        $webPath = $this->app['resources']->getPath('web');
+        $resources = $this->app['resources'];
+        $config = $this->app['config'];
+
+        $rootPath = $resources->getPath('root');
+        $extensionsPath = $resources->getPath('extensions');
+        $srcPath = $resources->getPath('src');
+        $webPath = $resources->getPath('web');
         $pathToRoot = Path::makeRelative($rootPath, $extensionsPath);
         $pathToWeb = Path::makeRelative($webPath, $extensionsPath);
         $eventPath = Path::makeRelative($srcPath . '/Composer/EventListener', $extensionsPath);
         /** @deprecated Handle BC on 'stability' key until 4.0 */
-        $minimumStability = $this->app['config']->get('general/extensions/stability') ?: $this->app['config']->get('general/extensions/composer/minimum-stability', 'stable');
+        $minimumStability = $config->get('general/extensions/stability') ?: $config->get('general/extensions/composer/minimum-stability', 'stable');
+
+        $config = $config->get('general/extensions/composer/options', []) + [
+            'discard-changes'   => true,
+            'preferred-install' => 'dist',
+        ];
 
         // Enforce standard settings
         $defaults = [
@@ -125,10 +133,7 @@ class JsonManager
             ],
             'minimum-stability' => $minimumStability,
             'prefer-stable'     => true,
-            'config'            => [
-                'discard-changes'   => true,
-                'preferred-install' => 'dist',
-            ],
+            'config'            => $config,
             'provide' => [
                 'bolt/bolt' => Bolt\Version::forComposer(),
             ],

--- a/src/Controller/Backend/Extend.php
+++ b/src/Controller/Backend/Extend.php
@@ -444,6 +444,7 @@ class Extend extends BackendBase
             'online'         => $this->app['extend.online'],
             'extensionsPath' => $extensionsPath,
             'site'           => $this->app['extend.site'],
+            'extendVersion'  => Bolt\Version::forComposer(),
         ];
     }
 


### PR DESCRIPTION
* Fix "option" key handling in `extension/composer.json`
* This sends the "Composer" version of Bolt to the marketplace so it can remove packages without matching version constraints

FYI: `simpleforms` is the one I was testing on, as there is nothing available (even `dev-master` is for < 3.0 as it was retired in place of BoltForms)



**NOTE:** This will need an asset rebuild post-merge