### PR TITLE
Fix PathResolver infinite recursion

### DIFF
--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -151,15 +151,26 @@ class PathResolver
     }
 
     /**
-     * Resolves and returns all known paths.
+     * Returns the names of all paths.
      *
      * @return array
      */
-    public function resolveAll()
+    public function names()
     {
-        return array_map(function ($path) {
-            return $this->resolve($path);
-        }, $this->paths);
+        return array_keys($this->rawAll());
+    }
+
+    /**
+     * Returns all path names and their raw definitions.
+     *
+     * @return array
+     */
+    protected function rawAll()
+    {
+        $paths = $this->paths;
+        unset($paths['root']);
+
+        return $paths;
     }
 
     /**

--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -108,7 +108,7 @@ class PathResolver
             $alias = $match[1];
 
             if (!isset($this->paths[$this->normalizeName($alias)])) {
-                throw new \InvalidArgumentException("Failed to resolve path. Alias %$alias% is not defined.");
+                throw new PathResolutionException("Failed to resolve path. Alias %$alias% is not defined.");
             }
 
             // absolute if alias is at start of path

--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -72,6 +72,10 @@ class PathResolver
     {
         $name = $this->normalizeName($name);
 
+        if (strpos($path, "%$name%") !== false) {
+            throw new \InvalidArgumentException('Paths cannot reference themselves.');
+        }
+
         $this->paths[$name] = $path;
     }
 

--- a/src/Exception/PathResolutionException.php
+++ b/src/Exception/PathResolutionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Bolt\Exception;
+
+class PathResolutionException extends \RuntimeException
+{
+}

--- a/tests/phpunit/unit/Configuration/PathResolverTest.php
+++ b/tests/phpunit/unit/Configuration/PathResolverTest.php
@@ -67,6 +67,16 @@ class PathResolverTest extends TestCase
         $this->assertSame('/foo/derp', $resolver->resolve('bar'), 'Initial paths were not applied');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Paths cannot reference themselves.
+     */
+    public function testDefineSelfReference()
+    {
+        $resolver = new PathResolver('/root/');
+        $resolver->define('foo', '%foo%/bar');
+    }
+
     public function testRaw()
     {
         $resolver = new PathResolver('/', [

--- a/tests/phpunit/unit/Configuration/PathResolverTest.php
+++ b/tests/phpunit/unit/Configuration/PathResolverTest.php
@@ -54,7 +54,7 @@ class PathResolverTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Bolt\Exception\PathResolutionException
      * @expectedExceptionMessage Failed to resolve path. Alias %nope% is not defined.
      */
     public function testUndefinedAliasFails()

--- a/tests/phpunit/unit/Configuration/PathResolverTest.php
+++ b/tests/phpunit/unit/Configuration/PathResolverTest.php
@@ -101,23 +101,13 @@ class PathResolverTest extends TestCase
         $this->assertNull($resolver->raw('derp'), 'Raw() should return null for undefined path');
     }
 
-    /**
-     * @depends testResolve
-     */
-    public function testResolveAll()
+    public function testNames()
     {
-        $resolver = new PathResolver('/root/', [
-            'web'   => 'public',
-            'files' => '%web%/files',
+        $resolver = new PathResolver('/', [
+            'bar' => 'foo',
+            'hello' => 'world',
         ]);
 
-        $this->assertEquals(
-            [
-                'web'   => '/root/public',
-                'files' => '/root/public/files',
-                'root'  => '/root',
-            ],
-            $resolver->resolveAll()
-        );
+        $this->assertEquals(['bar', 'hello'], $resolver->names());
     }
 }

--- a/tests/phpunit/unit/Configuration/PathResolverTest.php
+++ b/tests/phpunit/unit/Configuration/PathResolverTest.php
@@ -40,6 +40,20 @@ class PathResolverTest extends TestCase
     }
 
     /**
+     * @expectedException \Bolt\Exception\PathResolutionException
+     * @expectedExceptionMessage Failed to resolve path. Infinite recursion detected.
+     */
+    public function testResolveInfiniteRecursion()
+    {
+        $resolver = new PathResolver('/root/', [
+            'a' => '%b%',
+            'b' => '%a%',
+        ]);
+
+        $resolver->resolve('a');
+    }
+
+    /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Failed to resolve path. Alias %nope% is not defined.
      */


### PR DESCRIPTION
- A `PathResolutionException is now thrown when infinite recursion is detected.
- An `InvalidArgumentException` is now thrown when trying to define a path that references itself.
- Added `names()` which returns a list of defined names.
- Removed `resolveAll()` it wasn't used and if needed one can loop using `names()` method.