### PR TITLE
$content type issue in UploadContainer->save

### DIFF
--- a/src/Filesystem/UploadContainer.php
+++ b/src/Filesystem/UploadContainer.php
@@ -41,7 +41,7 @@ class UploadContainer implements ContainerInterface
      */
     public function save($file, $content)
     {
-        $this->filesystem->put($file, $content);
+        $this->filesystem->put($file, (string)$content);
     }
 
     /**


### PR DESCRIPTION
Cast $content in save to a string to avoid quirks in external modules where $content is an integer

Details
-------

There's an issue in the `flysystem-rackspace` package that causes the lock file upload to fail because the $content of the lock file is generated from `time()` and flysystem-rackspace is expecting that to be a string.
