### PR TITLE
[3.2] Translations refresh

### DIFF
--- a/app/resources/translations/cs_CZ/messages.cs_CZ.yml
+++ b/app/resources/translations/cs_CZ/messages.cs_CZ.yml
@@ -1,27 +1,18 @@
-# app/resources/translations/cs_CZ/messages.cs_CZ.yml – generated on 2016-11-06 08:42:36 Europe/Amsterdam
+# app/resources/translations/cs_CZ/messages.cs_CZ.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   6 unused messages
+#  no unused messages
 #  12 untranslated messages
-#  90 untranslated keyword based messages
+#  92 untranslated keyword based messages
 #  80 translations
-# 440 keyword based translations
-
-#--- 6 unused messages --------------------------------------------------------
-
-"Selection:": "Výběr:"
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
-"field.slug.button.link": "Odkaz na:"
+# 439 keyword based translations
 
 #--- 12 untranslated messages -------------------------------------------------
 
@@ -38,7 +29,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "Video": #
 
-#--- 90 untranslated keyword based messages -----------------------------------
+#--- 92 untranslated keyword based messages -----------------------------------
 
 "contenttypes.generic.group.meta": # "Meta"
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
@@ -47,6 +38,7 @@
 "field.video.pixel": # "pixel"
 "general.phrase.author": # "Author"
 "general.phrase.change-log": # "Change Log"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.delete": # "Delete"
 "general.phrase.depublish-explanation": # "If set, the record will be automatically depublished on the given date."
 "general.phrase.info": # "Info"
@@ -126,9 +118,9 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
-"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 "permissions.roles.label.anonymous": # "Anonymous"
 
@@ -215,7 +207,7 @@
 "You've been logged on successfully.": "Byl jste úspěšně přihlášen/a."
 "filtered by <em>'%filter%'</em>": "filtrováno dle <em>'%filter%'</em>"
 
-#--- 440 keyword based translations -------------------------------------------
+#--- 439 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Akce pro %contenttypes%"
 contenttypes.generic.actions-one: "Akce pro %contenttype%"
@@ -449,7 +441,6 @@ general.phrase.others: "Ostatní"
 general.phrase.overview: "Přehled"
 general.phrase.overview-for: "Přehled"
 general.phrase.owner-colon: "Vlastník:"
-general.phrase.page: "Strana"
 general.phrase.pager-showing-from-to-of: "Zobrazuji %pager_for% %from% - %to% z %count%"
 general.phrase.path: "Cesta"
 general.phrase.path-colon: "Cesta:"

--- a/app/resources/translations/de_DE/messages.de_DE.yml
+++ b/app/resources/translations/de_DE/messages.de_DE.yml
@@ -1,10 +1,10 @@
-# app/resources/translations/de_DE/messages.de_DE.yml – generated on 2017-03-18 10:13:06 UTC
+# app/resources/translations/de_DE/messages.de_DE.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
@@ -12,7 +12,7 @@
 #  no untranslated messages
 #  no untranslated keyword based messages
 #  92 translations
-# 532 keyword based translations
+# 531 keyword based translations
 
 #--- 92 translations ----------------------------------------------------------
 
@@ -109,7 +109,7 @@
 "You've been logged on successfully.": "Erfolgreich eingeloggt!"
 "filtered by <em>'%filter%'</em>": "gefiltert nach <em>'%filter%'</em>"
 
-#--- 532 keyword based translations -------------------------------------------
+#--- 531 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Aktionen für %contenttypes%"
 contenttypes.generic.actions-one: "Aktionen für %contenttype%"
@@ -359,7 +359,6 @@ general.phrase.others: "Andere"
 general.phrase.overview: "Übersicht"
 general.phrase.overview-for: "Übersicht für"
 general.phrase.owner-colon: "Besitzer:"
-general.phrase.page: "Seite"
 general.phrase.pager-showing-from-to-of: "Zeige %pager_for% %from% - %to% von %count%"
 general.phrase.path: "Pfad"
 general.phrase.path-colon: "Pfad"

--- a/app/resources/translations/el/messages.el.yml
+++ b/app/resources/translations/el/messages.el.yml
@@ -1,27 +1,18 @@
-# app/resources/translations/el/messages.el.yml – generated on 2016-11-06 08:42:35 Europe/Amsterdam
+# app/resources/translations/el/messages.el.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   6 unused messages
+#  no unused messages
 #  72 untranslated messages
-# 344 untranslated keyword based messages
+# 345 untranslated keyword based messages
 #  20 translations
 # 186 keyword based translations
-
-#--- 6 unused messages --------------------------------------------------------
-
-"component.changelog-pager.page": #
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
 
 #--- 72 untranslated messages -------------------------------------------------
 
@@ -98,7 +89,7 @@
 "View (saved version) on site": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 344 untranslated keyword based messages ----------------------------------
+#--- 345 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.created": # "This %contenttype% was created"
 "contenttypes.generic.group.meta": # "Meta"
@@ -156,6 +147,7 @@
 "general.phrase.add-selected": # "Add Selected"
 "general.phrase.author": # "Author"
 "general.phrase.browswer-platform": # "Browser / platform"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -227,7 +219,6 @@
 "general.phrase.order": # "Order"
 "general.phrase.other-content": # "Other content"
 "general.phrase.others": # "Others"
-"general.phrase.page": # "Page"
 "general.phrase.path-image-file": # "Path to image file"
 "general.phrase.please-logon": # "Please log on."
 "general.phrase.publish": # "Publish"
@@ -408,11 +399,11 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.label.create-folder": # "Create folder"
 "page.file-management.message.create-file": # "Please enter a new file name!"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -1,36 +1,18 @@
-# app/resources/translations/en_GB/messages.en_GB.yml – generated on 2016-11-06 08:42:39 Europe/Amsterdam
+# app/resources/translations/en_GB/messages.en_GB.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#  15 unused messages
+#  no unused messages
 #   4 untranslated messages
 #  no untranslated keyword based messages
 #  88 translations
