### PR TITLE
[3.3][Deprecation] LogChangeRepository::countChangeLog()

### DIFF
--- a/src/Controller/Backend/Log.php
+++ b/src/Controller/Backend/Log.php
@@ -129,7 +129,7 @@ class Log extends BackendBase
             $data = [
                 'title'   => Trans::__('logs.change-log.contenttypes.all'),
                 'entries' => $this->changeLogRepository()->getChangeLog($queryOptions),
-                'count'   => $this->changeLogRepository()->countChangeLog(),
+                'count'   => $this->changeLogRepository()->count(),
                 'content' => null,
             ];
         } else {

--- a/src/Storage/Repository/LogChangeRepository.php
+++ b/src/Storage/Repository/LogChangeRepository.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Storage\Repository;
 
+use Bolt\Helpers\Deprecated;
 use Doctrine\DBAL\Query\QueryBuilder;
 
 /**
@@ -48,10 +49,14 @@ class LogChangeRepository extends BaseLogRepository
     /**
      * Get a count of change log entries.
      *
+     * @deprecated since 3.3, will be removed in 4.0
+     *
      * @return integer
      */
     public function countChangeLog()
     {
+        Deprecated::method(3.3, 'Use count() instead.');
+
         $query = $this->countChangeLogQuery();
 
         return $this->getCount($query->execute()->fetch());
@@ -59,6 +64,8 @@ class LogChangeRepository extends BaseLogRepository
 
     /**
      * Build the query to get a count of change log entries.
+     *
+     * @deprecated since 3.3, will be removed in 4.0
      *
      * @return QueryBuilder
      */

--- a/tests/phpunit/unit/Logger/ChangeLogTest.php
+++ b/tests/phpunit/unit/Logger/ChangeLogTest.php
@@ -35,7 +35,7 @@ class ChangeLogTest extends BoltUnitTest
         $this->assertEquals(1, count($logs2));
     }
 
-    public function testCountChangeLog()
+    public function testLegacyCountChangeLog()
     {
         $count = $this->getLogChangeRepository()->countChangeLog();
         $this->assertGreaterThanOrEqual(1, $count);


### PR DESCRIPTION
Replaced by `count()`