### PR TITLE
ScriptHandler updates

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -3,14 +3,8 @@
 namespace Bolt;
 
 use Bolt\Configuration\Composer;
-use Bolt\Configuration\PathResolverFactory;
-use Bolt\Configuration\ResourceManager;
 use Bolt\Configuration\Standard;
 use Bolt\Exception\BootException;
-use Bolt\Extension\ExtensionInterface;
-use LogicException;
-use Silex;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Second stage loader. Do bootstrapping within a new local scope to avoid
@@ -20,9 +14,7 @@ use Symfony\Component\Yaml\Yaml;
  * - Initialize mb functions for UTF-8
  * - Figure out root path
  * - Bring in the autoloader
- * - Load initialization config from .bolt file
- * - Load and verify configuration
- * - Initialize the application
+ * - Call Bolt\Bootstrap to create the application
  *
  * @throws BootException
  *
@@ -63,143 +55,5 @@ return call_user_func(function () {
         BootException::earlyExceptionComposer();
     }
 
-    /*
-     * Load initialization config needed to bootstrap application.
-     *
-     * In order for paths to be customized and still have the standard
-     * index.php (web) and nut (CLI) work, there needs to be a standard
-     * place these are defined. This is ".bolt.yml" or ".bolt.php" in the
-     * project root (determined above).
-     *
-     * Yes, YAML and PHP are supported here (not both). YAML works for
-     * simple values and PHP supports any programmatic logic if required.
-     */
-    $config = [
-        'application' => null,
-        'resources'   => null,
-        'paths'       => [],
-        'services'    => [],
-        'extensions'  => [],
-    ];
-
-    if (file_exists($rootPath . '/.bolt.yml')) {
-        $yaml = Yaml::parse(file_get_contents($rootPath . '/.bolt.yml')) ?: [];
-        $config = array_replace_recursive($config, $yaml);
-    } elseif (file_exists($rootPath . '/.bolt.php')) {
-        $php = include $rootPath . '/.bolt.php';
-    }
-
-    // An extra handler if a PHP bootstrap is provided, allow the bootstrap file to return
-    // a pre-initialized Bolt Application rather than the config array.
-    if (isset($php) && is_array($php)) {
-        $config = array_replace_recursive($config, $php);
-    } elseif (isset($php) && $php instanceof Silex\Application) {
-        return $php;
-    }
-
-    // If application object is provided, assume it is ready to go.
-    if ($config['application'] instanceof Silex\Application) {
-        return $config['application'];
-    }
-
-    $pathResolverFactoryFactory = \Pimple::share(function () use ($rootPath, $config) {
-        $pathResolverFactory = new PathResolverFactory();
-        $pathResolverFactory->setRootPath($rootPath);
-        $pathResolverFactory->addPaths((array) $config['paths']);
-
-        return $pathResolverFactory;
-    });
-
-    $resourcesFactory = \Pimple::share(function () use ($config, $resourcesClass, $rootPath, $pathResolverFactoryFactory) {
-        // Use resources from config, or instantiate the class based on mapping above.
-        if ($config['resources'] instanceof ResourceManager) {
-            $resources = $config['resources'];
-        } else {
-            if ($config['resources'] !== null && is_a($config['resources'], ResourceManager::class, true)) {
-                $resourcesClass = $config['resources'];
-            }
-
-            $passPathResolverFactory = false;
-            if ($resourcesClass === Composer::class || $resourcesClass === Standard::class) {
-                $passPathResolverFactory = true;
-            } else {
-                $r = (new \ReflectionClass($resourcesClass))->getConstructor();
-                if ($r->getNumberOfParameters() > 2 && $r->getParameters()[2]->getClass()->name === PathResolverFactory::class) {
-                    $passPathResolverFactory = true;
-                }
-            }
-
-            if ($passPathResolverFactory) {
-                $pathResolverFactory = $pathResolverFactoryFactory(null);
-                $resources = new $resourcesClass($rootPath, null, $pathResolverFactory);
-            } else {
-                $resources = new $resourcesClass($rootPath);
-            }
-        }
-        /** @var \Bolt\Configuration\ResourceManager $resources */
-
-        // Set any non-standard paths
-        foreach ((array) $config['paths'] as $name => $path) {
-            $resources->setPath($name, $path, false);
-        }
-
-        $resources->verify();
-
-        return $resources;
-    });
-
-    // If resources is already initialized, go ahead and customize it now.
-    if ($config['resources'] instanceof ResourceManager) {
-        $resourcesFactory = $resourcesFactory(null);
-    }
-
-    // Create the 'Bolt application'
-    $appClass = Application::class;
-    if ($config['application'] !== null && is_a($config['application'], Silex\Application::class, true)) {
-        $appClass = $config['application'];
-    }
-    /** @var Silex\Application $app */
-    $app = new $appClass([
-        'resources'             => $resourcesFactory,
-        'path_resolver_factory' => $pathResolverFactoryFactory,
-        'path_resolver.root'    => $rootPath,
-        'path_resolver.paths'   => (array) $config['paths'],
-        'resources.bootstrap'   => $config['resources'] !== null,
-    ]);
-
-    foreach ((array) $config['services'] as $service) {
-        $params = [];
-        if (is_array($service)) {
-            $key = key($service);
-            $params = $service[$key];
-            $service = $key;
-        }
-
-        if (is_string($service) && is_a($service, Silex\ServiceProviderInterface::class, true)) {
-            $service = new $service();
-        }
-        if ($service instanceof Silex\ServiceProviderInterface) {
-            $app->register($service, $params);
-        }
-
-    }
-
-    $app['extensions'] = $app->share(
-        $app->extend('extensions', function ($extensions) use ($config) {
-            foreach ((array)$config['extensions'] as $extensionClass) {
-                if (is_string($extensionClass) && class_exists($extensionClass, true)) {
-                    $extensionClass = new $extensionClass();
-                } else {
-                    throw new LogicException(sprintf('Unable to load extension class %s', $extensionClass));
-                }
-                if ($extensionClass instanceof ExtensionInterface) {
-                    $extensions->add($extensionClass);
-                }
-            }
-
-            return $extensions;
-        })
-    );
-
-    return $app;
+    return Bootstrap::run($rootPath, $resourcesClass);
 });

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Bolt;
+
+use Bolt\Configuration\Composer;
+use Bolt\Configuration\MyComposer;
+use Bolt\Configuration\PathResolverFactory;
+use Bolt\Configuration\ResourceManager;
+use Bolt\Configuration\Standard;
+use Bolt\Extension\ExtensionInterface;
+use LogicException;
+use Silex;
+use Symfony\Component\Yaml\Yaml;
+use Webmozart\PathUtil\Path;
+
+/**
+ * Handles creating the Application with .bolt.[yml|php] configuration.
+ *
+ * This does not handle autoloading.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Bootstrap
+{
+    /**
+     * Create the application.
+     *
+     * @param string $rootPath
+     *
+     * @return Silex\Application
+     */
+    public static function run($rootPath)
+    {
+        /*
+         * Load initialization config needed to bootstrap application.
+         *
+         * In order for paths to be customized and still have the standard
+         * index.php (web) and nut (CLI) work, there needs to be a standard
+         * place these are defined. This is ".bolt.yml" or ".bolt.php" in the
+         * project root (determined above).
+         *
+         * Yes, YAML and PHP are supported here (not both). YAML works for
+         * simple values and PHP supports any programmatic logic if required.
+         */
+        $config = [
+            'application' => null,
+            'resources'   => null,
+            'paths'       => [],
+            'services'    => [],
+            'extensions'  => [],
+        ];
+
+        $rootPath = Path::canonicalize($rootPath);
+
+        if (file_exists($rootPath . '/.bolt.yml')) {
+            $yaml = Yaml::parse(file_get_contents($rootPath . '/.bolt.yml')) ?: [];
+            $config = array_replace_recursive($config, $yaml);
+        } elseif (file_exists($rootPath . '/.bolt.php')) {
+            $php = include $rootPath . '/.bolt.php';
+        }
+
+        // An extra handler if a PHP bootstrap is provided, allow the bootstrap file to return
+        // a pre-initialized Bolt Application rather than the config array.
+        if (isset($php) && is_array($php)) {
+            $config = array_replace_recursive($config, $php);
+        } elseif (isset($php) && $php instanceof Silex\Application) {
+            return $php;
+        }
+
+        // If application object is provided, assume it is ready to go.
+        if ($config['application'] instanceof Silex\Application) {
+            return $config['application'];
+        }
+
+        $pathResolverFactoryFactory = \Pimple::share(function () use ($rootPath, $config) {
+            $pathResolverFactory = new PathResolverFactory();
+            $pathResolverFactory->setRootPath($rootPath);
+            $pathResolverFactory->addPaths((array) $config['paths']);
+
+            return $pathResolverFactory;
+        });
+
+        $resourcesClass = func_num_args() > 1 ? func_get_arg(1) : Standard::class;
+        $resourcesFactory = \Pimple::share(function () use ($config, $resourcesClass, $rootPath, $pathResolverFactoryFactory) {
+            // Use resources from config, or instantiate the class based on mapping above.
+            if ($config['resources'] instanceof ResourceManager) {
+                $resources = $config['resources'];
+            } else {
+                if ($config['resources'] !== null && is_a($config['resources'], ResourceManager::class, true)) {
+                    $resourcesClass = $config['resources'];
+                }
+
+                $passPathResolverFactory = false;
+                if ($resourcesClass === Composer::class || $resourcesClass === Standard::class) {
+                    $passPathResolverFactory = true;
+                } else {
+                    $r = (new \ReflectionClass($resourcesClass))->getConstructor();
+                    if ($r->getNumberOfParameters() > 2 && $r->getParameters()[2]->getClass()->name === PathResolverFactory::class) {
+                        $passPathResolverFactory = true;
+                    }
+                }
+
+                if ($passPathResolverFactory) {
+                    $pathResolverFactory = $pathResolverFactoryFactory(null);
+                    $resources = new $resourcesClass($rootPath, null, $pathResolverFactory);
+                } else {
+                    $resources = new $resourcesClass($rootPath);
+                }
+            }
+            /** @var \Bolt\Configuration\ResourceManager $resources */
+
+            // Set any non-standard paths
+            foreach ((array) $config['paths'] as $name => $path) {
+                $resources->setPath($name, $path, false);
+            }
+
+            $resources->verify();
+
+            return $resources;
+        });
+
+        // If resources is already initialized, go ahead and customize it now.
+        if ($config['resources'] instanceof ResourceManager) {
+            $resourcesFactory = $resourcesFactory(null);
+        }
+
+        // Create the 'Bolt application'
+        $appClass = Application::class;
+        if ($config['application'] !== null && is_a($config['application'], Silex\Application::class, true)) {
+            $appClass = $config['application'];
+        }
+        /** @var Silex\Application $app */
+        $app = new $appClass([
+            'resources'             => $resourcesFactory,
+            'path_resolver_factory' => $pathResolverFactoryFactory,
+            'path_resolver.root'    => $rootPath,
+            'path_resolver.paths'   => (array) $config['paths'],
+            'resources.bootstrap'   => $config['resources'] !== null,
+        ]);
+
+        foreach ((array) $config['services'] as $service) {
+            $params = [];
+            if (is_array($service)) {
+                $key = key($service);
+                $params = $service[$key];
+                $service = $key;
+            }
+
+            if (is_string($service) && is_a($service, Silex\ServiceProviderInterface::class, true)) {
+                $service = new $service();
+            }
+            if ($service instanceof Silex\ServiceProviderInterface) {
+                $app->register($service, $params);
+            }
+        }
+
+        $app['extensions'] = $app->share(
+            $app->extend(
+                'extensions',
+                function ($extensions) use ($config) {
+                    foreach ((array) $config['extensions'] as $extensionClass) {
+                        if (is_string($extensionClass) && class_exists($extensionClass, true)) {
+                            $extensionClass = new $extensionClass();
+                        } else {
+                            throw new LogicException(sprintf('Unable to load extension class %s', $extensionClass));
+                        }
+                        if ($extensionClass instanceof ExtensionInterface) {
+                            $extensions->add($extensionClass);
+                        }
+                    }
+
+                    return $extensions;
+                }
+            )
+        );
+
+        return $app;
+    }
+}

