### PR TITLE
[3.3] Fix for sortable selects.

### DIFF
--- a/src/Twig/Extension/ArrayExtension.php
+++ b/src/Twig/Extension/ArrayExtension.php
@@ -165,7 +165,11 @@ class ArrayExtension extends Extension
     public function unique($arr1, $arr2)
     {
         $merged = array_unique(array_merge($arr1, $arr2), SORT_REGULAR);
+        $compiled = [];
+        foreach ($merged as $val) {
+            $compiled[$val[0]] = $val;
+        }
 
-        return $merged;
+        return $compiled;
     }
 }


### PR DESCRIPTION
Fixes #6561

Reindex merged unique arrays on the key so we have a standard way to check available values

This replicates the setup we currently have in 3.2 and recently fixed.