### PR TITLE
[3.2] Fix metadata nullable assignment

### DIFF
--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -189,7 +189,7 @@ class MetadataDriver implements MappingDriver
                 'type'             => $column->getType()->getName(),
                 'fieldtype'        => $this->getFieldTypeFor($contentKey, $column),
                 'length'           => $column->getLength(),
-                'nullable'         => $column->getNotnull(),
+                'nullable'         => !$column->getNotnull(),
                 'platformOptions'  => $column->getPlatformOptions(),
                 'precision'        => $column->getPrecision(),
                 'scale'            => $column->getScale(),


### PR DESCRIPTION
Invert `$column->getNotnull()` return value as it defines if a column is **not** nullable … I'm calling :koala: 