### PR TITLE
[3.3]  Remove hard requirement on PHP mbstring extension

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -21,10 +21,6 @@ use Bolt\Exception\BootException;
  * @return \Silex\Application
  */
 return call_user_func(function () {
-    // Use UTF-8 for all multi-byte functions
-    \mb_internal_encoding('UTF-8');
-    \mb_http_output('UTF-8');
-
     // Resolve Bolt-root
     $boltRootPath = realpath(__DIR__ . '/..');
 
@@ -42,6 +38,11 @@ return call_user_func(function () {
         }
 
         require_once $autoloadPath;
+
+        /** @deprecated Can be removed when support for PHP 5.5 is dropped. */
+        // Use UTF-8 for all multi-byte functions
+        \mb_internal_encoding('UTF-8');
+        \mb_http_output('UTF-8');
 
         return Bootstrap::run($rootPath, $resourcesClass);
     }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "ext-fileinfo": "*",
         "ext-gd": "*",
         "ext-json": "*",
-        "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-pdo": "*",
         "ext-xml": "*",


### PR DESCRIPTION
Composer doesn't use any mbstring functions in the autoloader, only in the RFS where it checks for the module. Additionally, from [PHP 5.6 onward](http://php.net/manual/en/ini.core.php#ini.default-charset), UTF-8  is default (see link for more details).

So this PR, removes the requirement from `composer.json`, and moved the function calls to just after the autoloader.