### PR TITLE
[WIP] Fixed #6649 by avoiding setting values of JSON columns to '' (which P…

### DIFF
--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -150,7 +150,7 @@ trait ContentValuesTrait
                         if (!empty($this->values[$field]['url'])) {
                             $newvalue[$field] = json_encode($this->values[$field]);
                         } else {
-                            $newvalue[$field] = '';
+                            $newvalue[$field] = null;
                         }
                         break;
 
@@ -158,7 +158,7 @@ trait ContentValuesTrait
                         if (!empty($this->values[$field]['latitude']) && !empty($this->values[$field]['longitude'])) {
                             $newvalue[$field] = json_encode($this->values[$field]);
                         } else {
-                            $newvalue[$field] = '';
+                            $newvalue[$field] = null;
                         }
                         break;
 
@@ -166,7 +166,7 @@ trait ContentValuesTrait
                         if (!empty($this->values[$field]['file'])) {
                             $newvalue[$field] = json_encode($this->values[$field]);
                         } else {
-                            $newvalue[$field] = '';
+                            $newvalue[$field] = null;
                         }
                         break;
 
@@ -174,9 +174,8 @@ trait ContentValuesTrait
                     case 'filelist':
                         if (is_array($this->values[$field])) {
                             $newvalue[$field] = json_encode($this->values[$field]);
-                        } elseif (!empty($this->values[$field]) && strlen($this->values[$field]) < 3) {
-                            // Don't store '[]'
-                            $newvalue[$field] = '';
+                        } else {
+                            $newvalue[$field] = '[]';
                         }
                         break;
 
@@ -209,7 +208,7 @@ trait ContentValuesTrait
             if (!empty($this['templatefields'])) {
                 $newvalue['templatefields'] = json_encode($this->values['templatefields']->getValues(true, true));
             } else {
-                $newvalue['templatefields'] = '';
+                $newvalue['templatefields'] = '[]';
             }
         }
 


### PR DESCRIPTION
…ostgreSQL doesn't like)

This fixes the problem on PostgreSQL, however, it causes lots of the PHPUnits to fail on SQLite:

```
PDOException: SQLSTATE[23000]: Integrity constraint violation: 19 NOT NULL constraint failed: bolt_showcases.geolocation
```

It seems that the JSON columns get created as nullable for PostgreSQL (as expected) but not for SQLite (why not?), so I'm not sure how to progress this ... 