### PR TITLE
[3.4][Deprecations] Use namespaced Twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "symfony/web-profiler-bundle": "^2.8",
         "symfony/yaml": "^2.8",
         "tdammers/htmlmaid": "~0.7",
-        "twig/twig": "^1.28",
+        "twig/twig": "^1.34.2",
         "ua-parser/uap-php": "^3.4"
     },
     "require-dev": {

--- a/src/Asset/Snippet/Snippet.php
+++ b/src/Asset/Snippet/Snippet.php
@@ -3,7 +3,7 @@
 namespace Bolt\Asset\Snippet;
 
 use Bolt\Controller\Zone;
-use Twig_Markup as Markup;
+use Twig\Markup;
 
 /**
  * Snippet objects.

--- a/src/Asset/Widget/Queue.php
+++ b/src/Asset/Widget/Queue.php
@@ -13,8 +13,8 @@ use Bolt\Render;
 use Doctrine\Common\Cache\CacheProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Twig_Environment as TwigEnvironment;
-use Twig_Markup as TwigMarkup;
+use Twig\Environment;
+use Twig\Markup;
 
 /**
  * Widget queue processor.
@@ -32,7 +32,7 @@ class Queue implements QueueInterface
     protected $injector;
     /** @var \Doctrine\Common\Cache\CacheProvider */
     protected $cache;
-    /** @var TwigEnvironment */
+    /** @var Environment */
     protected $render;
 
     /** @var boolean */
@@ -41,11 +41,11 @@ class Queue implements QueueInterface
     /**
      * Constructor.
      *
-     * NOTE: Constructor type hint for TwigEnvironment omitted for BC, add in v4
+     * NOTE: Constructor type hint for Environment omitted for BC, add in v4
      *
-     * @param Injector        $injector
-     * @param CacheProvider   $cache
-     * @param TwigEnvironment $render
+     * @param Injector      $injector
+     * @param CacheProvider $cache
+     * @param Environment   $render
      */
     public function __construct(Injector $injector, CacheProvider $cache, $render)
     {
@@ -54,7 +54,7 @@ class Queue implements QueueInterface
         $this->render = $render;
 
         if ($render instanceof Render) {
-            Deprecated::warn('Passing Bolt\Render to the widget queue constructor', 3.3, 'Pass in Twig_Environment instead.');
+            Deprecated::warn('Passing Bolt\Render to the widget queue constructor', 3.3, 'Pass in Twig\Environment instead.');
         }
     }
 
@@ -86,7 +86,7 @@ class Queue implements QueueInterface
      *
      * @param string $key
      *
-     * @return TwigMarkup|string
+     * @return Markup|string
      */
     public function getRendered($key)
     {

--- a/src/EventListener/ConfigListener.php
+++ b/src/EventListener/ConfigListener.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Twig_Environment as Environment;
+use Twig\Environment;
 
 /**
  * Configuration checks at the start of the request cycle.

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Twig_Environment as Environment;
+use Twig\Environment;
 
 /**
  * HTTP kernel exception routing listener.

--- a/src/EventListener/NotFoundListener.php
+++ b/src/EventListener/NotFoundListener.php
@@ -12,9 +12,9 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Twig_Environment as TwigEnvironment;
-use Twig_Error_Loader as LoaderError;
-use Twig_Error_Runtime as RuntimeError;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
 
 /**
  * Renders the not found page in the event of an HTTP exception.
@@ -29,7 +29,7 @@ class NotFoundListener implements EventSubscriberInterface
     protected $storage;
     /** @var TemplateChooser */
     protected $templateChooser;
-    /** @var TwigEnvironment */
+    /** @var Environment */
     private $twig;
 
     /**
@@ -38,9 +38,9 @@ class NotFoundListener implements EventSubscriberInterface
      * @param string          $notFoundPage
      * @param Storage         $storage
      * @param TemplateChooser $templateChooser
-     * @param TwigEnvironment $twig
+     * @param Environment $twig
      */
-    public function __construct($notFoundPage, Storage $storage, TemplateChooser $templateChooser, TwigEnvironment $twig)
+    public function __construct($notFoundPage, Storage $storage, TemplateChooser $templateChooser, Environment $twig)
     {
         $this->notFoundPage = $notFoundPage;
         $this->storage = $storage;

--- a/src/EventListener/TemplateViewListener.php
+++ b/src/EventListener/TemplateViewListener.php
@@ -7,7 +7,7 @@ use Bolt\Response\TemplateView;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Twig_Environment as TwigEnvironment;
+use Twig\Environment;
 
 /**
  * Converts controller results that are TemplateView's to TemplateResponse's.
@@ -16,15 +16,15 @@ use Twig_Environment as TwigEnvironment;
  */
 class TemplateViewListener implements EventSubscriberInterface
 {
-    /** @var TwigEnvironment */
+    /** @var Environment */
     protected $twig;
 
     /**
      * Constructor.
      *
-     * @param TwigEnvironment $twig
+     * @param Environment $twig
      */
-    public function __construct(TwigEnvironment $twig)
+    public function __construct(Environment $twig)
     {
         $this->twig = $twig;
     }

--- a/src/Extension/TwigTrait.php
+++ b/src/Extension/TwigTrait.php
@@ -5,12 +5,12 @@ namespace Bolt\Extension;
 use Bolt\Filesystem\Handler\DirectoryInterface;
 use Bolt\Twig\SecurityPolicy;
 use Pimple as Container;
-use Twig_Environment as Environment;
-use Twig_Error_Loader as LoaderError;
-use Twig_Extension_Sandbox as Sandbox;
-use Twig_Loader_Filesystem as FilesystemLoader;
-use Twig_SimpleFilter as TwigFilter;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Extension\SandboxExtension;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Twig function/filter addition and interface functions for an extension.
@@ -150,12 +150,12 @@ trait TwigTrait
 
     private function updateSandboxPolicy(Environment $twig)
     {
-        if (!$twig->hasExtension(Sandbox::class)) {
+        if (!$twig->hasExtension(SandboxExtension::class)) {
             return;
         }
 
-        /** @var Sandbox $sandbox */
-        $sandbox = $twig->getExtension(Sandbox::class);
+        /** @var SandboxExtension $sandbox */
+        $sandbox = $twig->getExtension(SandboxExtension::class);
         $policy = $sandbox->getSecurityPolicy();
         if (!$policy instanceof SecurityPolicy) {
             return;

--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -4,7 +4,7 @@ namespace Bolt\Legacy;
 
 use Bolt\Storage\Entity;
 use Silex;
-use Twig_Markup as Markup;
+use Twig\Markup;
 
 /**
  * Legacy Content class.

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -15,10 +15,10 @@ use Silex\ServiceProviderInterface;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\AssetExtension;
 use Symfony\Bridge\Twig\Extension\HttpFoundationExtension;
-use Twig_Environment as Environment;
-use Twig_Extension_Sandbox as SandboxExtension;
-use Twig_Extension_StringLoader as StringLoaderExtension;
-use Twig_Loader_Chain as ChainLoader;
+use Twig\Environment;
+use Twig\Extension\SandboxExtension;
+use Twig\Extension\StringLoaderExtension;
+use Twig\Loader\ChainLoader;
 
 class TwigServiceProvider implements ServiceProviderInterface
 {

--- a/src/Render.php
+++ b/src/Render.php
@@ -6,8 +6,8 @@ use Bolt\Helpers\Deprecated;
 use Bolt\Response\TemplateResponse;
 use Silex;
 use Symfony\Component\HttpFoundation\Response;
-use Twig_Error_Loader as LoaderError;
-use Twig_ExistsLoaderInterface as ExistsLoaderInterface;
+use Twig\Error\LoaderError;
+use Twig\Loader\ExistsLoaderInterface;
 
 /**
  * Wrapper around Twig's render() function. Handles the following responsibilities:.

--- a/src/Response/BoltResponse.php
+++ b/src/Response/BoltResponse.php
@@ -4,8 +4,8 @@ namespace Bolt\Response;
 
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Stopwatch\Stopwatch;
-use Twig_Error as TwigError;
-use Twig_Template as Template;
+use Twig\Error\Error;
+use Twig\Template;
 
 /**
  * BoltResponse uses a renderer and context variables
@@ -216,7 +216,7 @@ class BoltResponse extends Response
     private function handleException(\Exception $e)
     {
         trigger_error($e->getMessage() . "\n" . $e->getTraceAsString(), E_USER_WARNING);
-        if ($e instanceof TwigError) {
+        if ($e instanceof Error) {
             return '<strong>' . $e->getRawMessage() . '</strong>';
         }
 

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -7,9 +7,9 @@ use Bolt\Helpers\Input;
 use Bolt\Legacy;
 use Bolt\Library as Lib;
 use Bolt\Storage\Field\Collection\RepeatingFieldCollection;
-use Twig_Environment as Environment;
-use Twig_Error_Loader as LoaderError;
-use Twig_Markup as Markup;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Markup;
 
 /**
  * Trait class for ContentType relations.
@@ -62,7 +62,7 @@ trait ContentValuesTrait
      * @param boolean      $includeTitle
      * @param string|array $focus
      *
-     * @return \Twig_Markup
+     * @return Markup
      */
     public function excerpt($length = 200, $includeTitle = false, $focus = null)
     {

--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -5,7 +5,7 @@ namespace Bolt\Storage\Field\Collection;
 use Bolt\Storage\Entity\FieldValue;
 use Doctrine\Common\Collections\ArrayCollection;
 use ParsedownExtra as Markdown;
-use Twig_Markup as Markup;
+use Twig\Markup;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Storage/Field/Type/TemplateFieldsType.php
+++ b/src/Storage/Field/Type/TemplateFieldsType.php
@@ -9,7 +9,7 @@ use Bolt\Storage\Mapping\ContentType;
 use Bolt\Storage\QuerySet;
 use Bolt\TemplateChooser;
 use Doctrine\DBAL\Types\Type;
-use Twig_Environment as TwigEnvironment;
+use Twig\Environment;
 
 /**
  * This is one of a suite of basic Bolt field transformers that handles
@@ -21,7 +21,7 @@ class TemplateFieldsType extends FieldTypeBase
 {
     /** @var TemplateChooser */
     public $chooser;
-    /** @var TwigEnvironment */
+    /** @var Environment */
     private $twig;
 
     /**
@@ -30,9 +30,9 @@ class TemplateFieldsType extends FieldTypeBase
      * @param array           $mapping
      * @param EntityManager   $em
      * @param TemplateChooser $chooser
-     * @param TwigEnvironment $twig
+     * @param Environment     $twig
      */
-    public function __construct(array $mapping, EntityManager $em, TemplateChooser $chooser, TwigEnvironment $twig)
+    public function __construct(array $mapping, EntityManager $em, TemplateChooser $chooser, Environment $twig)
     {
         parent::__construct($mapping, $em);
         $this->chooser = $chooser;

--- a/src/Twig/ArrayAccessSecurityProxy.php
+++ b/src/Twig/ArrayAccessSecurityProxy.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
 use IteratorAggregate;
 use IteratorIterator;
 use Traversable;
-use Twig_Extension_Sandbox as Sandbox;
+use Twig\Extension\SandboxExtension;
 
 /**
  * This is a proxy for arrays and ArrayAccess objects that verifies access with a Twig Sandbox.
@@ -24,7 +24,7 @@ class ArrayAccessSecurityProxy implements ArrayAccess, Countable, IteratorAggreg
 
     /** @var array|ArrayAccess */
     protected $object;
-    /** @var Sandbox */
+    /** @var SandboxExtension */
     protected $sandbox;
     /** @var string */
     protected $class;
@@ -33,11 +33,11 @@ class ArrayAccessSecurityProxy implements ArrayAccess, Countable, IteratorAggreg
      * Constructor.
      *
      * @param array|ArrayAccess $array       The object or array to proxy to
-     * @param Sandbox           $sandbox     The Sandbox to verify with
+     * @param SandboxExtension  $sandbox     The Sandbox to verify with
      * @param string            $fakeClass   A class name to use for checking with Sandbox and dumper (if object)
      * @param bool              $transparent Whether this proxy should be transparent to the VarDumper
      */
-    public function __construct($array, Sandbox $sandbox, $fakeClass = null, $transparent = true)
+    public function __construct($array, SandboxExtension $sandbox, $fakeClass = null, $transparent = true)
     {
         if (!is_array($array) && !$array instanceof ArrayAccess) {
             throw new InvalidArgumentException('Must be given an array, or an object implementing ArrayAccess');

--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -3,10 +3,10 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFilter as TwigFilter;
-use Twig_SimpleFunction as TwigFunction;
-use Twig_SimpleTest as TwigTest;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\TwigTest;
 
 /**
  * Admin (back-end) functionality Twig extension.
@@ -15,7 +15,7 @@ use Twig_SimpleTest as TwigTest;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class AdminExtension extends Extension
+class AdminExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Extension/ArrayExtension.php
+++ b/src/Twig/Extension/ArrayExtension.php
@@ -2,16 +2,16 @@
 
 namespace Bolt\Twig\Extension;
 
-use Twig_Extension as Extension;
-use Twig_SimpleFilter as TwigFilter;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Bolt specific Twig functions and filters that provide array manipulation.
  *
  * @internal
  */
-class ArrayExtension extends Extension
+class ArrayExtension extends AbstractExtension
 {
     private $orderOn;
     private $orderAscending;

--- a/src/Twig/Extension/BoltExtension.php
+++ b/src/Twig/Extension/BoltExtension.php
@@ -8,15 +8,15 @@ use Bolt\Configuration\PathsProxy;
 use Bolt\Storage\EntityManagerInterface;
 use Bolt\Twig\SetcontentTokenParser;
 use Bolt\Twig\SwitchTokenParser;
-use Twig_Extension as Extension;
-use Twig_SimpleFilter as TwigFilter;
-use Twig_SimpleFunction as TwigFunction;
-use Twig_Extension_GlobalsInterface as GlobalsInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Bolt base Twig functionality and definitions.
  */
-class BoltExtension extends Extension implements GlobalsInterface
+class BoltExtension extends AbstractExtension implements GlobalsInterface
 {
     /** @var EntityManagerInterface */
     private $em;

--- a/src/Twig/Extension/DumpExtension.php
+++ b/src/Twig/Extension/DumpExtension.php
@@ -4,8 +4,8 @@ namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime\DumpRuntime;
 use Symfony\Bridge\Twig\TokenParser\DumpTokenParser;
-use Twig_SimpleFunction as TwigFunction;
-use Twig_Extension as Extension;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Modified version of Twig Bridge's DumpExtension to use runtime loading.
@@ -13,7 +13,7 @@ use Twig_Extension as Extension;
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
-class DumpExtension extends Extension
+class DumpExtension extends AbstractExtension
 {
     public function getFunctions()
     {

--- a/src/Twig/Extension/HtmlExtension.php
+++ b/src/Twig/Extension/HtmlExtension.php
@@ -3,9 +3,9 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFilter as TwigFilter;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * HTML functionality Twig extension.
@@ -14,7 +14,7 @@ use Twig_SimpleFunction as TwigFunction;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class HtmlExtension extends Extension
+class HtmlExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Extension/ImageExtension.php
+++ b/src/Twig/Extension/ImageExtension.php
@@ -3,9 +3,9 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFilter as TwigFilter;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Image functionality Twig extension.
@@ -14,7 +14,7 @@ use Twig_SimpleFunction as TwigFunction;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ImageExtension extends Extension
+class ImageExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Extension/RecordExtension.php
+++ b/src/Twig/Extension/RecordExtension.php
@@ -3,9 +3,9 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFilter as TwigFilter;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Content record functionality Twig extension.
@@ -14,7 +14,7 @@ use Twig_SimpleFunction as TwigFunction;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class RecordExtension extends Extension
+class RecordExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Extension/RoutingExtension.php
+++ b/src/Twig/Extension/RoutingExtension.php
@@ -3,8 +3,8 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Routing functionality Twig extension.
@@ -13,7 +13,7 @@ use Twig_SimpleFunction as TwigFunction;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class RoutingExtension extends Extension
+class RoutingExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Extension/TextExtension.php
+++ b/src/Twig/Extension/TextExtension.php
@@ -3,9 +3,9 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFilter as TwigFilter;
-use Twig_SimpleTest as TwigTest;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigTest;
 
 /**
  * Text functionality Twig extension.
@@ -14,7 +14,7 @@ use Twig_SimpleTest as TwigTest;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class TextExtension extends Extension
+class TextExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Extension/UserExtension.php
+++ b/src/Twig/Extension/UserExtension.php
@@ -3,8 +3,8 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * User functionality Twig extension.
@@ -13,7 +13,7 @@ use Twig_SimpleFunction as TwigFunction;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class UserExtension extends Extension
+class UserExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Extension/UtilsExtension.php
+++ b/src/Twig/Extension/UtilsExtension.php
@@ -3,8 +3,8 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * General-purpose utility functionality Twig extension.
@@ -13,7 +13,7 @@ use Twig_SimpleFunction as TwigFunction;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class UtilsExtension extends Extension
+class UtilsExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/Extension/WidgetExtension.php
+++ b/src/Twig/Extension/WidgetExtension.php
@@ -3,8 +3,8 @@
 namespace Bolt\Twig\Extension;
 
 use Bolt\Twig\Runtime;
-use Twig_Extension as Extension;
-use Twig_SimpleFunction as TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Widget functionality Twig extension.
@@ -13,7 +13,7 @@ use Twig_SimpleFunction as TwigFunction;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class WidgetExtension extends Extension
+class WidgetExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Twig/FilesystemLoader.php
+++ b/src/Twig/FilesystemLoader.php
@@ -6,9 +6,9 @@ use Bolt\Filesystem\Exception\ExceptionInterface;
 use Bolt\Filesystem\FilesystemInterface;
 use Bolt\Filesystem\Handler\DirectoryInterface;
 use Bolt\Filesystem\Handler\FileInterface;
-use Twig_Error_Loader as LoaderError;
-use Twig_Loader_Filesystem as TwigFilesystemLoader;
-use Twig_Source as TwigSource;
+use Twig\Error\LoaderError;
+use Twig\Loader\FilesystemLoader as TwigFilesystemLoader;
+use Twig\Source;
 
 /**
  * Loads templates from a Bolt\Filesystem interface.
@@ -55,7 +55,7 @@ class FilesystemLoader extends TwigFilesystemLoader
     {
         $file = $this->findTemplate($name);
 
-        return new TwigSource($file->read(), $name);
+        return new Source($file->read(), $name);
     }
 
     /**

--- a/src/Twig/Runtime/DumpRuntime.php
+++ b/src/Twig/Runtime/DumpRuntime.php
@@ -3,10 +3,10 @@
 namespace Bolt\Twig\Runtime;
 
 use Bolt\Users;
-use Twig_Environment as Environment;
-use Twig_Template as Template;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Twig\Environment;
+use Twig\Template;
 
 /**
  * Twig Bridge's DumpExtension's runtime logic with custom enabled check.

--- a/src/Twig/Runtime/HtmlRuntime.php
+++ b/src/Twig/Runtime/HtmlRuntime.php
@@ -9,7 +9,7 @@ use Bolt\Legacy\Content;
 use Bolt\Menu\MenuBuilder;
 use Bolt\Storage\EntityManager;
 use Maid\Maid;
-use Twig_Environment as Environment;
+use Twig\Environment;
 
 /**
  * Bolt specific Twig functions and filters for HTML.

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -12,7 +12,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\Glob;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Twig_Environment as Environment;
+use Twig\Environment;
 
 /**
  * Bolt specific Twig functions and filters that provide \Bolt\Legacy\Content manipulation.

--- a/src/Twig/Runtime/WidgetRuntime.php
+++ b/src/Twig/Runtime/WidgetRuntime.php
@@ -4,8 +4,8 @@ namespace Bolt\Twig\Runtime;
 
 use Bolt\Asset\Widget\Queue;
 use Bolt\Controller\Zone;
-use Twig_Environment as Environment;
-use Twig_Markup as Markup;
+use Twig\Environment;
+use Twig\Markup;
 
 /**
  * Bolt specific Twig functions and filters for HTML.

--- a/src/Twig/RuntimeLoader.php
+++ b/src/Twig/RuntimeLoader.php
@@ -3,7 +3,7 @@
 namespace Bolt\Twig;
 
 use Pimple as Container;
-use Twig_RuntimeLoaderInterface as RuntimeLoaderInterface;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
 /**
  * Twig RuntimeLoader implementation.

--- a/src/Twig/SafeEnvironment.php
+++ b/src/Twig/SafeEnvironment.php
@@ -3,8 +3,8 @@
 namespace Bolt\Twig;
 
 use Bolt\Helpers\Deprecated;
-use Twig_Environment as Environment;
-use Twig_Extension_Sandbox as Sandbox;
+use Twig\Environment;
+use Twig\Extension\SandboxExtension;
 use Twig_ExtensionInterface as ExtensionInterface;
 
 /**
@@ -23,10 +23,10 @@ class SafeEnvironment extends TwigEnvironmentWrapper
     /**
      * Constructor.
      *
-     * @param Environment $env
-     * @param Sandbox     $sandbox
+     * @param Environment      $env
+     * @param SandboxExtension $sandbox
      */
-    public function __construct(Environment $env, Sandbox $sandbox)
+    public function __construct(Environment $env, SandboxExtension $sandbox)
     {
         Deprecated::method(3.3);
 

--- a/src/Twig/SecurityPolicy.php
+++ b/src/Twig/SecurityPolicy.php
@@ -2,12 +2,12 @@
 
 namespace Bolt\Twig;
 
-use Twig_Markup as Markup;
-use Twig_Sandbox_SecurityError as SecurityError;
-use Twig_Sandbox_SecurityNotAllowedFilterError as SecurityNotAllowedFilterError;
-use Twig_Sandbox_SecurityNotAllowedFunctionError as SecurityNotAllowedFunctionError;
-use Twig_Sandbox_SecurityNotAllowedTagError as SecurityNotAllowedTagError;
-use Twig_Sandbox_SecurityPolicyInterface as SecurityPolicyInterface;
+use Twig\Markup;
+use Twig\Sandbox\SecurityError as SecurityError;
+use Twig\Sandbox\SecurityNotAllowedFilterError;
+use Twig\Sandbox\SecurityNotAllowedFunctionError;
+use Twig\Sandbox\SecurityNotAllowedTagError;
+use Twig\Sandbox\SecurityPolicyInterface;
 use Twig_TemplateInterface as TemplateInterface;
 
 /**

--- a/src/Twig/SetcontentNode.php
+++ b/src/Twig/SetcontentNode.php
@@ -3,9 +3,9 @@
 namespace Bolt\Twig;
 
 use Bolt\Twig\Extension\BoltExtension;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Node;
 use Twig_Compiler as Compiler;
-use Twig_Node as Node;
-use Twig_Node_Expression_Array as NodeExpressionArray;
 
 /**
  * Twig setcontent node.
@@ -17,14 +17,14 @@ class SetcontentNode extends Node
     /**
      * Constructor.
      *
-     * @param string              $name
-     * @param Node                $contentType
-     * @param NodeExpressionArray $arguments
-     * @param array               $whereArguments
-     * @param int                 $lineNo
-     * @param null                $tag
+     * @param string          $name
+     * @param Node            $contentType
+     * @param ArrayExpression $arguments
+     * @param array           $whereArguments
+     * @param int             $lineNo
+     * @param null            $tag
      */
-    public function __construct($name, Node $contentType, NodeExpressionArray $arguments, array $whereArguments, $lineNo, $tag = null)
+    public function __construct($name, Node $contentType, ArrayExpression $arguments, array $whereArguments, $lineNo, $tag = null)
     {
         parent::__construct(
             $whereArguments,

--- a/src/Twig/SetcontentTokenParser.php
+++ b/src/Twig/SetcontentTokenParser.php
@@ -2,17 +2,17 @@
 
 namespace Bolt\Twig;
 
-use Twig_Node_Expression_Array as NodeExpressionArray;
-use Twig_Node_Expression_Constant as NodeExpressionConstant;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\TokenParser\AbstractTokenParser;
 use Twig_Token as Token;
-use Twig_TokenParser as TokenParser;
 
 /**
  * Twig {{ setcontent }} token parser.
  *
  * @author Bob den Otter <bob@twokings.nl>
  */
-class SetcontentTokenParser extends TokenParser
+class SetcontentTokenParser extends AbstractTokenParser
 {
     /**
      * {@inheritdoc}
@@ -21,7 +21,7 @@ class SetcontentTokenParser extends TokenParser
     {
         $lineno = $token->getLine();
 
-        $arguments = new NodeExpressionArray([], $lineno);
+        $arguments = new ArrayExpression([], $lineno);
         $whereArguments = [];
 
         // name - the new variable with the results
@@ -44,7 +44,7 @@ class SetcontentTokenParser extends TokenParser
             if ($this->parser->getStream()->test(Token::NAME_TYPE, 'limit')) {
                 $this->parser->getStream()->next();
                 $limit = $this->parser->getExpressionParser()->parseExpression();
-                $arguments->addElement($limit, new NodeExpressionConstant('limit', $lineno));
+                $arguments->addElement($limit, new ConstantExpression('limit', $lineno));
             }
 
             // order / orderby parameter
@@ -52,7 +52,7 @@ class SetcontentTokenParser extends TokenParser
                 $this->parser->getStream()->test(Token::NAME_TYPE, 'orderby')) {
                 $this->parser->getStream()->next();
                 $order = $this->parser->getExpressionParser()->parseExpression();
-                $arguments->addElement($order, new NodeExpressionConstant('order', $lineno));
+                $arguments->addElement($order, new ConstantExpression('order', $lineno));
             }
 
             // paging / allowpaging parameter
@@ -60,8 +60,8 @@ class SetcontentTokenParser extends TokenParser
                 $this->parser->getStream()->test(Token::NAME_TYPE, 'allowpaging')) {
                 $this->parser->getStream()->next();
                 $arguments->addElement(
-                    new NodeExpressionConstant(true, $lineno),
-                    new NodeExpressionConstant('paging', $lineno)
+                    new ConstantExpression(true, $lineno),
+                    new ConstantExpression('paging', $lineno)
                 );
             }
 
@@ -69,8 +69,8 @@ class SetcontentTokenParser extends TokenParser
             if ($this->parser->getStream()->test(Token::NAME_TYPE, 'printquery')) {
                 $this->parser->getStream()->next();
                 $arguments->addElement(
-                    new NodeExpressionConstant(true, $lineno),
-                    new NodeExpressionConstant('printquery', $lineno)
+                    new ConstantExpression(true, $lineno),
+                    new ConstantExpression('printquery', $lineno)
                 );
             }
 
@@ -78,8 +78,8 @@ class SetcontentTokenParser extends TokenParser
             if ($this->parser->getStream()->test(Token::NAME_TYPE, 'returnsingle')) {
                 $this->parser->getStream()->next();
                 $arguments->addElement(
-                    new NodeExpressionConstant(true, $lineno),
-                    new NodeExpressionConstant('returnsingle', $lineno)
+                    new ConstantExpression(true, $lineno),
+                    new ConstantExpression('returnsingle', $lineno)
                 );
             }
 
@@ -87,8 +87,8 @@ class SetcontentTokenParser extends TokenParser
             if ($this->parser->getStream()->test(Token::NAME_TYPE, 'nohydrate')) {
                 $this->parser->getStream()->next();
                 $arguments->addElement(
-                    new NodeExpressionConstant(false, $lineno),
-                    new NodeExpressionConstant('hydrate', $lineno)
+                    new ConstantExpression(false, $lineno),
+                    new ConstantExpression('hydrate', $lineno)
                 );
             }
 

--- a/src/Twig/SwitchNode.php
+++ b/src/Twig/SwitchNode.php
@@ -2,7 +2,7 @@
 
 namespace Bolt\Twig;
 
-use Twig_Node as Node;
+use Twig\Node\Node;
 use Twig_Compiler as Compiler;
 
 /**

--- a/src/Twig/SwitchTokenParser.php
+++ b/src/Twig/SwitchTokenParser.php
@@ -2,10 +2,10 @@
 
 namespace Bolt\Twig;
 
-use Twig_Error_Syntax as TwigSyntaxError;
-use Twig_Node as Node;
+use Twig\Error\SyntaxError;
+use Twig\Node\Node;
+use Twig\TokenParser\AbstractTokenParser;
 use Twig_Token as Token;
-use Twig_TokenParser as TokenParser;
 
 /**
  * Adapted from code originally in Twig/extensions.
@@ -25,14 +25,14 @@ use Twig_TokenParser as TokenParser;
  *
  * @see: https://gist.github.com/maxgalbu/9409182
  */
-class SwitchTokenParser extends TokenParser
+class SwitchTokenParser extends AbstractTokenParser
 {
     /**
      * Parses a token and returns a node.
      *
      * @param Token $token A Token instance
      *
-     * @throws TwigSyntaxError
+     * @throws SyntaxError
      *
      * @return Node A Twig node instance
      */
@@ -73,7 +73,7 @@ class SwitchTokenParser extends TokenParser
                 default:
                     $message = sprintf('Unexpected end of template. Twig was looking for the following tags "case", "default", or "endswitch" to close the "switch" block started at line %d)', $v->getLine());
 
-                    throw new TwigSyntaxError($message, $v->getLine());
+                    throw new SyntaxError($message, $v->getLine());
             }
         }
 

--- a/src/Twig/TwigEnvironmentWrapper.php
+++ b/src/Twig/TwigEnvironmentWrapper.php
@@ -2,8 +2,8 @@
 
 namespace Bolt\Twig;
 
+use Twig\Environment;
 use Twig_CompilerInterface as CompilerInterface;
-use Twig_Environment as Environment;
 use Twig_ExtensionInterface as ExtensionInterface;
 use Twig_LexerInterface as LexerInterface;
 use Twig_LoaderInterface as LoaderInterface;

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -451,7 +451,7 @@ class FrontendTest extends ControllerUnitTest
     }
 
     /**
-     * @expectedException \Twig_Error_Loader
+     * @expectedException \Twig\Error\LoaderError
      * @expectedExceptionMessage Template "nonexistent.twig" is not defined.
      */
     public function testFailingTemplateRender()

--- a/tests/phpunit/unit/Extension/TwigTraitTest.php
+++ b/tests/phpunit/unit/Extension/TwigTraitTest.php
@@ -8,7 +8,7 @@ use Bolt\Filesystem\Handler\DirectoryInterface;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\TwigExtension;
 use Bolt\Twig\FilesystemLoader;
-use Twig_Loader_Array as ArrayLoader;
+use Twig\Loader\ArrayLoader;
 
 /**
  * Class to test Bolt\Extension\TwigTrait.

--- a/tests/phpunit/unit/Extensions/Mock/TwigExtension.php
+++ b/tests/phpunit/unit/Extensions/Mock/TwigExtension.php
@@ -2,14 +2,14 @@
 
 namespace Bolt\Tests\Extensions\Mock;
 
-use Twig_Extension as Extension;
+use Twig\Extension\AbstractExtension;
 
 /**
  * Class to test correct operation and locations of composer configuration.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class TwigExtension extends Extension
+class TwigExtension extends AbstractExtension
 {
     public function getName()
     {

--- a/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
@@ -5,7 +5,7 @@ namespace Bolt\Tests\Provider;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Extension\BoltExtension;
 use Bolt\Twig\SafeEnvironment;
-use Twig_Environment as Environment;
+use Twig\Environment;
 
 /**
  * @covers \Bolt\Provider\TwigServiceProvider

--- a/tests/phpunit/unit/Twig/AbstractTestTokenParser.php
+++ b/tests/phpunit/unit/Twig/AbstractTestTokenParser.php
@@ -3,12 +3,12 @@
 namespace Bolt\Tests\Twig;
 
 use Bolt\Tests\BoltUnitTest;
-use Twig_TokenParser as TokenParser;
-use Twig_Environment as Environment;
-use Twig_LoaderInterface as LoaderInterface;
-use Twig_Node as Node;
-use Twig_Parser as Parser;
-use Twig_TokenStream as TokenStream;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
+use Twig\Node\Node;
+use Twig\Parser;
+use Twig\TokenParser\AbstractTokenParser;
+use Twig\TokenStream;
 
 /**
  * Abstract TokenParser test base.
@@ -23,12 +23,12 @@ abstract class AbstractTestTokenParser extends BoltUnitTest
      * @return Parser
      */
     /**
-     * @param TokenStream $tokenStream
-     * @param TokenParser $testParser
+     * @param TokenStream         $tokenStream
+     * @param AbstractTokenParser $testParser
      *
      * @return Parser
      */
-    protected function getParser(TokenStream $tokenStream, TokenParser $testParser)
+    protected function getParser(TokenStream $tokenStream, AbstractTokenParser $testParser)
     {
         $env = new Environment($this->getMockBuilder(LoaderInterface::class)->getMock());
         $parser = new Parser($env);

--- a/tests/phpunit/unit/Twig/Runtime/DumpRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/DumpRuntimeTest.php
@@ -6,10 +6,10 @@ use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Runtime\DumpRuntime;
 use Bolt\Users;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
-use Twig_Environment as Environment;
-use Twig_Loader_Array as ArrayLoader;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
 
 /**
  * Class to test Bolt\Twig\Runtime\DumpRuntime.

--- a/tests/phpunit/unit/Twig/SetcontentTokenParserTest.php
+++ b/tests/phpunit/unit/Twig/SetcontentTokenParserTest.php
@@ -4,15 +4,15 @@ namespace Bolt\Tests\Twig;
 
 use Bolt\Twig\SetcontentNode;
 use Bolt\Twig\SetcontentTokenParser;
-use Twig_Compiler as Compiler;
-use Twig_Environment as Environment;
-use Twig_LoaderInterface as LoaderInterface;
-use Twig_Node_Body as NodeBody;
-use Twig_Node_Module as NodeModule;
-use Twig_Source as Source;
-use Twig_Token as Token;
-use Twig_TokenParser as TokenParser;
-use Twig_TokenStream as TokenStream;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
+use Twig\Node\BodyNode;
+use Twig\Node\ModuleNode;
+use Twig\Source;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+use Twig\TokenStream;
 
 /**
  * Class to test Twig {{ setcontent }} token classes.
@@ -24,7 +24,7 @@ class SetcontentTestTokenParser extends AbstractTestTokenParser
     public function testClass()
     {
         $setContentParser = new SetcontentTokenParser();
-        $this->assertInstanceOf(TokenParser::class, $setContentParser);
+        $this->assertInstanceOf(AbstractTokenParser::class, $setContentParser);
     }
 
     public function testGetTag()
@@ -74,9 +74,9 @@ class SetcontentTestTokenParser extends AbstractTestTokenParser
         $twigTokenStream = new TokenStream($streamTokens, new Source(null, 'clippy'));
 
         $parser = $this->getParser($twigTokenStream, new SetcontentTokenParser());
-        /** @var NodeModule $setContentNode */
+        /** @var ModuleNode $setContentNode */
         $setContentNode = $parser->parse($twigTokenStream);
-        /** @var NodeBody $bodyNodes */
+        /** @var BodyNode $bodyNodes */
         $bodyNodes = $setContentNode->getNode('body');
 
         /** @var SetcontentNode $bodyNode */

--- a/tests/phpunit/unit/Twig/SwitchTokenParserTest.php
+++ b/tests/phpunit/unit/Twig/SwitchTokenParserTest.php
@@ -4,16 +4,16 @@ namespace Bolt\Tests\Twig;
 
 use Bolt\Twig\SwitchNode;
 use Bolt\Twig\SwitchTokenParser;
-use Twig_Compiler as Compiler;
-use Twig_Environment as Environment;
-use Twig_LoaderInterface as LoaderInterface;
-use Twig_Node as Node;
-use Twig_Node_Module as NodeModule;
-use Twig_Node_Set as NodeSet;
-use Twig_Source as Source;
-use Twig_Token as Token;
-use Twig_TokenParser as TokenParser;
-use Twig_TokenStream as TokenStream;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
+use Twig\Node\ModuleNode;
+use Twig\Node\Node;
+use Twig\Node\SetNode;
+use Twig\Source;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+use Twig\TokenStream;
 
 /**
  * Class to test Twig {{ switch }} token classes.
@@ -25,7 +25,7 @@ class SwitchTokenParserTest extends AbstractTestTokenParser
     public function testClass()
     {
         $switchTokenParser = new SwitchTokenParser();
-        $this->assertInstanceOf(TokenParser::class, $switchTokenParser);
+        $this->assertInstanceOf(AbstractTokenParser::class, $switchTokenParser);
     }
 
     public function testGetTag()
@@ -101,12 +101,12 @@ class SwitchTokenParserTest extends AbstractTestTokenParser
         $twigTokenStream = new TokenStream($streamTokens, new Source(null, 'clippy'));
 
         $parser = $this->getParser($twigTokenStream, new SwitchTokenParser());
-        /** @var NodeModule $nodeModule */
+        /** @var ModuleNode $nodeModule */
         $nodeModule = $parser->parse($twigTokenStream);
         /** @var Node $bodyNodes */
         $bodyNodes = $nodeModule->getNode('body')->getIterator()->current();
 
-        /** @var NodeSet $setNode */
+        /** @var SetNode $setNode */
         $setNode = $bodyNodes->getNode(0);
         /** @var SwitchNode $switchNode */
         $switchNode = $bodyNodes->getNode(1);
@@ -167,7 +167,7 @@ class SwitchTokenParserTest extends AbstractTestTokenParser
     }
 
     /**
-     * @expectedException \Twig_Error_Syntax
+     * @expectedException \Twig\Error\SyntaxError
      * @expectedExceptionMessageRegExp /Twig was looking for the following tags "case", "default", or "endswitch"/
      */
     public function testParseBad()
@@ -196,7 +196,7 @@ class SwitchTokenParserTest extends AbstractTestTokenParser
         $twigTokenStream = new TokenStream($streamTokens, new Source(null, 'clippy'));
 
         $parser = $this->getParser($twigTokenStream, new SwitchTokenParser());
-        /** @var NodeModule $nodeModule */
+        /** @var ModuleNode $nodeModule */
         $parser->parse($twigTokenStream);
     }
 }


### PR DESCRIPTION
So the awesome Nicolas Grekas has [added namespace aliases to Twig](https://github.com/twigphp/Twig/pull/2484) and followed up by [migrating Symfony 2.7+](https://github.com/symfony/symfony/pull/22962) to use said namespaces … yes, from Symfony 2.7 up :wink: 

This PR does the same where possible, there are a couple of remainders, but they are stuck by inheritance. Either way, **Twig 3 is coming** and it **is namespaced** :tada: :champagne: 

For the sake of history, this is a follow up on #6625