-# 530 keyword based translations
-
-#--- 15 unused messages -------------------------------------------------------
-
-"Alas, no about!": "Alas, no about!"
-"Chapter": "Chapter"
-"Chapters": "Chapters"
-"Edit": "Edit"
-"No content found.": "No content found."
-"No results found for '%SEARCHTERM%'. Please try another search.": "No results found for '%SEARCHTERM%'. Please try another search."
-"Overview for": "Overview for"
-"Permalink": "Permalink"
-"Read more": "Read more"
-"Related content": "Related content"
-"Search": "Search"
-"Search results for <b>%search%</b>.": "Search results for <b>%search%</b>."
-"Search …": "Search …"
-"There currently is no Block with 'about-us' as its slug. If you create one, it will be shown here. Go to 'Configuration' > 'Check Database' and select 'Add sample Records' to automatically generate this Block.": "Database' and select 'Add sample Records' to automatically generate this Block.\""
-"Written by <em>%name%</em> on %date%": "Written by <em>%name%</em> on %date%"
+# 531 keyword based translations
 
 #--- 4 untranslated messages --------------------------------------------------
 
@@ -130,7 +112,7 @@
 "You've been logged on successfully.": "You've been logged on successfully."
 "filtered by <em>'%filter%'</em>": "filtered by <em>'%filter%'</em>"
 
-#--- 530 keyword based translations -------------------------------------------
+#--- 531 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Actions for %contenttypes%"
 contenttypes.generic.actions-one: "Actions for this %contenttype%"
@@ -248,6 +230,7 @@ general.phrase.change-log: "Change Log"
 general.phrase.check-again: "Check again"
 general.phrase.check-database: "Check database"
 general.phrase.choose-record-link-to: "Please choose the record you want to link to:"
+general.phrase.clashing-relation: "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 general.phrase.clear-cache: "Clear the cache"
 general.phrase.clear-cache-again: "Clear cache again"
 general.phrase.clear-cache-complete: "Cleared cache."
@@ -324,7 +307,6 @@ general.phrase.hints-colon: "Hints:"
 general.phrase.id: "Id"
 general.phrase.info: "Info"
 general.phrase.invalid-taxonomy-slug: "In the taxonomy '%taxonomy%' the slug for option '%option%' contains a slash. Please edit taxonomy.yml, and correct this."
-general.phrase.clashing-relation: "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 general.phrase.ip.address: "IP address"
 general.phrase.keyword-ellipsis: "Keyword …"
 general.phrase.last-edited-on-colon: "Last edited on:"
@@ -380,7 +362,6 @@ general.phrase.others: "Others"
 general.phrase.overview: "Overview"
 general.phrase.overview-for: "Overview for"
 general.phrase.owner-colon: "Owner:"
-general.phrase.page: "Page"
 general.phrase.pager-showing-from-to-of: "Showing %pager_for% %from% - %to% of %count%"
 general.phrase.path: "Path"
 general.phrase.path-colon: "Path:"
@@ -646,11 +627,11 @@ page.extend.message.shows-updates: "This won't install anything, just show you a
 page.extend.message.start-using-extension: "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 page.extend.message.updated: "Everything is up to date!"
 page.extend.message.updating: "Searching for available updates …"
+page.extend.options: "Extension Options"
 page.extend.pagetitle: "Extend %BOLTNAME%"
 page.extend.theme.generation.failure: "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 page.extend.theme.generation.missing.name: "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: "Theme successfully generated. You can now edit it directly from your theme folder."
-page.extend.options: "Extension Options"
 
 page.file-management.label.create-file: "Create File"
 page.file-management.label.create-folder: "Create folder"

--- a/app/resources/translations/es_ES/messages.es_ES.yml
+++ b/app/resources/translations/es_ES/messages.es_ES.yml
@@ -1,27 +1,32 @@
-# app/resources/translations/es_ES/messages.es_ES.yml – generated on 2016-11-06 08:42:30 Europe/Amsterdam
+# app/resources/translations/es_ES/messages.es_ES.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#  no unused messages
+#   1 unused messages
 #  no untranslated messages
-#   5 untranslated keyword based messages
+#   7 untranslated keyword based messages
 #  92 translations
-# 525 keyword based translations
+# 524 keyword based translations
 
-#--- 5 untranslated keyword based messages ------------------------------------
+#--- 1 unused messages --------------------------------------------------------
+
+"general.phrase.page": "Página"
+
+#--- 7 untranslated keyword based messages ------------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.depublish-explanation": # "If set, the record will be automatically depublished on the given date."
 "general.phrase.status-explanation": # "The status defines whether or not this record is published. Select 'Timed publish' to automatically publish on the set Publication Date."
 "nut.greeting": # "Welcome to Bolt!"
 "nut.version": # "version"
-"page.extend.options": #
+"page.extend.options": # "Extension Options"
 
 #--- 92 translations ----------------------------------------------------------
 
@@ -118,7 +123,7 @@
 "You've been logged on successfully.": "Has iniciado sesión exitosamente"
 "filtered by <em>'%filter%'</em>": "filtrado por <em>'%filter%'</em>"
 
-#--- 525 keyword based translations -------------------------------------------
+#--- 524 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Acciones para %contenttypes%"
 contenttypes.generic.actions-one: "Acciones para %contenttype%"
@@ -365,7 +370,6 @@ general.phrase.others: "Otros"
 general.phrase.overview: "Listado"
 general.phrase.overview-for: "Listado de"
 general.phrase.owner-colon: "Propietario"
-general.phrase.page: "Página"
 general.phrase.pager-showing-from-to-of: "Mostrando %pager_for% %from% - %to% de %count%"
 general.phrase.path: "Ruta"
 general.phrase.path-colon: "Ruta"

--- a/app/resources/translations/fi/messages.fi.yml
+++ b/app/resources/translations/fi/messages.fi.yml
@@ -1,26 +1,18 @@
-# app/resources/translations/fi/messages.fi.yml – generated on 2016-11-06 08:42:42 Europe/Amsterdam
+# app/resources/translations/fi/messages.fi.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   5 unused messages
+#  no unused messages
 #  27 untranslated messages
-# 141 untranslated keyword based messages
+# 143 untranslated keyword based messages
 #  65 translations
-# 389 keyword based translations
-
-#--- 5 unused messages --------------------------------------------------------
-
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
+# 388 keyword based translations
 
 #--- 27 untranslated messages -------------------------------------------------
 
@@ -52,7 +44,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "Video": #
 
-#--- 141 untranslated keyword based messages ----------------------------------
+#--- 143 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.group.meta": # "Meta"
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
@@ -69,6 +61,7 @@
 "general.bolt-welcome-new-site": # "Welcome to your new Bolt site, %USER%."
 "general.phrase.add-selected": # "Add Selected"
 "general.phrase.author": # "Author"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.delete": # "Delete"
 "general.phrase.delete-set": # "Delete Set"
