### PR TITLE
[2.2] Be more specific with DBAL dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
         "brandonwamboldt/utilphp" : "~1.0",
         "cocur/slugify" : "~1.0",
         "composer/composer" : "^1.2",
+        "doctrine/annotations": "1.2.*",
+        "doctrine/collections": "1.3.*",
         "doctrine/dbal" : "2.5.1",
         "erusev/parsedown-extra" : "~0.2",
         "ext-mbstring" : "*",


### PR DESCRIPTION
The 1.* version requirement pulls in the latest versions of both annotations and collections and these require PHP 5.6 or later.
Specifying 1.2 and 1.3 respectively ensures the versions match the platform requirements of Bolt.
