### PR TITLE
[4.0] Lock Codeception (again) at version 2.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     },
     "require-dev": {
         "bolt/codingstyle": "^1.0",
-        "codeception/codeception": "^2.3.1",
+        "codeception/codeception": "2.3.1",
         "league/flysystem-memory": "^1.0",
         "lstrojny/phpunit-function-mocker": "^1.0",
         "phpunit/dbunit": "^3.0",


### PR DESCRIPTION
Codeception & Symfony PHPUnit Bridge are both trying to class alias PHPUnit 4/5 classes to v6 namespaced ones, this breaks Codeception tests. :boom: 