@@ -191,9 +184,9 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
@@ -265,7 +258,7 @@
 "You've been logged on successfully.": "Uloskirjautuminen onnistui."
 "filtered by <em>'%filter%'</em>": "suodatettu <em>'%filter%'</em>"
 
-#--- 389 keyword based translations -------------------------------------------
+#--- 388 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Sisältötyyppien toiminnot"
 contenttypes.generic.actions-one: "Tämän sisältötyypin toiminnot"
@@ -470,7 +463,6 @@ general.phrase.order-colon-sort: "Järjestys: %sort%"
 general.phrase.overview: "Yleiskatsaus"
 general.phrase.overview-for: "Yleiskatsaus:"
 general.phrase.owner-colon: "Omistaja"
-general.phrase.page: "Sivu"
 general.phrase.pager-showing-from-to-of: "Näytetään sivu %pager_for% (%from% - %to% / %count%)"
 general.phrase.path: "Polku"
 general.phrase.path-colon: "Polku"

--- a/app/resources/translations/fr/messages.fr.yml
+++ b/app/resources/translations/fr/messages.fr.yml
@@ -1,37 +1,18 @@
-# app/resources/translations/fr/messages.fr.yml – generated on 2016-11-06 08:42:38 Europe/Amsterdam
+# app/resources/translations/fr/messages.fr.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#  16 unused messages
+#  no unused messages
 #   4 untranslated messages
-#   4 untranslated keyword based messages
+#   6 untranslated keyword based messages
 #  88 translations
-# 526 keyword based translations
-
-#--- 16 unused messages -------------------------------------------------------
-
-"Alas, no about!": "Hélas, aucun à propos !"
-"Chapter": "Chapitre"
-"Chapters": "Chapitres"
-"Edit": "Editer"
-"No content found.": "Aucun contenu trouvé."
-"No results found for '%SEARCHTERM%'. Please try another search.": "Aucun résultat trouvé pour '%SEARCHTERM%'. Veuillez essayer une nouvelle recherche."
-"Overview for": "Vue d'ensemble pour"
-"Permalink": "Lien permanent"
-"Read more": "En lire plus"
-"Related content": "Contenu lié"
-"Search": "Recherche"
-"Search results for <b>%search%</b>.": "Chercher des resultats pour <b>%search%</b>."
-"Search …": "Rechercher…"
-"There currently is no Block with 'about-us' as its slug. If you create one, it will be shown here. Go to 'Configuration' > 'Check Database' and select 'Add sample Records' to automatically generate this Block.": "Il n'y a actuellement aucun bloc avec le slug 'about-us'. Si vous créez un, il sera affiché ici. Aller dans 'Configuration' > 'Vérifier la base de données' et sélectionnez 'Ajouter des exemples' pour générer automatiquement ce bloc."
-"Written by <em>%name%</em> on %date%": "Ecrit par <em>%name%</em> le %date%"
-"field.slug.button.link": "Lier à :"
+# 525 keyword based translations
 
 #--- 4 untranslated messages --------------------------------------------------
 
@@ -40,13 +21,14 @@
 "Group": #
 "Groups": #
 
-#--- 4 untranslated keyword based messages ------------------------------------
+#--- 6 untranslated keyword based messages ------------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 "field.slug.button.generate": # "Generate from:"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "nut.greeting": # "Welcome to Bolt!"
 "nut.version": # "version"
-"page.extend.options": #
+"page.extend.options": # "Extension Options"
 
 #--- 88 translations ----------------------------------------------------------
 
@@ -139,7 +121,7 @@
 "You've been logged on successfully.": "Connexion réussie."
 "filtered by <em>'%filter%'</em>": "filtré par <em>'%filter%'</em>"
 
-#--- 526 keyword based translations -------------------------------------------
+#--- 525 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Actions pour les %contenttypes%"
 contenttypes.generic.actions-one: "Actions pour ce(tte) %contenttype%"
@@ -386,7 +368,6 @@ general.phrase.others: "Autres"
 general.phrase.overview: "Vue d'ensemble"
 general.phrase.overview-for: "Aperçu pour"
 general.phrase.owner-colon: "Propriétaire :"
-general.phrase.page: "Page"
 general.phrase.pager-showing-from-to-of: "Affichage des %pager_for% %from% à %to% sur %count%"
 general.phrase.path: "Chemin"
 general.phrase.path-colon: "Chemin :"

--- a/app/resources/translations/hu/messages.hu.yml
+++ b/app/resources/translations/hu/messages.hu.yml
@@ -1,27 +1,18 @@
-# app/resources/translations/hu/messages.hu.yml – generated on 2016-11-06 08:42:31 Europe/Amsterdam
+# app/resources/translations/hu/messages.hu.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   6 unused messages
+#  no unused messages
 #  19 untranslated messages
-#  78 untranslated keyword based messages
+#  79 untranslated keyword based messages
 #  73 translations
 # 452 keyword based translations
-
-#--- 6 unused messages --------------------------------------------------------
-
-"Selection:": "Kiválasztás:"
-"field.slug.button.link": #
-"page.extend.button.config": "Konfiguráció"
-"page.extend.button.readme": "Olvass el"
-"page.extend.button.uninstall": "Eltávolítás"
-"page.extend.button.versions": "Verziók"
 
 #--- 19 untranslated messages -------------------------------------------------
 
@@ -45,7 +36,7 @@
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
-#--- 78 untranslated keyword based messages -----------------------------------
+#--- 79 untranslated keyword based messages -----------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 "contenttypes.generic.invalid-relation": # "In the ContentType for '%contenttype%', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
@@ -61,6 +52,7 @@
 "general.bolt-configuration-issues-detected": # "Bolt has detected one or more configuration issues. You should resolve these, for optimum performance:"
 "general.phrase.access-denied-self-action": # "You cannot '%s' yourself."
 "general.phrase.add-selected": # "Add Selected"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.delete-set": # "Delete Set"
 "general.phrase.depublish": # "Depublish"
@@ -414,7 +406,6 @@ general.phrase.others: "Egyebek"
 general.phrase.overview: "Áttekintés"
 general.phrase.overview-for: "Áttekintés:"
 general.phrase.owner-colon: "Tulajdonos:"
-general.phrase.page: "Oldal"
 general.phrase.pager-showing-from-to-of: "%from% - %to% %pager_for% mutatása, összesen %count%"
 general.phrase.path: "Útvonal"
 general.phrase.path-colon: "Útvonal"
