### PR TITLE
[3.2] Composer config key is called "config", not "options"

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -407,7 +407,7 @@ hash_strength: 10
 #         prefer-stable: true            # Prefer stable releases over development ones
 #         prefer-dist: true              # Forces installation from package dist even for dev versions.
 #         prefer-source: false           # Forces installation from package sources when possible, including VCS information.
-#         options:
+#         config:
 #             optimize-autoloader: false     # Optimize autoloader during autoloader dump.
 #             classmap-authoritative: false  # Autoload classes from the classmap only. Implicitly enables `optimize-autoloader`.
 

--- a/src/Composer/JsonManager.php
+++ b/src/Composer/JsonManager.php
@@ -114,7 +114,7 @@ class JsonManager
         /** @deprecated Handle BC on 'stability' key until 4.0 */
         $minimumStability = $config->get('general/extensions/stability') ?: $config->get('general/extensions/composer/minimum-stability', 'stable');
 
-        $config = $config->get('general/extensions/composer/options', []) + [
+        $config = $config->get('general/extensions/composer/config', []) + [
             'discard-changes'   => true,
             'preferred-install' => 'dist',
         ];


### PR DESCRIPTION
Un-derping a derp in #6616

c.f. https://getcomposer.org/doc/06-config.md