### PR TITLE
[3.3] Fix TemplateView handling

### DIFF
--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -5,7 +5,6 @@ namespace Bolt\Controller\Async;
 use Bolt;
 use Bolt\Extension\ExtensionInterface;
 use Bolt\Filesystem;
-use Bolt\Response\TemplateView;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Repository;
 use GuzzleHttp\Exception\RequestException;
@@ -33,14 +32,26 @@ class General extends AsyncBase
             ->bind('changelogrecord');
 
         $c->get('/dashboardnews', 'dashboardNews')
-            ->bind('dashboardnews');
+            ->bind('dashboardnews')
+            ->after(function (Request $request, Response $response) {
+                $response->setSharedMaxAge(3600);
+            })
+        ;
 
         $c->get('/lastmodified/{contenttypeslug}/{contentid}', 'lastModified')
             ->value('contentid', '')
-            ->bind('lastmodified');
+            ->bind('lastmodified')
+            ->after(function (Request $request, Response $response) {
+                $response->setSharedMaxAge(60);
+            })
+        ;
 
         $c->get('/latestactivity', 'latestActivity')
-            ->bind('latestactivity');
+            ->bind('latestactivity')
+            ->after(function (Request $request, Response $response) {
+                $response->setSharedMaxAge(3600);
+            })
+        ;
 
         $c->get('/makeuri', 'makeUri')
             ->bind('makeuri');
@@ -58,6 +69,9 @@ class General extends AsyncBase
                 }
 
                 return $extension;
+            })
+            ->after(function (Request $request, Response $response) {
+                $response->setSharedMaxAge(180);
             })
         ;
 
@@ -130,7 +144,6 @@ class General extends AsyncBase
         ];
 
         $response = $this->render('@bolt/components/panel-news.twig', ['context' => $context]);
-        $this->setResponseMaxAge(3600);
 
         return $response;
     }
@@ -177,7 +190,6 @@ class General extends AsyncBase
                 ],
             ]
         );
-        $this->setResponseMaxAge(3600);
 
         return $response;
     }
@@ -291,7 +303,6 @@ class General extends AsyncBase
         $html = $this->app['markdown']->text($readme);
 
         $response = new Response($html);
-        $this->setResponseMaxAge(180);
 
         return $response;
     }
@@ -472,10 +483,7 @@ class General extends AsyncBase
             'filtered'    => $isFiltered,
         ];
 