@@ -639,11 +630,11 @@ page.extend.message.shows-updates: "Ezzel semmit sem telepítesz csak áttekinth
 page.extend.message.start-using-extension: "Most használatba veheted a telepített bővítményeket. A dokumentáció és a beüzemelési instrukciók az alábbi linken érhető el."
 page.extend.message.updated: "Minden naprakész"
 page.extend.message.updating: "A lehetséges frissítések keresése…"
+page.extend.options: "Bővítmény opciók"
 page.extend.pagetitle: "A %BOLTNAME% kibővítése"
 page.extend.theme.generation.failure: "Nem tudjuk előállítani a témát. Olyan mint ha a téma mappa nem lenne írható. Ellenőrizd a jogokat és próbáld újra!"
 page.extend.theme.generation.missing.name: "Nincs a témának neve. Így a téma nem állítható elő."
 page.extend.theme.generation.success: "A téma rendben elkészült. Mostantól közvetlenül szerkesztheted a téma mappában."
-page.extend.options: "Bővítmény opciók"
 
 page.file-management.label.create-file: "Fájl létrehozása"
 page.file-management.label.create-folder: "Könyvtár létrehozása"

--- a/app/resources/translations/id/messages.id.yml
+++ b/app/resources/translations/id/messages.id.yml
@@ -1,30 +1,18 @@
-# app/resources/translations/id/messages.id.yml – generated on 2016-11-06 08:42:29 Europe/Amsterdam
+# app/resources/translations/id/messages.id.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   9 unused messages
+#  no unused messages
 #  78 untranslated messages
-# 379 untranslated keyword based messages
+# 380 untranslated keyword based messages
 #  14 translations
 # 151 keyword based translations
-
-#--- 9 unused messages --------------------------------------------------------
-
-"component.changelog-detail.field": #
-"component.changelog-detail.value-new": #
-"component.changelog-detail.value-old": #
-"component.changelog-pager.page": #
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
 
 #--- 78 untranslated messages -------------------------------------------------
 
@@ -107,7 +95,7 @@
 "You've been logged on successfully.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 379 untranslated keyword based messages ----------------------------------
+#--- 380 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.actions-all": # "Actions for %contenttypes%"
 "contenttypes.generic.actions-one": # "Actions for this %contenttype%"
@@ -185,6 +173,7 @@
 "general.phrase.author": # "Author"
 "general.phrase.change-current-status": # "Click to change current status."
 "general.phrase.choose-record-link-to": # "Please choose the record you want to link to:"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -258,7 +247,6 @@
 "general.phrase.order": # "Order"
 "general.phrase.other-content": # "Other content"
 "general.phrase.others": # "Others"
-"general.phrase.page": # "Page"
 "general.phrase.pager-showing-from-to-of": # "Showing %pager_for% %from% - %to% of %count%"
 "general.phrase.path-image-file": # "Path to image file"
 "general.phrase.please-logon": # "Please log on."
@@ -450,11 +438,11 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.label.create-folder": # "Create folder"
 "page.file-management.message.create-file": # "Please enter a new file name!"

--- a/app/resources/translations/it/messages.it.yml
+++ b/app/resources/translations/it/messages.it.yml
@@ -1,30 +1,18 @@
-# app/resources/translations/it/messages.it.yml – generated on 2016-11-06 08:42:48 Europe/Amsterdam
+# app/resources/translations/it/messages.it.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   9 unused messages
+#  no unused messages
 #  72 untranslated messages
-# 324 untranslated keyword based messages
+# 326 untranslated keyword based messages
 #  20 translations
-# 206 keyword based translations
-
-#--- 9 unused messages --------------------------------------------------------
-
-"component.changelog-detail.by": #
-"component.changelog-detail.field": #
-"component.changelog-detail.value-new": #
-"component.changelog-detail.value-old": #
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
+# 205 keyword based translations
 
 #--- 72 untranslated messages -------------------------------------------------
 
@@ -101,7 +89,7 @@
 "View (saved version) on site": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 324 untranslated keyword based messages ----------------------------------
+#--- 326 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.group.meta": # "Meta"
 "contenttypes.generic.group.template": # "Template"
@@ -148,6 +136,7 @@
 "general.phrase.by": # "by"
 "general.phrase.change-current-status": # "Click to change current status."
 "general.phrase.change-log": # "Change Log"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -396,11 +385,11 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.label.create-folder": # "Create folder"
 "page.file-management.message.create-file": # "Please enter a new file name!"
@@ -452,7 +441,7 @@
 "Title": "Titolo"
 "You've been logged on successfully.": "Accesso effettuato con successo."
 
-#--- 206 keyword based translations -------------------------------------------
+#--- 205 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Azioni per contenuti %contenttypes%"
 contenttypes.generic.actions-one: "Azioni per questo contenuto %contenttype%"
@@ -574,7 +563,6 @@ general.phrase.order-colon-sort: "Ordine: %sort%"
 general.phrase.overview: "Anteprima"
 general.phrase.overview-for: "Anteprima"
 general.phrase.owner-colon: "Proprietario:"
-general.phrase.page: "Pagina"
 general.phrase.pager-showing-from-to-of: "Visualizzo %pager_for% %from% - %to% di %count%"
 general.phrase.path: "Percorso"
 general.phrase.permalink: "Link permanente"

--- a/app/resources/translations/ja/messages.ja.yml
+++ b/app/resources/translations/ja/messages.ja.yml
@@ -1,27 +1,18 @@
-# app/resources/translations/ja/messages.ja.yml – generated on 2016-11-06 08:42:41 Europe/Amsterdam
+# app/resources/translations/ja/messages.ja.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   6 unused messages
+#  no unused messages
 #  51 untranslated messages
-# 258 untranslated keyword based messages
+# 260 untranslated keyword based messages
 #  41 translations
-# 272 keyword based translations
-
-#--- 6 unused messages --------------------------------------------------------
-
-"component.changelog-detail.by": #
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
+# 271 keyword based translations
 
 #--- 51 untranslated messages -------------------------------------------------
 
@@ -77,7 +68,7 @@
 "View (saved version) on site": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 258 untranslated keyword based messages ----------------------------------
+#--- 260 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.group.ungrouped": # "Ungrouped"
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
@@ -112,6 +103,7 @@
 "general.phrase.add-selected": # "Add Selected"
 "general.phrase.author": # "Author"
 "general.phrase.by": # "by"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -321,11 +313,11 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.create-file": # "Please enter a new file name!"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
