### PR TITLE
Overwritable Output

### DIFF
--- a/src/Nut/Helper/QuestionHelper.php
+++ b/src/Nut/Helper/QuestionHelper.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Bolt\Nut\Helper;
+
+use Bolt\Nut\Output\OverwritableOutputInterface;
+use GuzzleHttp\Psr7\FnStream;
+use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\StreamWrapper;
+use Symfony\Component\Console\Helper\SymfonyQuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * A QuestionHelper that can remove all output when done.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+final class QuestionHelper extends SymfonyQuestionHelper
+{
+    /** @var bool */
+    private $remove;
+    /** @var Question */
+    private $question;
+    /** @var OverwritableOutputInterface */
+    private $output;
+    /** @var bool */
+    private $autocomplete;
+    /** @var bool */
+    private static $stty;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        // Initialize input stream.
+        $this->setInputStream(null);
+    }
+
+    /**
+     * Ask a question to the user and then remove the question & answer.
+     *
+     * @param InputInterface              $input
+     * @param OverwritableOutputInterface $output
+     * @param Question                    $question
+     *
+     * @return mixed|string The user answer
+     */
+    public function askThenRemove(InputInterface $input, OverwritableOutputInterface $output, Question $question)
+    {
+        // Following suit of ask().
+        if (!$input->isInteractive()) {
+            return $question->getDefault();
+        }
+
+        $this->remove = true;
+        $this->question = $question;
+        $this->output = $output;
+        $this->autocomplete = $this->question->getAutocompleterValues() !== null && $this->hasSttyAvailable();
+
+        $this->output->capture();
+
+        // Wrap normalizer to remove latest question & answer since
+        // it is called for each iteration if answer is not valid.
+        $normalizer = $question->getNormalizer();
+        $question->setNormalizer(function ($value) use ($normalizer) {
+            $this->output->remove();
+            $this->output->capture();
+
+            if (is_callable($normalizer)) {
+                return $normalizer($value);
+            }
+
+            return $value;
+        });
+
+        try {
+            $value = $this->ask($input, $this->output, $question);
+        } finally {
+            $this->remove = false;
+            $this->question = null;
+            $this->output->remove();
+            $this->output = null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Wrap input stream to call our onRead method.
+     */
+    public function setInputStream($stream)
+    {
+        $stream = new Stream($stream ?: STDIN);
+        $stream = FnStream::decorate($stream, [
+            'read' => function ($length) use ($stream) {
+                $ret = $stream->read($length);
+                $this->onRead($ret);
+
+                return $ret;
+            },
+        ]);
+        $stream = StreamWrapper::getResource($stream);
+
+        parent::setInputStream($stream);
+    }
+
+    /**
+     * On input stream read.
+     *
+     * We capture user input here if applicable.
+     *
+     * We can't use the return value of ask() because it is trimmed.
+     * We need to account for those extra characters when overwriting.
+     *
+     * @param string $data
+     */
+    protected function onRead($data)
+    {
+        if (!$this->remove || $this->autocomplete || $this->question->isHidden()) {
+            return;
+        }
+
+        $this->output->captureUserInput($data);
+    }
+
+    /**
+     * Returns whether Stty is available or not.
+     *
+     * @return bool
+     */
+    private function hasSttyAvailable()
+    {
+        if (null !== self::$stty) {
+            return self::$stty;
+        }
+
+        exec('stty 2>&1', $output, $exitcode);
+
+        return self::$stty = $exitcode === 0;
+    }
+}

--- a/src/Nut/Helper/Table.php
+++ b/src/Nut/Helper/Table.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bolt\Nut\Helper;
+
+use Bolt\Nut\Output\OverwritableOutputInterface;
+use Symfony\Component\Console\Helper\Table as BaseTable;
+
+/**
+ * Extends Symfony's Table to provide an overwrite method.
+ *
+ * Table values can be updated then, instead of calling render(),
+ * call overwrite() and the previous table will be removed and
+ * the new one will be rendered.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Table extends BaseTable
+{
+    /** @var OverwritableOutputInterface */
+    private $output;
+    /** @var bool */
+    private $previouslyRendered;
+
+    /**
+     * Constructor.
+     *
+     * @param OverwritableOutputInterface $output
+     */
+    public function __construct(OverwritableOutputInterface $output)
+    {
+        $this->output = $output;
+        parent::__construct($this->output);
+    }
+
+    /**
+     * Remove previously rendered table, then render again with new data.
+     *
+     * This assumes the table is the last output on the terminal.
+     */
+    public function overwrite()
+    {
+        if (!$this->previouslyRendered) {
+            $this->previouslyRendered = true;
+        } else {
+            $this->output->remove();
+        }
+        $this->output->capture();
+        $this->render();
+    }
+}

