### PR TITLE
Make sure `wysiwyg` fields have the correct label, strip trailing `:` from alerts.

### DIFF
--- a/app/src/js/obj-validation.js
+++ b/app/src/js/obj-validation.js
@@ -86,13 +86,16 @@ Bolt.validation = (function () {
      */
     function showAlertbox(id, field, msg) {
         var alertbox;
+        var fieldname = $('label[for="' + field.id + '"]').contents().first().text().trim() || field.name;
+
+        fieldname = fieldname.replace(/(.*):+$/g, "$1" );
 
         alertbox = Bolt.data(
             'validation.alertbox',
             {
                 '%NOTICE_ID%': id,
                 '%FIELD_ID%': field.id,
-                '%FIELD_NAME%': $('label[for="' + field.id + '"]').contents().first().text().trim() || field.name,
+                '%FIELD_NAME%': fieldname,
                 '%MESSAGE%':  msg || $(field).data('errortext') || Bolt.data('validation.generic_msg')
             }
         );

--- a/app/view/twig/editcontent/fields/_html.twig
+++ b/app/view/twig/editcontent/fields/_html.twig
@@ -43,6 +43,7 @@
 {% block fieldset_label_text  labelkey %}
 {% block fieldset_label_info  option.info %}
 {% block fieldset_label_class 'col-xs-12' %}
+{% block fieldset_label_for   key %}
 
 {% block fieldset_controls %}
     <div class="col-xs-12">


### PR DESCRIPTION
Fixes #6629 