@@ -383,7 +375,7 @@
 "Video": "動画"
 "You've been logged on successfully.": "正常にログインしました。"
 
-#--- 272 keyword based translations -------------------------------------------
+#--- 271 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "%contenttypes%の操作"
 contenttypes.generic.actions-one: "この%contenttype%の操作"
@@ -534,7 +526,6 @@ general.phrase.order-colon-sort: "並び順： %sort%"
 general.phrase.overview: "一覧"
 general.phrase.overview-for: "一覧"
 general.phrase.owner-colon: "所有者："
-general.phrase.page: "ページ"
 general.phrase.pager-showing-from-to-of: "%page_for%を表示 %from%～%to%件目 / 全 %count% 件"
 general.phrase.path: "パス"
 general.phrase.path-colon: "パス："

--- a/app/resources/translations/nb/messages.nb.yml
+++ b/app/resources/translations/nb/messages.nb.yml
@@ -1,30 +1,18 @@
-# app/resources/translations/nb/messages.nb.yml – generated on 2016-11-06 08:42:40 Europe/Amsterdam
+# app/resources/translations/nb/messages.nb.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   9 unused messages
+#  no unused messages
 #  65 untranslated messages
-# 345 untranslated keyword based messages
+# 346 untranslated keyword based messages
 #  27 translations
 # 185 keyword based translations
-
-#--- 9 unused messages --------------------------------------------------------
-
-"component.changelog-detail.field": #
-"component.changelog-detail.value-new": #
-"component.changelog-detail.value-old": #
-"component.changelog-pager.page": #
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
 
 #--- 65 untranslated messages -------------------------------------------------
 
@@ -94,7 +82,7 @@
 "View (saved version) on site": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 345 untranslated keyword based messages ----------------------------------
+#--- 346 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.actions-all": # "Actions for %contenttypes%"
 "contenttypes.generic.actions-one": # "Actions for this %contenttype%"
@@ -164,6 +152,7 @@
 "general.phrase.add-selected": # "Add Selected"
 "general.phrase.author": # "Author"
 "general.phrase.change-current-status": # "Click to change current status."
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -228,7 +217,6 @@
 "general.phrase.order": # "Order"
 "general.phrase.other-content": # "Other content"
 "general.phrase.others": # "Others"
-"general.phrase.page": # "Page"
 "general.phrase.path-image-file": # "Path to image file"
 "general.phrase.profile": # "Profile"
 "general.phrase.publish": # "Publish"
@@ -408,11 +396,11 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.label.create-folder": # "Create folder"
 "page.file-management.message.create-file": # "Please enter a new file name!"

--- a/app/resources/translations/nl_NL/messages.nl_NL.yml
+++ b/app/resources/translations/nl_NL/messages.nl_NL.yml
@@ -1,26 +1,18 @@
-# app/resources/translations/nl_NL/messages.nl_NL.yml – generated on 2016-11-06 08:42:34 Europe/Amsterdam
+# app/resources/translations/nl_NL/messages.nl_NL.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   5 unused messages
+#  no unused messages
 #  12 untranslated messages
-#  25 untranslated keyword based messages
+#  27 untranslated keyword based messages
 #  80 translations
-# 505 keyword based translations
-
-#--- 5 unused messages --------------------------------------------------------
-
-"Selection:": "Selectie:"
-"page.extend.button.config": "Instellingen"
-"page.extend.button.readme": "Leesmij"
-"page.extend.button.uninstall": "Deinstalleer"
-"page.extend.button.versions": "Versies"
+# 504 keyword based translations
 
 #--- 12 untranslated messages -------------------------------------------------
 
@@ -37,9 +29,10 @@
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
-#--- 25 untranslated keyword based messages -----------------------------------
+#--- 27 untranslated keyword based messages -----------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.error-cache-clear": # "Failed to clear cache. You should delete it manually."
 "general.phrase.invalid-taxonomy-slug": # "In the taxonomy '%taxonomy%' the slug for option '%option%' contains a slash. Please edit taxonomy.yml, and correct this."
@@ -63,7 +56,7 @@
 "page.extend.message.invalid-theme-source-dir": # "Invalid theme source directory: %SOURCE%"
 "page.extend.message.package-dependencies": # "Packages that depend on this"
 "page.extend.message.running-update-all": # "Running updates"
-"page.extend.options": #
+"page.extend.options": # "Extension Options"
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 80 translations ----------------------------------------------------------
@@ -149,7 +142,7 @@
 "You've been logged on successfully.": "Je bent succesvol ingelogd."
 "filtered by <em>'%filter%'</em>": "gefilterd door <em>'%filter%'</em>"
 
-#--- 505 keyword based translations -------------------------------------------
+#--- 504 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Handelingen voor %contenttypes%"
 contenttypes.generic.actions-one: "Handelingen voor deze %contenttype%"
@@ -393,7 +386,6 @@ general.phrase.others: "Anderen"
 general.phrase.overview: "Overzicht"
 general.phrase.overview-for: "Overzicht van"
 general.phrase.owner-colon: "Eigenaar:"
-general.phrase.page: "Pagina"
 general.phrase.pager-showing-from-to-of: "Toont %pager_for% %from% - %to% van %count%"
 general.phrase.path: "Pad"
 general.phrase.path-colon: "Pad:"

--- a/app/resources/translations/pl_PL/messages.pl_PL.yml
+++ b/app/resources/translations/pl_PL/messages.pl_PL.yml
@@ -1,27 +1,18 @@
-# app/resources/translations/pl_PL/messages.pl_PL.yml – generated on 2016-11-06 08:42:46 Europe/Amsterdam
+# app/resources/translations/pl_PL/messages.pl_PL.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   6 unused messages
+#  no unused messages
 #  28 untranslated messages
-# 142 untranslated keyword based messages
+# 144 untranslated keyword based messages
 #  64 translations
-# 388 keyword based translations
-
-#--- 6 unused messages --------------------------------------------------------
-
-"Selection:": "Wybór:"
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
+# 387 keyword based translations
 
 #--- 28 untranslated messages -------------------------------------------------
 
@@ -54,7 +45,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 142 untranslated keyword based messages ----------------------------------
+#--- 144 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 "contenttypes.generic.invalid-relation": # "In the ContentType for '%contenttype%', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
@@ -71,6 +62,7 @@
 "general.bolt-documentation": # "Bolt documentation"
 "general.bolt-welcome-new-site": # "Welcome to your new Bolt site, %USER%."
 "general.phrase.add-selected": # "Add Selected"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.delete-set": # "Delete Set"
 "general.phrase.depublish-explanation": # "If set, the record will be automatically depublished on the given date."
