### PR TITLE
[CodeClimate] Enable grep engine

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,59 @@
 engines:
     grep:
         enabled: true
+        exclude_paths:
+            - "!tests"
         config:
             patterns:
+                twig-namespace:
+                    pattern: ([^use ]Twig_[^Simple])
+                    annotation: "Don't use un-aliased, snake_cased, `Twig_*` references"
+                    severity: blocker
+                    categories: Compatibility
+                    content: >
+                        In preparation for Twig eventually namespacing, and in the interests of keeping
+                        things clear and clean, alias `Twig_*` classes, e.g.
+
+                          * `use Twig_Environment as Environment;`
+                          * `use Twig_Extension as Extension;`
+                          * `use Twig_Markup as Markup;`
+                    path_patterns:
+                        - "**/*.php"
+                twig-simple:
+                    pattern: ([^use ]Twig_Simple)
+                    annotation: "Don't use deprecated `Twig_Simple*` extension references"
+                    severity: blocker
+                    categories: Compatibility
+                    content: >
+                        Twig version 2 has deprecated `Twig_Simple*` extension functions, and
+                        replaced them with class names minus the "Simple".
+
+                        In preparation for this, ensure that `Twig_Simple*` classes are imported
+                        using an alias, e.g.
+
+                          * `use Twig_SimpleFilter as TwigFilter;`
+                          * `use Twig_SimpleFunction as TwigFunction;`
+                          * `use Twig_SimpleTest as TwigTest;`
+                    path_patterns:
+                        - "**/*.php"
+                phpunit-namespace:
+                    pattern: ([^use ]PHPUnit_(Framework|Util|Extensions|Runner|TextUI|Exception)_)
+                    annotation: "Don't use deprecated, snake_cased, `PHPUnit_*` references"
+                    severity: blocker
+                    categories: Compatibility
+                    content: >
+                        PHPUnit 6 has migrated to namespaces, and as such we're using import aliases
+                        for PHPUnit classes that match the version 6 namespace, e.g.
+
+                          * `use PHPUnit_Framework_MockObject_MockObject as MockObject;`
+
+                        Note that PHPUnit already has alias classes defined for `PHPUnit_Framework_Assert`
+                        and `PHPUnit_Framework_TestCase`, so imports need simply be, e.g.
+
+                          * `use PHPUnit\Framework\Assert;`
+                          * `use PHPUnit\Framework\TestCase;`
+                    path_patterns:
+                        - "tests/phpunit/**/*.php"
     duplication:
         enabled: true
         config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,8 @@
 engines:
+    grep:
+        enabled: true
+        config:
+            patterns:
     duplication:
         enabled: true
         config:
@@ -9,7 +13,6 @@ engines:
         enabled: true
         config:
             standard: "ruleset.xml"
-
 prepare:
     fetch:
         - url: "https://raw.githubusercontent.com/bolt/codingstyle/master/PhpCodeSniffer/Bolt/ruleset.xml"


### PR DESCRIPTION
CodeClimate have introduced a [grep engine](https://docs.codeclimate.com/v1.0/docs/grep) that might just solve one of my concerns about keeping track of re-introduction of deprecated, or deprecation prevention, code.

Firstly, I have added a check on new tests for PHPUnit deprecations … we can go from there.

As CodeClimate test on `release/3.3` and PRs only, I am going to use this one as a testing ground until happy, i.e. …
