### PR TITLE
[4.0] Remove mb_internal_encoding() & mb_http_output() from bootstrap

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -19,10 +19,6 @@ use Bolt\Exception\BootException;
  * @return \Silex\Application
  */
 return call_user_func(function () {
-    // Use UTF-8 for all multi-byte functions
-    \mb_internal_encoding('UTF-8');
-    \mb_http_output('UTF-8');
-
     // Resolve Bolt-root
     $boltRootPath = realpath(__DIR__ . '/..');
 


### PR DESCRIPTION
PHP 5.5 is no longer supported, and from PHP 5.6 the defaults are UTF-8.

Follow-up to #6748