@@ -195,9 +187,9 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
-"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 64 translations ----------------------------------------------------------
@@ -267,7 +259,7 @@
 "View (saved version) on site": "Przeglądaj (zapisaną wersję) na witrynie"
 "You've been logged on successfully.": "Zostałeś zalogowany."
 
-#--- 388 keyword based translations -------------------------------------------
+#--- 387 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Akcje dla %contenttypes%"
 contenttypes.generic.actions-one: "Akcje dla tego %contenttype%"
@@ -472,7 +464,6 @@ general.phrase.order-colon-sort: "Kolejność: %sort%"
 general.phrase.overview: "Przegląd"
 general.phrase.overview-for: "Informacje dla"
 general.phrase.owner-colon: "Właściciel:"
-general.phrase.page: "Strona"
 general.phrase.pager-showing-from-to-of: "Wyświetlanie %pager_for% %from% - %to% z %count%"
 general.phrase.path: "Ścieżka"
 general.phrase.path-colon: "Ścieżka:"

--- a/app/resources/translations/pt/messages.pt.yml
+++ b/app/resources/translations/pt/messages.pt.yml
@@ -1,27 +1,18 @@
-# app/resources/translations/pt/messages.pt.yml – generated on 2016-11-06 08:42:47 Europe/Amsterdam
+# app/resources/translations/pt/messages.pt.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   6 unused messages
+#  no unused messages
 #   8 untranslated messages
-#  33 untranslated keyword based messages
+#  35 untranslated keyword based messages
 #  84 translations
-# 497 keyword based translations
-
-#--- 6 unused messages --------------------------------------------------------
-
-"Selection:": "Seleção:"
-"field.slug.button.link": "Ligar a:"
-"page.extend.button.config": "Configurar"
-"page.extend.button.readme": "Informações"
-"page.extend.button.uninstall": "Desinstalar"
-"page.extend.button.versions": "Versões"
+# 496 keyword based translations
 
 #--- 8 untranslated messages --------------------------------------------------
 
@@ -34,10 +25,11 @@
 "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
-#--- 33 untranslated keyword based messages -----------------------------------
+#--- 35 untranslated keyword based messages -----------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 "field.slug.button.generate": # "Generate from:"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.depublish-explanation": # "If set, the record will be automatically depublished on the given date."
 "general.phrase.error-mail-options-not-set": # "The email configuration setting 'mailoptions' hasn't been set. Bolt may be unable to send password reset."
 "general.phrase.error-session-data-login": # "Unable to retrieve login session data. Please check your system's PHP session settings."
@@ -67,8 +59,8 @@
 "page.extend.message.loading-disabled": # "Extensions loading has been disabled by an administrator in the %CONFIG% file. You may install, update and uninstall extensions but they will not load until this setting has been changed."
 "page.extend.message.package-dependencies": # "Packages that depend on this"
 "page.extend.message.running-update-all": # "Running updates"
+"page.extend.options": # "Extension Options"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
-"page.extend.options": #
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 84 translations ----------------------------------------------------------
@@ -158,7 +150,7 @@
 "You've been logged on successfully.": "Autenticação realizada com sucesso!"
 "filtered by <em>'%filter%'</em>": "filtrados por <em>'%filter%'</em>"
 
-#--- 497 keyword based translations -------------------------------------------
+#--- 496 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Ações para %contenttypes%"
 contenttypes.generic.actions-one: "Ações para %contenttype%"
@@ -401,7 +393,6 @@ general.phrase.others: "Outros"
 general.phrase.overview: "Visão geral"
 general.phrase.overview-for: "Visão geral sobre"
 general.phrase.owner-colon: "Proprietário:"
-general.phrase.page: "Página"
 general.phrase.pager-showing-from-to-of: "A exibir página %pager_for% %from% - %to% de %count%"
 general.phrase.path: "Caminho"
 general.phrase.path-colon: "Caminho:"

--- a/app/resources/translations/pt_BR/messages.pt_BR.yml
+++ b/app/resources/translations/pt_BR/messages.pt_BR.yml
@@ -1,26 +1,18 @@
-# app/resources/translations/pt_BR/messages.pt_BR.yml – generated on 2016-11-06 08:42:45 Europe/Amsterdam
+# app/resources/translations/pt_BR/messages.pt_BR.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   5 unused messages
+#  no unused messages
 #  45 untranslated messages
-# 215 untranslated keyword based messages
+# 217 untranslated keyword based messages
 #  47 translations
-# 315 keyword based translations
-
-#--- 5 unused messages --------------------------------------------------------
-
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
+# 314 keyword based translations
 
 #--- 45 untranslated messages -------------------------------------------------
 
@@ -70,7 +62,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 215 untranslated keyword based messages ----------------------------------
+#--- 217 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.group.meta": # "Meta"
 "contenttypes.generic.group.template": # "Template"
@@ -95,6 +87,7 @@
 "general.phrase.access-denied-privilege-edit-user": # "You do not have the right privileges to edit that user."
 "general.phrase.access-denied-self-action": # "You cannot '%s' yourself."
 "general.phrase.author": # "Author"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -275,11 +268,11 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
@@ -339,7 +332,7 @@
 "View (saved version) on site": "Visualizar (versão salva) no site"
 "You've been logged on successfully.": "Autenticação realizada com sucesso!"
 
-#--- 315 keyword based translations -------------------------------------------
+#--- 314 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Ações para %contenttypes%"
 contenttypes.generic.actions-one: "Ações para %contenttype%"
@@ -517,7 +510,6 @@ general.phrase.order-colon-sort: "Ordenar: %sort%"
 general.phrase.overview: "Visualizar"
 general.phrase.overview-for: "Visualização para"
 general.phrase.owner-colon: "Criador"
-general.phrase.page: "Página"
 general.phrase.pager-showing-from-to-of: "Mostrando página %pager_for% %from% - %to% de %count%"
 general.phrase.path: "Caminho"
 general.phrase.path-colon: "Caminho"

--- a/app/resources/translations/ru/messages.ru.yml
+++ b/app/resources/translations/ru/messages.ru.yml
@@ -1,4 +1,4 @@
-# app/resources/translations/ru/messages.ru.yml – generated on 2017-01-02 07:50:25 Europe/Amsterdam
+# app/resources/translations/ru/messages.ru.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
 #          at the moment. This is an ongoing process. Translations currently in the
