### PR TITLE
[4.0] Phase I: Symfony 3 & Silex 2 project filesystem layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Bolt specific stuff. Don't put config files, databases or 'vendor' in Git.
-app/cache/*
 app/config/*.yml
 app/config/extensions/
 app/database/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ app/database/*
 files/*
 extensions/*
 thumbs/
+var/*
 vendor/
 theme/*
 !theme/base-*

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -275,9 +275,10 @@ debug_trace_argument_limit: 4       # Determine how many steps in the backtrace 
 #production_error_level: 8181 # = E_ALL &~ E_NOTICE &~ E_WARNING &~ E_DEPRECATED &~ E_USER_DEPRECATED
 
 # System debug logging
+#
 # This will enable intensive logging of Silex functions and will be very hard on
-# performance and log file size.    The log file will be created in your cache
-# directory.
+# performance and log file size. The log file will be created in your site's
+# var/log/ directory.
 #
 # Enable this for short time periods only when diagnosing system issues.
 # The level can be either: DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY

--- a/src/Composer/Action/BaseAction.php
+++ b/src/Composer/Action/BaseAction.php
@@ -68,7 +68,7 @@ abstract class BaseAction
     {
         if (!$this->composer) {
             // Set composer environment variables
-            putenv('COMPOSER_HOME=' . $this->app['path_resolver']->resolve('%cache%/composer'));
+            putenv('COMPOSER_HOME=' . $this->app['path_resolver']->resolve('%var%/composer'));
 
             // Set working directory
             chdir($this->getOptions()->baseDir());

--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -37,6 +37,7 @@ class PathResolver
             'database'          => '%app%/database',
             'extensions'        => '%site%/extensions',
             'extensions_config' => '%config%/extensions',
+            'var'               => '%site%/var',
             'web'               => '%site%/public',
             'files'             => '%web%/files',
             'themes'            => '%web%/theme',

--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -32,7 +32,7 @@ class PathResolver
         return [
             'site'              => '.',
             'app'               => '%site%/app',
-            'cache'             => '%app%/cache',
+            'cache'             => '%var%/cache',
             'config'            => '%app%/config',
             'database'          => '%app%/database',
             'extensions'        => '%site%/extensions',

--- a/src/Provider/FilesystemServiceProvider.php
+++ b/src/Provider/FilesystemServiceProvider.php
@@ -44,6 +44,8 @@ class FilesystemServiceProvider implements ServiceProviderInterface
                         'extensions_config' => new Filesystem(new Local($app['path_resolver']->resolve('extensions_config'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's cache directory
                         'cache'             => new Filesystem(new Local($app['path_resolver']->resolve('cache'), LOCK_EX, Local::SKIP_LINKS)),
+                        // Volatile data
+                        'var'               => new Filesystem(new Local($app['path_resolver']->resolve('var'), LOCK_EX, Local::SKIP_LINKS)),
                     ],
                     [
                         new Plugin\HasUrl(),

--- a/src/Provider/LoggerServiceProvider.php
+++ b/src/Provider/LoggerServiceProvider.php
@@ -89,7 +89,7 @@ class LoggerServiceProvider implements ServiceProviderInterface
         };
 
         $app['monolog.logfile'] = function ($app) {
-            return $app['path_resolver']->resolve('%cache%/' . $app['config']->get('general/debuglog/filename'));
+            return $app['path_resolver']->resolve('%var%/log/' . $app['config']->get('general/debuglog/filename'));
         };
 
         $app['monolog.handler'] = $app->extend(

--- a/src/Provider/SessionServiceProvider.php
+++ b/src/Provider/SessionServiceProvider.php
@@ -207,7 +207,7 @@ class SessionServiceProvider implements ServiceProviderInterface
                 // If php.ini is using the default (files) handler, use ours instead to prevent this problem.
                 if ($options->get('save_handler') === 'files') {
                     $options->set('save_handler', 'filesystem');
-                    $options->set('save_path', 'cache://.sessions');
+                    $options->set('save_path', 'var://sessions');
                 }
 
                 $overrides = $app['session.options'];

--- a/var/.gitignore
+++ b/var/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore


### PR DESCRIPTION
tl;dr Keep volatile/generated data out of `app/` and in `var/` … as it done on real operating systems! (yes @SahAssar, that dig/joke was especially for your amusement :wink:)

## Background

In Symfony 3, things got a little more sane as far as the location of different filesystem targets, full details on the [Symfony Best Practices guide](http://symfony.com/doc/current/best_practices/creating-the-project.html#structuring-the-application), but in brief a **project's** layout should look something like this (slightly adjusted for Bolt)

```
%site%/
├─ app/
│  ├─ config/
│  └─ Resources/
├─ bin
│  └─ nut
├─ src/
│  └─ {bundled(s)}
├─ var/
│  ├─ cache/
│  ├─ logs/
│  └─ sessions/
├─ tests/
├─ vendor/
└─ web/
```
Where:

| | Description
|-|----------------
| `app/` | The application configuration, templates and translations.
| `bin/` | Executable files (e.g. bin/console).
| `src/` | The project's PHP code.
| `tests/` | Automatic tests (e.g. Unit tests).
| `var/` | Generated files (cache, logs, etc.).
| `vendor/` | The third-party dependencies.
| `web/` | The web root directory.

## PR Changes
- Add 'var' mount point to filesystem/path resolver
- Move `app/cache` to a `var/cache`
- Move session store to an **un-hidden directory** in var
- Move COMPOSER_HOME to `var/composer/`
- Move debug log file(s) to `var/log/`
