### PR TITLE
Extensions assets path

### DIFF
--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -35,13 +35,14 @@ class PathResolver
             'cache'             => '%app%/cache',
             'config'            => '%app%/config',
             'database'          => '%app%/database',
-            'extensions'        => '%site%/extensions',
-            'extensions_config' => '%config%/extensions',
             'var'               => '%site%/var',
             'web'               => '%site%/public',
             'files'             => '%web%/files',
             'themes'            => '%web%/theme',
             'bolt_assets'       => '%web%/bolt-public',
+            'extensions'        => '%site%/extensions',
+            'extensions_assets' => '%web%/extensions',
+            'extensions_config' => '%config%/extensions',
         ];
     }
 

--- a/src/Extension/AssetTrait.php
+++ b/src/Extension/AssetTrait.php
@@ -181,15 +181,17 @@ trait AssetTrait
         }
 
         $app = $this->getContainer();
+        /** @var \Bolt\Filesystem\Manager $filesystem */
+        $filesystem = $app['filesystem'];
 
-        $file = $app['filesystem']->getFile("extensions_assets://{$this->getId()}/$path");
+        $file = $filesystem->getFile("extensions_assets://{$this->getId()}/$path");
         if ($file->exists()) {
             $asset->setPackageName('extensions')->setPath($file->getPath());
 
             return;
         }
 
-        $themeFile = $app['filesystem']->getFile("theme://$path");
+        $themeFile = $filesystem->getFile("theme://$path");
         if ($themeFile->exists()) {
             $asset->setPackageName('theme');
 

--- a/src/Extension/AssetTrait.php
+++ b/src/Extension/AssetTrait.php
@@ -180,16 +180,16 @@ trait AssetTrait
             return;
         }
 
-        $file = $this->getWebDirectory()->getFile($asset->getPath());
+        $app = $this->getContainer();
+
+        $file = $app['filesystem']->getFile("extensions_assets://{$this->getId()}/$path");
         if ($file->exists()) {
             $asset->setPackageName('extensions')->setPath($file->getPath());
 
             return;
         }
 
-        $app = $this->getContainer();
-
-        $themeFile = $app['filesystem']->getFile(sprintf('theme://%s', $path));
+        $themeFile = $app['filesystem']->getFile("theme://$path");
         if ($themeFile->exists()) {
             $asset->setPackageName('theme');
 
@@ -200,8 +200,8 @@ trait AssetTrait
             "Couldn't add file asset '%s': File does not exist in either %s or %s directories. Make sure the file exists in either of these locations, by " .
             'placing the file there manually (for Bundled Extensions) or by uninstalling / installing the extension again (for Managed Extensions).',
             $path,
-            $this->getWebDirectory()->getFullPath(),
-            $themeFile->getFullPath()
+            $file->getParent()->getFullPath(),
+            $themeFile->getParent()->getFullPath()
         );
         $app['logger.system']->error($message, ['event' => 'extensions']);
     }

--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -29,7 +29,10 @@ class AssetServiceProvider implements ServiceProviderInterface
                 $packages->addPackage('bolt', $bolt);
                 $packages->addPackage('bolt_assets', $bolt); // For FS plugin
 
-                $packages->addPackage('extensions', new PathPackage('', $app['asset.version_strategy']('web'), $app['asset.context']));
+                $ext = $app['asset.package_factory']('extensions_assets');
+                $packages->addPackage('extensions', $ext);
+                $packages->addPackage('extensions_assets', $ext); // For FS plugin
+
                 $packages->addPackage('files', $app['asset.package_factory']('files'));
                 $packages->addPackage('theme', $app['asset.package_factory']('theme'));
                 $packages->addPackage('themes', $app['asset.package_factory']('themes'));

--- a/src/Provider/FilesystemServiceProvider.php
+++ b/src/Provider/FilesystemServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Bolt\Provider;
 
 use Bolt\Common\Deprecated;
+use Bolt\Configuration\PathResolver;
 use Bolt\Filesystem\Adapter\Local;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\LazyFilesystem;
