### PR TITLE
[3.3] Remove remaining Twig global use

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -301,13 +301,13 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                     {% for taxonomyslug, values in content.taxonomy %}
                         {% if values|length > 1 %}
                             <li>
-                                <a class="nolink">{{ config.get('taxonomy')[taxonomyslug].name }}:
+                                <a class="nolink">{{ app.config.get('taxonomy')[taxonomyslug].name }}:
                                     <i class="fa fa-tag"></i> {{ values|join(", ")|excerpt(24) }}
                                 </a>
                             </li>
                         {% else %}
                             <li>
-                                <a class="nolink">{{ config.get('taxonomy')[taxonomyslug].singular_name }}:
+                                <a class="nolink">{{ app.config.get('taxonomy')[taxonomyslug].singular_name }}:
                                     <i class="fa fa-tag"></i> {{ values|first|excerpt(24) }}
                                 </a>
                             </li>

--- a/app/view/twig/_base/_page.twig
+++ b/app/view/twig/_base/_page.twig
@@ -61,10 +61,10 @@
         <script src="{{ script }}"></script>
     {% endfor %}
 
-    <link rel="shortcut icon" href="{{ config.get('general/branding/favicon') ?: asset('img/favicon-bolt.ico', 'bolt') }}">
-    <link rel="apple-touch-icon" sizes="57x57" href="{{ config.get('general/branding/apple-touch-icon') ?: asset('img/apple-touch-icon.png', 'bolt') }}">
+    <link rel="shortcut icon" href="{{ app.config.get('general/branding/favicon') ?: asset('img/favicon-bolt.ico', 'bolt') }}">
+    <link rel="apple-touch-icon" sizes="57x57" href="{{ app.config.get('general/branding/apple-touch-icon') ?: asset('img/apple-touch-icon.png', 'bolt') }}">
     {% for size in ['72x72', '114x114', '144x144'] %}
-        <link rel="apple-touch-icon" sizes="{{ size }}" href="{{ config.get('general/branding/apple-touch-icon-' ~ size) ?: asset('img/apple-touch-icon-' ~ size ~ '.png', 'bolt') }}">
+        <link rel="apple-touch-icon" sizes="{{ size }}" href="{{ app.config.get('general/branding/apple-touch-icon-' ~ size) ?: asset('img/apple-touch-icon-' ~ size ~ '.png', 'bolt') }}">
     {% endfor %}
 </head>
 
