### PR TITLE
[3.2] Missed 'app.config' to 'config' changes

### DIFF
--- a/app/theme_defaults/maintenance_default.twig
+++ b/app/theme_defaults/maintenance_default.twig
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>{{ app.config.get('general/sitename') }} | Maintenance</title>
+    <title>{{ config.get('general/sitename') }} | Maintenance</title>
     <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,400italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ paths.app }}theme_defaults/maintenance.css">
 
@@ -15,7 +15,7 @@
     <img src="{{ app.paths.app }}view/img/bolt-logo.png" width="150" height="62" alt="Bolt" class="logo">
 
     <div class="alert">
-        <h1><b>{{ app.config.get('general/sitename') }}</b> &raquo; Maintenance</h1>
+        <h1><b>{{ config.get('general/sitename') }}</b> &raquo; Maintenance</h1>
         <p>
             This website is currently offline, as we are performing site maintenance. <br>
             Please be patient - we'll be back shortly!

--- a/theme/base-2016/listing.twig
+++ b/theme/base-2016/listing.twig
@@ -22,7 +22,7 @@
                is set to true. This way we keep 'grouping' intact in the listing. #}
             {% if not taxonomy.has_sortorder %}
                 {# If we specified an order in config.yml, sort them here, accordingly: #}
-                {% set records = records|order(app.config.get('general/listing_sort')) %}
+                {% set records = records|order(config.get('general/listing_sort')) %}
             {% endif %}
         {% endif %}
 

--- a/theme/base-2016/partials/_aside.twig
+++ b/theme/base-2016/partials/_aside.twig
@@ -56,7 +56,7 @@
            Lastly, "path('contentlisting', {'contenttypeslug': ct.slug})" will output something like '/pages',
            effectively creating a working link to that contenttpye's listing page. #}
 
-        {% for ct in app.config.get('contenttypes') if not ct.viewless|default(false) %}
+        {% for ct in config.get('contenttypes') if not ct.viewless|default(false) %}
 
             {% setcontent records = ct.slug ~ "/latest/3" %}
 

--- a/theme/base-2016/partials/_header.twig
+++ b/theme/base-2016/partials/_header.twig
@@ -6,11 +6,11 @@
 
 {% set headerimage = asset('images/' ~ random(theme.headerimage), 'theme') %}
 
-{# the values in the 'app.config' object are taken directly from the file app/config/config.yml #}
+{# the values in the 'config' object are taken directly from the file app/config/config.yml #}
 <div class="large-12 columns headertitle">
-<h2>{{ app.config.get('general/sitename') }}</h2>
-    {% if app.config.get('general/payoff') %}
-        <p>{{ app.config.get('general/payoff') }}</p>
+<h2>{{ config.get('general/sitename') }}</h2>
+    {% if config.get('general/payoff') %}
+        <p>{{ config.get('general/payoff') }}</p>
     {% endif %}
 </div>
 <div class="large-12 columns headerphoto" style='background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.2) 60%, rgba(255, 255, 255, 0.5)), url({{ headerimage }})'>

--- a/theme/base-2016/partials/_master.twig
+++ b/theme/base-2016/partials/_master.twig
@@ -10,8 +10,8 @@
            sitename. If there is no title, we append the sitename with the payoff, if there is one. #}
         <title>
             {%- if record.title is defined %}{{ record.title|striptags }} | {% endif -%}
-                {{ app.config.get('general/sitename') -}}
-            {% if record.title is not defined and app.config.get('general/payoff') %} | {{ app.config.get('general/payoff') }}{% endif -%}
+                {{ config.get('general/sitename') -}}
+            {% if record.title is not defined and config.get('general/payoff') %} | {{ config.get('general/payoff') }}{% endif -%}
         </title>
         <link rel="stylesheet" href="{{ asset('css/foundation.css', 'theme') }}">
         <link rel="stylesheet" href="{{ asset('css/theme.css', 'theme') }}">


### PR DESCRIPTION
I have to admit, "missed" is something of a misnomer as it turned out. I was checking something and found a few of these that were missed in the 3.3 work, and as 3.2 is going to stay open for a while, I figured this bit is safe here as `app.config` and `config` are the same object.