### PR TITLE
[3.3] Allow lookup of non-ContentType repositories by alias

### DIFF
--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -168,6 +168,12 @@ class MetadataDriver implements MappingDriver
                 return $class;
             }
         }
+        if (array_key_exists($alias, $this->defaultAliases)) {
+            $class = $this->defaultAliases[$alias];
+            if (class_exists($class)) {
+                return $class;
+            }
+        }
 
         return $this->fallbackEntity;
     }
@@ -491,6 +497,7 @@ class MetadataDriver implements MappingDriver
      */
     public function loadMetadataForClass($className, ClassMetadata $metadata = null)
     {
+        $fullClassName = null;
         if (null === $metadata) {
             $fullClassName = $this->resolveClassName($className);
             $metadata = new BoltClassMetadata($fullClassName, $this->namingStrategy);
@@ -500,9 +507,13 @@ class MetadataDriver implements MappingDriver
         }
 
         $className = $this->normalizeClassName($className);
+        $resolvedClassName = $fullClassName && array_key_exists($fullClassName, $this->metadata)
+            ? $fullClassName
+            : $className
+        ;
 
-        if (array_key_exists($className, $this->metadata)) {
-            $data = $this->metadata[$className];
+        if (array_key_exists($resolvedClassName, $this->metadata)) {
+            $data = $this->metadata[$resolvedClassName];
             $metadata->setTableName($data['table']);
             $metadata->setIdentifier($data['identifier']);
             $metadata->setFieldMappings($data['fields']);


### PR DESCRIPTION
Currently you can `$app['storage']->getRepository('bolt_pages')` (or any CT), and the repo will resolve.

This PR allows `$app['storage']->getRepository('bolt_log_system')`, instead of having to `$app['storage']->getRepository(\Bolt\Storage\Entity\LogSystem::class)`