### PR TITLE
[3.x] Serializable & cacheable entities

### DIFF
--- a/src/Configuration/ConfigurationValueProxy.php
+++ b/src/Configuration/ConfigurationValueProxy.php
@@ -4,6 +4,7 @@ namespace Bolt\Configuration;
 
 use ArrayAccess;
 use Bolt\Config;
+use Serializable;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -15,7 +16,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class ConfigurationValueProxy implements ArrayAccess, EventSubscriberInterface
+class ConfigurationValueProxy implements ArrayAccess, Serializable, EventSubscriberInterface
 {
     /** @var mixed|null */
     protected $data;
@@ -121,5 +122,24 @@ class ConfigurationValueProxy implements ArrayAccess, EventSubscriberInterface
     {
         $this->checked = false;
         $this->initialize();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        $this->initialize();
+
+        return serialize($this->data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        $this->checked = true;
+        $this->data = unserialize($serialized);
     }
 }

--- a/src/Storage/Collection/LazyCollection.php
+++ b/src/Storage/Collection/LazyCollection.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Storage\Collection;
 
+use Bolt\Storage\Entity\Content;
 use Bolt\Storage\EntityProxy;
 use Doctrine\Common\Collections\ArrayCollection;
 
@@ -26,12 +27,13 @@ class LazyCollection extends ArrayCollection
     }
 
     /**
-     *  Force loads the proxy objects and returns the real objects
+     * Force loads the proxy objects and returns the required data for Twig.
      */
