### PR TITLE
[3.2] Fix orphan taxonomy entities on delete

### DIFF
--- a/src/EventListener/StorageEventListener.php
+++ b/src/EventListener/StorageEventListener.php
@@ -8,8 +8,10 @@ use Bolt\Events\StorageEvents;
 use Bolt\Exception\AccessControlException;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Request\ProfilerAwareTrait;
+use Bolt\Storage\Collection;
 use Bolt\Storage\Database\Schema;
 use Bolt\Storage\Entity;
+use Bolt\Storage\EntityManagerInterface;
 use Bolt\Storage\EventProcessor;
 use Bolt\Translation\Translator as Trans;
 use PasswordLib\Password\Factory as PasswordFactory;
@@ -24,6 +26,8 @@ class StorageEventListener implements EventSubscriberInterface
 {
     use ProfilerAwareTrait;
 
+    /** @var EntityManagerInterface */
+    protected $em;
     /** @var EventProcessor\TimedRecord */
     protected $timedRecord;
     /** @var Schema\SchemaManagerInterface */
@@ -40,6 +44,7 @@ class StorageEventListener implements EventSubscriberInterface
     /**
      * Constructor.
      *
+     * @param EntityManagerInterface        $em
      * @param EventProcessor\TimedRecord    $timedRecord
      * @param Schema\SchemaManagerInterface $schemaManager
      * @param UrlGeneratorInterface         $urlGenerator
@@ -48,6 +53,7 @@ class StorageEventListener implements EventSubscriberInterface
      * @param integer                       $hashStrength
      */
     public function __construct(
+        EntityManagerInterface $em,
         EventProcessor\TimedRecord $timedRecord,
         Schema\SchemaManagerInterface $schemaManager,
         UrlGeneratorInterface $urlGenerator,
@@ -55,6 +61,7 @@ class StorageEventListener implements EventSubscriberInterface
         PasswordFactory $passwordFactory,
         $hashStrength
     ) {
+        $this->em = $em;
         $this->timedRecord = $timedRecord;
         $this->schemaManager = $schemaManager;
         $this->urlGenerator = $urlGenerator;
@@ -95,6 +102,33 @@ class StorageEventListener implements EventSubscriberInterface
         if (!in_array(Permissions::ROLE_EVERYONE, $roles)) {
             $roles[] = Permissions::ROLE_EVERYONE;
             $entity->setRoles($roles);
+        }
+    }
+
+    /**
+     * Pre-delete event to delete an entities taxonomy & relation entities.
+     *
+     * @param StorageEvent $event
+     */
+    public function onPreDelete(StorageEvent $event)
+    {
+        $entity = $event->getContent();
+        if (!$entity instanceof Entity\Content) {
+            return;
+        }
+        $taxonomies = $entity->getTaxonomy();
+        if ($taxonomies instanceof Collection\Taxonomy) {
+            $repo = $this->em->getRepository(Entity\Taxonomy::class);
+            foreach ($taxonomies as $taxonomy) {
+                $repo->delete($taxonomy);
+            }
+        }
+        $relations = $entity->getRelation();
+        if ($relations instanceof Collection\Relations) {
+            $repo = $this->em->getRepository(Entity\Relations::class);
+            foreach ($relations as $relation) {
+                $repo->delete($relation);
+            }
         }
     }
 
@@ -192,6 +226,7 @@ class StorageEventListener implements EventSubscriberInterface
             KernelEvents::REQUEST       => ['onKernelRequest', 31],
             StorageEvents::PRE_SAVE     => ['onUserEntityPreSave', Application::EARLY_EVENT],
             StorageEvents::POST_HYDRATE => 'onPostHydrate',
+            StorageEvents::PRE_DELETE   => 'onPreDelete',
         ];
     }
 }

--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -275,6 +275,7 @@ class StorageServiceProvider implements ServiceProviderInterface
         $app['storage.listener'] = $app->share(
             function () use ($app) {
                 return new StorageEventListener(
+                    $app['storage.lazy'],
                     $app['storage.event_processor.timed'],
                     $app['schema.lazy'],
                     $app['url_generator.lazy'],

--- a/tests/phpunit/unit/EventListener/StorageEventListenerTest.php
+++ b/tests/phpunit/unit/EventListener/StorageEventListenerTest.php
@@ -7,6 +7,7 @@ use Bolt\Events\StorageEvent;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Storage\Database\Schema\SchemaManagerInterface;
 use Bolt\Storage\Entity\Users;
+use Bolt\Storage\EntityManager;
 use Bolt\Storage\EventProcessor\TimedRecord;
 use PasswordLib\Password\Factory as PasswordFactory;
 use PasswordLib\Password\Implementation\Blowfish;
@@ -17,6 +18,8 @@ class StorageEventListenerTest extends \PHPUnit_Framework_TestCase
 {
     /** @var Users */
     private $user;
+    /** @var EntityManager */
+    private $em;
     /** @var TimedRecord */
     private $timedRecord;
     /** @var SchemaManagerInterface */
@@ -36,6 +39,7 @@ class StorageEventListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->user = $this->prophesize(Users::class);
 
+        $this->em = $this->prophesize(EntityManager::class);
         $this->timedRecord = $this->prophesize(TimedRecord::class);
         $this->schemaManager = $this->prophesize(SchemaManagerInterface::class);
         $this->urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
@@ -43,9 +47,9 @@ class StorageEventListenerTest extends \PHPUnit_Framework_TestCase
         $this->passwordFactory = $this->prophesize(PasswordFactory::class);
 
         $this->listener = new StorageEventListener(
+            $this->em->reveal(),
             $this->timedRecord->reveal(),
             $this->schemaManager->reveal(),
-
             $this->urlGenerator->reveal(),
             $this->flashLogger->reveal(),
             $this->passwordFactory->reveal(),


### PR DESCRIPTION
Fixes #6651 by adding a pre-delete event to delete an entity's taxonomy entities.

/me waves at @sbonardt 