### PR TITLE
Implement missing method `LogSystemRepository::countSystemLog()`

### DIFF
--- a/src/Storage/Repository/LogSystemRepository.php
+++ b/src/Storage/Repository/LogSystemRepository.php
@@ -7,4 +7,28 @@ namespace Bolt\Storage\Repository;
  */
 class LogSystemRepository extends BaseLogRepository
 {
+    /**
+     * Get a count of system log entries.
+     *
+     * @return integer
+     */
+    public function countSystemLog()
+    {
+        $query = $this->countSystemLogQuery();
+
+        return $this->getCount($query->execute()->fetch());
+    }
+
+    /**
+     * Build the query to get a count of system log entries.
+     *
+     * @return QueryBuilder
+     */
+    public function countSystemLogQuery()
+    {
+        $qb = $this->createQueryBuilder();
+        $qb->select('COUNT(id) as count');
+
+        return $qb;
+    }
 }


### PR DESCRIPTION
Analogous to https://github.com/bolt/bolt/blob/release/3.3/src/Storage/Repository/LogChangeRepository.php#L48-L71

This method is needed for a check i'm adding to `bolt/configuration-notices`.