-    public function serialize()
+    public function getProxy()
     {
         $output = [];
         foreach ($this as $element) {
+            /** @var Content $proxy */
             $proxy = $element->getProxy();
             $output[] = $proxy->getContenttype() . '/' . $proxy->getSlug();
         }

--- a/src/Storage/Database/Prefill/RecordContentGenerator.php
+++ b/src/Storage/Database/Prefill/RecordContentGenerator.php
@@ -33,6 +33,7 @@ class RecordContentGenerator
     private $defaultTitles;
     /** @var array */
     private $createSummary;
+
     /**
      * Constructor.
      *
@@ -159,7 +160,7 @@ class RecordContentGenerator
 
         $taxonomies = null;
         /** @var Entity\Taxonomy $taxonomy */
-        foreach ($contentEntity->getTaxonomy()->toArray() as $taxonomy) {
+        foreach ($contentEntity->getTaxonomy() as $taxonomy) {
             $type = $taxonomy->getTaxonomytype();
             $taxonomies[$type][] = $taxonomy->getName();
         }

--- a/src/Storage/Entity/Entity.php
+++ b/src/Storage/Entity/Entity.php
@@ -4,12 +4,13 @@ namespace Bolt\Storage\Entity;
 
 use ArrayAccess;
 use JsonSerializable;
+use Serializable;
 
 /**
  * An abstract class that other entities can inherit. Provides automatic getters and setters along
  * with serialization.
  */
-abstract class Entity implements ArrayAccess, JsonSerializable
+abstract class Entity implements ArrayAccess, JsonSerializable, Serializable
 {
     use MagicAttributeTrait;
     use EntitySerializeTrait;

--- a/src/Storage/Entity/Entity.php
+++ b/src/Storage/Entity/Entity.php
@@ -17,6 +17,9 @@ abstract class Entity implements ArrayAccess, JsonSerializable
 
     /** @var int */
     protected $id;
+    /** @var array */
+    protected $_internal = ['contenttype'];
+
 
     /**
      * Constructor.
@@ -73,8 +76,36 @@ abstract class Entity implements ArrayAccess, JsonSerializable
         $this->id = $id;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function __toString()
     {
         return (string) $this->getId();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
+    {
+        $data = [];
+        foreach ($this as $k => $v) {
+            if (strpos($k, '_') === 0) {
+                continue;
+            }
+            if (in_array($k, $this->_internal)) {
+                continue;
+            }
+            $method = 'serialize' . $k;
+            $data[$k] = $this->$method();
+        }
+
+        foreach ($this->_fields as $k => $v) {
+            $method = 'serialize' . $k;
+            $data[$k] = $this->$method();
+        }
+
+        return $data;
     }
 }

--- a/src/Storage/Entity/TemplateFields.php
+++ b/src/Storage/Entity/TemplateFields.php
@@ -21,15 +21,25 @@ class TemplateFields extends Entity
         return $this->$accessor();
     }
 
-    public function serialize()
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
     {
-        $fields = $this->getContenttype()->getFields();
+        /** @var \Bolt\Storage\Mapping\ContentType $contentType */
+        $contentType = $this->get('contenttype');
+        if (!method_exists($contentType, 'getFields')) {
+            throw new \BadMethodCallException(
+                sprintf('ContentType contained in %s does not implement getFields()', __CLASS__)
+            );
+        }
+        $fields = $contentType->getFields();
         $values = [];
         foreach ($fields as $field) {
             $fieldName = $field['fieldname'];
             $val = $this->$fieldName;
             if (in_array($field['type'], ['date','datetime'])) {
-                $val = (string)$this->$fieldName;
+                $val = (string) $this->$fieldName;
             }
             if (is_callable([$val, 'serialize'])) {
                 $val = $val->serialize();

--- a/src/Storage/EntityProxy.php
+++ b/src/Storage/EntityProxy.php
@@ -2,11 +2,13 @@
 
 namespace Bolt\Storage;
 
+use Serializable;
+
 /**
  *  This class is used by lazily loaded entities. It stores a reference to an entity but only
  *  fetches it on demand.
  */
-class EntityProxy
+class EntityProxy implements Serializable
 {
     /** @var string */
     public $entity;
@@ -90,5 +92,22 @@ class EntityProxy
         $this->load();
 
         return $this->proxy;
+    }
+
+    /**
+     * @internal
+     */
+    public function serialize()
+    {
+        return serialize($this->getProxy());
+    }
+
+    /**
+     * @internal
+     */
+    public function unserialize($serialized)
+    {
+        $this->proxy = unserialize($serialized);
+        $this->loaded = true;
     }
 }

--- a/src/Storage/Field/Collection/RepeatingFieldCollection.php
+++ b/src/Storage/Field/Collection/RepeatingFieldCollection.php
@@ -3,17 +3,19 @@
 namespace Bolt\Storage\Field\Collection;
 
 use Bolt\Exception\FieldConfigurationException;
+use Bolt\Helpers\Deprecated;
 use Bolt\Storage\Entity\FieldValue;
 use Bolt\Storage\EntityManager;
 use Bolt\Storage\Field\Type\FieldTypeBase;
 use Doctrine\Common\Collections\ArrayCollection;
+use Serializable;
 
 /**
  * This class stores an array collection of Fields.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
-class RepeatingFieldCollection extends ArrayCollection
+class RepeatingFieldCollection extends ArrayCollection implements Serializable
 {
     /** @var EntityManager */
     protected $em;
@@ -283,6 +285,9 @@ class RepeatingFieldCollection extends ArrayCollection
         return new FieldCollection();
     }
 
+    /**
+     * {@inhertdoc}
+     */
     public function serialize()
     {
         $output = [];
@@ -290,6 +295,23 @@ class RepeatingFieldCollection extends ArrayCollection
             $output[$collection] = $vals->serialize();
         }
 
-        return $output;
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+        if (isset($trace[0]['file'])) {
+            Deprecated::method(3.4, 'toArray');
+
+            return $output;
+        }
+
+        return serialize($output);
+    }
+
+    /**
+     * @internal
+     */
+    public function unserialize($serialized)
+    {
+        foreach ($serialized as $k => $v) {
+            $this->set($k, $v);
+        }
     }
 }


### PR DESCRIPTION
## Problem A

Due to legacy (in most cases) entity objects in a lot of cases can't `serialize()`, e.g. for things like caches. 
as mostly for legacy reasons. they contain closures like `Application` (e.g. by `Config` being needed via proxy for taxonomy, or `EntityManager for relations`).

This is causing breakage in a number of areas, and causing me to chase :ghost: on two upcoming branches :smile: 

I am seeing broken serialised objects in session caches when the 1% random log-out that isn't caused by config settings, is **actually** serialisation breaking.

Also, as an example of where this is blocking things… 75-90% of the current dashboard loading time (assuming warm caches) is data that could be tag-cached, even in memory … but instead a ridiculous amount of logic in re-re-re-repeated on every page load. Of the example, 3/4 of that is just the menus … see where I am going with this :wink: 

## Problem B

`EntitySerializeTrait` provides the interface contract methods for entity serialisation

`JsonSerializable` :+1:, but not for `Serializable` .

Obviously adding `unserialize()` is a proverbial no-brainer.

However, currently `serialize()` returns an _array_, the interface requires the implementer to do the pre-processing, and return a serialised _string_. Changing that becomes a BC break.

## Proposed Solution

OK, let's talk … This PR makes the serialisation work, but does potentially break some corner-case use. 

There is probably something else I have missed, and am not "sold" on the chosen function name/use of the renamed functions in the collections classes