@@ -8,21 +8,11 @@
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   7 unused messages
+#  no unused messages
 #  11 untranslated messages
-# 162 untranslated keyword based messages
+# 164 untranslated keyword based messages
 #  81 translations
-# 368 keyword based translations
-
-#--- 7 unused messages --------------------------------------------------------
-
-"component.changelog-detail.by": #
-"The field %field% has been changed to %newValue%": "Значение поля %field% было изменено на %newValue%"
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
+# 367 keyword based translations
 
 #--- 11 untranslated messages -------------------------------------------------
 
@@ -38,7 +28,7 @@
 "Testing connection to extension server failed: %errormessage%": #
 "The field %field% has been changed to \"%newValue%\"": #
 
-#--- 162 untranslated keyword based messages ----------------------------------
+#--- 164 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.group.ungrouped": # "Ungrouped"
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
@@ -61,6 +51,7 @@
 "general.phrase.add-selected": # "Add Selected"
 "general.phrase.author": # "Author"
 "general.phrase.by": # "by"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -196,10 +187,10 @@
 "page.extend.message.running-update-all": # "Running updates"
 "page.extend.message.shows-updates": # "This won't install anything, just show you available updates"
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
+"page.extend.options": # "Extension Options"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
 "panel.latest-activity.by": # "by"
@@ -288,7 +279,7 @@
 "You've been logged on successfully.": "Вы успешно вошли."
 "filtered by <em>'%filter%'</em>": "фильтровано через <em>'%filter%'</em>"
 
-#--- 368 keyword based translations -------------------------------------------
+#--- 367 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Действия для %contenttypes%"
 contenttypes.generic.actions-one: "Действия для этой %contenttype%"
@@ -468,7 +459,6 @@ general.phrase.order-colon-sort: "Сортировка: %sort%"
 general.phrase.overview: "Обзор"
 general.phrase.overview-for: "Обзор для"
 general.phrase.owner-colon: "Владелец:"
-general.phrase.page: "Страница"
 general.phrase.pager-showing-from-to-of: "Показ %pager_for% %from% - %to% из %count%"
 general.phrase.path: "Путь"
 general.phrase.path-colon: "Путь:"

--- a/app/resources/translations/sv_SE/messages.sv_SE.yml
+++ b/app/resources/translations/sv_SE/messages.sv_SE.yml
@@ -1,27 +1,18 @@
-# app/resources/translations/sv_SE/messages.sv_SE.yml – generated on 2016-11-06 08:42:32 Europe/Amsterdam
+# app/resources/translations/sv_SE/messages.sv_SE.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   6 unused messages
+#  no unused messages
 #  16 untranslated messages
-#  46 untranslated keyword based messages
+#  48 untranslated keyword based messages
 #  76 translations
-# 484 keyword based translations
-
-#--- 6 unused messages --------------------------------------------------------
-
-"Selection:": "Val:"
-"field.slug.button.link": "Länka till:"
-"page.extend.button.config": "Konfiguration"
-"page.extend.button.readme": "Readme"
-"page.extend.button.uninstall": "Avinstallera"
-"page.extend.button.versions": "Versioner"
+# 483 keyword based translations
 
 #--- 16 untranslated messages -------------------------------------------------
 
@@ -42,7 +33,7 @@
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
-#--- 46 untranslated keyword based messages -----------------------------------
+#--- 48 untranslated keyword based messages -----------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 "field.slug.button.generate": # "Generate from:"
@@ -50,6 +41,7 @@
 "field.video.width": # "Width"
 "general.bolt-configuration-issues-detected": # "Bolt has detected one or more configuration issues. You should resolve these, for optimum performance:"
 "general.phrase.add-selected": # "Add Selected"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.depublish-explanation": # "If set, the record will be automatically depublished on the given date."
 "general.phrase.error-cache-clear": # "Failed to clear cache. You should delete it manually."
@@ -89,7 +81,7 @@
 "page.extend.message.package-dependencies": # "Packages that depend on this"
 "page.extend.message.package-install-info-fail": # "Unable to get installation information for %PACKAGE% %VERSION%."
 "page.extend.message.running-update-all": # "Running updates"
-"page.extend.options": #
+"page.extend.options": # "Extension Options"
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 #--- 76 translations ----------------------------------------------------------
@@ -171,7 +163,7 @@
 "You've been logged on successfully.": "Du är nu inloggad."
 "filtered by <em>'%filter%'</em>": "filtrerat efter <em>\"%filter%\"</em>"
 
-#--- 484 keyword based translations -------------------------------------------
+#--- 483 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "Åtgärder för %contenttypes%"
 contenttypes.generic.actions-one: "Åtgärder för denna %contenttype%"
@@ -403,7 +395,6 @@ general.phrase.others: "Andra"
 general.phrase.overview: "Överblick"
 general.phrase.overview-for: "Överblick för"
 general.phrase.owner-colon: "Ägare:"
-general.phrase.page: "Sida"
 general.phrase.pager-showing-from-to-of: "Visar %pager_for% %from% - %to% av %count%"
 general.phrase.path: "Sökväg"
 general.phrase.path-colon: "Sökväg:"

--- a/app/resources/translations/zh_CN/messages.zh_CN.yml
+++ b/app/resources/translations/zh_CN/messages.zh_CN.yml
@@ -1,26 +1,18 @@
-# app/resources/translations/zh_CN/messages.zh_CN.yml – generated on 2016-11-06 08:42:37 Europe/Amsterdam
+# app/resources/translations/zh_CN/messages.zh_CN.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   5 unused messages
+#  no unused messages
 #  43 untranslated messages
-# 195 untranslated keyword based messages
+# 197 untranslated keyword based messages
 #  49 translations
-# 335 keyword based translations
-
-#--- 5 unused messages --------------------------------------------------------
-
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
+# 334 keyword based translations
 
 #--- 43 untranslated messages -------------------------------------------------
 
@@ -68,7 +60,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 195 untranslated keyword based messages ----------------------------------
+#--- 197 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 "contenttypes.generic.invalid-relation": # "In the ContentType for '%contenttype%', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
@@ -92,6 +84,7 @@
 "general.phrase.add-selected": # "Add Selected"
 "general.phrase.author": # "Author"
 "general.phrase.change-log": # "Change Log"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -250,11 +243,11 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
 "page.extend.theme.generation.success": # "Theme successfully generated. You can now edit it directly from your theme folder."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
