### PR TITLE
Add pager to base-2016 search template

### DIFF
--- a/theme/base-2016/search.twig
+++ b/theme/base-2016/search.twig
@@ -60,5 +60,7 @@
         {% endfor %}
 
         {# If there are more records than will fit on one page, the pager is shown. #}
+        {{ pager(template = 'partials/_sub_pager.twig') }}
+
 
 {% endblock main %}


### PR DESCRIPTION
The include of the pager seemed to be missing, the comment was the only thing there