@@ -21,33 +22,35 @@ class FilesystemServiceProvider implements ServiceProviderInterface
     {
         $app['filesystem'] = $app->share(
             function ($app) {
+                /** @var PathResolver $resolver */
+                $resolver = $app['path_resolver'];
                 $manager = new Manager(
                     [
                         // Bolt's project directory. Not configurable.
                         // Use for anything that's supposed to be in core:
                         // src files, our twig templates, our js & css files, our translations, etc.
-                        'bolt'              => new Filesystem(new Local($app['path_resolver']->resolve('bolt'), LOCK_EX, Local::SKIP_LINKS)),
+                        'bolt'              => new Filesystem(new Local($resolver->resolve('bolt'), LOCK_EX, Local::SKIP_LINKS)),
                         // Root directory. Not configurable.
-                        'root'              => new Filesystem(new Local($app['path_resolver']->resolve('root'), LOCK_EX, Local::SKIP_LINKS)),
+                        'root'              => new Filesystem(new Local($resolver->resolve('root'), LOCK_EX, Local::SKIP_LINKS)),
 
                         // User's web root
-                        'web'               => new Filesystem(new Local($app['path_resolver']->resolve('web'), LOCK_EX, Local::SKIP_LINKS)),
+                        'web'               => new Filesystem(new Local($resolver->resolve('web'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's files directory
-                        'files'             => new Filesystem(new Local($app['path_resolver']->resolve('files'), LOCK_EX, Local::SKIP_LINKS)),
+                        'files'             => new Filesystem(new Local($resolver->resolve('files'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's synced bolt assets directory
-                        'bolt_assets'       => new Filesystem(new Local($app['path_resolver']->resolve('bolt_assets'), LOCK_EX, Local::SKIP_LINKS)),
+                        'bolt_assets'       => new Filesystem(new Local($resolver->resolve('bolt_assets'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's config directory
-                        'config'            => new Filesystem(new Local($app['path_resolver']->resolve('config'), LOCK_EX, Local::SKIP_LINKS)),
+                        'config'            => new Filesystem(new Local($resolver->resolve('config'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's themes directory
-                        'themes'            => new Filesystem(new Local($app['path_resolver']->resolve('themes'), LOCK_EX, Local::SKIP_LINKS)),
+                        'themes'            => new Filesystem(new Local($resolver->resolve('themes'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's extension directory
-                        'extensions'        => new Filesystem(new Local($app['path_resolver']->resolve('extensions'), LOCK_EX, Local::SKIP_LINKS)),
+                        'extensions'        => new Filesystem(new Local($resolver->resolve('extensions'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's extension assets directory
-                        'extensions_assets' => new Filesystem(new Local($app['path_resolver']->resolve('extensions_assets'), LOCK_EX, Local::SKIP_LINKS)),
+                        'extensions_assets' => new Filesystem(new Local($resolver->resolve('extensions_assets'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's extension config directory
-                        'extensions_config' => new Filesystem(new Local($app['path_resolver']->resolve('extensions_config'), LOCK_EX, Local::SKIP_LINKS)),
+                        'extensions_config' => new Filesystem(new Local($resolver->resolve('extensions_config'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's cache directory
-                        'cache'             => new Filesystem(new Local($app['path_resolver']->resolve('cache'), LOCK_EX, Local::SKIP_LINKS)),
+                        'cache'             => new Filesystem(new Local($resolver->resolve('cache'), LOCK_EX, Local::SKIP_LINKS)),
 
                         'app'     => new LazyFilesystem(function () use ($app) {
                             Deprecated::warn('The "app" filesystem', 3.3, 'Use a filesystem at a more specific mount point instead.');

--- a/src/Provider/FilesystemServiceProvider.php
+++ b/src/Provider/FilesystemServiceProvider.php
@@ -42,6 +42,8 @@ class FilesystemServiceProvider implements ServiceProviderInterface
                         'themes'            => new Filesystem(new Local($app['path_resolver']->resolve('themes'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's extension directory
                         'extensions'        => new Filesystem(new Local($app['path_resolver']->resolve('extensions'), LOCK_EX, Local::SKIP_LINKS)),
+                        // User's extension assets directory
+                        'extensions_assets' => new Filesystem(new Local($app['path_resolver']->resolve('extensions_assets'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's extension config directory
                         'extensions_config' => new Filesystem(new Local($app['path_resolver']->resolve('extensions_config'), LOCK_EX, Local::SKIP_LINKS)),
                         // User's cache directory

--- a/tests/phpunit/unit/Asset/AssetsProviderTest.php
+++ b/tests/phpunit/unit/Asset/AssetsProviderTest.php
@@ -37,7 +37,7 @@ HTML;
 <head>
 <meta charset="utf-8" />
 <link rel="stylesheet" href="existing.css" media="screen">
-<link rel="stylesheet" href="/testfile.css?5e544598b8d78644071a6f25fd8bba82" media="screen">
+<link rel="stylesheet" href="/extensions/testfile.css?5e544598b8d78644071a6f25fd8bba82" media="screen">
 </head>
 <body>
 <script src="existing.js"></script>
@@ -53,7 +53,7 @@ HTML;
 </head>
 <body>
 <script src="existing.js"></script>
-<link rel="stylesheet" href="/testfile.css?5e544598b8d78644071a6f25fd8bba82" media="screen">
+<link rel="stylesheet" href="/extensions/testfile.css?5e544598b8d78644071a6f25fd8bba82" media="screen">
 </body>
 </html>
 HTML;
@@ -63,7 +63,7 @@ HTML;
 <head>
 <meta charset="utf-8" />
 <link rel="stylesheet" href="existing.css" media="screen">
-<script src="/testfile.js?289fc946f38fee1a3e947eca1d6208b6"></script>
+<script src="/extensions/testfile.js?289fc946f38fee1a3e947eca1d6208b6"></script>
 </head>
 <body>
 <script src="existing.js"></script>
@@ -79,7 +79,7 @@ HTML;
 </head>
 <body>
 <script src="existing.js"></script>
-<script src="/testfile.js?289fc946f38fee1a3e947eca1d6208b6"></script>
+<script src="/extensions/testfile.js?289fc946f38fee1a3e947eca1d6208b6"></script>
 </body>
 </html>
 HTML;
@@ -265,7 +265,9 @@ HTML;
     public function testJsProcessAssets()
     {
         $app = $this->getApp();
-        $javaScript = JavaScript::create('testfile.js');
+        $javaScript = JavaScript::create('testfile.js')
+            ->setPackageName('extensions')
+        ;
         $app['asset.queue.file']->add($javaScript);
         $app = $this->getApp();
 
@@ -279,6 +281,7 @@ HTML;
     {
         $app = $this->getApp();
         $javaScript = JavaScript::create('testfile.js')
+            ->setPackageName('extensions')
             ->setLate(true)
         ;
         $app['asset.queue.file']->add($javaScript);
@@ -291,7 +294,9 @@ HTML;
     public function testCssProcessAssets()
     {
         $app = $this->getApp();
-        $stylesheet = Stylesheet::create('testfile.css');
+        $stylesheet = Stylesheet::create('testfile.css')
+            ->setPackageName('extensions')
+        ;
         $app['asset.queue.file']->add($stylesheet);
         $response = new Response($this->template);
 
@@ -303,6 +308,7 @@ HTML;
     {
         $app = $this->getApp();
         $stylesheet = Stylesheet::create('testfile.css')
+            ->setPackageName('extensions')
             ->setLate(true)
         ;
         $app['asset.queue.file']->add($stylesheet);

--- a/tests/phpunit/unit/Extension/AssetTraitTest.php
+++ b/tests/phpunit/unit/Extension/AssetTraitTest.php
@@ -95,25 +95,24 @@ class AssetTraitTest extends BoltUnitTest
 
         $filesystem = new Manager([
             'theme' => new Filesystem(new Memory()),
-            'web'   => new Filesystem(new Memory()),
+            'extensions_assets' => new Filesystem(new Memory()),
         ]);
         $this->setService('filesystem', $filesystem);
 
         $ext = new AssetExtension();
         $ext->setAssets([new JavaScript('js/test.js')]);
         $ext->setContainer($app);
-        $ext->setWebDirectory($filesystem->getDir('web://extensions/local/bolt/koala'));
 
         $ext->register($app);
 
-        $filesystem->put('web://extensions/local/bolt/koala/js/test.js', '');
+        $filesystem->put('extensions_assets://Bolt/Asset/js/test.js', '');
 
         $fileQueue = $app['asset.queue.file']->getQueue();
 
         /** @var JavaScript $queued */
         $queued = reset($fileQueue['javascript']);
         $this->assertInstanceOf(JavaScript::class, $queued);
-        $this->assertSame('extensions/local/bolt/koala/js/test.js', $queued->getFileName());
+        $this->assertSame('Bolt/Asset/js/test.js', $queued->getFileName());
         $this->assertSame('extensions', $queued->getPackageName());
     }
 
@@ -123,7 +122,7 @@ class AssetTraitTest extends BoltUnitTest
 
         $filesystem = new Manager([
             'theme' => new Filesystem(new Memory()),
-            'web'   => new Filesystem(new Memory()),
+            'extensions_assets' => new Filesystem(new Memory()),
         ]);
         $this->setService('filesystem', $filesystem);
 
@@ -132,7 +131,6 @@ class AssetTraitTest extends BoltUnitTest
         $ext = new AssetExtension();
         $ext->setAssets([new JavaScript('js/test.js')]);
         $ext->setContainer($app);
-        $ext->setWebDirectory($filesystem->getDir('web://bolt/koala'));
 
         $ext->register($app);
 


### PR DESCRIPTION
It makes much more sense to have a `extensions_assets` path for ...extensions assets..than having it map to the web directory directly.

This doesn't change much in practice other than this:
```twig
{{ asset('extensions/carson/extension/file.js', 'extensions') }}
```
to
```twig
{{ asset('carson/extension/file.js', 'extensions') }}
```

/cc @SahAssar