### PR TITLE
[3.4] Base entity get()/set()

### DIFF
--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -47,31 +47,13 @@ class Content extends Entity
     protected $sortorder;
 
     /**
-     * Getter for templates using {{ content.get(title) }} functions.
-     *
-     * @param string $key
-     *
-     * @return mixed
-     */
-    public function get($key)
-    {
-        if ($key === 'title') {
-            return $this->getTitle();
-        }
-
-        return $this->$key;
-    }
-
-    /**
-     * Setter for content values.
-     *
-     * @param string $key
-     * @param mixed  $value
+     * {@inheritdoc}
      */
     public function set($key, $value)
     {
         $setter = 'set' . ucfirst($key);
         if (is_array($value)) {
+            // Filter empty values from the array
             $value = array_filter($value);
         }
         $this->$setter($value);

--- a/src/Storage/Entity/Entity.php
+++ b/src/Storage/Entity/Entity.php
@@ -32,6 +32,32 @@ abstract class Entity implements ArrayAccess, JsonSerializable
     }
 
     /**
+     * Return an entity field value by name.
+     *
+     * @param string $key The entity field name
+     *
+     * @return mixed
+     */
+    public function get($key)
+    {
+        $method = 'get' . ucfirst($this->camelize($key));
+
+        return $this->$method();
+    }
+
+    /**
+     * Set an entity field value by name.
+     *
+     * @param string $key
+     * @param mixed  $value
+     */
+    public function set($key, $value)
+    {
+        $method = 'set' . ucfirst($key);
+        $this->$method($value);
+    }
+
+    /**
      * @return int
      */
     public function getId()

--- a/src/Storage/Entity/LogSystem.php
+++ b/src/Storage/Entity/LogSystem.php
@@ -20,6 +20,8 @@ class LogSystem extends Entity
     /** @var string */
     protected $route;
     /** @var string */
+    protected $requesturi;
+    /** @var string */
     protected $ip;
     /** @var string */
     protected $context;
@@ -120,6 +122,22 @@ class LogSystem extends Entity
     public function setRoute($route)
     {
         $this->route = $route;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequesturi()
+    {
+        return $this->requesturi;
+    }
+
+    /**
+     * @param string $requestUri
+     */
+    public function setRequesturi($requestUri)
+    {
+        $this->requesturi = $requestUri;
     }
 
     /**


### PR DESCRIPTION
This gives all entities the ability to use `$entity->get($fieldName')` or `$entity->set($fieldName, $fieldValue')`.

Previously only ContentType entities could use this, and the `set()` is preserved in the CT entity as it additionally filters the `$value` array, and while that's fine for our ContentTypes, it is not a decision we should make for other entities.

Also with the current state, should you make the mistake of calling `get()` or `set()` on a non-CT entity currently, the magic method strips the prefix, ending up with an empty key to tray and find a value with.

A note on the forwarding of the calls, a number of entity getters & setters handle mutation.