--- a/src/Composer/Script/BootstrapYamlUpdater.php
+++ b/src/Composer/Script/BootstrapYamlUpdater.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Bolt\Composer\Script;
+
+use Bolt\Collection\Bag;
+use Bolt\Helpers\Str;
+use Composer\IO\IOInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+use Webmozart\PathUtil\Path;
+
+/**
+ * Updates .bolt.yml paths for changes with PathResolver introduced in 3.3.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class BootstrapYamlUpdater
+{
+    const FILENAME = '.bolt.yml';
+
+    /** @var IOInterface */
+    private $io;
+    /** @var Filesystem */
+    private $filesystem;
+
+    /**
+     * Constructor.
+     *
+     * @param IOInterface $io
+     * @param Filesystem  $filesystem
+     */
+    public function __construct(IOInterface $io, Filesystem $filesystem = null)
+    {
+        $this->io = $io;
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
+     * Update .bolt.yml file if needed.
+     */
+    public function update()
+    {
+        if (!file_exists(static::FILENAME)) {
+            return;
+        }
+
+        $contents = Yaml::parse(file_get_contents(static::FILENAME)) ?: [];
+
+        if (!isset($contents['paths'])) {
+            return;
+        }
+
+        $originalPaths = $contents['paths'];
+        $contents['paths'] = $newPaths = $this->updatePaths(new Bag($originalPaths))->toArray();
+
+        if ($originalPaths === $newPaths) {
+            return;
+        }
+
+        $this->save($contents);
+    }
+
+    /**
+     * Save updated data .bolt.yml file, or remove if it matches defaults.
+     *
+     * @param array $contents
+     */
+    public function save(array $contents)
+    {
+        // Custom paths
+        if (count($contents['paths']) > 0) {
+            $str = Yaml::dump($contents);
+            try {
+                $this->filesystem->dumpFile(static::FILENAME, $str);
+                $version = \Bolt\Version::VERSION;
+                $this->io->writeError([
+                    "<info>Bolt has updated the <comment>paths</comment> in your <comment>.bolt.yml</comment> file for $version.</info>\n",
+                ]);
+            } catch (IOException $e) {
+                $this->io->writeError([
+                    'The <comment>paths</comment> in your <comment>.bolt.yml</comment> file can be simplified.',
+                    'You should update your <comment>.bolt.yml</comment> file to this:',
+                    '',
+                    "<info>$str</info>",
+                    ''
+                ]);
+            }
+
+            return;
+        }
+
+        $this->io->writeError('The paths in your <comment>.bolt.yml</comment> file match the defaults now.');
+
+        // No custom paths and no other options = delete.
+        if ($onlyPaths = !array_diff_key($contents, ['paths' => 0])) {
+            try {
+                $this->filesystem->remove(static::FILENAME);
+                $this->io->writeError("<info>Since this file is optional we've deleted it for you.</info>\n");
+            } catch (IOException $e) {
+                $this->io->writeError("<info>It is safe to delete it.</info>\n");
+            }
+
+            return;
+        }
+
+        // No custom paths, but other options.
+        try {
+            unset($contents['paths']);
+            $this->filesystem->dumpFile(static::FILENAME, Yaml::dump($contents));
+            $this->io->writeError("<info>We've removed them from the file for you.</info>\n");
+        } catch (IOException $e) {
+            $this->io->writeError("<info>It is safe and encouraged to remove them.</info>\n");
+        }
+    }
+
+    /**
+     * Update paths.
+     *
+     * @param Bag $paths
+     *
+     * @return Bag
+     */
+    public function updatePaths(Bag $paths)
+    {
+        if ($paths->isEmpty()) {
+            return $paths;
+        }
+
+        if ($web = $paths['web']) {
+            if ($web === 'public') {
+                $paths->remove('web');
+            } elseif (strpos($web, '%site%') !== 0) {
+                $paths['web'] = '%site%/' . $web;
+            }
+        }
+        $webLength = strlen($web . '/');
+
+        if ($files = $paths['files']) {
+            if ($files === $web . '/files') {
+                $paths->remove('files');
+            } elseif (strpos($files, $web . '/') === 0) {
+                $paths['files'] = '%web%/' . substr($files, $webLength);
+            }
+        }
+
+        if ($paths->has('themebase')) {
+            $themes = $paths->remove('themebase');
+            if ($themes === $web . '/theme') {
+                // nothing
+            } elseif (strpos($themes, $web . '/') === 0) {
+                $paths['themes'] = '%web%/' . substr($themes, $webLength);
+            }
+        }
+
+        if ($paths->has('view')) {
+            $boltAssets = $paths->remove('view');
+            if ($boltAssets === $web . '/bolt-public/view') {
+                // nothing
+            } elseif (strpos($boltAssets, $web . '/') === 0) {
+                $paths['bolt_assets'] = '%web%/' . substr($boltAssets, $webLength);
+            }
+        }
+
+        if ($paths->has('app')) {
+            return $paths;
+        }
+
+        $appPathKeys = ['cache', 'config', 'database'];
+        $appPaths = array_intersect_key($paths->toArray(), array_flip($appPathKeys));
+        // Only paths without %app% alias in them.
+        $appPaths = array_filter($appPaths, function ($path) {
+            return strpos($path, '%app%') === false;
+        });
+        if (empty($appPaths)) {
+            return $paths;
+        }
+        $app = $this->determineMostCommonBaseAppPath($appPaths);
+
+        if ($app === 'app') {
+            // "app/" is the default "app" path, so don't bother setting.
+            $appPathToTrim = 'app/';
+        } elseif ($app === '') {
+            // no common base path so just ignore app path alias
+            $appPathToTrim = '';
+        } else {
+            // custom app path, set it.
+            $site = $paths->get('site', '.');
+            $paths['app'] = '%site%/' . Path::makeRelative($app, $site);
+            $appPathToTrim = $app . '/';
+        }
+
+        foreach ($appPathKeys as $key) {
+            if (!($path = $paths[$key])) {
+                continue;
+            }
+            if ($appPathToTrim && strpos($path, $appPathToTrim) === 0) {
+                $path = Str::replaceFirst($appPathToTrim, '', $path);
+                if ($path === $key) {
+                    $paths->remove($key);
+                } else {
+                    $paths[$key] = '%app%/' . $path;
+                }
+            } else {
+                $paths[$key] = $path;
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Determine the most common app path.
+     *
+     * @param string[] $paths
+     *
+     * @return string
+     */
+    private function determineMostCommonBaseAppPath($paths)
+    {
+        $paths = array_values($paths);
+
+        $options = [];
+        $options[] = Path::getLongestCommonBasePath($paths);
+        if (isset($paths[1])) {
+            $options[] = Path::getLongestCommonBasePath([$paths[0], $paths[1]]);
+        }
+        if (isset($paths[2])) {
+            $options[] = Path::getLongestCommonBasePath([$paths[1], $paths[2]]);
+            $options[] = Path::getLongestCommonBasePath([$paths[0], $paths[2]]);
+        }
+        rsort($options);
+
+        return reset($options);
+    }
+}

--- a/src/Composer/Script/DirectoryConfigurator.php
+++ b/src/Composer/Script/DirectoryConfigurator.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Bolt\Composer\Script;
+
+use Composer\IO\IOInterface;
+use Composer\Script\Event;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+use Webmozart\PathUtil\Path;
+
+class DirectoryConfigurator
+{
+    /** @var IOInterface */
+    private $io;
+    /** @var Filesystem */
+    private $filesystem;
+    /** @var array */
+    private $composerExtra;
+    /** @var int */
+    private $dirMode;
+
+    /**
+     * Constructor.
+     *
+     * @param IOInterface       $io
+     * @param array             $composerExtra
+     * @param Filesystem|null   $filesystem
+     */
+    public function __construct(IOInterface $io, array $composerExtra = [], Filesystem $filesystem = null)
+    {
+        $this->io = $io;
+        $this->composerExtra = $composerExtra;
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    public static function fromEvent(Event $event)
+    {
+        return new static($event->getIO(), $event->getComposer()->getPackage()->getExtra());
+    }
+
+    public function run()
+    {
+        $this->configureDirs();
+    }
+
+    protected function configureDirs()
+    {
+        $web = $this->configureDir('web', 'public', '', false);
+        $themes = $this->configureDir('themes', 'theme', $web . '/');
+        $files = $this->configureDir('files', 'files', $web . '/');
+
+        $config = $this->configureDir('config', 'app/config');
+        $database = $this->configureDir('database', 'app/database');
+        $cache = $this->configureDir('cache', 'app/cache');
+
+        $config = [
+            'paths' => [
+                'cache'       => $cache,
+                'config'      => $config,
+                'database'    => $database,
+                'web'         => $web,
+                'themes'      => $themes,
+                'files'       => $files,
+                'bolt_assets' => $web . '/bolt-public/view',
+            ],
+        ];
+        $this->filesystem->dumpFile('.bolt.yml', Yaml::dump($config));
+
+        $chmodDirs = [
+            'extensions',
+            $web . '/extensions',
+            $web . '/thumbs',
+        ];
+        $this->filesystem->chmod($chmodDirs, $this->configureDirMode());
+    }
+
+    /**
+     * @param string $name
+     * @param string $defaultInSkeleton
+     * @param string $prefix
+     * @param bool   $chmod
+     *
+     * @return string
+     */
+    protected function configureDir($name, $defaultInSkeleton, $prefix = '', $chmod = true)
+    {
+        $default = $this->getOption($name . '-dir', $defaultInSkeleton);
+
+        $validator = function ($value) use ($prefix, $name) {
+            if ($prefix) {
+                $basePath = Path::makeAbsolute($prefix, getcwd());
+                $path = Path::makeAbsolute($value, $basePath);
+                if (!Path::isBasePath($basePath, $path)) {
+                    throw new \RuntimeException("The $name directory must be inside the $prefix directory.");
+                }
+            }
+
+            return Path::canonicalize($value);
+        };
+
+        $default = $validator($default);
+
+        $relative = $prefix ? '<comment>' . $prefix . '</comment>' : 'project root';
+        $question = sprintf('<info>Where do you want your <comment>%s</comment> directory? (relative to %s) [default: <comment>%s</comment>] </info>', $name, $relative, $default);
+        $dir = $this->io->askAndValidate($question, $validator, null, $default);
+
+        $origin = $prefix . $defaultInSkeleton;
+        $target = $prefix . $dir;
+
+        $dirMode = $this->configureDirMode();
+
+        if ($origin !== $target) {
+            $this->io->writeError(sprintf('Moving <info>%s</info> directory from <info>%s</info> to <info>%s</info>', $name, $origin, $target));
+            $this->filesystem->mkdir(dirname($target)); // ensure parent directory exists
+            $this->filesystem->rename($origin, $target);
+        }
+
+        if ($chmod) {
+            $it = (new Finder())->directories()->in($target)->append([$target]);
+            $this->filesystem->chmod($it, $dirMode);
+        }
+
+        return $target;
+    }
+
+    /**
+     * Gets the directory mode value, sets umask with it, and returns it.
+     *
+     * @return int
+     */
+    protected function configureDirMode()
+    {
+        if ($this->dirMode === null) {
+            $dirMode = $this->getOption('dir-mode', 0777);
+            $dirMode = is_string($dirMode) ? octdec($dirMode) : $dirMode;
+
+            umask(0777 - $dirMode);
+
+            $this->dirMode = $dirMode;
+        }
+
+        return $this->dirMode;
+    }
+
+    /**
+     * Get an option from environment variable or composer's extra section.
+     *
+     * Example: With key "dir-mode" it checks for "BOLT_DIR_MODE" environment variable,
+     * then "bolt-dir-mode" in composer's extra section, then returns given default value.
+     *
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    protected function getOption($key, $default = null)
+    {
+        if ($value = $this->getEnvOption($key)) {
+            return $value;
+        }
+
+        $key = strtolower(str_replace('_', '-', $key));
+
+        if (strpos($key, 'bolt-') !== false) {
+            $key = 'bolt-' . $key;
+        }
+
+        return isset($this->composerExtra[$key]) ? $this->composerExtra[$key] : $default;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return array|false|string
+     */
+    protected function getEnvOption($key)
+    {
+        $key = strtoupper(str_replace('-', '_', $key));
+
+        if (strpos($key, 'BOLT_') !== false) {
+            $key = 'BOLT_' . $key;
+        }
+
+        return getenv($key);
+    }
+}

--- a/src/Composer/Script/DirectorySyncer.php
+++ b/src/Composer/Script/DirectorySyncer.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Bolt\Composer\Script;
+
+use Bolt\Bootstrap;
+use Bolt\Configuration\PathResolver;
+use Composer\IO\IOInterface;
+use Composer\Script\Event;
+use Silex\Application;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Syncs directories from core to user project.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class DirectorySyncer
+{
+    /** @var PathResolver */
+    private $userResolver;
+    /** @var PathResolver */
+    private $boltResolver;
+    /** @var IOInterface */
+    private $io;
+    /** @var Options */
+    private $options;
+    /** @var Filesystem */
+    private $filesystem;
+
+    /**
+     * Constructor.
+     *
+     * @param PathResolver $userResolver
+     * @param PathResolver $boltResolver
+     * @param IOInterface  $io
+     * @param Options|null $options
+     * @param Filesystem   $filesystem
+     */
+    public function __construct(
+        PathResolver $userResolver,
+        PathResolver $boltResolver,
+        IOInterface $io,
+        Options $options = null,
+        Filesystem $filesystem = null
+    ) {
+        $this->userResolver = $userResolver;
+        $this->boltResolver = $boltResolver;
+        $this->io = $io;
+        $this->options = $options ?: new Options();
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
+     * Create from Composer Event.
+     *
+     * @param Event $event
+     *
+     * @return DirectorySyncer
+     */
+    public static function fromEvent(Event $event)
+    {
+        $boltDir = $event->getComposer()->getConfig()->get('vendor-dir') . '/bolt/bolt';
+
+        /**
+         * Use bootstrap.php to ensure autoloader and correct root path is used.
+         * @var Application $userApp
+         */
+        $userApp = require $boltDir . '/app/bootstrap.php';
+        $userResolver = $userApp['path_resolver'];
+
+        $app = Bootstrap::run($boltDir);
+        $boltResolver = $app['path_resolver'];
+
+        return new static($userResolver, $boltResolver, $event->getIO(), Options::fromEvent($event));
+    }
+
+    /**
+     * @param string $name        The name of the path alias in PathResolver to sync
+     * @param bool   $delete      Whether to delete files that are not in the source directory
+     * @param array  $onlySubDirs Only sync these sub dirs if given
+     */
+    public function sync($name, $delete = false, $onlySubDirs = [])
+    {
+        $origin = $this->boltResolver->resolve($name);
+        $target = $this->userResolver->resolve($name);
+
+        if ($origin === $target) {
+            return;
+        }
+
+        $this->io->writeError("Installing <info>$name</info> to <info>$target</info>");
+
+        $old = umask(0777 - $this->options->getDirMode());
+        try {
+            if ($onlySubDirs) {
+                foreach ($onlySubDirs as $subDir) {
+                    $this->mirror($origin . '/' . $subDir, $target . '/' . $subDir, $delete);
+                }
+            } else {
+                $this->mirror($origin, $target, $delete);
+            }
+        } finally {
+            umask($old);
+        }
+    }
+
+    /**
+     * Helper to make mirror calls shorter.
+     *
+     * @param string $origin
+     * @param string $target
+     * @param bool   $delete
+     */
+    private function mirror($origin, $target, $delete = false)
+    {
+        $this->filesystem->mirror($origin, $target, null, ['override' => true, 'delete' => $delete]);
+    }
+}

--- a/src/Composer/Script/Options.php
+++ b/src/Composer/Script/Options.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Bolt\Composer\Script;
+
+use Composer\Script\Event;
+
+/**
+ * Handles options in composer's extra section and env vars.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Options
+{
+    /** @var array */
+    private $composerExtra;
+
+    /**
+     * Constructor.
+     *
+     * @param array $composerExtra
+     */
+    public function __construct(array $composerExtra = [])
+    {
+        $this->composerExtra = $composerExtra;
+    }
+
+    /**
+     * Create from a Composer event object.
+     *
+     * @param Event $event
+     *
+     * @return Options
+     */
+    public static function fromEvent(Event $event)
+    {
+        return new static($event->getComposer()->getPackage()->getExtra());
+    }
+
+    /**
+     * Returns the directory mode.
+     *
+     * @return int
+     */
+    public function getDirMode()
+    {
+        $dirMode = $this->get('dir-mode', 0777);
+        $dirMode = is_string($dirMode) ? octdec($dirMode) : $dirMode;
+
+        return $dirMode;
+    }
+
+    /**
+     * Get an option from environment variable or composer's extra section.
+     *
+     * Example: With key "dir-mode" it checks for "BOLT_DIR_MODE" environment variable,
+     * then "bolt-dir-mode" in composer's extra section, then returns given default value.
+     *
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if ($value = $this->getEnv($key)) {
+            return $value;
+        }
+
+        $key = strtolower(str_replace('_', '-', $key));
+
+        if (strpos($key, 'bolt-') !== 0) {
+            $key = 'bolt-' . $key;
+        }
+
+        return isset($this->composerExtra[$key]) ? $this->composerExtra[$key] : $default;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return array|false|string
+     */
+    protected function getEnv($key)
+    {
+        $key = strtoupper(str_replace('-', '_', $key));
+
+        if (strpos($key, 'BOLT_') !== 0) {
+            $key = 'BOLT_' . $key;
+        }
+
+        return getenv($key);
+    }
+}

--- a/src/Composer/Script/PathCustomizer.php
+++ b/src/Composer/Script/PathCustomizer.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Bolt\Composer\Script;
+
+use Bolt\Configuration\PathResolver;
+use Bolt\Nut\Helper\Table;
+use Bolt\Nut\Output\ModifiableOutput;
+use Bolt\Nut\Output\ModifiableOutputInterface;
+use Bolt\Nut\Style\NutStyle;
+use Composer\IO\ConsoleIO;
+use Composer\IO\IOInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Webmozart\PathUtil\Path;
+
+/**
+ * Interactively allows CLI user to modify PathResolver paths.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+final class PathCustomizer
+{
+    /** @var PathResolver */
+    private $resolver;
+    /** @var InputInterface */
+    private $input;
+    /** @var ModifiableOutputInterface */
+    private $output;
+    /** @var NutStyle */
+    private $io;
+    /** @var Table */
+    private $pathsTable;
+
+    /**
+     * Constructor.
+     *
+     * @param PathResolver    $resolver
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     */
+    public function __construct(PathResolver $resolver, InputInterface $input, OutputInterface $output)
+    {
+        if ($output instanceof ConsoleOutputInterface) {
+            $output = $output->getErrorOutput();
+        }
+        if (!$output instanceof ModifiableOutputInterface) {
+            $output = new ModifiableOutput($output);
+        }
+
+        $this->resolver = $resolver;
+        $this->input = $input;
+        $this->output = $output;
+
+        $this->io = new NutStyle($input, $output);
+    }
+
+    /**
+     * Create PathCustomizer from Composer's IOInterface.
+     *
+     * @param PathResolver $resolver
+     * @param IOInterface  $io
+     *
+     * @return PathCustomizer
+     */
+    public static function fromComposer(PathResolver $resolver, IOInterface $io)
+    {
+        $input = new ArrayInput([]);
+        $input->setInteractive($io->isInteractive());
+
+        if ($io instanceof ConsoleIO) {
+            $ref = new \ReflectionProperty($io, 'output');
+            $ref->setAccessible(true);
+            $output = $ref->getValue($io);
+        } else {
+            $output = new NullOutput();
+        }
+
+        return new static($resolver, $input, $output);
+    }
+
+    /**
+     * Run the customizer.
+     */
+    public function run()
+    {
+        if (!$this->input->isInteractive()) {
+            return;
+        }
+
+        $cwd = getcwd();
+        $info = <<<OUT
+
+All paths are currently relative to the current working directory (`$cwd`)
+
+Paths can have aliases to other paths. These are specified with a word surrounded by percents.
+For example, if we defined `user` as `/Users/Me`, then `%user%/my-site` would resolve to `/Users/Me/my-site`
+
+OUT;
+        // Replace backticks with actual styles
+        $info = preg_replace_callback('/`([^`]*)`/', function ($match) {
+            return "<comment>{$match[1]}</comment>";
+        }, $info);
+        $this->output->writeln($info);
+
+        do {
+            $this->renderPaths();
+
+            $name = $this->askPathToModify();
+            if ($name === null) {
+                break;
+            }
+
+            $this->askAndSetNewPathValue($name);
+        } while (true);
+    }
+
+    /**
+     * Render paths table.
+     */
+    protected function renderPaths()
+    {
+        if (!$this->pathsTable) {
+            $this->pathsTable = new Table($this->output);
+            $style = clone Table::getStyleDefinition('symfony-style-guide');
+            $this->pathsTable->setStyle($style);
+
+            $this->pathsTable->setHeaders(['#', 'Name', 'Path']);
+
+            $style = clone $style;
+            $style->setCellHeaderFormat('<info>%s</info>');
+            $this->pathsTable->setColumnStyle(0, $style);
+        }
+
+        $i = 0;
+        $rows = [];
+        $root = $this->resolver->resolve('root');
+        foreach ($this->resolver->names() as $name) {
+            $raw = $this->resolver->raw($name);
+            $resolved = $this->resolver->resolve($name);
+            $resolved = Path::makeRelative($resolved, $root);
+            if ($resolved === '') {
+                $resolved = '.';
+            }
+            $path = "<comment>$raw</comment>";
+            if ($raw !== $resolved) {
+                $path .= " ($resolved)";
+            }
+            $rows[] = ['<info>' . ++$i . '</info>', "<info>$name</info>", $path];
+        }
+        $this->pathsTable->setRows($rows);
+
+        $this->pathsTable->overwrite();
+    }
+
+    /**
+     * Ask which path to modify.
+     *
+     * @return string|null The path name to modify or null to finish.
+     */
+    protected function askPathToModify()
+    {
+        $names = $this->resolver->names();
+        $count = count($names);
+
+        $question = new Question('Enter # or name to modify or empty to continue');
+        $question->setValidator(function ($value) use ($names, $count) {
+            if ($value === null) {
+                return $value;
+            }
+
+            if (!is_numeric($value) && array_search($value, $names) !== false) {
+                return $value;
+            } elseif ($value > 0 && $value <= $count) {
+                return $names[$value - 1];
+            }
+
+            throw new \Exception("Please enter a name or a number between 1 and $count.");
+        });
+        $question->setAutocompleterValues($names);
+
+        return $this->io->askQuestionThenRemove($question);
+    }
+
+    /**
+     * Ask for the new value for the given path name and set it.
+     *
+     * @param string $name
+     */
+    protected function askAndSetNewPathValue($name)
+    {
+        $previous = $this->resolver->raw($name);
+        $question = new Question('Enter new value for ' . $name, $previous);
+        $question->setValidator(function ($value) use ($name, $previous) {
+            $this->resolver->define($name, $value);
+            // verify valid path.
+            try {
+                $this->resolver->resolve($name);
+            } catch (\Exception $e) {
+                $this->resolver->define($name, $previous); // revert path change
+                throw $e;
+            }
+        });
+        $this->io->askQuestionThenRemove($question);
+    }
+}

--- a/src/Composer/Script/ScriptHandlerUpdater.php
+++ b/src/Composer/Script/ScriptHandlerUpdater.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Bolt\Composer\Script;
+
+use Bolt\Composer\ScriptHandler;
+use Composer\IO\IOInterface;
+use Composer\Json\JsonFile;
+use Composer\Script\Event;
+use Composer\Script\ScriptEvents;
+
+/**
+ * Adds handler to composer.json scripts section or shows how (on error).
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class ScriptHandlerUpdater
+{
+    /** @var Event */
+    private $event;
+    /** @var IOInterface */
+    private $io;
+
+    /** @var array|null */
+    private $scripts;
+
+    /**
+     * Constructor.
+     *
+     * @param Event $event
+     */
+    public function __construct(Event $event)
+    {
+        $this->event = $event;
+        $this->io = $event->getIO();
+    }
+
+    /**
+     * Checks if composer.json scripts already have the handler we are adding.
+     *
+     * @return bool
+     */
+    public function needsUpdate()
+    {
+        return !$this->hasScript(ScriptEvents::POST_UPDATE_CMD, ScriptHandler::class . '::updateProject');
+    }
+
+    /**
+     * Attempt to update composer.json, or show how if we can't update the file.
+     */
+    public function update()
+    {
+        try {
+            $this->updateAutomatically();
+        } catch (\Exception $e) {
+            $this->showHow();
+        }
+    }
+
+    /**
+     * Update composer.json file.
+     */
+    private function updateAutomatically()
+    {
+        $source = $this->event->getComposer()->getConfig()->getConfigSource();
+        $file = new JsonFile($source->getName(), null, $this->io);
+        $contents = $file->read();
+
+        $this->scripts = $contents['scripts'] = $this->modifyScripts($contents['scripts']);
+
+        $file->write($contents);
+
+        $this->io->writeError([
+            '<info>',
+            'Bolt has a new separate composer script handler to help with updates!',
+            "We've automatically added this to your composer.json!",
+            '</info>',
+        ]);
+    }
+
+    /**
+     * Tell users of the change and show how the composer.json file should be updated.
+     */
+    private function showHow()
+    {
+        if (!$this->scripts) {
+            $scripts = $this->event->getComposer()->getPackage()->getScripts();
+            $scripts = $this->modifyScripts($scripts);
+        } else {
+            $scripts = $this->scripts;
+        }
+        $scripts = substr(JsonFile::encode(['scripts' => $scripts]), 1, -1);
+        $cls = str_replace("\\", "\\\\", ScriptHandler::class);
+        $name = "\"$cls::updateProject\",";
+        $scripts = str_replace($name, "<info>$name</info>", $scripts);
+
+        $this->io->writeError([
+            '',
+            "<info>Bolt has a new separate composer script handler to help with updates!</info>",
+            '<warning>Unfortunately, we could not update your composer.json file automatically.',
+            'Please update the "scripts" section of your composer.json file to this:</warning>',
+            $scripts,
+            '',
+        ]);
+    }
+
+    /**
+     * Add updateProject handler right before installAssets handler.
+     *
+     * @param string[] $scripts
+     *
+     * @return string[]
+     */
+    private function modifyScripts($scripts)
+    {
+        $updateScripts = (array) $scripts[ScriptEvents::POST_UPDATE_CMD];
+
+        $index = array_search(ScriptHandler::class . '::installAssets', $updateScripts) ?: 0;
+        array_splice($updateScripts, $index, 1, [ScriptHandler::class . '::updateProject', ScriptHandler::class . '::installAssets']);
+
+        $scripts[ScriptEvents::POST_UPDATE_CMD] = $updateScripts;
+
+        return $scripts;
+    }
+
+    /**
+     * @param string $eventName
+     * @param string $script
+     *
+     * @return bool
+     */
+    private function hasScript($eventName, $script)
+    {
+        $scripts = $this->event->getComposer()->getPackage()->getScripts();
+        if (!isset($scripts[$eventName])) {
+            return false;
+        }
+
+        return in_array($script, $scripts[$eventName]);
+    }
+}

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Composer;
 
+use Bolt\Composer\Script\BootstrapYamlUpdater;
 use Bolt\Composer\Script\ScriptHandlerUpdater;
 use Bolt\Exception\BootException;
 use Composer\Script\Event;
@@ -92,7 +93,7 @@ class ScriptHandler
      */
     public static function updateProject(Event $event)
     {
-        // TODO: Check if .bolt.yml should be updated.
+        (new BootstrapYamlUpdater($event->getIO()))->update();
     }
 
     /**

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -99,8 +99,6 @@ class ScriptHandler
         $database = static::configureDir($event, 'database', 'app/database');
         $cache = static::configureDir($event, 'cache', 'app/cache');
 
-        static::configureGitIgnore($event);
-
         $config = [
             'paths' => [
                 'cache'     => $cache,
@@ -202,24 +200,6 @@ class ScriptHandler
         }
 
         return static::$dirMode;
-    }
-
-    /**
-     * Optionally copy in Bolt's .gitignore file.
-     *
-     * @param Event $event
-     */
-    protected static function configureGitIgnore(Event $event)
-    {
-        $boltDir = sprintf('%s/bolt/bolt/', $event->getComposer()->getConfig()->get('vendor-dir'));
-        $question = sprintf(
-            '<info>Do you want to override the existing <comment>.gitignore</comment> file with the more restrictive one from <comment>vendor/bolt/bolt</comment>?</info>'
-        );
-        $confirm = $event->getIO()->askConfirmation($question, false);
-        if ($confirm) {
-            $fs = new Filesystem();
-            $fs->copy($boltDir . '.gitignore', getcwd() . '/.gitignore', true);
-        }
     }
 
     /**

--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -4,21 +4,13 @@ namespace Bolt\Composer;
 
 use Bolt\Composer\Script\BootstrapYamlUpdater;
 use Bolt\Composer\Script\DirectoryConfigurator;
-use Bolt\Composer\Script\Options;
+use Bolt\Composer\Script\DirectorySyncer;
 use Bolt\Composer\Script\ScriptHandlerUpdater;
-use Bolt\Exception\BootException;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
-use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
 
 class ScriptHandler
 {
-    /** @var \Silex\Application */
-    private static $app;
-    /** @var int */
-    private static $dirMode;
-
     /**
      * Install Bolt's assets.
      *
@@ -39,22 +31,8 @@ class ScriptHandler
 
         static::runUpdateProjectFromAssets($event);
 
-        $webDir = static::getWebDir($event);
-        if ($webDir === null) {
-            return;
-        }
-
-        $assetDir = static::getDir($event, 'bolt_assets', $webDir . '/bolt-public/view');
-
-        $filesystem = new Filesystem();
-
-        $originDir = __DIR__ . '/../../app/view/';
-        $targetDir = rtrim($assetDir, '/') . '/';
-
-        $event->getIO()->writeError(sprintf('Installing assets to <info>%s</info>', rtrim($targetDir, '/')));
-        foreach (['css', 'fonts', 'img', 'js'] as $dir) {
-            $filesystem->mirror($originDir . $dir, $targetDir . $dir, null, ['override' => true, 'delete' => true]);
-        }
+        $syncer = DirectorySyncer::fromEvent($event);
+        $syncer->sync('bolt_assets', true, ['css', 'fonts', 'img', 'js']);
     }
 
     /**
@@ -66,24 +44,10 @@ class ScriptHandler
      */
     public static function installThemesAndFiles(Event $event)
     {
-        static::configureDirMode($event);
+        $syncer = DirectorySyncer::fromEvent($event);
 
-        $webDir = static::getWebDir($event);
-        if ($webDir === null) {
-            return;
-        }
-
-        $filesystem = new Filesystem();
-
-        $root = __DIR__ . '/../../';
-
-        $target = static::getDir($event, 'files');
-        $event->getIO()->writeError(sprintf('Installing <info>files</info> to <info>%s</info>', $target));
-        $filesystem->mirror($root . 'files', $target, null, ['override' => true]);
-
-        $target = static::getDir($event, 'themebase');
-        $event->getIO()->writeError(sprintf('Installing <info>themes</info> to <info>%s</info>', $target));
-        $filesystem->mirror($root . 'theme', $target, null, ['override' => true]);
+        $syncer->sync('files');
+        $syncer->sync('themes');
     }
 
     /**
@@ -108,33 +72,8 @@ class ScriptHandler
     {
         DirectoryConfigurator::fromEvent($event)->run();
 
-        // reset app so the path changes are picked up
-        static::$app = null;
-
         // Install assets here since they they were skipped above
         static::installAssets($event, false);
-    }
-
-    /**
-     * Gets the directory mode value, sets umask with it, and returns it.
-     *
-     * @param Event $event
-     *
-     * @return number
-     */
-    protected static function configureDirMode(Event $event)
-    {
-        if (static::$dirMode === null) {
-            $options = Options::fromEvent($event);
-            $dirMode = $options->getDirMode();
-            $dirMode = is_string($dirMode) ? octdec($dirMode) : $dirMode;
-
-            umask(0777 - $dirMode);
-
-            static::$dirMode = $dirMode;
-        }
-
-        return static::$dirMode;
     }
 
     /**
@@ -157,90 +96,5 @@ class ScriptHandler
         $updater->update();
 
         static::updateProject($event);
-    }
-
-    /**
-     * Gets the web directory either from configured application or composer's extra section/environment variable.
-     *
-     * If the web directory doesn't exist an error is emitted and null is returned.
-     *
-     * @param Event $event
-     *
-     * @return string|null
-     */
-    protected static function getWebDir(Event $event)
-    {
-        $webDir = static::getDir($event, 'web', 'public');
-
-        if (!is_dir($webDir)) {
-            $error = '<error>The web directory (%s) was not found in %s, can not install assets.</error>';
-            $event->getIO()->write(sprintf($error, $webDir, getcwd()));
-
-            return null;
-        }
-
-        return $webDir;
-    }
-
-    /**
-     * Gets the directory requested either from configured application or composer's extra section/environment variable.
-     *
-     * @param Event       $event
-     * @param string      $name
-     * @param string|null $default
-     *
-     * @return string
-     */
-    protected static function getDir(Event $event, $name, $default = null)
-    {
-        try {
-            $app = static::getApp($event);
-
-            $dir = $app['path_resolver']->resolve($name);
-            $dir = Path::makeRelative($dir, getcwd());
-        } catch (BootException $e) {
-            $dir = static::getOption($event, $name . '-dir', $default);
-        }
-
-        return rtrim($dir, '/');
-    }
-
-    /**
-     * Loads the application once from bootstrap file (which is configured with .bolt.yml/.bolt.php file).
-     *
-     * NOTE: This only works on the "post-autoload-dump" command as the autoload.php file has not been generated before
-     * that point.
-     *
-     * @param Event $event
-     *
-     * @return \Silex\Application
-     */
-    protected static function getApp(Event $event)
-    {
-        if (static::$app === null) {
-            $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
-            static::$app = require $vendorDir . '/bolt/bolt/app/bootstrap.php';
-        }
-
-        return static::$app;
-    }
-
-    /**
-     * Get an option from environment variable or composer's extra section.
-     *
-     * Example: With key "dir-mode" it checks for "BOLT_DIR_MODE" environment variable,
-     * then "bolt-dir-mode" in composer's extra section, then returns given default value.
-     *
-     * @param Event  $event
-     * @param string $key
-     * @param mixed  $default
-     *
-     * @return mixed
-     */
-    protected static function getOption(Event $event, $key, $default = null)
-    {
-        $options = Options::fromEvent($event);
-
-        return $options->get($key, $default);
     }
 }

--- a/src/Configuration/PathDependencySorter.php
+++ b/src/Configuration/PathDependencySorter.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Bolt\Configuration;
+
+use Bolt\Exception\PathResolutionException;
+
+/**
+ * Sorts PathResolver paths based on their dependencies.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+final class PathDependencySorter
+{
+    /** @var PathResolver */
+    private $resolver;
+    /** @var array */
+    private $resolving = [];
+
+    /**
+     * Constructor.
+     *
+     * @param PathResolver $resolver
+     */
+    public function __construct(PathResolver $resolver)
+    {
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * Returns the list of path names sorted by least dependent first.
+     *
+     * @return string[]
+     */
+    public function getSortedNames()
+    {
+        $sorted = [];
+        $toSort = $this->getDependencies();
+
+        while (count($toSort) > 0) {
+            foreach ($toSort as $name => $dependencies) {
+                if (!array_diff($dependencies, $sorted)) {
+                    $sorted[] = $name;
+                    unset($toSort[$name]);
+                }
+            }
+        }
+
+        return $sorted;
+    }
+
+    /**
+     * Returns path names with their dependencies.
+     *
+     * @return array [name => dependencies]
+     */
+    private function getDependencies()
+    {
+        $dependencies = [];
+
+        foreach ($this->resolver->names() as $name) {
+            $dependencies[$name] = $this->getDependenciesRecursive($name);
+        }
+
+        return $dependencies;
+    }
+
+    /**
+     * Returns dependencies recursively for a path.
+     *
+     * @param string $path
+     * @param array  $dependencies
+     *
+     * @return array
+     */
+    private function getDependenciesRecursive($path, $dependencies = [])
+    {
+        $raw = $this->resolver->raw($path);
+        if ($raw !== null) {
+            $path = $raw;
+        }
+
+        preg_match_all('#%([^/\\\\]+)%#', $path, $matches);
+        foreach ($matches[1] as $alias) {
+            if (!in_array($alias, $dependencies, true)) {
+                $dependencies[] = $alias;
+            }
+
+            if (isset($this->resolving[$alias])) {
+                throw new PathResolutionException('Failed to resolve path dependencies. Infinite recursion detected.');
+            }
+
+            $this->resolving[$alias] = true;
+            try {
+                $dependencies = $this->getDependenciesRecursive($alias, $dependencies);
+            } finally {
+                unset($this->resolving[$alias]);
+            }
+        }
+
+        return $dependencies;
+    }
+}

--- a/src/Configuration/ResourceManager.php
+++ b/src/Configuration/ResourceManager.php
@@ -86,7 +86,7 @@ class ResourceManager
             if (in_array($frame['file'], [__DIR__ . '/ForwardToPathResolver.php', __DIR__ . '/ResourceManager.php', __DIR__ . '/Standard.php', __DIR__ . '/Composer.php'])) {
                 continue;
             }
-            if ($frame['file'] === dirname(dirname(__DIR__)) . '/app/bootstrap.php') {
+            if ($frame['file'] === dirname(__DIR__) . '/Bootstrap.php') {
                 break;
             }
             if ($frame['file'] === dirname(__DIR__) . '/Provider/PathServiceProvider.php') {
@@ -94,6 +94,7 @@ class ResourceManager
             }
 
             Deprecated::cls(static::class, 3.3);
+            break;
         }
 
         $this->pathManager = $container['pathmanager'];

--- a/src/Exception/BootException.php
+++ b/src/Exception/BootException.php
@@ -83,23 +83,6 @@ EOM;
     }
 
     /**
-     * Exception due to a missing .bolt.yml or .bolt.php file.
-     */
-    public static function earlyExceptionMissingLoaderConfig()
-    {
-        $message = <<<EOM
-This installation is missing either a .bolt.yml file (default), or a .bolt.php file.
-<br><br>
-If you have uploaded this install via a file manager or FTP, please check that 
-"show hidden files" is turned on. After doing so, you will be able to see this 
-file and you can upload it to the root of your Bolt installation.
-EOM;
-        echo sprintf(static::getEarlyExceptionHtml(), 'Bolt - Installation Incomplete', $message, static::getHintsComposer());
-
-        throw new static(strip_tags($message));
-    }
-
-    /**
      * Exception due to a PHP version being unsupported.
      */
     public static function earlyExceptionVersion()

