### PR TITLE
Fixes weird default selection of `/` for select fields populated from other contenttypes.

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -30,7 +30,8 @@
 
 {# Get the current selection. Either a single value, or an array. #}
 {% set selection = context.content.get(contentkey)|default(option.default) %}
-{% if selection is not iterable %}
+{# Make sure the value is either `null` (for empty), or cast to an array for a string. Prevent breakage when switching from 'single' to 'mulptiple' #}
+{% if selection is not iterable and selection is not empty  %}
     {% set selection = [ selection ] %}
 {% endif %}
 


### PR DESCRIPTION
Fixes #6693

