### PR TITLE
[3.3] Prevent filelist exceptions when file not found

### DIFF
--- a/app/view/twig/editcontent/fields/_filelist.twig
+++ b/app/view/twig/editcontent/fields/_filelist.twig
@@ -35,7 +35,7 @@
 
 {% set template_item %}
     <div class="item ui-state-default">
-        <div class="icon"><i class="fa fa-file-o"></i><span>%EXT_E%</span></div>
+        <div class="icon"><i class="fa %ICON%"></i><span>%EXT_E%</span></div>
         <input type="text" class="title" value="%TITLE_A%">
         <input type="hidden" class="filename" value="%FILEPATH_A%">
         <a href="#" class="remove"><i class="fa fa-times"></i></a>
@@ -64,13 +64,24 @@
         {# Filelist #}
         <div class="list">
             {% for item in list %}
-                {% set file = app['filesystem.matcher'].getFile(item.filename) %}
-                {{ template_item|replace({
-                    '%TITLE_A%':    item.title|e('html_attr'),
-                    '%FILEPATH_A%': file.path|e('html_attr'),
-                    '%FILEPATH_E%': file.path|e('html'),
-                    '%EXT_E%': file.extension|upper|e('html'),
-                })|raw }}
+                {% set file = context.file_matcher.getFile(item.filename, false) %}
+                {% if file is not null %}
+                    {{ template_item|replace({
+                        '%ICON%':       'fa-file-o',
+                        '%TITLE_A%':    item.title|e('html_attr'),
+                        '%FILEPATH_A%': file.path|e('html_attr'),
+                        '%FILEPATH_E%': file.path|e('html'),
+                        '%EXT_E%':      file.extension|upper|e('html'),
+                    })|raw }}
+                {% else %}
+                    {{ template_item|replace({
+                        '%ICON%':       'fa-question',
+                        '%TITLE_A%':    item.title|e('html_attr'),
+                        '%FILEPATH_A%': item.filename|e('html_attr'),
+                        '%FILEPATH_E%': item.filename|e('html'),
+                        '%EXT_E%':      '',
+                    })|raw }}
+                {% endif %}
             {% else %}
                 {{ template_empty|raw }}
             {% endfor %}

--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -66,14 +66,24 @@
         {# Imagelist #}
         <div class="list">
             {% for image in list %}
-                {% set file = app['filesystem.matcher'].getImage(image.filename) %}
-                {{ template_item|replace({
-                    '%TITLE_A%':    image.title|e('html_attr'),
-                    '%FILEPATH_E%': file.path|e('html'),
-                    '%FILEPATH_A%': file.path|e('html_attr'),
-                    '%PREVIEW_A%':  file.path|thumbnail(60, 40, 'c')|e('html_attr'),
-                    '%URL_A%':      file.url|e('html_attr'),
-                })|raw }}
+                {% set file = context.file_matcher.getImage(image.filename, false) %}
+                {% if file is not null %}
+                    {{ template_item|replace({
+                        '%TITLE_A%':    image.title|e('html_attr'),
+                        '%FILEPATH_E%': file.path|e('html'),
+                        '%FILEPATH_A%': file.path|e('html_attr'),
+                        '%PREVIEW_A%':  file.path|thumbnail(60, 40, 'c')|e('html_attr'),
+                        '%URL_A%':      file.url|e('html_attr'),
+                    })|raw }}
+                {% else %}
+                    {{ template_item|replace({
+                        '%TITLE_A%':    image.title|e('html_attr'),
+                        '%FILEPATH_E%': image.filename|e('html'),
+                        '%FILEPATH_A%': image.filename|e('html_attr'),
+                        '%PREVIEW_A%':  image.filename|thumbnail(60, 40, 'c')|e('html_attr'),
+                        '%URL_A%':      '#',
+                    })|raw }}
+                {% endif %}
             {% else %}
                 {{ template_empty|raw }}
             {% endfor %}

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -92,6 +92,7 @@ class Records extends BackendBase
         // We're doing a GET
         $duplicate = $request->query->get('duplicate', false);
         $context = $this->recordEdit()->action($content, $content->getContenttype(), $duplicate);
+        $context['file_matcher'] = $this->app['filesystem.matcher'];
 
         // Get the editreferrer
         $referrer = $this->getEditReferrer($request);


### PR DESCRIPTION
Currently in 3.3-HEAD, if you add a file to a filelist field, and that file is removed afterwards, the page will crash and be un-editable except for directly accessing the database, or replacing (which?) the file :wink: 

```
Twig_Error_Runtime in Template.php line 230:
An exception has been thrown during the rendering of a template ("File not found at path: 2017-06/refactor-wars.png") in "@bolt/editcontent/fields/_filelist.twig" at line 67.
```

This PR:
  - Adds a method to the path bridging `Matcher` class to check for the file's existence, prior to accessing it, which if not found **correctly** throws an exception.
  - Display's "known" information from the database when not found, and changes the icon to a `?`
    - Obviously that is UI, so "go for it" requesting changes to that, I just picked the first thing that came to mind to get the PR in and discussion moving