@@ -74,10 +74,10 @@
 
 {# Convert array of [assetPath, packageName] to actual url #}
 {% set ckCss = [] %}
-{% for assetData in config.get('general/wysiwyg/ck/contentsCss') %}
+{% for assetData in app.config.get('general/wysiwyg/ck/contentsCss') %}
     {% set ckCss = ckCss|merge([asset(assetData.0, assetData.1)]) %}
 {% endfor %}
-{% set ckConfig = config.get('general/wysiwyg/ck')|default({})|merge({'contentsCss': ckCss}) %}
+{% set ckConfig = app.config.get('general/wysiwyg/ck')|default({})|merge({'contentsCss': ckCss}) %}
 
 {% set bconfig = {
     locale: {
@@ -94,20 +94,20 @@
     },
     ckeditor: {
         lang:        ckeditor_lang,
-        images:      0 + config.get('general/wysiwyg/images'),
-        styles:      0 + config.get('general/wysiwyg/styles'),
-        tables:      0 + config.get('general/wysiwyg/tables'),
-        anchor:      0 + config.get('general/wysiwyg/anchor'),
-        fontcolor:   0 + config.get('general/wysiwyg/fontcolor'),
-        align:       0 + config.get('general/wysiwyg/align'),
-        subsuper:    0 + config.get('general/wysiwyg/subsuper'),
-        embed:       0 + config.get('general/wysiwyg/embed'),
-        blockquote:  0 + config.get('general/wysiwyg/blockquote'),
-        ruler:       0 + config.get('general/wysiwyg/ruler'),
-        strike:      0 + config.get('general/wysiwyg/strike'),
-        underline:   0 + config.get('general/wysiwyg/underline'),
-        codesnippet: 0 + config.get('general/wysiwyg/codesnippet'),
-        specialchar: 0 + config.get('general/wysiwyg/specialchar'),
+        images:      0 + app.config.get('general/wysiwyg/images'),
+        styles:      0 + app.config.get('general/wysiwyg/styles'),
+        tables:      0 + app.config.get('general/wysiwyg/tables'),
+        anchor:      0 + app.config.get('general/wysiwyg/anchor'),
+        fontcolor:   0 + app.config.get('general/wysiwyg/fontcolor'),
+        align:       0 + app.config.get('general/wysiwyg/align'),
+        subsuper:    0 + app.config.get('general/wysiwyg/subsuper'),
+        embed:       0 + app.config.get('general/wysiwyg/embed'),
+        blockquote:  0 + app.config.get('general/wysiwyg/blockquote'),
+        ruler:       0 + app.config.get('general/wysiwyg/ruler'),
+        strike:      0 + app.config.get('general/wysiwyg/strike'),
+        underline:   0 + app.config.get('general/wysiwyg/underline'),
+        codesnippet: 0 + app.config.get('general/wysiwyg/codesnippet'),
+        specialchar: 0 + app.config.get('general/wysiwyg/specialchar'),
         ck:          ckConfig,
         filebrowser: {
             browseUrl: path('recordbrowser'),
@@ -116,7 +116,7 @@
     },
     stackAddUrl: path('stack/add'),
     contentActionUrl: path('contentaction', global.request.query.all),
-    google_api_key: config.get('general/google_api_key'),
+    google_api_key: app.config.get('general/google_api_key'),
 } %}
 <script src="{{ asset('js/bolt.js', 'bolt') }}" data-config="{{ bconfig|json_encode }}" data-jsdata="{{ app.jsdata|json_encode }}"></script>
 

--- a/app/view/twig/_nav/_footer.twig
+++ b/app/view/twig/_nav/_footer.twig
@@ -3,7 +3,7 @@
     <footer id="bolt-footer" class="hidden-xs {% if global.request.cookies.get('sidebar') %}bolt-footer-hidden{% endif %}">
         {{ __('general.phrase.provided-by-colon') }}
         {{ app.config.get('general/branding/provided_link')|raw }} &ndash;
-        <i class="fa fa-cog"></i> <b>Bolt {{ bolt_version }}</b>:
+        <i class="fa fa-cog"></i> <b>Bolt {{ context.bolt_version }}</b>:
         <i class="fa fa-heart"></i > <a href="{{ path('about') }}">{{ __('general.about') }}</a> &ndash;
         <i class="fa fa-external-link-square"></i> <a href="http://bolt.cm" target="_blank">Bolt.cm</a>
     </footer>
@@ -11,7 +11,7 @@
 {% else %}
 
     <footer id="bolt-footer" class="hidden-xs bolt-footer-mini {% if global.request.cookies.get('sidebar') %}bolt-footer-hidden{% endif %}">
-        <i class="fa fa-cog"></i> <a href="http://bolt.cm" target="_blank">Bolt {{ bolt_version|replace({'alpha': 'α', ' beta ': 'β'}) }}</a> &ndash;
+        <i class="fa fa-cog"></i> <a href="http://bolt.cm" target="_blank">Bolt {{ context.bolt_version|replace({'alpha': 'α', ' beta ': 'β'}) }}</a> &ndash;
         <i class="fa fa-heart"></i > <a href="{{ path('about') }}">{{ __('general.about') }}</a>
     </footer>
 

--- a/app/view/twig/_nav/_primary.twig
+++ b/app/view/twig/_nav/_primary.twig
@@ -48,7 +48,7 @@
     <li class="dropdown">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">
             {# FIXME DTO: When the session hits the check timer, the user object can be empty #}
-            <i class="fa fa-fw fa-user"></i> <span>{{ user.displayname|default()|excerpt(16) }}</span> <i class="fa fa-caret-down"></i>
+            <i class="fa fa-fw fa-user"></i> <span>{{ context.user.displayname|default()|excerpt(16) }}</span> <i class="fa fa-caret-down"></i>
         </a>
         <ul class="dropdown-menu dropdown-user" role="menu" >
             <li>

--- a/app/view/twig/_sub/_messages.twig
+++ b/app/view/twig/_sub/_messages.twig
@@ -1,4 +1,4 @@
-{% macro flashbag() %}
+{% macro flashbag(user) %}
     {% import _self as self %}
 
     {# we only want to show these flashes to logged on users. #}
@@ -29,11 +29,11 @@
 {% if wrapper is defined and wrapper and app['logger.flash'].keys() is not empty %}
     <div class="row">
         <div class="col-md-8">
-            {{ self.flashbag(user) }}
+            {{ self.flashbag(context.user|default) }}
         </div>
     </div>
 {% else %}
-    {{ self.flashbag(user) }}
+    {{ self.flashbag(context.user|default) }}
 {% endif %}
 
 {# No Javascript #}

--- a/app/view/twig/activity/changelog.twig
+++ b/app/view/twig/activity/changelog.twig
@@ -15,7 +15,7 @@
     <div class="row">
         <div class="col-xs-12">
 
-            {% if not config.get('general/changelog/enabled') %}
+            {% if not app.config.get('general/changelog/enabled') %}
 
                 <div class="alert alert-info alert-dismissible">
                     <button type="button" class="close" data-dismiss="alert">×</button>

--- a/app/view/twig/editcontent/_taxonomies.twig
+++ b/app/view/twig/editcontent/_taxonomies.twig
@@ -9,8 +9,8 @@
 {% endif %}
 
 {% for taxonomyslug in context.contenttype.taxonomy|default([]) %}
-    {% if config.get('taxonomy')[taxonomyslug] is defined %}
-        {% set taxonomy = config.get('taxonomy')[taxonomyslug] %}
+    {% if app.config.get('taxonomy')[taxonomyslug] is defined %}
+        {% set taxonomy = app.config.get('taxonomy')[taxonomyslug] %}
 
         <div data-bolt-fieldset="{{ taxonomy.behaves_like }}">
             {# Prefix #}

--- a/app/view/twig/editcontent/editcontent.twig
+++ b/app/view/twig/editcontent/editcontent.twig
@@ -54,7 +54,7 @@
         hid_editreferrer: {
             name_id:  'editreferrer',
             type:     'hidden',
-            value:    editreferrer|default(''),
+            value:    context.editreferrer|default(''),
         },
 
         hid_contenttype: {

--- a/app/view/twig/editcontent/fields/_meta.twig
+++ b/app/view/twig/editcontent/fields/_meta.twig
@@ -120,18 +120,18 @@
             <label class="col-sm-4 control-label">{{ __('general.phrase.owner-colon') }}</label>
             <div class="col-sm-8">
                 <select{{ macro.attr(attributes.ownerid) }}>
-                    {% for user in users %}
+                    {% for user in context.users %}
                         {% set attr_opt = {
-                            value:     user.id,
-                            selected:  (context.contentowner and user.id == context.contentowner.id),
+                            value:     context.user.id,
+                            selected:  (context.contentowner and context.user.id == context.contentowner.id),
                         } %}
-                        <option{{ macro.attr(attr_opt) }}>{{ user.displayname }}</option>
+                        <option{{ macro.attr(attr_opt) }}>{{ context.user.displayname }}</option>
                     {% endfor %}
                 </select>
             </div>
         </div>
 
-        {% if config.get('general/changelog/enabled') %}
+        {% if app.config.get('general/changelog/enabled') %}
             <div class="form-group">
                 <label class="col-sm-4 control-label">{{ __('contenttypes.record.comment-add-colon') }}</label>
                 <div class="col-sm-8">

--- a/app/view/twig/mail/passwordreset.twig
+++ b/app/view/twig/mail/passwordreset.twig
@@ -1,4 +1,4 @@
-<p>Hello {{ user.displayname }},</p>
+<p>Hello {{ context.user.displayname }},</p>
 
 <p>You - or someone pretending to be you - has requested a password-reset for
     '{{ app.config.get('general/sitename') }}'. To reset your password, click the following link:

--- a/app/view/twig/users/_userlist-actions.twig
+++ b/app/view/twig/users/_userlist-actions.twig
@@ -1,6 +1,6 @@
 {% if isallowed('useredit') %}
     <div class="btn-group">
-    <a href="{{ path('useredit', {'id': user.id}) }}" class="btn btn-default btn-xs">
+    <a href="{{ path('useredit', {'id': context.user.id}) }}" class="btn btn-default btn-xs">
             <i class="fa fa-edit"></i> {{ __('general.phrase.edit') }}
     </a>
 
@@ -10,10 +10,10 @@
     </button>
 
     <ul class="dropdown-menu pull-right">
-        {% if context.currentuser.id != user.id  %}
-            {% if user.enabled %}
+        {% if context.currentuser.id != context.user.id  %}
+            {% if context.user.enabled %}
                 <li>
-                    <form action="{{ path('useraction', {'action': 'disable', 'id': user.id}) }}" method="post">
+                    <form action="{{ path('useraction', {'action': 'disable', 'id': context.user.id}) }}" method="post">
                         {{ include('@bolt/_sub/_csrf_token.twig') }}
                         <button type="submit" class="btn btn-block btn-link">
                             <span class="pull-left">{{ __('general.phrase.disable-user-name',{'%username%':user.displayname}) }}</span>
@@ -22,7 +22,7 @@
                 </li>
             {% else %}
                 <li>
-                    <form action="{{ path('useraction', {'action': 'enable', 'id': user.id}) }}" method="post">
+                    <form action="{{ path('useraction', {'action': 'enable', 'id': context.user.id}) }}" method="post">
                         {{ include('@bolt/_sub/_csrf_token.twig') }}
                         <button type="submit" class="btn btn-block btn-link">
                             <span class="pull-left">{{ __('general.phrase.enable-user-name',{'%username%':user.displayname}) }}</span>
@@ -31,7 +31,7 @@
                 </li>
             {% endif %}
             <li>
-                <form action="{{ path('useraction', {'action': 'delete', 'id': user.id}) }}" method="post">
+                <form action="{{ path('useraction', {'action': 'delete', 'id': context.user.id}) }}" method="post">
                     {{ include('@bolt/_sub/_csrf_token.twig') }}
                     <button type="submit" class="btn btn-block btn-link confirm"
                     data-confirm="{{ __('Are you sure you want to delete %username%?',{'%username%':user.displayname}) }}" >
@@ -46,18 +46,18 @@
 
         <li>
             <a class="nolink">
-                {{ __('general.phrase.last-seen') }}: <strong>{% if user.lastseen>"1000" %}{{ user.lastseen|date("Y-m-d H:i") }}{% else %}-{% endif %}</strong>
+                {{ __('general.phrase.last-seen') }}: <strong>{% if context.user.lastseen>"1000" %}{{ context.user.lastseen|date("Y-m-d H:i") }}{% else %}-{% endif %}</strong>
             </a>
         </li>
 
         <li>
             <a class="nolink">
-                {{ __('general.phrase.last-known-ip') }}: <strong>{% if user.lastip!="" %}{{ user.lastip }}{% else %}-{% endif %}</strong>
+                {{ __('general.phrase.last-known-ip') }}: <strong>{% if context.user.lastip!="" %}{{ context.user.lastip }}{% else %}-{% endif %}</strong>
             </a>
         </li>
     </ul>
 </div>
-{% elseif context.currentuser.id == user.id %}
+{% elseif context.currentuser.id == context.user.id %}
     <a href="{{ path('profile') }}" class="btn btn-default btn-xs">
         <i class="fa fa-edit"></i> {{ __('general.phrase.profile') }}
     </a>

--- a/app/view/twig/users/_userlist.twig
+++ b/app/view/twig/users/_userlist.twig
@@ -27,7 +27,7 @@
                 </td>
 
                 <td class="hidden-xs">
-                    {{ user.lastseen ? buic_moment(user.lastseen) : '-' }}
+                    {{ user.lastseen|default ? buic_moment(user.lastseen|default) : '-' }}
                 </td>
 
                 <td class="contenttypes">

--- a/src/Controller/Backend/BackendBase.php
+++ b/src/Controller/Backend/BackendBase.php
@@ -42,6 +42,14 @@ abstract class BackendBase extends Base
             $context = ['context' => $context];
         }
 
+        /** @deprecated Deprecated since 3.0, to be removed in 4.0. */
+        $oldGlobals = $this->app['twig']->getGlobals();
+        foreach (['user', 'users', 'bolt_version'] as $key) {
+            if (!isset($context['context'][$key])) {
+                $context['context'][$key] = $oldGlobals[$key];
+            }
+        }
+
         return parent::render($template, $context, $globals);
     }
 

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -54,11 +54,8 @@ class Records extends BackendBase
             return $response;
         }
 
-        // Set the editreferrer in twig if it was not set yet.
-        $this->setEditReferrer($request);
-
         // Get the ContentType object
-        $contenttype = $this->getContentType($contenttypeslug);
+        $contentType = $this->getContentType($contenttypeslug);
 
         // Save the POSTed record
         if ($request->isMethod('POST')) {
@@ -68,7 +65,7 @@ class Records extends BackendBase
             $returnTo = $request->get('returnto');
             $editReferrer = $request->get('editreferrer');
 
-            return $this->recordSave()->action($formValues, $contenttype, $id, $new, $returnTo, $editReferrer);
+            return $this->recordSave()->action($formValues, $contentType, $id, $new, $returnTo, $editReferrer);
         }
 
         try {
@@ -81,7 +78,7 @@ class Records extends BackendBase
         }
 
         if ($new) {
-            $content = $repo->create(['contenttype' => $contenttypeslug, 'status' => $contenttype['default_status']]);
+            $content = $repo->create(['contenttype' => $contenttypeslug, 'status' => $contentType['default_status']]);
         } else {
             $content = $repo->find($id);
             if ($content === false) {
@@ -95,6 +92,12 @@ class Records extends BackendBase
         // We're doing a GET
         $duplicate = $request->query->get('duplicate', false);
         $context = $this->recordEdit()->action($content, $content->getContenttype(), $duplicate);
+
+        // Get the editreferrer
+        $referrer = $this->getEditReferrer($request);
+        if ($referrer) {
+            $content['editreferrer'] = $referrer;
+        }
 
         return $this->render('@bolt/editcontent/editcontent.twig', $context);
     }
@@ -242,20 +245,25 @@ class Records extends BackendBase
      *
      * @param Request $request
      *
-     * @return void
+     * @return string|null
      */
-    private function setEditReferrer(Request $request)
+    private function getEditReferrer(Request $request)
     {
         $tmp = parse_url($request->server->get('HTTP_REFERER'));
 
-        $tmpreferrer = $tmp['path'];
+        $referrer = $tmp['path'];
         if (!empty($tmp['query'])) {
-            $tmpreferrer .= '?' . $tmp['query'];
+            $referrer .= '?' . $tmp['query'];
         }
 
-        if (strpos($tmpreferrer, '/overview/') !== false || ($tmpreferrer === $this->generateUrl('dashboard') . '/')) {
-            $this->app['twig']->addGlobal('editreferrer', $tmpreferrer);
+        if (strpos($referrer, '/overview/') !== false || ($referrer === $this->generateUrl('dashboard') . '/')) {
+            if ($this->getOption('general/compatibility/twig_globals', true)) {
+                $this->app['twig']->addGlobal('editreferrer', $referrer);
+            }
+            return $referrer;
         }
+
+        return null;
     }
 
     /**

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1854,8 +1854,9 @@ class Storage
                 ->setCurrent($decoded['parameters']['page'])
                 ->setShowingFrom(($decoded['parameters']['page'] - 1) * $decoded['parameters']['limit'] + 1)
                 ->setShowingTo(($decoded['parameters']['page'] - 1) * $decoded['parameters']['limit'] + count($results));
-
-            $this->app['twig']->addGlobal('pager', $pager);
+            if ($this->app['config']->get('general/compatibility/twig_globals', true)) {
+                $this->app['twig']->addGlobal('pager', $pager);
+            }
         }
 
         $this->app['stopwatch']->stop('bolt.getcontent');

--- a/theme/base-2016/extrafields.twig
+++ b/theme/base-2016/extrafields.twig
@@ -4,7 +4,7 @@
 
     <h1>{{ record.title }}</h1>
 
-    {{ fields(template = 'partials/_sub_fields.twig') }}
+    {{ fields(record = record, template = 'partials/_sub_fields.twig') }}
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}

--- a/theme/base-2016/page.twig
+++ b/theme/base-2016/page.twig
@@ -15,7 +15,7 @@
     {{ record.body }}
 
     {# If there are repeaters, we should output them. #}
-    {{ fields(template = 'partials/_sub_fields.twig', common = false, repeaters = true) }}
+    {{ fields(record = record, template = 'partials/_sub_fields.twig', common = false, repeaters = true) }}
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}

--- a/theme/base-2016/partials/_sub_fields.twig
+++ b/theme/base-2016/partials/_sub_fields.twig
@@ -63,7 +63,7 @@
         {% endif %}
 
         {# Video fields #}
-        {% if fieldtype == "video" and value.responsive %}
+        {% if fieldtype == "video" and value.responsive|default %}
             <div class="flex-video {{ value.ratio > 1.5 ? 'widescreen' }}">
                 {{ value.responsive }}
             </div>

--- a/theme/base-2016/partials/_sub_fields.twig
+++ b/theme/base-2016/partials/_sub_fields.twig
@@ -134,7 +134,7 @@
 
     {# Finally, the repeaters #}
     {% if repeaters == true and record.fieldtype(key) == "repeater" %}
-        {% if (app.request.get('_route') != "preview") %}
+        {% if (global.request.get('_route') != "preview") %}
             {% for repeater in value %}
                 {% for key, repeaterfield in repeater %}
                     {{ macro.commonfield(repeater, key) }}

--- a/theme/base-2016/readme.md
+++ b/theme/base-2016/readme.md
@@ -126,7 +126,7 @@ For example, take a look at one of the simpler templates, `record.twig`:
 
         <h1>{{ record.title }}</h1>
 
-        {{ fields(template = 'partials/_sub_fields.twig') }}
+        {{ fields(record = record, template = 'partials/_sub_fields.twig') }}
 
         {{ include('partials/_recordfooter.twig', { 'record': record }) }}
 

--- a/theme/base-2016/record.twig
+++ b/theme/base-2016/record.twig
@@ -7,7 +7,7 @@
     {# Output all fields, in the order as defined in the contenttype.
        To change the generated html and configure the options, see:
        https://docs.bolt.cm/templating/fields-tag #}
-    {{ fields(template = 'partials/_sub_fields.twig') }}
+    {{ fields(record = record, template = 'partials/_sub_fields.twig') }}
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}


### PR DESCRIPTION
As per discussion in Tuesday's meeting.

@CarsonF On the `BackendBase` controller one, I know, I know … but scope … believe me they are used all over backend templates, and refactoring the entire backend template logic this close to release is just not on 

… my O.C.D. too :disappointed: 