--- a/src/Provider/PathServiceProvider.php
+++ b/src/Provider/PathServiceProvider.php
@@ -130,11 +130,5 @@ class PathServiceProvider implements ServiceProviderInterface
 
         $theme = $app['config']->get('general/theme');
         $resolver->define('theme', "%themes%/$theme");
-
-        if (!file_exists($resolver->resolve('web')) &&
-            (!file_exists($resolver->resolve('.bolt.yml')) || !file_exists($resolver->resolve('.bolt.php')))
-        ) {
-            BootException::earlyExceptionMissingLoaderConfig();
-        }
     }
 }

--- a/tests/codeception/extensions/CodeceptionEventsExtension.php
+++ b/tests/codeception/extensions/CodeceptionEventsExtension.php
@@ -1,5 +1,6 @@
 <?php
 
+use Bolt\Bootstrap;
 use Codeception\Event\SuiteEvent;
 use Codeception\Events;
 use Codeception\Util\Fixtures;
@@ -110,8 +111,7 @@ class CodeceptionEventsExtension extends \Codeception\Extension
 
     private function nut($args)
     {
-        /** @var \Silex\Application $app */
-        $app = require __DIR__ . '/../../../app/bootstrap.php';
+        $app = Bootstrap::run(__DIR__ . '/../../..');
         $nut = $app['nut'];
         $nut->setAutoExit(false);
 

--- a/tests/phpunit/unit/Composer/Script/BootstrapYamlUpdaterTest.php
+++ b/tests/phpunit/unit/Composer/Script/BootstrapYamlUpdaterTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace Bolt\Tests\Composer\Script;
+
+use Bolt\Collection\Bag;
+use Bolt\Composer\Script\BootstrapYamlUpdater;
+use Bolt\Version;
+use Composer\IO\BufferIO;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
+
+class BootstrapYamlUpdaterTest extends TestCase
+{
+    public function providePaths()
+    {
+        return [
+            '3.2 default' => [
+                [
+                    'cache'     => 'app/cache',
+                    'config'    => 'app/config',
+                    'database'  => 'app/database',
+                    'web'       => 'public',
+                    'themebase' => 'public/theme',
+                    'files'     => 'public/files',
+                    'view'      => 'public/bolt-public/view',
+                ],
+                []
+            ],
+
+            'custom web' => [
+                [
+                    'web'       => 'web',
+                    'themebase' => 'web/theme',
+                    'files'     => 'web/files',
+                    'view'      => 'web/bolt-public/view',
+                ],
+                [
+                    'web' => '%site%/web',
+                ]
+            ],
+
+            'custom app (same base folder)' => [
+                [
+                    'cache'    => 'myapp/cache',
+                    'config'   => 'myapp/config',
+                    'database' => 'myapp/database',
+                ],
+                [
+                    'app' => '%site%/myapp',
+                ]
+            ],
+
+            'custom app (one folder different)' => [
+                [
+                    'cache'    => 'var/cache',
+                    'config'   => 'myapp/config',
+                    'database' => 'myapp/database',
+                ],
+                [
+                    'app'   => '%site%/myapp',
+                    'cache' => 'var/cache',
+                ]
+            ],
+
+            'custom app (one folder different) #2' => [
+                [
+                    'cache'    => 'var/cache',
+                    'config'   => '../config',
+                    'database' => '../database',
+                ],
+                [
+                    'app'   => '%site%/..',
+                    'cache' => 'var/cache',
+                ]
+            ],
+
+            'custom app (all folders different)' => [
+                [
+                    'cache'    => 'var/cache',
+                    'config'   => 'myapp/config',
+                    'database' => '../database',
+                ],
+                [
+                    'cache'    => 'var/cache',
+                    'config'   => 'myapp/config',
+                    'database' => '../database',
+                ]
+            ],
+
+            'custom leaves' => [
+                [
+                    'cache'     => 'app/cache2',
+                    'config'    => 'app/config2',
+                    'database'  => 'app/database2',
+                    'web'       => 'public',
+                    'themebase' => 'public/theme2',
+                    'files'     => 'public/files2',
+                    'view'      => 'public/bolt-public/view2',
+                ],
+                [
+                    'cache'       => '%app%/cache2',
+                    'config'      => '%app%/config2',
+                    'database'    => '%app%/database2',
+                    'themes'      => '%web%/theme2',
+                    'files'       => '%web%/files2',
+                    'bolt_assets' => '%web%/bolt-public/view2',
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providePaths
+     *
+     * @param $previous
+     * @param $result
+     */
+    public function testPaths($previous, $result)
+    {
+        $updater = new BootstrapYamlUpdater(new BufferIO());
+
+        $actual = $updater->updatePaths(new Bag($previous));
+        $this->assertEquals($result, $actual->toArray());
+
+        // Ensure code is idempotent.
+        $actual = $updater->updatePaths($actual);
+        $this->assertEquals($result, $actual->toArray());
+    }
+
+    public function testSaveCustomPaths()
+    {
+        $config = [
+            'paths' => [
+                'app' => '%site%/app2',
+            ],
+        ];
+
+        $io = new BufferIO();
+        $filesystem = $this->getMock(Filesystem::class, ['dumpFile', 'remove']);
+        $filesystem->expects($this->once())
+            ->method('dumpFile')
+            ->with('.bolt.yml', Yaml::dump($config))
+        ;
+        $filesystem->expects($this->never())
+            ->method('remove')
+        ;
+
+        $updater = new BootstrapYamlUpdater($io, $filesystem);
+
+        $updater->save($config);
+
+        $output = $io->getOutput();
+        $this->assertContains(sprintf("Bolt has updated the paths in your .bolt.yml file for %s.\n", Version::VERSION), $output);
+    }
+
+    public function testSaveCustomPathsError()
+    {
+        $config = [
+            'paths' => [
+                'app' => '%site%/app2',
+            ],
+        ];
+
+        $io = new BufferIO();
+        $filesystem = $this->getMock(Filesystem::class, ['dumpFile', 'remove']);
+        $filesystem->expects($this->once())
+            ->method('dumpFile')
+            ->with('.bolt.yml', Yaml::dump($config))
+            ->willThrowException(new IOException(''))
+        ;
+        $filesystem->expects($this->never())
+            ->method('remove')
+        ;
+
+        $updater = new BootstrapYamlUpdater($io, $filesystem);
+
+        $updater->save($config);
+
+        $output = $io->getOutput();
+        $expected = <<<OUT
+The paths in your .bolt.yml file can be simplified.
+You should update your .bolt.yml file to this:
+
+paths:
+    app: '%site%/app2'
+
+OUT;
+        $this->assertContains($expected, $output);
+    }
+
+    public function testSaveEmptyPathsAndNoOtherOptions()
+    {
+        $io = new BufferIO();
+        $filesystem = $this->getMock(Filesystem::class, ['dumpFile', 'remove']);
+        $filesystem->expects($this->never())
+            ->method('dumpFile')
+        ;
+        $filesystem->expects($this->once())
+            ->method('remove')
+        ;
+
+        $updater = new BootstrapYamlUpdater($io, $filesystem);
+
+        $updater->save([
+            'paths' => [],
+        ]);
+
+        $output = $io->getOutput();
+        $this->assertContains('The paths in your .bolt.yml file match the defaults now.', $output);
+        $this->assertContains("Since this file is optional we've deleted it for you.", $output);
+    }
+
+    public function testSaveEmptyPathsAndNoOtherOptionsError()
+    {
+        $io = new BufferIO();
+        $filesystem = $this->getMock(Filesystem::class, ['dumpFile', 'remove']);
+        $filesystem->expects($this->never())
+            ->method('dumpFile')
+        ;
+        $filesystem->expects($this->once())
+            ->method('remove')
+            ->willThrowException(new IOException(''))
+        ;
+
+        $updater = new BootstrapYamlUpdater($io, $filesystem);
+
+        $updater->save([
+            'paths' => [],
+        ]);
+
+        $output = $io->getOutput();
+        $this->assertContains('The paths in your .bolt.yml file match the defaults now.', $output);
+        $this->assertContains('It is safe to delete it.', $output);
+    }
+
+    public function testSaveEmptyPathsButOtherOptions()
+    {
+        $io = new BufferIO();
+        $filesystem = $this->getMock(Filesystem::class, ['dumpFile', 'remove']);
+        $filesystem->expects($this->once())
+            ->method('dumpFile')
+            ->with('.bolt.yml', "application: My\\App\n")
+        ;
+        $filesystem->expects($this->never())
+            ->method('remove')
+        ;
+
+        $updater = new BootstrapYamlUpdater($io, $filesystem);
+
+        $updater->save([
+            'paths' => [],
+            'application' => 'My\App',
+        ]);
+
+        $output = $io->getOutput();
+        $this->assertContains('The paths in your .bolt.yml file match the defaults now.', $output);
+        $this->assertContains("We've removed them from the file for you.", $output);
+    }
+
+    public function testSaveEmptyPathsButOtherOptionsError()
+    {
+        $io = new BufferIO();
+        $filesystem = $this->getMock(Filesystem::class, ['dumpFile', 'remove']);
+        $filesystem->expects($this->once())
+            ->method('dumpFile')
+            ->with('.bolt.yml', "application: My\\App\n")
+            ->willThrowException(new IOException(''))
+        ;
+        $filesystem->expects($this->never())
+            ->method('remove')
+        ;
+
+        $updater = new BootstrapYamlUpdater($io, $filesystem);
+
+        $updater->save([
+            'paths' => [],
+            'application' => 'My\App',
+        ]);
+
+        $output = $io->getOutput();
+        $this->assertContains('The paths in your .bolt.yml file match the defaults now.', $output);
+        $this->assertContains('It is safe and encouraged to remove them.', $output);
+    }
+}


### PR DESCRIPTION
- [x] Added new `ScriptHandler::updateProject` handler where all changes we want to run on updates can go. Added code to automatically add this handler to user's `composer.json` file (or tell them how if we can't modify the file).
- [x] Added code (in `updateProject`) to update user's `.bolt.yml` file for 3.3 `PathResolver` changes.
- [x] Updated create project handler to use `PathResolver` and interactively allow path customization (thanks to #6680).
- [x] Removed check for `.bolt.yml` file since it is optional now.
- [x] Removed syncing `.gitignore`. Version in `composer-install` has been fixed.
- [x] Update `installAssets` to use `PathResolver`.
- [x] Update `installThemeAndFiles` to use `PathResolver`.