### PR TITLE
[3.4][Tests] Deprecation use checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ script:
   # Codeception
   - ./vendor/codeception/codeception/codecept build -vvv > /dev/null
   - ./vendor/codeception/codeception/codecept run --ext DotReporter
+  # Deprecation checks
+  - ./tests/scripts/deprecation-check.sh
 
 # Cache directories
 cache:

--- a/src/Render.php
+++ b/src/Render.php
@@ -7,7 +7,7 @@ use Bolt\Response\TemplateResponse;
 use Silex;
 use Symfony\Component\HttpFoundation\Response;
 use Twig_Error_Loader as LoaderError;
-use Twig_ExistsLoaderInterface;
+use Twig_ExistsLoaderInterface as ExistsLoaderInterface;
 
 /**
  * Wrapper around Twig's render() function. Handles the following responsibilities:.
@@ -103,7 +103,7 @@ class Render
          * Twig_LoaderInterface in Twig 2.0. Check for this
          * instead once we are there, and remove getSource() check.
          */
-        if ($loader instanceof Twig_ExistsLoaderInterface) {
+        if ($loader instanceof ExistsLoaderInterface) {
             return $loader->exists($template);
         }
 

--- a/tests/scripts/deprecation-check.sh
+++ b/tests/scripts/deprecation-check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+FAILED_CHECKS="0"
+
+function add_fail() {
+    FAILED_CHECKS=1
+    echo ""
+    echo -e "\033[0;31m[FAILED]\033[0m"
+}
+function add_pass() {
+    echo ""
+    echo -e "\033[0;32m[PASSED]\033[0m"
+}
+
+echo ""
+echo "Checking Twig namespace aliases"
+echo "-------------------------------"
+echo ""
+grep -rn -P '((?<!@see|@expectedException)(^use T|\\T))(wig_\w+)\s*;' src/ tests/phpunit/ tests/codeception/
+[[ $? -eq 0 ]] && add_fail || add_pass
+echo ""
+
+echo "Checking PHPUnit namespace aliases"
+echo "----------------------------------"
+echo ""
+grep -rn -P '((?<!@see)(^use P|\\P))(HPUnit_(Framework|Util|Extensions|Runner|TextUI|Exception)_\w+)\s*;' tests/phpunit/ tests/codeception/
+[[ $? -eq 0 ]] && add_fail || add_pass
+echo ""
+
+echo "Checking PHPUnit mocks"
+echo "----------------------"
+echo ""
+grep -rn -P 'this\->getMock\(' tests/phpunit/ tests/codeception/
+[[ $? -eq 0 ]] && add_fail || add_pass
+echo ""
+
+exit $FAILED_CHECKS


### PR DESCRIPTION
This adds checks to the Travis tests for use of deprecated Twig & PHPUnit classes, and fixes one instance in `src/`.

See the Travis run for output :smile: 