### PR TITLE
[3.3] Only set environment for Nut Twig commands on CLI

### DIFF
--- a/src/Provider/NutServiceProvider.php
+++ b/src/Provider/NutServiceProvider.php
@@ -131,7 +131,9 @@ class NutServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
-        $app['nut.command.twig_debug']->setTwigEnvironment($app['twig']);
-        $app['nut.command.twig_lint']->setTwigEnvironment($app['twig']);
+        if (PHP_SAPI === 'cli') {
+            $app['nut.command.twig_debug']->setTwigEnvironment($app['twig']);
+            $app['nut.command.twig_lint']->setTwigEnvironment($app['twig']);
+        }
     }
 }


### PR DESCRIPTION
This will prevent the classes from building on web requests :woman_facepalming: 