@@ -319,7 +312,7 @@
 "View (saved version) on site": "观看站点中(保存的版本)"
 "You've been logged on successfully.": "你已成功登录。"
 
-#--- 335 keyword based translations -------------------------------------------
+#--- 334 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "对%contenttypes%的操作"
 contenttypes.generic.actions-one: "对%contenttype%的操作"
@@ -497,7 +490,6 @@ general.phrase.order-colon-sort: "排序：%sort%"
 general.phrase.overview: "概览"
 general.phrase.overview-for: "概览"
 general.phrase.owner-colon: "所有者："
-general.phrase.page: "页面"
 general.phrase.pager-showing-from-to-of: "显示 %count% 条记录中的 %from% 到 %to% 条%pager_for%记录"
 general.phrase.path: "路径"
 general.phrase.path-colon: "路径:"

--- a/app/resources/translations/zh_TW/messages.zh_TW.yml
+++ b/app/resources/translations/zh_TW/messages.zh_TW.yml
@@ -1,26 +1,18 @@
-# app/resources/translations/zh_TW/messages.zh_TW.yml – generated on 2016-11-06 08:42:43 Europe/Amsterdam
+# app/resources/translations/zh_TW/messages.zh_TW.yml
 
 # Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the 
-#          repository are automatically mapped to the new scheme. Be aware that there 
-#          can be a race condition between that process and your PR so that it's 
-#          eventually necessary to remap your translations. If you're planning on 
+#          at the moment. This is an ongoing process. Translations currently in the
+#          repository are automatically mapped to the new scheme. Be aware that there
+#          can be a race condition between that process and your PR so that it's
+#          eventually necessary to remap your translations. If you're planning on
 #          updating your translations, it's best to ask on IRC to time your contribution
 #          in order to prevent merge conflicts.
 
-#   5 unused messages
+#  no unused messages
 #  43 untranslated messages
-# 179 untranslated keyword based messages
+# 181 untranslated keyword based messages
 #  49 translations
-# 351 keyword based translations
-
-#--- 5 unused messages --------------------------------------------------------
-
-"field.slug.button.link": #
-"page.extend.button.config": #
-"page.extend.button.readme": #
-"page.extend.button.uninstall": #
-"page.extend.button.versions": #
+# 350 keyword based translations
 
 #--- 43 untranslated messages -------------------------------------------------
 
@@ -68,7 +60,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 179 untranslated keyword based messages ----------------------------------
+#--- 181 untranslated keyword based messages ----------------------------------
 
 "contenttypes.generic.invalid-hyphen": # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 "contenttypes.generic.invalid-relation": # "In the ContentType for '%contenttype%', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
@@ -91,6 +83,7 @@
 "general.phrase.access-denied-self-action": # "You cannot '%s' yourself."
 "general.phrase.add-selected": # "Add Selected"
 "general.phrase.author": # "Author"
+"general.phrase.clashing-relation": # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 "general.phrase.clear-cache-complete": # "Cleared cache."
 "general.phrase.clear-change-log": # "Clear Change Log"
 "general.phrase.clear-system-log": # "Clear System Log"
@@ -239,10 +232,10 @@
 "page.extend.message.start-using-extension": # "You can now start using the installed extension, documentation and implementation instructions can be found using the link below."
 "page.extend.message.updated": # "Everything is up to date!"
 "page.extend.message.updating": # "Searching for available updates …"
+"page.extend.options": # "Extension Options"
 "page.extend.pagetitle": # "Extend %BOLTNAME%"
 "page.extend.theme.generation.failure": # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 "page.extend.theme.generation.missing.name": # "No theme name found. Theme is not generated."
-"page.extend.options": #
 "page.file-management.label.create-file": # "Create File"
 "page.file-management.message.save-failed-invalid-form": # "File '%s' could not be saved, because the form wasn't valid."
 "page.file-management.message.upload-not-writable": # "Unable to write to upload destination. Check permissions on %TARGET%"
@@ -303,7 +296,7 @@
 "View (saved version) on site": "觀看站點中(儲存的版本)"
 "You've been logged on successfully.": "你已成功登入。"
 
-#--- 351 keyword based translations -------------------------------------------
+#--- 350 keyword based translations -------------------------------------------
 
 contenttypes.generic.actions-all: "對%contenttypes%的操作"
 contenttypes.generic.actions-one: "對%contenttype%的操作"
@@ -484,7 +477,6 @@ general.phrase.order-colon-sort: "排序：%sort%"
 general.phrase.overview: "概覽"
 general.phrase.overview-for: "概覽"
 general.phrase.owner-colon: "所有者："
-general.phrase.page: "頁面"
 general.phrase.pager-showing-from-to-of: "顯示 %count% 條記錄中的 %from% 到 %to% 條%pager_for%記錄"
 general.phrase.path: "路徑"
 general.phrase.path-colon: "路徑:"

--- a/src/Translation/TranslationFile.php
+++ b/src/Translation/TranslationFile.php
@@ -314,12 +314,12 @@ class TranslationFile
 
         // Build List
         $indent = '    ';
-        $status = '# ' . $this->relPath . ' – generated on ' . date('Y-m-d H:i:s e') . "\n\n" .
+        $status = '# ' . $this->relPath . "\n\n" .
             '# Warning: Translations are in the process of being moved to a new keyword-based translation' . "\n" .
-            '#          at the moment. This is an ongoing process. Translations currently in the ' . "\n" .
-            '#          repository are automatically mapped to the new scheme. Be aware that there ' . "\n" .
-            '#          can be a race condition between that process and your PR so that it\'s ' . "\n" .
-            '#          eventually necessary to remap your translations. If you\'re planning on ' . "\n" .
+            '#          at the moment. This is an ongoing process. Translations currently in the' . "\n" .
+            '#          repository are automatically mapped to the new scheme. Be aware that there' . "\n" .
+            '#          can be a race condition between that process and your PR so that it\'s' . "\n" .
+            '#          eventually necessary to remap your translations. If you\'re planning on' . "\n" .
             '#          updating your translations, it\'s best to ask on IRC to time your contribution' . "\n" .
             '#          in order to prevent merge conflicts.' . "\n\n";
         $content = '';


### PR DESCRIPTION
Refresh of the translation keys for 3.2 … others branch will follow on merge.

I have also removed the "generated on" and some whitespace from the generated comment block at the top of the file, as presently this just adds to the size of a language file PR, and it is a potential for conflicts.