### PR TITLE
[3.2] Embed updates

### DIFF
--- a/src/Embed/Resolver.php
+++ b/src/Embed/Resolver.php
@@ -31,7 +31,7 @@ class Resolver
     }
 
     /**
-     * Return oEmbed information from a given URL.
+     * Return embed information from a given URL.
      *
      * @param UriInterface $url
      * @param string       $providerName
@@ -40,7 +40,8 @@ class Resolver
      */
     public function embed(UriInterface $url, $providerName)
     {
-        $providers = $this->getEmbedProviders($url);
+        $adapter = $this->getUrlAdapter($url);
+        $providers = $adapter->getProviders();
         if (!isset($providers[$providerName])) {
             return [];
         }
@@ -48,28 +49,6 @@ class Resolver
         $provider = $providers[$providerName];
 
         return $provider->getBag()->getAll();
-    }
-
-    /**
-     * Retrieve all of the embed providers from a given URL.
-     *
-     * @param UriInterface $url
-     *
-     * @throws EmbedResolverException
-     *
-     * @return \Embed\Providers\Provider[]
-     */
-    private function getEmbedProviders(UriInterface $url)
-    {
-        try {
-            $adapter = $this->getUrlAdapter($url);
-        } catch (InvalidUrlException $e) {
-            throw new EmbedResolverException($e->getMessage(), 1, $e);
-        } catch (EmbedException $e) {
-            throw new EmbedResolverException('Provider exception occurred', 2, $e);
-        }
-
-        return $adapter->getProviders();
     }
 
     /**
@@ -84,6 +63,14 @@ class Resolver
         $embedFactory = $this->embedFactory;
         $url = Url::create((string) $url);
 
-        return $embedFactory($url);
+        try {
+            $adapter = $embedFactory($url);
+        } catch (InvalidUrlException $e) {
+            throw new EmbedResolverException($e->getMessage(), 1, $e);
+        } catch (EmbedException $e) {
+            throw new EmbedResolverException('Provider exception occurred', 2, $e);
+        }
+
+        return $adapter;
     }
 }

--- a/src/Embed/Resolver.php
+++ b/src/Embed/Resolver.php
@@ -52,6 +52,34 @@ class Resolver
     }
 
     /**
+     * Return the best embeded image from a given URL.
+     *
+     * @param UriInterface $url
+     *
+     * @return string
+     */
+    public function image(UriInterface $url)
+    {
+        $adapter = $this->getUrlAdapter($url);
+
+        return $adapter->getImage();
+    }
+
+    /**
+     * Return embed images from a given URL.
+     *
+     * @param UriInterface $url
+     *
+     * @return array Values: url, width, height, size, mime (array)
+     */
+    public function images(UriInterface $url)
+    {
+        $adapter = $this->getUrlAdapter($url);
+
+        return $adapter->getImages();
+    }
+
+    /**
      * Return an API adapter matching the pattern of the given URL.
      *
      * @param UriInterface $url

--- a/src/Embed/Resolver.php
+++ b/src/Embed/Resolver.php
@@ -62,14 +62,14 @@ class Resolver
     private function getEmbedProviders(UriInterface $url)
     {
         try {
-            $info = $this->getUrlAdapter($url);
+            $adapter = $this->getUrlAdapter($url);
         } catch (InvalidUrlException $e) {
             throw new EmbedResolverException($e->getMessage(), 1, $e);
         } catch (EmbedException $e) {
             throw new EmbedResolverException('Provider exception occurred', 2, $e);
         }
 
-        return $info->getProviders();
+        return $adapter->getProviders();
     }
 
     /**

--- a/src/Provider/EmbedServiceProvider.php
+++ b/src/Provider/EmbedServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Bolt\Provider;
 
-use Bolt\Embed\Resolver;
 use Bolt\Embed\GuzzleDispatcher;
+use Bolt\Embed\Resolver;
 use Embed\Embed;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
@@ -25,7 +25,7 @@ class EmbedServiceProvider implements ServiceProviderInterface
 
         $app['embed.dispatcher'] = $app->share(
             function ($app) {
-                return new GuzzleDispatcher($app['guzzle.client']);
+                return new GuzzleDispatcher($app['guzzle.client'], $app['guzzle.handler_stack']);
             }
         );
 

--- a/src/Provider/EmbedServiceProvider.php
+++ b/src/Provider/EmbedServiceProvider.php
@@ -30,8 +30,23 @@ class EmbedServiceProvider implements ServiceProviderInterface
         );
 
         $app['embed.factory.config'] = $app->share(
-            function () {
-                return [];
+            function ($app) {
+                return [
+                    'min_image_width'     => 60,
+                    'min_image_height'    => 60,
+                    'images_blacklist'    => null,
+                    'choose_bigger_image' => false,
+                    'html'                => [
+                        'max_images'      => 10,
+                        'external_images' => false,
+                    ],
+                    'oembed' => [
+                        'parameters' => [],
+                    ],
+                    'google' => [
+                        'key' => $app['config']->get('general/google_api_key'),
+                    ],
+                ];
             }
         );
 

--- a/tests/phpunit/unit/Embed/ResolverTest.php
+++ b/tests/phpunit/unit/Embed/ResolverTest.php
@@ -44,7 +44,7 @@ class ResolverTest extends BoltUnitTest
         $client = new Client(['handler' => $handler]);
 
         $factory = function ($url, $options = []) use ($requestUrl, $client) {
-            $dispatcher = new Embed\GuzzleDispatcher($client);
+            $dispatcher = new Embed\GuzzleDispatcher($client, HandlerStack::create());
             /** @var \Embed\Adapters\Adapter $info */
             return \Embed\Embed::create($url, $options, $dispatcher);
         };


### PR DESCRIPTION
Time-pressure-free follow up on #6636

* Correctly handle redirected URLs (bug fix)
* Add parameters to the configuration service
* Shrink resolver code
* Implement `GuzzleDispatcher::dispatchImages()` — this isn't (yet?) used internally, but an unfinished interface and Team OCD :stuck_out_tongue_winking_eye: 
  * P.S. Not handling Guzzle 5 on this one, did someone say "internal & currently unused"