### PR TITLE
fix complex search crash bug

### DIFF
--- a/src/Storage/Entity/ContentSearchTrait.php
+++ b/src/Storage/Entity/ContentSearchTrait.php
@@ -155,9 +155,9 @@ trait ContentSearchTrait
 
         $wordMatches = 0;
         $cntWords = count($words);
-        for ($i = 0; $i < $cntWords; $i++) {
-            if (strstr($lowSubject, $words[$i])) {
-                $wordMatches++;
+        foreach (array_keys($words) as $k) {
+            if (strstr($lowSubject, $words[$k])) {
+                ++$wordMatches;
             }
         }
         if ($wordMatches > 0) {

--- a/tests/phpunit/unit/Storage/StorageTest.php
+++ b/tests/phpunit/unit/Storage/StorageTest.php
@@ -162,7 +162,14 @@ class StorageTest extends BoltUnitTest
         $app = $this->getApp();
         $app['request'] = Request::create('/');
         $storage = new Storage($app);
+
+        // Test simple search
         $result = $storage->searchContent('lorem');
+        $this->assertGreaterThan(0, count($result));
+        $this->assertTrue($result['query']['valid']);
+
+        // Test complex search
+        $result = $storage->searchContent('I like lorem');
         $this->assertGreaterThan(0, count($result));
         $this->assertTrue($result['query']['valid']);
 


### PR DESCRIPTION
This PR fixes a bug where a search like "a nice day" will crash the site if there is any content containing "day". 

Details
-------

The crash is triggered because single character search words like "I" or "a" are filtered out before the search in a way that leaves the search words index dirty. When matches are found and the index is used to weight the results, the app crashes.

PS: I don't like brown M&Ms
