### PR TITLE
[3.3] Script handler

### DIFF
--- a/src/Composer/Script/DirectoryConfigurator.php
+++ b/src/Composer/Script/DirectoryConfigurator.php
@@ -204,6 +204,9 @@ class DirectoryConfigurator
         $dirMode = $this->options->getDirMode();
         foreach ($pathNames as $name) {
             $path = $this->resolver->resolve($name);
+            if (!$this->filesystem->exists($path)) {
+                $this->filesystem->mkdir($path);
+            }
             $this->filesystem->chmod($path, $dirMode);
         }
     }

--- a/src/Composer/Script/DirectoryConfigurator.php
+++ b/src/Composer/Script/DirectoryConfigurator.php
@@ -92,7 +92,7 @@ class DirectoryConfigurator
             }
         }
 
-        if ($this->io->askConfirmation("Do you want to use Bolt's standard folder structure? ")) {
+        if ($this->io->askConfirmation("Do you want to use Bolt's standard folder structure? [<info>yes</info>] ")) {
             return;
         }
 

--- a/src/Composer/Script/DirectoryConfigurator.php
+++ b/src/Composer/Script/DirectoryConfigurator.php
@@ -120,7 +120,7 @@ class DirectoryConfigurator
             return;
         }
 
-        $this->io->writeError('Writing customized paths to <comment>.bolt.yml</>');
+        $this->io->writeError('Writing customized paths to <comment>.bolt.yml</comment>');
 
         $config = [
             'paths' => $customized,
@@ -167,7 +167,7 @@ class DirectoryConfigurator
         }
 
         $this->verbose(
-            sprintf('Moving <info>%s</> directory from <info>%s</> to <info>%s</>', $name, $origin, $target)
+            sprintf('Moving <info>%s</info> directory from <info>%s</info> to <info>%s</info>', $name, $origin, $target)
         );
 
         // ensure parent directory exists

--- a/src/Composer/Script/DirectoryConfigurator.php
+++ b/src/Composer/Script/DirectoryConfigurator.php
@@ -174,6 +174,21 @@ class DirectoryConfigurator
         $this->filesystem->mkdir(dirname($target), $this->options->getDirMode());
 
         $this->filesystem->rename($origin, $target);
+
+        $parts = explode('/', $target);
+        if (count($parts) > 1) {
+            return;
+        }
+        $match = "/^{$parts[0]}/";
+        $replace = sprintf(
+            '%s%s',
+            strpos($name, '/') === 0 ? '' : '%site%/',
+            $parts[0]
+        );
+        $target = preg_replace($match, $replace, $target);
+
+        $this->defaults->define($name, $target);
+        $this->resolver->define($name, $target);
     }
 
     /**

--- a/src/Composer/Script/DirectoryConfigurator.php
+++ b/src/Composer/Script/DirectoryConfigurator.php
@@ -172,8 +172,11 @@ class DirectoryConfigurator
 
         // ensure parent directory exists
         $this->filesystem->mkdir(dirname($target), $this->options->getDirMode());
-
-        $this->filesystem->rename($origin, $target);
+        if ($this->filesystem->exists($origin)) {
+            $this->filesystem->rename($origin, $target);
+        } else {
+            $this->filesystem->mkdir($target, $this->options->getDirMode());
+        }
 
         $parts = explode('/', $target);
         if (count($parts) > 1) {

--- a/src/Composer/Script/PathCustomizer.php
+++ b/src/Composer/Script/PathCustomizer.php
@@ -4,8 +4,8 @@ namespace Bolt\Composer\Script;
 
 use Bolt\Configuration\PathResolver;
 use Bolt\Nut\Helper\Table;
-use Bolt\Nut\Output\ModifiableOutput;
-use Bolt\Nut\Output\ModifiableOutputInterface;
+use Bolt\Nut\Output\OverwritableOutput;
+use Bolt\Nut\Output\OverwritableOutputInterface;
 use Bolt\Nut\Style\NutStyle;
 use Composer\IO\ConsoleIO;
 use Composer\IO\IOInterface;
@@ -28,7 +28,7 @@ final class PathCustomizer
     private $resolver;
     /** @var InputInterface */
     private $input;
-    /** @var ModifiableOutputInterface */
+    /** @var OverwritableOutputInterface */
     private $output;
     /** @var NutStyle */
     private $io;
@@ -47,8 +47,8 @@ final class PathCustomizer
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();
         }
-        if (!$output instanceof ModifiableOutputInterface) {
-            $output = new ModifiableOutput($output);
+        if (!$output instanceof OverwritableOutputInterface) {
+            $output = new OverwritableOutput($output);
         }
 
         $this->resolver = $resolver;


### PR DESCRIPTION
OK, so this is hours of hammering out different use-cases and debugging minus xdebug :disappointed: 

The `exists()` & `mkdir()`s need to be in both places, as if you don't modify paths, you skip the directory renaming logic, which itself needs to verify/create the target or target's base. Literally a catch-22.

Now the `define()`s were interesting, as my base use-case was to use `%site%/web/` for `web`, and `%web%/bolt-web/view` for `bolt_view`. So we move the parent first, then siblings. That meant that as the `bolt_view` sibling's base had already changed, the resolvers still thought it was located elsewhere. If someone can check my logic a few ways on that, I'd be grateful, it was a lot to think though in a short period of time.

Finally, the `explode()` part is ugly as sin, but it can go later … I gets the job done **now**, and is not exposing anything new on the API.