### PR TITLE
[4.0][Tests] Update Ccodeception to ^2.3.3 & PHPUnit Bridge to ^3.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     },
     "require-dev": {
         "bolt/codingstyle": "^1.0",
-        "codeception/codeception": "2.3.1",
+        "codeception/codeception": "^2.3.3",
         "league/flysystem-memory": "^1.0",
         "lstrojny/phpunit-function-mocker": "^1.0",
         "phpunit/dbunit": "^3.0",
@@ -69,7 +69,7 @@
         "psr/simple-cache": "^1.0",
         "sebastian/phpcpd": "^2.0",
         "sorien/silex-pimple-dumper": "^1.0",
-        "symfony/phpunit-bridge": "^3.3@RC"
+        "symfony/phpunit-bridge": "^3.3.2"
     },
     "conflict": {
         "rossriley/flysystem53": "*"


### PR DESCRIPTION
Upstream has made sufficient changes that these two versions now work together again.

Lets hope this is the last of this "fun" :wink: 