### PR TITLE
[3.2] Clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,59 +8,53 @@ files/*
 extensions/*
 thumbs/
 vendor/
-phpunit.xml
 theme/*
 !theme/base-*
-!theme/default
-
-# Unless you want to store vendor's "state" in your Git repo.
-composer.phar
 composer.lock
 
-# Files related to testing
+# Bolt development files
+app/src/tmp/
+app/src/docs/
+app/src/grunt-local/*.js
+app/view/maps/
+pimple.json
+
+# Bolt testing files
+coverage.xml
+phpunit.xml
+*.codeception-backup
 tests/codeception/_output
 tests/codeception/_support/*Tester.php
 tests/codeception/_support/_generated/
-tests/codeception/acceptance/AcceptanceTester.php
-tests/codeception/functional/FunctionalTester.php
-tests/codeception/unit/UnitTester.php
-*.codeception-backup
 tests/phpunit/web-root/
+
+# Common developer tools
+codeception.phar
+composer.phar
+php-cs-fixer.phar
+scrutinizer.phar
 
 # NPM, Gulp and Grunt stuff
 node_modules
 bower_components
 npm-debug.log
 .sass-cache
-app/src/tmp/
-app/src/docs/
-app/src/grunt-local/*.js
 !yarn.lock
 
 # Sourcemaps
-app/view/maps/
 *.map
 
 # File-system cruft and temporary files
-scrutinizer.phar
-php-cs-fixer.phar
 .DS_Store
 .idea
 __*
 ._*
-web
 Vagrantfile
 .vagrant*
 *.sublime-*
-/tags
 .*.swp
 .swp
 *.lock
-!yarn.lock
-.gitignore
 .buildpath
 .project
-/bolt.log
-coverage.xml
-pimple.json
 dump.php


### PR DESCRIPTION
* Group ignores contextually … Moar pretty :stuck_out_tongue_winking_eye: 
* Remove `!theme/default` as it is no longer in the repo
* Remove duplicate `!yarn.lock`
* Remove Codeception v1 ignores
* Removed `web`, `/tags` & `.gitignore` … WTF?
* Removed `/bolt.log` as it is written to the cache directory
