### PR TITLE
[3.3][Deprecation] Use Request::isMethodSafe() according to standard

### DIFF
--- a/src/EventListener/DisableXssProtectionListener.php
+++ b/src/EventListener/DisableXssProtectionListener.php
@@ -37,7 +37,7 @@ class DisableXssProtectionListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if ($request->isMethodSafe()) {
+        if ($request->isMethodSafe(false)) {
             return;
         }
 


### PR DESCRIPTION
According to standard in [RFC7231](https://tools.ietf.org/html/rfc7231#section-4.2.1)

>   Of the request methods defined by this specification, the GET, HEAD,
>   OPTIONS, and TRACE methods are defined to be safe.

So Symfony have [deprecated its use in 3.2](https://github.com/symfony/symfony/commit/34e7b956dd46cc03973ba90ce93523557a26a3e0) without a parameter to indicate spec, or BC.

… just keeping `master` quiet :wink: 