-        $response = $this->render('@bolt/components/panel-lastmodified.twig', ['context' => $context]);
-        $this->setResponseMaxAge(60);
-
-        return $response;
+        return $this->render('@bolt/components/panel-lastmodified.twig', ['context' => $context]);
     }
 
     /**
@@ -498,9 +506,6 @@ class General extends AsyncBase
             'contenttype' => $contenttype,
         ];
 
-        $response = $this->render('@bolt/components/panel-lastmodified.twig', ['context' => $context]);
-        $this->setResponseMaxAge(60);
-
-        return $response;
+        return $this->render('@bolt/components/panel-lastmodified.twig', ['context' => $context]);
     }
 }

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -5,6 +5,7 @@ namespace Bolt\Controller\Async;
 use Bolt;
 use Bolt\Extension\ExtensionInterface;
 use Bolt\Filesystem;
+use Bolt\Response\TemplateView;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Repository;
 use GuzzleHttp\Exception\RequestException;
@@ -129,7 +130,7 @@ class General extends AsyncBase
         ];
 
         $response = $this->render('@bolt/components/panel-news.twig', ['context' => $context]);
-        $response->setSharedMaxAge(3600)->setPublic();
+        $this->setResponseMaxAge(3600);
 
         return $response;
     }
@@ -176,7 +177,7 @@ class General extends AsyncBase
                 ],
             ]
         );
-        $response->setPublic()->setSharedMaxAge(3600);
+        $this->setResponseMaxAge(3600);
 
         return $response;
     }
@@ -290,7 +291,7 @@ class General extends AsyncBase
         $html = $this->app['markdown']->text($readme);
 
         $response = new Response($html);
-        $response->setSharedMaxAge(180)->setPublic();
+        $this->setResponseMaxAge(180);
 
         return $response;
     }
@@ -472,7 +473,7 @@ class General extends AsyncBase
         ];
 
         $response = $this->render('@bolt/components/panel-lastmodified.twig', ['context' => $context]);
-        $response->setPublic()->setSharedMaxAge(60);
+        $this->setResponseMaxAge(60);
 
         return $response;
     }
@@ -498,7 +499,7 @@ class General extends AsyncBase
         ];
 
         $response = $this->render('@bolt/components/panel-lastmodified.twig', ['context' => $context]);
-        $response->setPublic()->setSharedMaxAge(60);
+        $this->setResponseMaxAge(60);
 
         return $response;
     }

--- a/src/Controller/Async/Widget.php
+++ b/src/Controller/Async/Widget.php
@@ -17,7 +17,11 @@ class Widget extends AsyncBase
     protected function addRoutes(ControllerCollection $c)
     {
         $c->get('/widget/{key}', 'widget')
-            ->bind('widget');
+            ->bind('widget')
+            ->after(function (Request $request, Response $response) {
+                $response->setSharedMaxAge(180);
+            })
+        ;
     }
 
     /**
@@ -53,7 +57,6 @@ class Widget extends AsyncBase
 
         $html = $this->app['asset.queue.widget']->getRendered($key);
         $response = new Response($html);
-        $this->setResponseMaxAge(180);
 
         return $response;
     }

--- a/src/Controller/Async/Widget.php
+++ b/src/Controller/Async/Widget.php
@@ -53,7 +53,7 @@ class Widget extends AsyncBase
 
         $html = $this->app['asset.queue.widget']->getRendered($key);
         $response = new Response($html);
-        $response->setSharedMaxAge(180)->setPublic();
+        $this->setResponseMaxAge(180);
 
         return $response;
     }

--- a/src/Controller/Backend/Authentication.php
+++ b/src/Controller/Backend/Authentication.php
@@ -22,7 +22,14 @@ class Authentication extends BackendBase
     protected function addRoutes(ControllerCollection $c)
     {
         $c->get('/login', 'getLogin')
-            ->bind('login');
+            ->bind('login')
+            ->after(function (Request $request, Response $response) {
+                $response->setVary('Cookies', false)->setMaxAge(0)->setPrivate();
+                if ($response->isRedirection()) {
+                    $response->headers->clearCookie($this->app['token.authentication.name']);
+                }
+            })
+        ;
 
         $c->post('/login', 'postLogin')
             ->bind('postLogin');
@@ -58,14 +65,7 @@ class Authentication extends BackendBase
             return $this->redirect(preg_replace('/^http:/i', 'https:', $request->getUri()));
         }
 
-        $response = $this->render('@bolt/login/login.twig', ['randomquote' => true]);
-        $response->setVary('Cookies', false)->setMaxAge(0)->setPrivate();
-
-        if ($resetCookies) {
-            $response->headers->clearCookie($this->app['token.authentication.name']);
-        }
-
-        return $response;
+        return $this->render('@bolt/login/login.twig', ['randomquote' => true]);
     }
 
     /**

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -701,10 +701,10 @@ class Users extends BackendBase
     private function notifyUserSetupEmail(Request $request, $displayName, $email)
     {
         // Create a welcome email
-        $mailhtml = $this->render(
+        $mailHtml = $this->app['twig']->render(
             '@bolt/email/firstuser.twig',
-            ['sitename' => $this->getOption('general/sitename')]
-        )->getContent();
+            ['context' => ['sitename' => $this->getOption('general/sitename')]]
+        );
 
         try {
             // Send a welcome email
@@ -717,8 +717,8 @@ class Users extends BackendBase
                 ->setFrom($from)
                 ->setReplyTo($from)
                 ->setTo([$email   => $displayName])
-                ->setBody(strip_tags($mailhtml))
-                ->addPart($mailhtml, 'text/html');
+                ->setBody(strip_tags($mailHtml))
+                ->addPart($mailHtml, 'text/html');
 
             $failedRecipients = [];
 

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -465,16 +465,4 @@ abstract class Base implements ControllerProviderInterface
     {
         return $this->app['resources'];
     }
-
-    /**
-     * Add a middleware that sets the response caching parameters.
-     *
-     * @param int $maxAge Number of seconds to set `Cache-Control s-maxage`
-     */
-    protected function setResponseMaxAge($maxAge)
-    {
-        $this->app->after(function (Request $request, Response $response) use ($maxAge) {
-            $response->setSharedMaxAge($maxAge)->setPublic();
-        });
-    }
 }

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -465,4 +465,16 @@ abstract class Base implements ControllerProviderInterface
     {
         return $this->app['resources'];
     }
