### PR TITLE
[3.3] Allow 'extensions_config' as a prefix for FilePermissions checks

### DIFF
--- a/src/Filesystem/FilePermissions.php
+++ b/src/Filesystem/FilePermissions.php
@@ -35,6 +35,7 @@ class FilePermissions
 
         $this->allowedPrefixes = [
             'config',
+            'extensions_config',
             'files',
             'theme',
             'themes',


### PR DESCRIPTION
"Edit configuration" links won't work on installed extensions in 3.3-HEAD right now

Fixes: #6763