### PR TITLE
[3.3] Remove phpmd/phpmd & squizlabs/php_codesniffer from require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,6 @@
         "codeception/codeception": "^2.2",
         "league/flysystem-memory": "^1.0",
         "lstrojny/phpunit-function-mocker": "0.3.0",
-        "phpmd/phpmd": "^2.2",
         "phpunit/dbunit": "^1.3",
         "phpunit/php-code-coverage": "^2.0",
         "phpunit/phpunit": "^4.8",
@@ -88,7 +87,6 @@
         "psr/simple-cache": "^1.0",
         "sebastian/phpcpd": "^2.0",
         "sorien/silex-pimple-dumper": "^1.0",
-        "squizlabs/php_codesniffer": "^2.0",
         "symfony/phpunit-bridge": "^2.8"
     },
     "conflict": {


### PR DESCRIPTION
* `squizlabs/php_codesniffer` is only required by `bolt/codingstyle` so moved there
* `phpmd/phpmd` isn't used, can be downloaded or installed separately, and has a dependency chain that is making me want to :cry: 