+
+    /**
+     * Add a middleware that sets the response caching parameters.
+     *
+     * @param int $maxAge Number of seconds to set `Cache-Control s-maxage`
+     */
+    protected function setResponseMaxAge($maxAge)
+    {
+        $this->app->after(function (Request $request, Response $response) use ($maxAge) {
+            $response->setSharedMaxAge($maxAge)->setPublic();
+        });
+    }
 }

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -81,14 +81,14 @@ abstract class Base implements ControllerProviderInterface
 
         $template = $twig->resolveTemplate($template);
 
-        if ($this->getOption('compatibility/twig_globals', true)) {
+        if ($this->getOption('general/compatibility/twig_globals', true)) {
             foreach ($globals as $name => $value) {
                 $twig->addGlobal($name, $value);
             }
         }
         $context += $globals;
 
-        if ($this->getOption('compatibility/template_view', false)) {
+        if ($this->getOption('general/compatibility/template_view', false)) {
             return new TemplateView($template->getTemplateName(), $context);
         }
         Deprecated::warn(

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -61,9 +61,11 @@ class Frontend extends ConfigurableBase
         // If we are in maintenance mode and current user is not logged in, show maintenance notice.
         if ($this->getOption('general/maintenance_mode')) {
             if (!$this->isAllowed('maintenance-mode')) {
+                $twig = $this->app['twig'];
                 $template = $this->templateChooser()->maintenance();
-                $response = $this->render($template);
-                $response->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE);
+
+                $html = $twig->resolveTemplate($template)->render([]);
+                $response = new TemplateResponse($template, [], $html, Response::HTTP_SERVICE_UNAVAILABLE);
 
                 return $response;
             }

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Controller\Async;
 
 use Bolt\Filesystem\Handler\HandlerInterface;
-use Bolt\Response\TemplateResponse;
+use Bolt\Response\TemplateView;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -60,8 +60,7 @@ class FilesystemManagerTest extends ControllerUnitTest
         $this->setRequest(Request::create('/async/browse'));
         $response = $this->controller()->browse($this->getRequest(), self::FILESYSTEM, '/');
 
-        $this->assertInstanceOf(TemplateResponse::class, $response);
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertInstanceOf(TemplateView::class, $response);
         $this->assertEquals('@bolt/async/browse.twig', $response->getTemplate());
     }
 
@@ -276,9 +275,8 @@ class FilesystemManagerTest extends ControllerUnitTest
 
         $response = $this->controller()->recordBrowser();
 
-        $this->assertTrue($response instanceof TemplateResponse);
+        $this->assertTrue($response instanceof TemplateView);
         $this->assertSame('@bolt/recordbrowser/recordbrowser.twig', $response->getTemplate());
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Async/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Async/GeneralTest.php
@@ -3,7 +3,7 @@
 namespace Bolt\Tests\Controller\Async;
 
 use Bolt\Controller\Zone;
-use Bolt\Response\TemplateResponse;
+use Bolt\Response\TemplateView;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
@@ -58,9 +58,8 @@ class GeneralTest extends ControllerUnitTest
 
         $response = $this->controller()->changeLogRecord('pages', 1);
 
-        $this->assertTrue($response instanceof TemplateResponse);
+        $this->assertTrue($response instanceof TemplateView);
         $this->assertSame('@bolt/components/panel-change-record.twig', $response->getTemplate());
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testDashboardNewsWithInvalidRequest()
@@ -130,9 +129,8 @@ class GeneralTest extends ControllerUnitTest
         $this->setRequest(Request::create('/async/dashboardnews'));
 
         $response = $this->controller()->dashboardNews($this->getRequest());
-        $this->assertTrue($response instanceof TemplateResponse);
+        $this->assertTrue($response instanceof TemplateView);
         $this->assertSame('@bolt/components/panel-news.twig', $response->getTemplate());
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testLastModified()
@@ -141,9 +139,8 @@ class GeneralTest extends ControllerUnitTest
 
         $response = $this->controller()->lastModified('page', 1);
 
-        $this->assertTrue($response instanceof TemplateResponse);
+        $this->assertTrue($response instanceof TemplateView);
         $this->assertSame('@bolt/components/panel-lastmodified.twig', $response->getTemplate());
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testLatestactivity()
@@ -152,9 +149,8 @@ class GeneralTest extends ControllerUnitTest
 
         $response = $this->controller()->latestActivity();
 
-        $this->assertTrue($response instanceof TemplateResponse);
+        $this->assertTrue($response instanceof TemplateView);
         $this->assertSame('@bolt/components/panel-activity.twig', $response->getTemplate());
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Async/StackTest.php
+++ b/tests/phpunit/unit/Controller/Async/StackTest.php
@@ -4,13 +4,12 @@ namespace Bolt\Tests\Controller\Async;
 
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\Manager;
-use Bolt\Response\TemplateResponse;
+use Bolt\Response\TemplateView;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use League\Flysystem\Memory\MemoryAdapter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class to test correct operation of src/Controller/Async/Stack.
@@ -52,9 +51,8 @@ class StackTest extends ControllerUnitTest
 
         $response = $this->controller()->show(Request::create('/async/stack/show'));
 
-        $this->assertTrue($response instanceof TemplateResponse);
+        $this->assertTrue($response instanceof TemplateView);
         $this->assertSame('@bolt/components/stack/panel.twig', $response->getTemplate());
-        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
     /**

--- a/tests/phpunit/unit/Controller/Backend/ExtendTest.php
+++ b/tests/phpunit/unit/Controller/Backend/ExtendTest.php
@@ -80,7 +80,6 @@ class ExtendTest extends ControllerUnitTest
 
         $response = $this->controller()->overview();
 
-        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('@bolt/extend/extend.twig', $response->getTemplate());
     }
 
@@ -92,7 +91,6 @@ class ExtendTest extends ControllerUnitTest
 
         $response = $this->controller()->installPackage();
 
-        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
         $this->assertEquals('@bolt/extend/_action-modal.twig', $response->getTemplate());
     }
 

--- a/tests/phpunit/unit/Controller/Backend/GeneralTest.php
+++ b/tests/phpunit/unit/Controller/Backend/GeneralTest.php
@@ -6,9 +6,10 @@ use Bolt\Application;
 use Bolt\Controller\Zone;
 use Bolt\Legacy\Storage;
 use Bolt\Logger\FlashLogger;
-use Bolt\Response\TemplateResponse;
+use Bolt\Response\TemplateView;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Prophecy\Argument\Token\StringContainsToken;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -160,7 +161,7 @@ class GeneralTest extends ControllerUnitTest
         $this->setRequest(Request::create('/bolt/tr/contenttypes/en_CY'));
         $response = $this->controller()->translation($this->getRequest(), 'contenttypes', 'en_CY');
 
-        $this->assertTrue($response instanceof TemplateResponse, 'Response is not instance of TemplateResponse');
+        $this->assertTrue($response instanceof TemplateView, 'Response is not instance of TemplateView');
         $this->assertEquals('@bolt/editlocale/editlocale.twig', $response->getTemplate());
         $context = $response->getContext();
         $this->assertEquals('contenttypes.en_CY.yml', $context['context']['basename']);
@@ -197,10 +198,7 @@ class GeneralTest extends ControllerUnitTest
         ));
 
         $flash = $this->prophesize(FlashLogger::class);
-        $flash->keys()->shouldBeCalled();
-        $flash->get('info')->shouldBeCalled();
-        $flash->get('success')->shouldBeCalled();
-        $flash->get('error')->shouldBeCalled();
+        /** @var FlashLogger|ObjectProphecy $flash */
         $flash->error(new StringContainsToken('could not be saved'))->shouldBeCalled();
         $this->setService('logger.flash', $flash->reveal());
 

--- a/tests/phpunit/unit/Controller/Backend/UsersTest.php
+++ b/tests/phpunit/unit/Controller/Backend/UsersTest.php
@@ -124,7 +124,7 @@ class UsersTest extends ControllerUnitTest
             ]
         );
         $this->setRequest($request);
-        $this->getApp()['request_stack']->push($request);
+        $this->getService('request_stack')->push($request);
         $response = $this->controller()->first($this->getRequest());
         $this->assertEquals('/bolt', $response->getTargetUrl());
     }


### PR DESCRIPTION
* Don't crash when TwmplateView is really enabled
  * Fix config lookup of "compatibility" config values
  * TemplateView BC for routes accessing a rendered response, assuming a Response object
* Render email with Twig, as Swiftmailer messages need strings
* Controller helper to add a middleware that sets the response caching parameters
* Render maintenance mode template directly, as before() is before other listeners
* Dispatch view events for stack add() renders, as they are returned inside JSON
* [Tests] Update for template view, and test legacy on front-end
