### PR TITLE
Change passwordlib to use random_bytes instead of any of its sources.

### DIFF
--- a/src/Legacy/PasswordLib/PasswordLibFactory.php
+++ b/src/Legacy/PasswordLib/PasswordLibFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Bolt\Legacy\PasswordLib;
+
+use PasswordLib\Password\AbstractPassword;
+use PasswordLib\Password\Factory;
+
+/**
+ * A PasswordLib Factory that uses our random generator.
+ *
+ * @internal
+ */
+final class PasswordLibFactory extends Factory
+{
+    /** @var AbstractPassword[] */
+    protected $implementations = [];
+    /** @var PasswordLibRandomGenerator */
+    private $generator;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createHash($password, $prefix = '$2a$')
+    {
+        if ($prefix === false) {
+            throw new \DomainException('Unsupported Prefix Supplied');
+        }
+        foreach ($this->implementations as $impl) {
+            if ($impl::getPrefix() == $prefix) {
+                /** @var AbstractPassword $instance */
+                $instance = new $impl;
+                $instance->setGenerator($this->getGenerator());
+                return $instance->create($password);
+            }
+        }
+        throw new \DomainException('Unsupported Prefix Supplied');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function verifyHash($password, $hash)
+    {
+        foreach ($this->implementations as $impl) {
+            if ($impl::detect($hash)) {
+                /** @var AbstractPassword $instance */
+                $instance = $impl::loadFromHash($hash);
+                $instance->setGenerator($this->getGenerator());
+                return $instance->verify($password, $hash);
+            }
+        }
+        throw new \DomainException('Unsupported Password Hash Supplied');
+    }
+
+    private function getGenerator()
+    {
+        if (!$this->generator) {
+            $this->generator = new PasswordLibRandomGenerator();
+        }
+
+        return $this->generator;
+    }
+}

--- a/src/Legacy/PasswordLib/PasswordLibRandomGenerator.php
+++ b/src/Legacy/PasswordLib/PasswordLibRandomGenerator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Bolt\Legacy\PasswordLib;
+
+use PasswordLib\Random\Generator;
+use PasswordLib\Random\Source;
+
+/**
+ * A PasswordLib Random Generator that uses random_bytes.
+ *
+ * @internal
+ */
+final class PasswordLibRandomGenerator extends Generator
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate($size)
+    {
+        return random_bytes($size);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateInt($min = 0, $max = PHP_INT_MAX)
+    {
+        return random_int($min, $max);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateString($length, $characters = '')
+    {
+        return substr(bin2hex(random_bytes($length)), 0, $length);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSource(Source $source)
+    {
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMixer()
+    {
+        throw new \RuntimeException('This does not use Mixers.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSources()
+    {
+        return [];
+    }
+}

--- a/src/Provider/AccessControlServiceProvider.php
+++ b/src/Provider/AccessControlServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Bolt\Provider;
 
 use Bolt\AccessControl;
-use PasswordLib\Password\Factory as PasswordFactory;
+use Bolt\Legacy\PasswordLib\PasswordLibFactory;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -67,7 +67,7 @@ class AccessControlServiceProvider implements ServiceProviderInterface
 
         $app['password_factory'] = $app->share(
             function () {
-                return new PasswordFactory();
+                return new PasswordLibFactory();
             }
         );
 


### PR DESCRIPTION
This specifically fixes `/dev/urandom` not being readable. This is all throw away code once we don't need PasswordLib anymore.