### PR TITLE
[4.0] Update web profiler bundle to Symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symfony/translation": "^3.0",
         "symfony/validator": "^3.0",
         "symfony/var-dumper": "^3.0",
-        "symfony/web-profiler-bundle": "^2.8",
+        "symfony/web-profiler-bundle": "^3.0",
         "symfony/yaml": "^3.0",
         "tdammers/htmlmaid": "~0.7",
         "twig/twig": "^1.28",


### PR DESCRIPTION
Having the web profiler bundle locked at ^2.8 is holding back a few feature branches, and all paths lead to Silex.

Includes a few "workarounds" that I'll pull out in the Silex 2 branch post-merge … the hacks aren't goin' to production :wink: 