--- a/src/Nut/Helper/Terminal.php
+++ b/src/Nut/Helper/Terminal.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Bolt\Nut\Helper;
+
+/**
+ * An easy way to get the terminal's width/height.
+ *
+ * Values are not cached here for accuracy, so limited calls to this class is recommended.
+ *
+ * This started from Symfony's code, and modified to be its own class and to use a signal handler if available.
+ *
+ * Symfony 3.x does have their own Terminal class, but values are cached there. If the user resizes their terminal
+ * window the code will never know about it.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+final class Terminal
+{
+    private static $width;
+    private static $height;
+    private static $pcntlEnabled;
+    private static $pcntlAsync;
+    private static $pcntlNeedsUpdate = true;
+
+    /**
+     * Returns the Terminal's width.
+     *
+     * @return int
+     */
+    public static function getWidth()
+    {
+        $width = getenv('COLUMNS');
+        if ($width !== false) {
+            return (int) trim($width);
+        }
+
+        static::updateDimensions();
+
+        return static::$width;
+    }
+
+    /**
+     * Returns the Terminal's height.
+     *
+     * @return int
+     */
+    public static function getHeight()
+    {
+        $height = getenv('LINES');
+        if ($height !== false) {
+            return (int) trim($height);
+        }
+
+        static::updateDimensions();
+
+        return static::$height;
+    }
+
+    /**
+     * Update our dimension properties.
+     */
+    private static function updateDimensions()
+    {
+        if (!static::checkPcntl()) {
+            return;
+        }
+
+        static::fetchDimensions();
+    }
+
+    /**
+     * Initializes and checks if we have received a SIGWINCH signal.
+     *
+     * @return bool Whether dimensions should be fetched.
+     */
+    private static function checkPcntl()
+    {
+        if (static::$pcntlEnabled === null) {
+            if (!extension_loaded('pcntl')) {
+                static::$pcntlEnabled = false;
+                return true;
+            }
+            static::$pcntlEnabled = true;
+
+            if (version_compare(PHP_VERSION, '7.1', '>=')) {
+                pcntl_async_signals(true);
+                static::$pcntlAsync = true;
+            }
+
+            // This can be dispatched multiple times when resizing,
+            // so it's important that we throttle fetching dimensions.
+            pcntl_signal(SIGWINCH, function () {
+                static::$pcntlNeedsUpdate = true;
+            });
+        } elseif (static::$pcntlEnabled === false) {
+            return true;
+        }
+
+        if (!static::$pcntlAsync) {
+            pcntl_signal_dispatch();
+        }
+
+        return static::$pcntlNeedsUpdate;
+    }
+
+    /**
+     * Fetch dimensions based on platform.
+     */
+    private static function fetchDimensions()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $dimensions = static::getAnsiCon();
+            if (!$dimensions) {
+                $dimensions = static::getConsoleMode();
+            }
+        } else {
+            $dimensions = static::getSttyColumns();
+        }
+
+        // Default, if above methods fail.
+        $dimensions += [80, 50];
+
+        static::$width = $dimensions[0];
+        static::$height = $dimensions[1];
+
+        // Reset signal handler flag.
+        static::$pcntlNeedsUpdate = false;
+    }
+
+    /**
+     * Parse width & height from ANSICON env var.
+     *
+     * @return int[]
+     */
+    private static function getAnsiCon()
+    {
+        if (preg_match('/^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$/', trim(getenv('ANSICON')), $matches)) {
+            // extract [w, H] from "wxh (WxH)"
+            // or [w, h] from "wxh"
+            return [
+                (int) $matches[1],
+                isset($matches[4]) ? (int) $matches[4] : (int) $matches[2],
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * Run console mode command and parse output to width & height.
+     *
+     * @return int[]
+     */
+    private static function getConsoleMode()
+    {
+        $info = static::runCommand('mode CON');
+
+        if ($info && preg_match('/--------+\r?\n.+?(\d+)\r?\n.+?(\d+)\r?\n/', $info, $matches)) {
+            // extract [w, h] from "wxh"
+            return [(int) $matches[2], (int) $matches[1]];
+        }
+
+        return [];
+    }
+
+    /**
+     * Run stty command and parse output to width & height.
+     *
+     * @return int[]
+     */
+    private static function getSttyColumns()
+    {
+        $info = static::runCommand('stty -a | grep columns');
+
+        if ($info && preg_match('/rows.(\d+);.columns.(\d+);/i', $info, $matches)) {
+            // extract [w, h] from "rows h; columns w;"
+        } elseif ($info && preg_match('/;.(\d+).rows;.(\d+).columns/i', $info, $matches)) {
+            // extract [w, h] from "; h rows; w columns"
+        } else {
+            return [];
+        }
+
+        return [(int) $matches[2], (int) $matches[1]];
+    }
+
+    /**
+     * Run a command.
+     *
+     * @param string $command
+     *
+     * @return string|null
+     */
+    private static function runCommand($command)
+    {
+        if (!function_exists('proc_open')) {
+            return null;
+        }
+
+        $descriptorSpec = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open($command, $descriptorSpec, $pipes, null, null, ['suppress_errors' => true]);
+        if (!is_resource($process)) {
+            return null;
+        }
+
+        $info = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        return $info;
+    }
+}

--- a/src/Nut/Output/Capture.php
+++ b/src/Nut/Output/Capture.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Bolt\Nut\Output;
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Helper\Helper;
+
+/**
+ * Holds text that could be overwritten in console.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+final class Capture
+{
+    private $text = '';
+
+    public function append($text)
+    {
+        $text = $this->cleanAutocomplete($text);
+
+        $this->text .= $text;
+    }
+
+    public function overwrite(OutputFormatterInterface $formatter, $width)
+    {
+        $lines = $this->getLines($this->text, $width, $formatter);
+
+        if ($lines[count($lines) - 1] === '') {
+            array_pop($lines);
+        }
+
+        $lineCount = count($lines);
+
+        if (!$lines) {
+            return '';
+        }
+
+        $overwrite = '';
+        // go to first line
+        $overwrite .= sprintf("\033[%dF", $lineCount);
+        // fill whitespace for each line
+        foreach ($lines as $line) {
+            $length = Helper::strlenWithoutDecoration($formatter, $line);
+            $overwrite .= str_repeat("\x20", $length) . PHP_EOL;
+        }
+        // go back to first line
+        $overwrite .= sprintf("\033[%dF", $lineCount);
+
+        return $overwrite;
+    }
+
+    private function cleanAutocomplete($newText)
+    {
+        if ($newText === "\033[K") {
+            return '';
+        }
+        if ($newText === "\033[1D") {
+            $this->text = substr($this->text, 0, -1);
+            return '';
+        }
+        if ($newText === "\0338") {
+            $index = strrpos($this->text, "\0337");
+            $this->text = substr($this->text, 0, $index);
+            return '';
+        }
+
+        return $newText;
+    }
+
+    private function getLines($text, $width, OutputFormatterInterface $formatter)
+    {
+        $rawLines = explode(PHP_EOL, $text);
+
+        $lines = [];
+        foreach ($rawLines as $line) {
+            $length = Helper::strlenWithoutDecoration($formatter, $line);
+            if ($length <= $width) {
+                $lines[] = $line;
+            } else {
+                $lines = array_merge($lines, $this->chunk($line, $width));
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Splits buffer into parts of given width accounting for ANSI styling.
+     *
+     * @param string $text
+     * @param int    $width
+     *
+     * @return string[]
+     */
+    private function chunk($text, $width)
+    {
+        $chunks = [];
+        $current = '';
+        $currentLength = 0;
+        $styleStack = [];
+
+        $bufferLength = mb_strwidth($text);
+        for ($i = 0; $i < $bufferLength; $i++) {
+            if ($text[$i] === "\033") { // start of formatting?
+                // Add to current and skip length.
+                $length = strpos($text, 'm', $i) - $i;
+                $style = substr($text, $i, $length + 1);
+                $current .= $style;
+                $i += $length;
+
+                $codes = explode(';', substr($style, 2, -1));
+                $start = (bool) array_diff($codes, [22, 24, 25, 27, 28, 39, 49]);
+                if ($start) {
+                    $styleStack[] = $codes;
+                } else {
+                    array_pop($styleStack);
+                }
+            } else {
+                $current .= $text[$i];
+                $currentLength++;
+            }
+
+            if ($currentLength >= $width || $i + 1 === $bufferLength) {
+                foreach (array_reverse($styleStack) as $startStyleCodes) {
+                    $endStyleCodes = [];
+                    foreach ($startStyleCodes as $code) {
+                        if (strlen($code) === 1) {
+                            $endStyleCodes[] = '2' . $code;
+                        } elseif ($code[0] === '3') {
+                            $endStyleCodes[] = '39';
+                        } elseif ($code[0] === '4') {
+                            $endStyleCodes[] = '49';
+                        }
+                    }
+                    $current .= sprintf("\033[%sm", implode(';', $endStyleCodes));
+                }
+                $chunks[] = $current;
+                $current = '';
+                $currentLength = 0;
+
+                foreach ($styleStack as $startStyleCodes) {
+                    $current .= sprintf("\033[%sm", implode(';', $startStyleCodes));
+                }
+            }
+        }
+
+        return $chunks;
+    }
+}

--- a/src/Nut/Output/OutputWrapperTrait.php
+++ b/src/Nut/Output/OutputWrapperTrait.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Bolt\Nut\Output;
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Trait to help create OutputInterface wrappers.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+trait OutputWrapperTrait
+{
+    /** @var OutputInterface */
+    protected $output;
+
+    public function write($messages, $newline = false, $options = 0)
+    {
+        $this->output->write($messages, $newline, $options);
+    }
+
+    public function writeln($messages, $options = 0)
+    {
+        $this->output->writeln($messages, $options);
+    }
+
+    public function isQuiet()
+    {
+        return OutputInterface::VERBOSITY_QUIET === $this->getVerbosity();
+    }
+
+    public function isVerbose()
+    {
+        return OutputInterface::VERBOSITY_VERBOSE <= $this->getVerbosity();
+    }
+
+    public function isVeryVerbose()
+    {
+        return OutputInterface::VERBOSITY_VERY_VERBOSE <= $this->getVerbosity();
+    }
+
+    public function isDebug()
+    {
+        return OutputInterface::VERBOSITY_DEBUG <= $this->getVerbosity();
+    }
+
+    public function setVerbosity($level)
+    {
+        $this->output->setVerbosity($level);
+    }
+
+    public function getVerbosity()
+    {
+        return $this->output->getVerbosity();
+    }
+
+    public function setDecorated($decorated)
+    {
+        $this->output->setDecorated($decorated);
+    }
+
+    public function isDecorated()
+    {
+        return $this->output->isDecorated();
+    }
+
+    public function setFormatter(OutputFormatterInterface $formatter)
+    {
+        $this->output->setFormatter($formatter);
+    }
+
+    public function getFormatter()
+    {
+        return $this->output->getFormatter();
+    }
+}

--- a/src/Nut/Output/OverwritableOutput.php
+++ b/src/Nut/Output/OverwritableOutput.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Bolt\Nut\Output;
+
+use Bolt\Nut\Helper\Terminal;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * An Output wrapper that can capture groups of output and remove/overwrite them later.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+final class OverwritableOutput implements OverwritableOutputInterface
+{
+    use OutputWrapperTrait;
+
+    /** @var BufferedOutput */
+    private $buffer;
+    /** @var Capture[] */
+    private $captures = [];
+
+    /**
+     * Constructor.
+     *
+     * @param OutputInterface $output
+     */
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+        $this->buffer = new BufferedOutput($output->getVerbosity(), $output->isDecorated(), $output->getFormatter());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function capture()
+    {
+        array_unshift($this->captures, new Capture());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function captureUserInput($input)
+    {
+        if (!$this->captures) {
+            $this->capture();
+        }
+        $this->captures[0]->append($input);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove()
+    {
+        if (!$this->captures) {
+            return;
+        }
+
+        $capture = array_shift($this->captures);
+
+        if (!$this->isDecorated()) {
+            return;
+        }
+
+        $overwrite = $capture->overwrite($this->getFormatter(), Terminal::getWidth());
+
+        $this->output->write($overwrite);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($messages, $newline = false, $options = 0)
+    {
+        if ($this->captures) {
+            $this->buffer->write($messages, $newline, $options);
+            $buffer = $this->buffer->fetch();
+            $this->captures[0]->append($buffer);
+        }
+
+        $this->output->write($messages, $newline, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeln($messages, $options = 0)
+    {
+        $this->write($messages, true, $options);
+    }
+}

--- a/src/Nut/Output/OverwritableOutputInterface.php
+++ b/src/Nut/Output/OverwritableOutputInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bolt\Nut\Output;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * An Output that can capture groups of output text and remove/overwrite them later.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+interface OverwritableOutputInterface extends OutputInterface
+{
+    /**
+     * Start capturing output to remove.
+     *
+     * This should start a new capture each time it is called.
+     */
+    public function capture();
+
+    /**
+     * Remove output from latest capture.
+     */
+    public function remove();
+
+    /**
+     * Add user input to latest capture.
+     *
+     * This is a special case where the user writes to console but it doesn't go through our output.
+     * We need to manually add it to keep the console in sync.
+
+     * @param string $input
+     */
+    public function captureUserInput($input);
+}

--- a/src/Nut/Style/NutStyle.php
+++ b/src/Nut/Style/NutStyle.php
@@ -2,15 +2,125 @@
 
 namespace Bolt\Nut\Style;
 
+use Bolt\Nut\Helper\QuestionHelper;
+use Bolt\Nut\Output\OverwritableOutput;
+use Bolt\Nut\Output\OverwritableOutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Nut custom style.
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
+ * @author Carson Full <carsonfull@gmail.com>
  */
-class NutStyle extends SymfonyStyle
+class NutStyle extends SymfonyStyle implements OverwritableOutputInterface, OverwritableStyleInterface
 {
+    /** @var InputInterface */
+    protected $input;
+    /** @var OverwritableOutputInterface */
+    protected $output;
+    /** @var QuestionHelper */
+    protected $questionHelper;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+        if (!$output instanceof OverwritableOutputInterface) {
+            $output = new OverwritableOutput($output);
+        }
+        $this->output = $output;
+        parent::__construct($input, $output);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function askThenRemove($question, $default = null, $validator = null)
+    {
+        $question = new Question($question, $default);
+        $question->setValidator($validator);
+
+        return $this->askQuestionThenRemove($question);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function askHiddenThenRemove($question, $validator = null)
+    {
+        $question = new Question($question);
+
+        $question->setHidden(true);
+        $question->setValidator($validator);
+
+        return $this->askQuestionThenRemove($question);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function confirmThenRemove($question, $default = true)
+    {
+        return $this->askQuestionThenRemove(new ConfirmationQuestion($question, $default));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function choiceThenRemove($question, array $choices, $default = null)
+    {
+        if (null !== $default) {
+            $values = array_flip($choices);
+            $default = $values[$default];
+        }
+
+        return $this->askQuestionThenRemove(new ChoiceQuestion($question, $choices, $default));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function askQuestionThenRemove(Question $question)
+    {
+        if (!$this->questionHelper) {
+            $this->questionHelper = new QuestionHelper();
+        }
+
+        return $this->questionHelper->askThenRemove($this->input, $this, $question);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function capture()
+    {
+        $this->output->capture();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove()
+    {
+        $this->output->remove();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function captureUserInput($input)
+    {
+        $this->output->captureUserInput($input);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Nut/Style/OverwritableStyleInterface.php
+++ b/src/Nut/Style/OverwritableStyleInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Bolt\Nut\Style;
+
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\StyleInterface;
+
+/**
+ * An extension of StyleInterface that adds user input methods that remove their output afterwards.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+interface OverwritableStyleInterface extends StyleInterface
+{
+    /**
+     * Asks a question then removes the question & answer.
+     *
+     * @param string        $question
+     * @param string|null   $default
+     * @param callable|null $validator
+     *
+     * @return string
+     */
+    public function askThenRemove($question, $default = null, $validator = null);
+
+    /**
+     * Asks a question with the user input hidden then removes the question.
+     *
+     * @param string        $question
+     * @param callable|null $validator
+     *
+     * @return string
+     */
+    public function askHiddenThenRemove($question, $validator = null);
+
+    /**
+     * Asks for confirmation then removes the question & answer.
+     *
+     * @param string $question
+     * @param bool   $default
+     *
+     * @return bool
+     */
+    public function confirmThenRemove($question, $default = true);
+
+    /**
+     * Asks a choice question then removes the question & answer.
+     *
+     * @param string          $question
+     * @param array           $choices
+     * @param string|int|null $default
+     *
+     * @return string
+     */
+    public function choiceThenRemove($question, array $choices, $default = null);
+
+    /**
+     * Asks a question then removes the question & answer.
+     *
+     * @param Question $question
+     *
+     * @return mixed|string
+     */
+    public function askQuestionThenRemove(Question $question);
+}


### PR DESCRIPTION
This will help in making more interactive console commands. 
It is already used in the incoming composer project configurator changes.

## Prompts
This adds functionality to ask questions and then remove the output.
```php
$io = new NutStyle($input, $output);

$name = $io->askThenRemove('Name?', $default = 'Carson');

$password = $io->askHiddenThenRemove('Password?');

if ($io->confirmThenRemove('Continue?', $default = true)) {}

$color = $io->choiceThenRemove('Pick color', ['red', 'blue'], $default = 'blue');
```
After each answer the question & answer are removed from the terminal.

## Table
This also adds a `Table` which can overwrite previous data. 
```php
$table = new Table($output);

while (true) {
    $data = []; // determine (new/updated) data
    $table->setRows($data);

    $table->overwrite();

    sleep(1);
}
```
Instead of rendering a table for each iteration, it _appears_ to be one table with values updated.

## Terminal Dimensions
I've also added an easier way to get terminal width/height via the `Terminal` class. More info in class doc.
