### PR TITLE
[3.4] More Symfony Forms updates

### DIFF
--- a/app/src/js/init.js
+++ b/app/src/js/init.js
@@ -215,13 +215,15 @@ var init = {
     bindPrefill: function () {
         "use strict";
 
-        $('#check-all').on('click', function () {
+        var checkboxes = $('#form_contenttypes').find(':checkbox');
+
+        $('#prefill_check_all').on('click', function () {
             // because jQuery is being retarded.
             // See: http://stackoverflow.com/questions/5907645/jquery-chrome-and-checkboxes-strange-behavior
-            $("#form_contenttypes :checkbox").removeAttr('checked').trigger('click');
+            checkboxes.removeAttr('checked').trigger('click');
         });
-        $('#uncheck-all').on('click', function () {
-            $("#form_contenttypes :checkbox").removeAttr('checked');
+        $('#prefill_uncheck_all').on('click', function () {
+            checkboxes.removeAttr('checked');
         });
     },
 

--- a/app/src/js/init.js
+++ b/app/src/js/init.js
@@ -39,7 +39,7 @@ var init = {
     },
 
     /*
-     * Bind editfile field
+     * Bind file_edit_contents field
      *
      * @param {object} data
      * @returns {undefined}
@@ -55,7 +55,7 @@ var init = {
         var editor;
 
         if (typeof CodeMirror !== 'undefined') {
-            editor = CodeMirror.fromTextArea(document.getElementById('form_contents'), {
+            editor = CodeMirror.fromTextArea(document.getElementById('file_edit_contents'), {
                 lineNumbers: true,
                 autofocus: true,
                 foldGutter: {
@@ -81,9 +81,9 @@ var init = {
                         }
                     },
                     "Ctrl-S": function () {
-                        $('#saveeditfile').click();
+                        $('#file_edit_save').click();
                     },
-                    "Ctrl-H": "replaceAll",
+                    "Ctrl-H": "replaceAll"
                 },
                 tabSize: 4,
                 indentUnit: 4,
@@ -97,8 +97,11 @@ var init = {
             editor.setSize(null, newheight);
         }
 
-        $('#saveeditfile').on('click', function () {
+        $('#file_edit_save').on('click', function (e) {
             Bolt.events.fire('Bolt.File.Save.Start');
+
+            // Disable the form POST
+            e.preventDefault();
 
             // Copy back to the textarea.
             if (editor) {
@@ -108,11 +111,16 @@ var init = {
             var msgNotSaved = 'Not saved';
 
             // Disable the buttons, to indicate stuff is being done.
-            $('#saveeditfile').addClass('disabled');
-            $('#saveeditfile i').addClass('fa-spin fa-spinner');
+            $('#file_edit_save').addClass('disabled');
+            $('#file_edit_save i').addClass('fa-spin fa-spinner');
             $('p.lastsaved').text(Bolt.data('editcontent.msg.saving'));
 
-            $.post('?returnto=ajax', $('#editfile').serialize())
+            var button = $(e.target);
+            var postData = $('form[name="file_edit"]').serialize()
+                + '&' + encodeURI(button.attr('name'))
+                + '=' + encodeURI(button.attr('value'))
+            ;
+            $.post('?returnto=ajax', postData)
                 .done(function (data) {
                     if (!data.ok) {
                         alert(data.msg);
@@ -131,8 +139,8 @@ var init = {
 
                     // Re-enable buttons
                     window.setTimeout(function () {
-                        $('#saveeditfile').removeClass('disabled').blur();
-                        $('#saveeditfile i').removeClass('fa-spin fa-spinner');
+                        $('#file_edit_save').removeClass('disabled').blur();
+                        $('#file_edit_save i').removeClass('fa-spin fa-spinner');
                     }, 300);
                 });
         });
@@ -147,7 +155,7 @@ var init = {
     bindEditLocale: function (data) {
         "use strict";
 
-        var editor = CodeMirror.fromTextArea(document.getElementById('form_contents'), {
+        var editor = CodeMirror.fromTextArea(document.getElementById('file_edit_contents'), {
             lineNumbers: true,
             autofocus: true,
             tabSize: 4,

--- a/app/src/js/modules/actions.js
+++ b/app/src/js/modules/actions.js
@@ -74,6 +74,25 @@
 
     };
 
+    /**
+     * Ensure that button clicked state is added to form data on submission.
+     *
+     * @function submit
+     * @memberof Bolt.actions
+     *
+     * @param {Object} form   The form to submit
+     * @param {Object} button The button that triggered
+     */
+    actions.submit = function (form, button) {
+        var el = $('<input type="hidden" />');
+
+        el.attr('name', button.name)
+            .val(1)
+            .appendTo(form);
+
+        form.submit();
+    };
+
     // Apply mixin container
     bolt.actions = actions;
 

--- a/app/src/js/modules/editcontent.js
+++ b/app/src/js/modules/editcontent.js
@@ -465,14 +465,14 @@
      */
     function initKeyboardShortcuts() {
         // We're on a regular 'edit content' page, if we have a sidebarsavecontinuebutton.
-        // If we're on an 'edit file' screen,  we have a #saveeditfile
-        if ($('#sidebarsavecontinuebutton').is('*') || $('#saveeditfile').is('*')) {
+        // If we're on an 'edit file' screen,  we have a #file_edit_save
+        if ($('#sidebarsavecontinuebutton').is('*') || $('#file_edit_save').is('*')) {
 
             // Bind ctrl-s and meta-s for saving..
             $('body, input').bind('keydown.ctrl_s keydown.meta_s', function (event) {
                 event.preventDefault();
                 watchChanges();
-                $('#sidebarsavecontinuebutton, #saveeditfile').trigger('click');
+                $('#sidebarsavecontinuebutton, #file_edit_save').trigger('click');
             });
 
             // Initialize watching for changes on "the form".

--- a/app/src/js/modules/editcontent.js
+++ b/app/src/js/modules/editcontent.js
@@ -73,7 +73,7 @@
     function hasChanged() {
         var changes = 0;
 
-        $('form#editcontent').find('input, textarea, select').each(function () {
+        $('form[name="content_edit"]').find('input, textarea, select').each(function () {
             if (this.type === 'textarea' && $(this).hasClass('ckeditor')) {
                 if (ckeditor.instances[this.id].checkDirty()) {
                     changes++;
@@ -97,13 +97,13 @@
      * @memberof Bolt.editcontent
      */
     function watchChanges() {
-        $('form#editcontent').find('input, textarea, select').each(function () {
+        $('form[name="content_edit"]').find('input, textarea, select').each(function () {
             if (this.type === 'textarea' && $(this).hasClass('ckeditor')) {
                 if (ckeditor.instances[this.id].checkDirty()) {
                     ckeditor.instances[this.id].updateElement();
                     ckeditor.instances[this.id].resetDirty();
                 }
-            }else{
+            } else {
                 var val = getComparable(this);
                 if (val !== undefined) {
                     $(this).data('watch', val);
@@ -127,8 +127,8 @@
      * @memberof Bolt.editcontent
      */
     function indicateSavingAction() {
-        $('#sidebarsavecontinuebutton, #savecontinuebutton, #liveeditorsavecontinuebutton').addClass('disabled');
-        $('#sidebarsavecontinuebutton i, #savecontinuebutton i').addClass('fa-spin fa-spinner');
+        $('#sidebar_save, #content_edit_save, #live_editor_save').addClass('disabled');
+        $('#sidebar_save i, #content_edit_save i').addClass('fa-spin fa-spinner');
         $('p.lastsaved').text(bolt.data('editcontent.msg.saving'));
     }
 
@@ -140,8 +140,10 @@
      * @memberof Bolt.editcontent
      */
     function initValidation() {
+        var editForm = $('form[name="content_edit"]');
+
         // Set handler to validate form submit.
-        $('#editcontent')
+        editForm
             .attr('novalidate', 'novalidate')
             .on('submit', function (event) {
                 var valid = bolt.validation.run(this);
@@ -156,7 +158,7 @@
         );
 
         // Basic custom validation handler.
-        $('#editcontent').on('boltvalidate', function () {
+        editForm.on('boltvalidate', function () {
             var valid = bolt.validation.run(this);
 
             $(this).data('valid', valid);
@@ -166,7 +168,7 @@
     }
 
     /**
-     * Initialize persistent tabgroups.
+     * Initialize persistent tab groups.
      *
      * @static
      * @function initTabGroups
@@ -174,13 +176,15 @@
      */
     function initTabGroups() {
         // Show selected tab.
-        var hash = window.location.hash;
+        var hash = window.location.hash,
+            filerTabs = $('#filtertabs');
+
         if (hash) {
-            $('#filtertabs a[href="#tab-' + hash.replace(/^#/, '') + '"]').tab('show');
+            filerTabs.find('a[href="#tab-' + hash.replace(/^#/, '') + '"]').tab('show');
         }
 
         // Set Tab change handler.
-        $('#filtertabs a').click(function () {
+        filerTabs.find('a').click(function () {
             var top;
 
             $(this).tab('show');
@@ -198,13 +202,23 @@
      * @memberof Bolt.editcontent
      */
     function initPreview() {
+        var editForm = $('form[name="content_edit"]');
+
+        // Enable the preview buttons, as they are useless without JavaScript
+        editForm.find('#sidebar_preview').attr('disabled', false);
+        editForm.find('#content_edit_preview').attr('disabled', false);
+
+        $('#sidebar_preview').bind('click', function () {
+            $('#content_edit_preview').trigger('click');
+        });
+
         // To preview the page, we set the target of the form to a new URL, and open it in a new window.
-        $('#previewbutton, #sidebarpreviewbutton').bind('click', function (e) {
+        $('#content_edit_preview').bind('click', function (e) {
             var newAction = $(e.target).data('url');
 
             e.preventDefault();
-            $('#editcontent').attr('action', newAction).attr('target', '_blank').submit();
-            $('#editcontent').attr('action', '').attr('target', '_self');
+            editForm.attr('action', newAction).attr('target', '_blank').submit();
+            editForm.attr('action', '').attr('target', '_self');
         });
     }
 
@@ -224,40 +238,27 @@
      * @static
      * @function initDelete
      * @memberof Bolt.editcontent
-     *
-     * @param {BindData} data - Editcontent configuration data
      */
-    function initDelete(data) {
-        $('#deletebutton, #sidebardeletebutton').bind('click', function (e) {
+    function initDelete() {
+        $('#sidebar_delete').bind('click', function () {
+            $('#content_edit_delete').trigger('click');
+        });
+
+        $('#content_edit_delete').bind('click', function (e) {
             e.preventDefault();
+
+            var button = this;
             bootbox.confirm(
                 bolt.data('editcontent.delete'),
                 function (confirmed) {
                     $('.alert').alert(); // Dismiss alert messages
                     if (confirmed === true) {
-                        var form = $('#id').closest('form'),
-                            ctype = $('#contenttype').val(),
-                            id = $('#id').val(),
-                            token = form.find('input[name="bolt_csrf_token"]').val(),
-                            actionUrl = data.actionUrl,
-                            modifications = {};
+                        var editForm = $('form[name="content_edit"]');
 
-                        modifications[ctype] = {};
-                        modifications[ctype][id] = {'delete': null};
+                        // We don't care about changes, the delete is confirmed.
+                        window.onbeforeunload = null;
 
-                        // Fire delete request.
-                        $.ajax({
-                            url: actionUrl,
-                            type: 'POST',
-                            data: {
-                                'bolt_csrf_token': token,
-                                'contenttype': ctype,
-                                'actions': modifications
-                            },
-                            success: function () {
-                                window.location.href = data.overviewUrl;
-                            }
-                        });
+                        bolt.actions.submit(editForm, button);
                     }
                 }
             );
@@ -265,50 +266,32 @@
     }
 
     /**
-     * Initialize save button handlers.
+     * Initialize "save and create new" button handlers.
      *
      * @static
-     * @function initSave
+     * @function initSaveCreateNew
      * @memberof Bolt.editcontent
      */
-    function initSave() {
-        // Save the page.
-        $('#sidebarsavebutton').bind('click', function () {
-            $('#savebutton').trigger('click');
+    function initSaveCreateNew() {
+        $('#sidebar_save_create').bind('click', function () {
+            $('#content_edit_save_create').trigger('click');
         });
 
-        $('#savebutton').bind('click', function () {
+        $('#content_edit_save_create').bind('click', function () {
             indicateSavingAction();
             watchChanges();
+            bolt.actions.submit($('form[name="content_edit"]'), this);
         });
     }
 
     /**
-     * Initialize "save and new " button handlers.
-     *
-     * @static
-     * @function initSaveNew
-     * @memberof Bolt.editcontent
-     */
-    function initSaveNew() {
-        $('#sidebarsavenewbutton, #savenewbutton').bind('click', function () {
-            indicateSavingAction();
-            watchChanges();
-
-            // Do a regular post, and expect to be redirected back to the "new record" page.
-            var newaction = '?returnto=saveandnew';
-            $('#editcontent').attr('action', newaction).submit();
-        });
-    }
-
-    /**
-     * Initialize "save and continue" button handlers.
+     * Initialize "save" button handlers.
      *
      * Clicking the button either triggers an "ajaxy" post, or a regular post which returns to this page.
      * The latter happens if the record doesn't exist yet, so it doesn't have an id yet.
      *
      * @static
-     * @function initSaveContinue
+     * @function initSave
      * @memberof Bolt.editcontent
      *
      * @fires "Bolt.Content.Save.Start"
@@ -318,14 +301,20 @@
      *
      * @param {BindData} data - Editcontent configuration data
      */
-    function initSaveContinue(data) {
-        $('#sidebarsavecontinuebutton, #savecontinuebutton').bind('click', function (e) {
+    function initSave(data) {
+        $('#sidebar_save').bind('click', function () {
+            $('#content_edit_save').trigger('click');
+        });
+
+        $('#content_edit_save').bind('click', function (e) {
             e.preventDefault();
 
+            var editForm = $('form[name="content_edit"]');
+
             // Trigger form validation
-            $('#editcontent').trigger('boltvalidate');
+            editForm.trigger('boltvalidate');
             // Check validation
-            if (!$('#editcontent').data('valid')) {
+            if (!editForm.data('valid')) {
                 return false;
             }
 
@@ -342,8 +331,12 @@
                     bolt.liveEditor.stop();
                 }
 
+                if (data.duplicate) {
+                    window.onbeforeunload = null;
+                }
+
                 // New record. Do a regular post, and expect to be redirected back to this page.
-                $('#editcontent').attr('action', '?returnto=new').submit();
+                bolt.actions.submit(editForm, this);
             } else {
                 watchChanges();
 
@@ -352,7 +345,12 @@
 
                 // Existing record. Do an 'ajaxy' post to update the record.
                 // Let the controller know we're calling AJAX and expecting to be returned JSON.
-                $.post('?returnto=ajax', $('#editcontent').serialize())
+                var button = $(e.target);
+                var postData = editForm.serialize()
+                    + '&' + encodeURI(button.attr('name'))
+                    + '=' + encodeURI(button.attr('value'))
+                ;
+                $.post('', postData)
                     .done(function (data) {
                         bolt.events.fire('Bolt.Content.Save.Done', {form: data});
 
@@ -369,12 +367,12 @@
                             .buicMoment()
                             .buicMoment('set', data.datechanged);
 
+                        var elSelected = $('#statusselect').find('option:selected');
                         $('a#lastsavedstatus strong').html(
-                            '<i class="fa fa-circle status-' + $('#statusselect option:selected').val() + '"></i> ' +
-                            $('#statusselect option:selected').text()
+                            '<i class="fa fa-circle status-' + elSelected.val() + '"></i> ' + elSelected.text()
                         );
                         // Display the 'save succeeded' icon in the buttons
-                        $('#sidebarsavecontinuebutton i, #savecontinuebutton i')
+                        $('#sidebar_save i, #content_edit_save i')
                             .removeClass('fa-flag fa-spin fa-spinner fa-exclamation-triangle')
                             .addClass('fa-check');
 
@@ -394,7 +392,7 @@
                                     // so we're catching arrays and ignoring
                                     // them, someone else can fix this!
                                 } else {
-                                    var field = $('#editcontent [name=' + index + ']');
+                                    var field = $(editForm.name).find('[name=' + index + ']');
 
                                     if (field.attr('type') === 'checkbox') {
                                         // A checkbox, so set with prop
@@ -434,7 +432,7 @@
                             .addClass('alert alert-danger');
 
                         // Display the 'save failed' icon in the buttons
-                        $('#sidebarsavecontinuebutton i, #savecontinuebutton i')
+                        $('#sidebar_save i, #content_edit_save i')
                             .removeClass('fa-flag fa-spin fa-spinner')
                             .addClass('fa-exclamation-triangle');
                     })
@@ -443,10 +441,11 @@
 
                         // Re-enable buttons
                         window.setTimeout(function () {
-                            $('#sidebarsavecontinuebutton, #savecontinuebutton, #liveeditorsavecontinuebutton').removeClass('disabled').blur();
+                            $('#sidebar_save, #content_edit_save, #live_editor_save')
+                                .removeClass('disabled').blur();
                         }, 1000);
                         window.setTimeout(function () {
-                            $('#sidebarsavecontinuebutton i, #savecontinuebutton i').addClass('fa-flag');
+                            $('#sidebar_save i, #content_edit_save i').addClass('fa-flag');
                         }, 5000);
                     }
                 );
@@ -456,23 +455,19 @@
 
     /**
      * Initialize keyboard shortcuts:
-     * - Click 'save' in Edit content screen.
-     * - Click 'save' in "edit file" screen.
+     * - Click 'save' in edit screen.
      *
      * @static
      * @function initKeyboardShortcuts
      * @memberof Bolt.editcontent
      */
     function initKeyboardShortcuts() {
-        // We're on a regular 'edit content' page, if we have a sidebarsavecontinuebutton.
-        // If we're on an 'edit file' screen,  we have a #file_edit_save
-        if ($('#sidebarsavecontinuebutton').is('*') || $('#file_edit_save').is('*')) {
-
+        if ($('#content_edit_save').is('*')) {
             // Bind ctrl-s and meta-s for saving..
             $('body, input').bind('keydown.ctrl_s keydown.meta_s', function (event) {
                 event.preventDefault();
                 watchChanges();
-                $('#sidebarsavecontinuebutton, #file_edit_save').trigger('click');
+                $('#content_edit_save').trigger('click');
             });
 
             // Initialize watching for changes on "the form".
@@ -496,9 +491,8 @@
      */
     editcontent.init = function (data) {
         initValidation();
-        initSave();
-        initSaveNew();
-        initSaveContinue(data);
+        initSave(data);
+        initSaveCreateNew();
         initPreview();
         initLiveEditor();
         initDelete(data);

--- a/app/src/js/modules/files.js
+++ b/app/src/js/modules/files.js
@@ -1,3 +1,4 @@
+/* eslint no-console: ["error", { allow: ["error"] }] */
 /**
  * Offers file/folder actions (create, delete, duplicate, rename) functionality utilizing AJAX requests.
  *
@@ -41,7 +42,7 @@
             },
             error: function (result) {
                 alert(result.responseText);
-                console.log(errMsg);
+                console.error(errMsg);
             }
         };
         if (success) {

--- a/app/src/js/modules/stack.js
+++ b/app/src/js/modules/stack.js
@@ -1,3 +1,4 @@
+/* eslint no-console: ["error", { allow: ["error"] }] */
 /**
  * Stack-related functionality.
  *
@@ -77,7 +78,7 @@
                 });
             })
             .fail(function () {
-                console.log('Failed to add file to stack');
+                console.error('Failed to add file to stack');
             });
     };
 

--- a/app/src/js/obj-validation.js
+++ b/app/src/js/obj-validation.js
@@ -1,3 +1,4 @@
+/* eslint no-console: ["error", { allow: ["error"] }] */
 /**
  * Form validation
  */
@@ -224,7 +225,7 @@ Bolt.validation = (function () {
                             break;
 
                         default:
-                            console.log('UNKNOWN VALIDATION' + task + " -> " + param);
+                            console.error('UNKNOWN VALIDATION' + task + " -> " + param);
                     }
                     // Stop on first error
                     if (error) {

--- a/app/src/js/widgets/buic/buicListing.js
+++ b/app/src/js/widgets/buic/buicListing.js
@@ -1,3 +1,4 @@
+/* eslint no-console: ["error", { allow: ["error"] }] */
 /**
  * @param {Object} $    - Global jQuery object
  * @param {Object} bolt - The Bolt module
@@ -133,8 +134,8 @@
                     */
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
-                    console.log(jqXHR.status + ' (' + errorThrown + '):');
-                    console.log(JSON.parse(jqXHR.responseText));
+                    console.error(jqXHR.status + ' (' + errorThrown + '):');
+                    console.error(JSON.parse(jqXHR.responseText));
                 },
                 dataType: 'html'
             });

--- a/app/src/js/widgets/fields/fieldBlock.js
+++ b/app/src/js/widgets/fields/fieldBlock.js
@@ -189,7 +189,9 @@
             var editors = container.find('.ckeditor');
 
             editors.each(function (i, editor) {
-                cke.instances[editor.id].destroy();
+                if (cke.instances[editor.id]) {
+                    cke.instances[editor.id].destroy();
+                }
                 cke.replace(editor.id);
             });
         },

--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -228,7 +228,9 @@
             var editors = container.find('.ckeditor');
 
             editors.each(function (i, editor) {
-                cke.instances[editor.id].destroy();
+                if (cke.instances[editor.id]) {
+                    cke.instances[editor.id].destroy();
+                }
                 cke.replace(editor.id);
             });
         },

--- a/app/src/js/widgets/fields/fieldSlug.js
+++ b/app/src/js/widgets/fields/fieldSlug.js
@@ -1,3 +1,4 @@
+/* eslint no-console: ["error", { allow: ["error"] }] */
 /**
  * @param {Object} $    - Global jQuery object
  * @param {Object} bolt - The Bolt module
@@ -243,7 +244,7 @@
                     }
                 })
                 .fail(function () {
-                    console.log('failed to get an URI');
+                    console.error('Failed to get URI for ' + self.options.slug + '/' + self.options.contentId);
                 })
                 .always(function () {
                     self._ui.group.removeClass('loading');

--- a/app/src/js/widgets/fields/fieldVideo.js
+++ b/app/src/js/widgets/fields/fieldVideo.js
@@ -101,7 +101,7 @@
         },
 
         /**
-         * Gets video embedding info from http://api.embed.ly and then updates video fields.
+         * Gets video embedding info from the internal embed API and then updates video fields.
          *
          * @private
          */
@@ -109,12 +109,12 @@
             var self = this,
                 url = bolt.data('endpoint.embed'),
                 form = $('#id').closest('form'),
-                token = form.find('input[name="bolt_csrf_token"]').val(),
+                token = form.find('input[name="content_edit[_token]"]').val(),
                 request = {
-                    format:          'json',
-                    url:             self._ui.url.val(),
-                    bolt_csrf_token: token,
-                    provider:        'oembed'
+                    format:   'json',
+                    url:      self._ui.url.val(),
+                    _token:   token,
+                    provider: 'oembed'
                 };
 
             // If val is emptied, clear the video fields.

--- a/app/src/sass/editcontent/_legacy.scss
+++ b/app/src/sass/editcontent/_legacy.scss
@@ -1,4 +1,4 @@
-#editcontent {
+form[name="content_edit"] {
 
     /*** General ***/
 

--- a/app/src/sass/modules/custom/_select2.scss
+++ b/app/src/sass/modules/custom/_select2.scss
@@ -1,7 +1,7 @@
 /**
  * Styles for Select2
  */
-#editcontent {
+form[name="content_edit"] {
     // Selection clear button.
     .select2-selection__clear {
         display: none;

--- a/app/theme_defaults/form_bolt_layout.twig
+++ b/app/theme_defaults/form_bolt_layout.twig
@@ -1,49 +1,25 @@
-{# overrides for the defaults in vendor/symfony/twig-bridge/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig #}
+{# overrides for the defaults in vendor/symfony/twig-bridge/Resources/views/Form/bootstrap_3_horizontal_layout.html.twig #}
+{% use "bootstrap_3_horizontal_layout.html.twig" %}
 
-{% block form_row %}
-    {% spaceless %}
-        <div class="form-group {% if errors|length > 0 %}has-error{% endif %}">
-            {{ form_label(form, null, {'label_attr': {'class':'col-sm-2 control-label' } }) }}
-            <div class="col-sm-10 col-md-6 col-lg-4">
-                {{ form_widget(form, {'attr' : { 'class' : 'form-control large' } }) }}
-                {{ form_errors(form) }}
-            </div>
+{% block form_row -%}
+    <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+        {{- form_label(form, null, {'label_attr': {'class':'col-sm-2 control-label' } }) -}}
+        <div class="col-sm-10 col-md-6 col-lg-4">
+            {{- form_widget(form, {'attr' : { 'class' : 'large' } }) -}}
+            {{- form_errors(form) -}}
         </div>
-    {% endspaceless %}
-{% endblock form_row %}
-
-{% block form_errors %}
-    {% spaceless %}
-        {% for error in errors %}
-            <span class="help-block">{{
-            error.messagePluralization is null
-            ? error.messageTemplate|trans(error.messageParameters, 'validators')
-            : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
-            }}</span>
-        {% endfor %}
-    {% endspaceless %}
-{% endblock form_errors %}
-
-{% block choice_widget_expanded %}
-    {% spaceless %}
-        <div>
-            {% for child in form %}
-                <div class="checkbox">
-                    <label>
-                    {{ form_widget(child) }}{{ child.vars.label -}}
-                    </label>
-                </div>
-            {% endfor %}
-        </div>
-    {% endspaceless %}
-{% endblock choice_widget_expanded %}
-
-{% block button_attributes %} class="btn btn-primary" {% endblock button_attributes %}
+    </div>
+{%- endblock form_row %}
 
 {# Button <i> used inside button_widget when set #}
-{%- block button_icon -%}{%- endblock button_icon -%}
+{%- block button_icon %}
+{% if block(form.parent.vars.name ~ '_' ~ name ~ '_button_icon') is defined %}
+    {{ block(form.parent.vars.name ~ '_' ~ name ~ '_button_icon') }}
+{% endif %}
+{% endblock button_icon -%}
 
 {%- block button_widget -%}
+    {% set attr = attr|merge({class: (attr.class|default('btn-primary') ~ ' btn')|trim}) %}
     {%- if label is empty -%}
         {%- if label_format is not empty -%}
             {% set label = label_format|replace({

--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -247,7 +247,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                         {% endif %}
                         {% if permissions.create %}
                             <li>
-                                <a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id, 'duplicate': 1}) }}">
+                                <a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'source': content.id, 'duplicate': 1}) }}">
                                     <i class="fa fa-copy"></i> {{ __('contenttypes.generic.duplicate', {'%contenttype%': content.contenttype.slug}) }}
                                 </a>
                             </li>
@@ -265,8 +265,9 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                     <li>
                         <a class="nolink">
                             {{ __('general.phrase.author-colon') }} <strong><i class="fa fa-user"></i>
-                                {% if content.user.displayname is defined %}
-                                    {{ content.user.displayname|excerpt(15) }}
+                                {% set owner = app.users.user(content.ownerid) %}
+                                {% if owner %}
+                                    {{ owner.displayname|excerpt(15) }}
                                 {% else %}
                                     <s>user {{ content.ownerid }}</s>
                                 {% endif %}</strong>

--- a/app/view/twig/_nav/_primary.twig
+++ b/app/view/twig/_nav/_primary.twig
@@ -30,7 +30,7 @@
     </li>
 
     {% if context.contenttype is defined %}
-    <li id="liveeditorsavecontinuebutton" class="save-live-editor">
+    <li id="live_editor_save" class="save-live-editor">
         <a>
             <i class="fa fa-fw fa-flag"></i>
             {{ __('contenttypes.generic.save', {'%contenttype%': context.contenttype.slug}) }}

--- a/app/view/twig/editcontent/_aside-delete.twig
+++ b/app/view/twig/editcontent/_aside-delete.twig
@@ -1,8 +1,7 @@
 {{ data('editcontent.delete', __('Are you sure you wish to delete this record? There is no undo.')) }}
 
 <div class="btn-group">
-    <button type="button" class="btn btn-silent-danger" id="sidebardeletebutton">
+    <button type="button" class="btn btn-silent-danger" id="sidebar_delete">
         <i class="fa fa-trash"></i> {{ __('contenttypes.generic.delete', {'%contenttype%': context.contenttype.slug}) }}
     </button>
-
 </div>

--- a/app/view/twig/editcontent/_aside-live-editor.twig
+++ b/app/view/twig/editcontent/_aside-live-editor.twig
@@ -1,6 +1,6 @@
 {% if context.contenttype.liveeditor is not defined or context.contenttype.liveeditor %}{# don't show for viewless contenttypes. #}
 <div class="btn-group hidden-xs">
-    <button type="button" class="btn btn-secondary" id="sidebar-live-editor-button">
+    <button type="button" class="btn btn-secondary" id="sidebar_live_edit">
         <i class="fa fa-pencil"></i> {{ __('general.phrase.live-edit') }}
     </button>
 </div>

--- a/app/view/twig/editcontent/_aside-preview.twig
+++ b/app/view/twig/editcontent/_aside-preview.twig
@@ -1,7 +1,7 @@
 {% if not context.contenttype.viewless|default(false) %}{# don't show for viewless contenttypes. #}
 <div class="btn-group">
     {% if app.routes.get('preview') %}
-        <button type="button" class="btn btn-default" id="sidebarpreviewbutton" data-url="{{ path('preview', {'contenttypeslug': context.contenttype.singular_slug}) }}">
+        <button type="button" class="btn btn-default" id="sidebar_preview" data-url="{{ path('preview', {'contenttypeslug': context.contenttype.singular_slug}) }}">
             <i class="fa fa-external-link-square"></i> {{ __('general.phrase.preview') }}
         </button>
     {% else %}

--- a/app/view/twig/editcontent/_aside-save.twig
+++ b/app/view/twig/editcontent/_aside-save.twig
@@ -1,5 +1,5 @@
 <div class="btn-group">
-    <button type="button" class="btn btn-primary" id="sidebarsavecontinuebutton">
+    <button type="button" class="btn btn-primary" id="sidebar_save">
         <i class="fa fa-flag"></i> {{ __('contenttypes.generic.save', {'%contenttype%': context.contenttype.singular_name}) }}
     </button>
 
@@ -10,13 +10,13 @@
 
     <ul class="dropdown-menu" role="menu">
         <li>
-            <button type="submit" class="btn btn-link" id="sidebarsavebutton">
+            <button type="submit" class="btn btn-link" id="save_return">
                 <i class="fa fa-fw fa-flag"></i> {{ __('general.phrase.save-and-return-overview') }}
             </button>
         </li>
 
         <li>
-            <button type="submit" class="btn btn-link" id="sidebarsavenewbutton">
+            <button type="submit" class="btn btn-link" id="sidebar_save_create">
                 <i class="fa fa-fw fa-flag"></i> {{ __('general.phrase.save-and-create-new-record') }}
             </button>
         </li>

--- a/app/view/twig/editcontent/_buttons.twig
+++ b/app/view/twig/editcontent/_buttons.twig
@@ -1,13 +1,14 @@
 {% from '@bolt/_buic/_moment.twig' import buic_moment %}
 
+{% form_theme context.form '@bolt/editcontent/form/editcontent_form_layout.twig' %}
+
 <div class="form-group hidden-xs">
     <div class="col-xs-12">
 
         {# Save Contentype #}
         <div class="btn-group">
-            <button type="button" class="btn btn-primary" id="savecontinuebutton">
-                <i class="fa fa-fw fa-flag"></i> {{ __('contenttypes.generic.save', {'%contenttype%': context.contenttype.singular_name}) }}
-            </button>
+            {{ form_widget(context.form.save) }}
+
             {# Dropdown #}
             <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
                 <span class="caret"></span>
@@ -15,24 +16,18 @@
             </button>
             <ul class="dropdown-menu" role="menu">
                 <li>
-                    <button type="submit" class="btn btn-link" id="savebutton">
-                        <i class="fa fa-fw fa-flag"></i> {{ __('general.phrase.save-and-return-overview') }}
-                    </button>
+                    {{ form_widget(context.form.save_return, {'attr': {'class': 'btn-link'}}) }}
                 </li>
                 <li>
-                    <button type="submit" class="btn btn-link" id="savenewbutton">
-                        <i class="fa fa-fw fa-flag"></i> {{ __('general.phrase.save-and-create-new-record') }}
-                    </button>
+                    {{ form_widget(context.form.save_create, {'attr': {'class': 'btn-link'}}) }}
                 </li>
             </ul>
         </div>
 
         {# Live Edit #}
-        {% if context.contenttype.liveeditor is not defined or context.contenttype.liveeditor %}
+        {% if context.contenttype.liveeditor|default(false) %}
             <div class="btn-group">
-                <button type="button" class="btn btn-secondary" id="live-editor-button">
-                    <i class="fa fa-pencil"></i> {{ __('general.phrase.live-edit') }}
-                </button>
+                {{ form_widget(context.form.live_edit, {'attr': {'class': 'btn-secondary'}}) }}
             </div>
         {% endif %}
 
@@ -40,13 +35,18 @@
         {% if not context.contenttype.viewless|default(false) %}
             <div class="btn-group">
                 {% if app.routes.get('preview') %}
-                    <button type="button" class="btn btn-default" id="previewbutton" data-url="{{ path('preview', {'contenttypeslug': context.contenttype.singular_slug}) }}">
-                        <i class="fa fa-external-link-square"></i> {{ __('general.phrase.preview') }}
-                    </button>
+                    {{ form_widget(context.form.preview, {
+                        'attr': {
+                            'class': 'btn-default',
+                            'data-url': path('preview', {'contenttypeslug': context.contenttype.singular_slug}),
+                            'disabled': true
+                        }
+                    }) }}
                 {% else %}
-                    <button type="button" class="btn btn-disabled">
-                        <i class="fa fa-external-link-square"></i> {{ __('general.phrase.no-preview') }}
-                    </button>
+                    {{ form_widget(context.form.preview, {
+                        'label': __('general.phrase.no-preview'),
+                        'attr': {'class': 'btn-default'}
+                    }) }}
                 {% endif %}
 
                 {# Dropdown #}
@@ -58,13 +58,16 @@
                     <ul class="dropdown-menu" role="menu">
                         <li>
                             <a href="{{ context.content.link }}" target="_blank">
-                                <i class="fa fa-external-link-square"></i> {{ __('View (saved version) on site') }}
+                                <i class="fa fa-external-link-square"> </i>{{ __('View (saved version) on site') }}
                             </a>
                         </li>
                     </ul>
                 {% endif %}
             </div>
         {% endif %}
+
+        {# Hidden delete button #}
+        {{ form_widget(context.form.delete, {'attr': {'class': 'btn-silent-danger'}}) }}
 
         {# Last saved #}
         <p class="lastsaved form-control-static">

--- a/app/view/twig/editcontent/editcontent.twig
+++ b/app/view/twig/editcontent/editcontent.twig
@@ -22,6 +22,8 @@
 {% block messages "" %}
 
 {% block page_main %}
+    {% form_theme context.form '@bolt/editcontent/form/editcontent_form_layout.twig' %}
+
     {% set status_names = {
         'published': __('general.phrase.published'),
         'held':      __('general.phrase.not-published'),
@@ -32,8 +34,10 @@
     {% set dateChanged %}{{ buic_moment(context.content.datechanged) }}{% endset %}
 
     {% set bind_data = {
+        bind:           'editcontent',
         savedon:        __('general.phrase.saved-on-colon') ~ ' <strong></strong> <small>(' ~ dateChanged ~ ')</small></p>',
         newRecord:      context.content.id != 0 ? false : true,
+        duplicate:      context.duplicate,
         msgNotSaved:    __('contenttypes.generic.saving-impossible', {'%contenttype%': context.contenttype.slug}),
         hasGroups:      context.has.tabs,
         singularSlug:   context.contenttype.singular_slug,
@@ -43,11 +47,8 @@
     } %}
 
     {% set attr_form = {
-        _bind:   ['editcontent', bind_data],
-        class:   'form-horizontal' ~ (context.has.tabs ? ' tab-content' : ''),
-        enctype: 'multipart/form-data',
-        id:      'editcontent',
-        method:  'post',
+        'data-bind': bind_data|json_encode,
+        'class':     'form-horizontal' ~ (context.has.tabs ? ' tab-content' : ''),
     } %}
 
     {% set attributes = {
@@ -82,8 +83,8 @@
                 </ul>
             {% endif %}
 
-            <form{{ macro.attr(attr_form) }}>
-                {{ include('@bolt/_sub/_csrf_token.twig') }}
+            {{ form_start(context.form, {'attr': attr_form}) }}
+                {{ form_widget(context.form._token) }}
 
                 <input{{ macro.attr(attributes.hid_editreferrer) }}>
                 <input{{ macro.attr(attributes.hid_contenttype) }}>
@@ -125,7 +126,8 @@
                 <input type="hidden" name="_live-editor-preview" value=""/>
 
                 {{ include('@bolt/editcontent/_buttons.twig') }}
-            </form>
+
+            {{ form_end(context.form, { 'render_rest': false }) }}
 
             {{ include('@bolt/editcontent/_includes-data.twig') }}
 

--- a/app/view/twig/editcontent/form/editcontent_form_layout.twig
+++ b/app/view/twig/editcontent/form/editcontent_form_layout.twig
@@ -1,0 +1,27 @@
+{% use 'form_bolt_layout.twig' %}
+
+{# Save button icons #}
+{%- block content_edit_save_button_icon %}
+    <i class="fa fa-fw fa-flag"> </i>
+{% endblock -%}
+{%- block content_edit_save_return_button_icon %}
+    <i class="fa fa-fw fa-flag"> </i>
+{% endblock -%}
+{%- block content_edit_save_create_button_icon %}
+    <i class="fa fa-fw fa-flag"> </i>
+{% endblock -%}
+
+{# Live edit icon #}
+{%- block content_edit_live_edit_button_icon %}
+    <i class="fa fa-pencil"> </i>
+{% endblock -%}
+
+{# Preview button icon #}
+{%- block content_edit_preview_button_icon %}
+    <i class="fa fa-external-link-square"> </i>
+{% endblock -%}
+
+{# Delete button icon #}
+{%- block content_edit_delete_button_icon %}
+    <i class="fa fa-trash"> </i>
+{% endblock -%}

--- a/app/view/twig/editfile/editfile.twig
+++ b/app/view/twig/editfile/editfile.twig
@@ -6,6 +6,15 @@
 
 {% block page_title context.write_allowed ? __('page.edit-file.title.edit') : __('page.edit-file.title.view') %}
 
+{% form_theme context.form 'form_bolt_layout.twig' _self %}
+
+{%- block file_edit_save_button_icon %}
+    <i class="fa fa-flag"> </i>
+{% endblock -%}
+{%- block file_edit_revert_button_icon %}
+    <i class="fa fa-undo"> </i>
+{% endblock -%}
+
 {% block page_main %}
 
     {% import '@bolt/_macro/_macro.twig' as macro %}
@@ -33,8 +42,7 @@
 
             {{ widgets('editfile_below_header', 'backend') }}
 
-            {# Ths "editfile" ID is being used by JavaScript … somewhere #}
-            {{ form_start(context.form, {'attr': {'id': 'editfile', 'class': 'form-inline', 'autocomplete': 'off'}}) }}
+            {{ form_start(context.form, {'attr': {'class': 'form-inline', 'autocomplete': 'off'}}) }}
                 {{ form_widget(context.form._token) }}
 
                 <div>
@@ -50,15 +58,12 @@
                 </div>
 
                 <div>
-                    <button type="button" id="saveeditfile" class="btn btn-primary" {% if not context.write_allowed %}disabled{% endif %}>
-                        <i class="fa fa-flag"></i> {{ __('page.edit-file.button.save') }}
-                    </button>
-                    <a class="btn btn-default confirm {% if not context.write_allowed %}disabled{% endif %}" style="margin-left: 24px;"
-                       data-confirm="{{ __("page.edit-file.confirm-revert") }}"
-                       href="{{ path('fileedit', {'namespace': context.file.mountPoint, 'file': context.file.path}) }}"
-                    >
-                        <i class="fa fa-undo"></i> {{ __("page.edit-file.button.revert") }}
-                    </a>
+                    {{ form_widget(context.form.save) }}
+                    {{ form_widget(context.form.revert, {'attr': {
+                        'class': 'btn-default confirm',
+                        'data-confirm': __('page.edit-file.confirm-revert'),
+                        'style': 'margin-left: 24px;'
+                    }}) }}
 
                   <div class="relatedfiles">
                     {% if context.related|length > 0 %}

--- a/app/view/twig/editlocale/editlocale.twig
+++ b/app/view/twig/editlocale/editlocale.twig
@@ -8,6 +8,8 @@
 
 {% block page_subtitle context.basename %}
 
+{% form_theme context.form 'form_bolt_layout.twig' _self %}
+
 {% block page_main %}
 
     {% import '@bolt/_macro/_macro.twig' as macro %}
@@ -17,6 +19,7 @@
             {{ form_start(context.form, {'attr': {'class': 'form-inline', 'autocomplete': 'off'}}) }}
                 <div>
                     {% set bind = ismobileclient() ? '' : {'bind': 'editlocale', 'readonly': context.write_allowed ? false : true} %}
+                    {{ form_errors(context.form.contents) }}
                     {{ form_widget(context.form.contents,
                         {
                             'class': 'CodeMirror-scroll',
@@ -30,7 +33,7 @@
                 {# Let's play "Hide the button" … #}
                 {% if context.write_allowed %}
                     {{ form_widget(context.form._token) }}
-                    {{ form_widget(context.form.submit, { 'attr': { 'class': 'btn btn-primary' } }) }}
+                    {{ form_widget(context.form.save) }}
                 {% endif %}
             {{ form_end(context.form, { 'render_rest': false }) }}
         </div>

--- a/app/view/twig/edituser/edituser.twig
+++ b/app/view/twig/edituser/edituser.twig
@@ -39,7 +39,7 @@
                 </p>
             {% endif %}
 
-            {{ form_start(context.form, {'attr': {'class': 'form-horizontal', 'autocomplete': 'off'}}) }}
+            {{ form_start(context.form, {'attr': {'autocomplete': 'off'}}) }}
                 {# Google Chrome, Firefox, MS Edge all require this trick to prevent password fields from auto-filling.
                    @see http://stackoverflow.com/questions/15738259/disabling-chrome-autofill #}
                 <input type="text" style="display:none;" />

--- a/app/view/twig/files/_upload.twig
+++ b/app/view/twig/files/_upload.twig
@@ -1,14 +1,17 @@
 {% import '@bolt/_macro/_macro.twig' as macro %}
+
+{% form_theme context.form 'form_bolt_layout.twig' _self %}
+
+{%- block button_icon %}
+    <i class="fa fa-fw fa-upload"> </i>
+{% endblock button_icon -%}
 <br>
 {{ form_start(context.form) }}
     <fieldset>
         <p><strong>{{ __('general.phrase.upload-file-to-directory') }}</strong> {{ macro.typepopover() }}</p>
-        {{ form_widget(context.form) }}
+        {{ form_widget(context.form.FileUpload) }}
         <div>
-            <button type="submit" class="btn btn-primary" disabled>
-                <i class="fa fa-fw fa-upload"></i>
-                <span>{{ __('general.phrase.upload-file') }}</span>
-            </button>
+            {{ form_widget(context.form.upload) }}
         </div>
     </fieldset>
 {{ form_end(context.form) }}
@@ -16,7 +19,6 @@
 <script>
     $(function() {
         $('input[type=file]').addClass('btn-secondary').bootstrapFileInput();
-
         $('input:file').change(
             function(){
                 if ($(this).val()) {
@@ -24,6 +26,5 @@
                 }
             }
         );
-
     });
 </script>

--- a/app/view/twig/firstuser/firstuser.twig
+++ b/app/view/twig/firstuser/firstuser.twig
@@ -73,11 +73,11 @@
     <script type="text/javascript">
         $(function() {
             // Attach and detach the progressbar.
-            var el = $('#progress-wrapper').detach()
-            $('#user_new_password_first').parent().append(el);
-
+            var el = $('#progress-wrapper').detach(),
+                pw = $('#user_new_password_first');
             // Initialize complexify, to indicate password strength.
-            $('#user_new_password_first').complexify({'strengthScaleFactor': 0.6, 'minimumChars': 6}, function (valid, complexity) {
+            pw.parent().append(el);
+            pw.complexify({'strengthScaleFactor': 0.6, 'minimumChars': 6}, function (valid, complexity) {
                 var progressBar = $('#complexity-bar');
                 progressBar.toggleClass('progress-bar-danger', (complexity < 40 ));
                 progressBar.toggleClass('progress-bar-warning', (complexity < 50 ));

--- a/app/view/twig/firstuser/firstuser.twig
+++ b/app/view/twig/firstuser/firstuser.twig
@@ -50,7 +50,7 @@
         {{ __('general.phrase.users-none-create-first-extended') }}
     </p>
 
-    {{ form_start(context.form, {'attr': {'class': 'form-horizontal submitspinner', 'autocomplete': "off"}}) }}
+    {{ form_start(context.form, {'attr': {'class': 'submitspinner', 'autocomplete': "off"}}) }}
         {# Google Chrome, Firefox, MS edge all require this trick to prevent password fields from auto-filling.
            @see http://stackoverflow.com/questions/15738259/disabling-chrome-autofill #}
         <input type="text" style="display:none;" />

--- a/app/view/twig/prefill/prefill.twig
+++ b/app/view/twig/prefill/prefill.twig
@@ -6,6 +6,24 @@
 
 {% block page_title __('general.phrase.database-prefill-dummy-content') %}
 
+{% form_theme context.form 'form_bolt_layout.twig' _self %}
+
+{%- block prefill_check_all_button_icon %}
+    <i class="fa fa-fw fa-check-square-o"> </i>
+{% endblock -%}
+{%- block prefill_uncheck_all_button_icon %}
+    <i class="fa fa-fw fa-square-o"> </i>
+{% endblock -%}
+{%- block prefill_submit_button_icon %}
+    <i class="fa fa-wrench"> </i>
+{% endblock -%}
+
+{% block checkbox_label -%}
+    {# Not pretty, but need valid SCSS changes as '.checkbox.label' overrides us here #}
+    {%- set label_attr = label_attr|merge({'style': 'font-weight: bold !important;'}) -%}
+    {{- block('checkbox_radio_label') -}}
+{%- endblock checkbox_label %}
+
 {% block page_main %}
     {% use '@bolt/prefill/_blocks.twig' %}
 
@@ -18,33 +36,28 @@
                 {{  block('prefill_response_pass') }}
             {% endif %}
 
-            {{ form_start(context.form, {'attr': {'class': 'form-horizontal'}}) }}
-                <div id="form">
-                    <div class="control-group">
-                        <div class="info">
-                            {{ app.translator.trans('prefill.short_help', {}, 'infos')|raw }}
-                        </div>
+            {{ form_start(context.form) }}
+            <div class="info">
+                {{ app.translator.trans('prefill.short_help', {}, 'infos')|raw }}
+            </div>
 
-                        <div id="form_contenttypes" style="border-bottom: 1px solid #eee; margin-bottom: 10px; width: 50%">
-                            {% for field in context.form.contenttypes %}
-                                <div>
-                                    <label>{{ form_widget(field) }}{{ field.vars.label }}</label>
-                                </div>
-                            {% endfor %}
-                        </div>
+            <div id="form_contenttypes" style="border-bottom: 1px solid #eee; margin-bottom: 10px; width: 50%">
+                {% for field in context.form.contenttypes %}
+                    <div>
+                        {{ form_widget(field) }}
                     </div>
-                </div>
+                {% endfor %}
+            </div>
 
-                {{ form_widget(context.form._token) }}
+            {{ form_widget(context.form._token) }}
 
-                <div style="margin-top: 12px">
-                    <button type="button" class="btn btn-xs" id="check-all"><i class="fa fa-fw fa-check-square-o"></i> {{ __('general.phrase.select-all') }}</button>
-                    <button type="button" class="btn btn-xs" id="uncheck-all"><i class="fa fa-fw fa-square-o"></i> {{ __('general.phrase.deselect-all') }}</button>
-                </div>
-                <div style="margin-top: 12px">
-                    <button type="submit" class="btn btn-primary"><i class="fa fa-wrench"></i> {{ __('general.phrase.database-prefill') }}</button>
-                </div>
-
+            <div style="margin-top: 12px">
+                {{ form_widget(context.form.check_all, {'attr': {'class': 'btn-xs'}, 'label': __('general.phrase.select-all') }) }}
+                {{ form_widget(context.form.uncheck_all, {'attr': {'class': 'btn-xs'}, 'label': __('general.phrase.deselect-all')}) }}
+            </div>
+            <div style="margin-top: 12px">
+                {{ form_widget(context.form.submit, {'label': __('general.phrase.database-prefill')}) }}
+            </div>
             {{ form_end(context.form) }}
 
         </div>

--- a/src/Application.php
+++ b/src/Application.php
@@ -227,7 +227,7 @@ class Application extends Silex\Application
         $this
             ->register(new Silex\Provider\HttpFragmentServiceProvider())
             ->register(new Silex\Provider\UrlGeneratorServiceProvider())
-            ->register(new Silex\Provider\ValidatorServiceProvider())
+            ->register(new Provider\ValidatorServiceProvider())
             ->register(new Provider\RoutingServiceProvider())
             ->register(new Silex\Provider\ServiceControllerServiceProvider()) // must be after Routing
             ->register(new Provider\SecurityServiceProvider())

--- a/src/Controller/Async/Embed.php
+++ b/src/Controller/Async/Embed.php
@@ -27,7 +27,9 @@ class Embed extends AsyncBase
         $c->post('/embed', 'embed')
             ->bind('embedRequestEndpoint')
             ->before(function (Request $request) {
-                if (!$this->isCsrfTokenValid($request->request->get('bolt_csrf_token'))) {
+                $tokenValue = $request->request->get('_token');
+                // Only accept valid tokens from the ContentType edit form, or the default "bolt" token ID
+                if ($tokenValue === null || !($this->isCsrfTokenValid($tokenValue, 'content_edit') || $this->isCsrfTokenValid($tokenValue))) {
                     return new JsonResponse(['error' => ['message' => 'Invalid CSRF token']], Response::HTTP_FORBIDDEN);
                 }
                 if ($request->request->has('provider')) {

--- a/src/Controller/Backend/FileManager.php
+++ b/src/Controller/Backend/FileManager.php
@@ -11,13 +11,12 @@ use Bolt\Filesystem\Handler\File;
 use Bolt\Filesystem\Handler\FileInterface;
 use Bolt\Filesystem\Handler\HandlerInterface;
 use Bolt\Form\FormType\FileEditType;
+use Bolt\Form\FormType\FileUploadType;
 use Bolt\Form\Validator\Constraints;
 use Bolt\Helpers\Input;
 use Bolt\Helpers\Str;
 use Bolt\Translation\Translator as Trans;
 use Silex\ControllerCollection;
-use Symfony\Component\Form\Extension\Core\Type\FileType;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -136,25 +135,14 @@ class FileManager extends BackendBase
         $form = null;
         if (!$request->query->has('CKEditor') && $this->isAllowed('files:uploads')) {
             // Define the "Upload here" form.
-            $form = $this->createFormBuilder(FormType::class)
-                ->add(
-                    'FileUpload',
-                    FileType::class,
-                    [
-                        'label'    => false,
-                        'multiple' => true,
-                        'attr'     => [
-                            'data-filename-placement' => 'inside',
-                            'title'                   => Trans::__('general.phrase.select-file'),
-                            'accept'                  => '.' . implode(',.', $this->getOption('general/accept_file_types')),
-                        ],
-                    ]
-                )
-                ->getForm();
+            $options = ['accept' => '.' . implode(',.', $this->getOption('general/accept_file_types'))];
+            $form = $this->createFormBuilder(FileUploadType::class, null, $options)
+                ->getForm()
+            ;
 
             // Handle the upload.
             $form->handleRequest($request);
-            if ($form->isSubmitted()) {
+            if ($form->isSubmitted() && $form->isValid()) {
                 $this->handleUpload($form, $directory);
 
                 return $this->redirectToRoute('files', ['path' => $directory->getPath(), 'namespace' => $directory->getMountPoint()]);

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -3,22 +3,17 @@
 namespace Bolt\Controller\Backend;
 
 use Bolt\Collection\Bag;
+use Bolt\Filesystem\Exception\IOException;
+use Bolt\Form\FormType\FileEditType;
 use Bolt\Form\FormType\PrefillType;
+use Bolt\Form\Validator\Constraints;
 use Bolt\Helpers\Input;
 use Bolt\Omnisearch;
 use Bolt\Requirement\BoltRequirements;
 use Bolt\Translation\TranslationFile;
 use Bolt\Translation\Translator as Trans;
 use Silex\ControllerCollection;
-use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Yaml\Exception\ParseException;
-use Symfony\Component\Yaml\Yaml;
 use Symfony\Requirements\PhpConfigRequirement;
 
 /**
@@ -236,35 +231,22 @@ class General extends BackendBase
      */
     public function translation(Request $request, $domain, $tr_locale)
     {
-        $tr = [
+        $tr = Bag::from([
             'domain' => $domain,
             'locale' => $tr_locale,
-        ];
+        ]);
 
         // Get the translation data
         $data = $this->getTranslationData($tr);
+        $options = [
+            'write_allowed'        => $tr['writeallowed'],
+            'contents_constraints' => [new Constraints\Yaml()],
+        ];
 
         // Create the form
-        $form = $this->createFormBuilder(FormType::class, $data)
-            ->add(
-                'contents',
-                TextareaType::class,
-                [
-                    'constraints' => [
-                        new Assert\NotBlank(),
-                        new Assert\Length(['min' => 10]),
-                    ],
-                ]
-            )
-            ->add(
-                'submit',
-                SubmitType::class,
-                [
-                    'label'    => Trans::__('page.edit-locale.button.save'),
-                    'disabled' => !$tr['writeallowed'],
-                ]
-            )
-            ->getForm();
+        $form = $this->createFormBuilder(FileEditType::class, $data, $options)
+            ->getForm()
+        ;
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
@@ -327,19 +309,18 @@ class General extends BackendBase
     /**
      * Get the translation data.
      *
-     * @param array $tr
+     * @param Bag $tr
      *
-     * @return string
+     * @return array
      */
-    private function getTranslationData(array &$tr)
+    private function getTranslationData(Bag $tr)
     {
-        $translation = new TranslationFile($this->app, $tr['domain'], $tr['locale']);
+        $translation = new TranslationFile($this->app, $tr->get('domain'), $tr->get('locale'));
 
         list($tr['path'], $tr['shortPath']) = $translation->path();
+        $tr->set('writeallowed', $translation->isWriteAllowed());
 
-        $this->app['logger.system']->info('Editing translation: ' . $tr['shortPath'], ['event' => 'translation']);
-
-        $tr['writeallowed'] = $translation->isWriteAllowed();
+        $this->app['logger.system']->info('Editing translation: ' . $tr->get('shortPath'), ['event' => 'translation']);
 
         return ['contents' => $translation->content()];
     }
@@ -348,42 +329,32 @@ class General extends BackendBase
      * Attempt to save the POST data for a translation file edit.
      *
      * @param string $contents
-     * @param array  $tr
+     * @param Bag    $tr
      *
      * @return boolean|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    private function saveTranslationFile($contents, array &$tr)
+    private function saveTranslationFile($contents, Bag $tr)
     {
         $contents = Input::cleanPostedData($contents) . "\n";
-
-        // Before trying to save a yaml file, check if it's valid.
-        try {
-            Yaml::parse($contents);
-        } catch (ParseException $e) {
-            $msg = Trans::__('page.file-management.message.save-failed-colon', ['%s' => $tr['shortPath']]);
-            $this->flashes()->error($msg . ' ' . $e->getMessage());
-
-            return false;
-        }
 
         // Clear any warning for file not found, we are creating it here
         // we'll set an error if someone still submits the form and write is not allowed
         $this->flashes()->clear();
 
+        $file = $this->filesystem()->getFile('bolt://' . $tr->get('shortPath'));
         try {
-            $fs = new Filesystem();
-            $fs->dumpFile($tr['path'], $contents);
+            $file->put($contents);
         } catch (IOException $e) {
-            $msg = Trans::__('general.phrase.file-not-writable', ['%s' => $tr['shortPath']]);
+            $msg = Trans::__('general.phrase.file-not-writable', ['%s' => $tr->get('shortPath')]);
             $this->flashes()->error($msg);
             $tr['writeallowed'] = false;
 
             return false;
         }
 
-        $msg = Trans::__('page.file-management.message.save-success', ['%s' => $tr['shortPath']]);
+        $msg = Trans::__('page.file-management.message.save-success', ['%s' => $tr->get('shortPath')]);
         $this->flashes()->info($msg);
 
-        return $this->redirectToRoute('translation', ['domain' => $tr['domain'], 'tr_locale' => $tr['locale']]);
+        return $this->redirectToRoute('translation', ['domain' => $tr->get('domain'), 'tr_locale' => $tr->get('locale')]);
     }
 }

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -3,6 +3,7 @@
 namespace Bolt\Controller\Backend;
 
 use Bolt\Collection\Bag;
+use Bolt\Form\FormType\PrefillType;
 use Bolt\Helpers\Input;
 use Bolt\Omnisearch;
 use Bolt\Requirement\BoltRequirements;
@@ -11,7 +12,6 @@ use Bolt\Translation\Translator as Trans;
 use Silex\ControllerCollection;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -193,18 +193,13 @@ class General extends BackendBase
             'attr' => [
                 'data-bind' => json_encode(['bind' => 'prefill']),
             ],
+            'contenttypes' => $choices,
         ];
-        $form = $this->createFormBuilder(FormType::class, [], $options)
-            ->add('contenttypes', ChoiceType::class, [
-                'choices'  => $choices,
-                'multiple' => true,
-                'expanded' => true,
-                // Can be removed when symfony/form:^3.0 is the minimum
-                'choices_as_values' => true,
-            ])
-            ->getForm();
+        $form = $this->createFormBuilder(PrefillType::class, [], $options)
+            ->getForm()
+        ;
 
-        if ($request->isMethod('POST') || $request->get('force') == 1) {
+        if ($request->isMethod('POST') || $request->query->getBoolean('force')) {
             $form->handleRequest($request);
             if ($form->get('contenttypes')->has('contenttypes')) {
                 $contentTypeNames = (array) $form->get('contenttypes')->getData();

--- a/src/Form/FormType/ContentEditType.php
+++ b/src/Form/FormType/ContentEditType.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Bolt\Form\FormType;
+
+use Bolt\Translation\Translator as Trans;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * ContentType editing form type.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ContentEditType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'save',
+                SubmitType::class,
+                [
+                    'label' => Trans::__('contenttypes.generic.save', ['%contenttype%' => $options['contenttype_name']])
+                ]
+            )
+            ->add(
+                'save_return',
+                SubmitType::class,
+                [
+                    'label' => Trans::__('general.phrase.save-and-return-overview'),
+                ]
+            )
+            ->add(
+                'save_create',
+                SubmitType::class,
+                [
+                    'label' => Trans::__('general.phrase.save-and-create-new-record'),
+                ]
+            )
+            ->add(
+                'live_edit',
+                ButtonType::class,
+                [
+                    'label' => Trans::__('general.phrase.live-edit'),
+                ]
+            )
+            ->add(
+                'preview',
+                ButtonType::class,
+                [
+                    'label' => Trans::__('general.phrase.preview'),
+                ]
+            )
+            ->add(
+                'delete',
+                SubmitType::class,
+                [
+                    'label' => Trans::__('contenttypes.generic.delete', ['%contenttype%' => $options['contenttype_name']]),
+                    'attr'  => [
+                        'style' => 'visibility: hidden;'
+                    ],
+                ]
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired('contenttype_name');
+    }
+}

--- a/src/Form/FormType/FileEditType.php
+++ b/src/Form/FormType/FileEditType.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Bolt\Form\FormType;
+
+use Bolt\Translation\Translator as Trans;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * File editing form type.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class FileEditType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'contents',
+                TextareaType::class,
+                [
+                    'constraints' => $options['contents_constraints'],
+                ]
+            )
+            ->add(
+                'revert',
+                SubmitType::class,
+                [
+                    'label'    => Trans::__('page.edit-file.button.revert'),
+                    'disabled' => !$options['write_allowed'],
+                ]
+            )
+            ->add(
+                'save',
+                SubmitType::class,
+                [
+                    'label'    => Trans::__('page.edit-file.button.save'),
+                    'disabled' => !$options['write_allowed'],
+                ]
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired('write_allowed')
+            ->setDefined('contents_allow_empty')
+            ->setAllowedValues('contents_allow_empty', [true, false])
+            ->setDefault('contents_allow_empty', true)
+        ;
+        $resolver->setDefined('contents_constraints')
+            ->setNormalizer('contents_constraints', function (Options $options, $value) {
+                if ($options['contents_allow_empty']) {
+                    return $value;
+                }
+                $value[] = new Assert\NotBlank();
+
+                return $value;
+            })
+        ;
+    }
+}

--- a/src/Form/FormType/FileUploadType.php
+++ b/src/Form/FormType/FileUploadType.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Bolt\Form\FormType;
+
+use Bolt\Translation\Translator as Trans;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * File upload form type.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class FileUploadType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'FileUpload',
+                FileType::class,
+                [
+                    'label'    => false,
+                    'multiple' => true,
+                    'attr'     => [
+                        'data-filename-placement' => 'inside',
+                        'title'                   => Trans::__('general.phrase.select-file'),
+                        'accept'                  => $options['accept'],
+                    ],
+                ]
+            )
+            ->add(
+                'upload',
+                SubmitType::class,
+                [
+                    'label'    => Trans::__('general.phrase.upload-file'),
+                    'disabled' => true,
+                ]
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired('accept');
+    }
+}

--- a/src/Form/FormType/PrefillType.php
+++ b/src/Form/FormType/PrefillType.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Bolt\Form\FormType;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Prefill form type.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class PrefillType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'contenttypes',
+                ChoiceType::class, [
+                    'choices'  => $options['contenttypes'],
+                    'multiple' => true,
+                    'expanded' => true,
+                    // Can be removed when symfony/form:^3.0 is the minimum
+                    'choices_as_values' => true,
+                ]
+            )
+            ->add('check_all', ButtonType::class)
+            ->add('uncheck_all', ButtonType::class)
+            ->add('submit', SubmitType::class)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setRequired('contenttypes');
+    }
+}

--- a/src/Form/Validator/Constraints/Yaml.php
+++ b/src/Form/Validator/Constraints/Yaml.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Bolt\Form\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * YAML validation constraint.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class Yaml extends Constraint
+{
+    public $message = 'This provided data does not parse as valid YAML: %error%.';
+}

--- a/src/Form/Validator/Constraints/YamlValidator.php
+++ b/src/Form/Validator/Constraints/YamlValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Bolt\Form\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml as Parser;
+
+/**
+ * YAML validator.
+ *
+ * Validates a given input string parses as valid YAML.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class YamlValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!is_string($value)) {
+            return $this->addViolation('YAML input was not a string.', $constraint);
+        }
+
+        try {
+            $arr = Parser::parse($value, true);
+        } catch (ParseException $e) {
+            return $this->addViolation($e->getMessage(), $constraint);
+        }
+
+        if (is_string($arr)) {
+            return $this->addViolation("YAML parses as a string. Did you forget a colon ':' at the end of the first key?", $constraint);
+        }
+
+        return false;
+    }
+
+    /**
+     * Add violation.
+     *
+     * @param mixed           $error
+     * @param Constraint|Yaml $constraint
+     *
+     * @return true
+     */
+    protected function addViolation($error, Constraint $constraint)
+    {
+        $this->context->buildViolation($constraint->message)
+            ->setParameter('%error%', $error)
+            ->addViolation()
+        ;
+
+        return true;
+    }
+}

--- a/src/Provider/ValidatorServiceProvider.php
+++ b/src/Provider/ValidatorServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bolt\Provider;
+
+use Silex\Application;
+use Silex\Provider;
+use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
+use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
+use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
+
+/**
+ * Validator service provider.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ValidatorServiceProvider extends Provider\ValidatorServiceProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function register(Application $app)
+    {
+
+        parent::register($app);
+
+        $app['validator.mapping.class_metadata_factory'] = $app->share(function ($app) {
+            return new LazyLoadingMetadataFactory(new StaticMethodLoader(), new DoctrineCache($app['cache']));
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot(Application $app)
+    {
+    }
+}

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -152,6 +152,7 @@ class Edit
             'content'          => $content,
             'allowed_status'   => $allowedStatuses,
             'contentowner'     => $contentowner,
+            'duplicate'        => $duplicate,
             'fields'           => $this->config->fields->fields(),
             'fieldtemplates'   => $this->getTemplateFieldTemplates($contentType, $content),
             'fieldtypes'       => $this->getUsedFieldtypes($contentType, $content, $contextHas),

--- a/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
+++ b/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
@@ -246,8 +246,8 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->amOnPage('/bolt/file/edit/config/config.yml');
 
         $yaml = $I->getUpdatedConfig();
-        $I->fillField('#form_contents', $yaml);
-        $I->click('Save', '#saveeditfile');
+        $I->fillField('#file_edit_contents', $yaml);
+        $I->click('Save', '#file_edit_save');
 
         $I->amOnPage('/bolt/file/edit/config/config.yml');
         $I->see('notfound: resources/not-found');
@@ -270,8 +270,8 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->amOnPage('/bolt/file/edit/config/contenttypes.yml');
 
         $yaml = $I->getUpdatedContentTypes();
-        $I->fillField('#form_contents', $yaml);
-        $I->click('Save', '#saveeditfile');
+        $I->fillField('#file_edit_contents', $yaml);
+        $I->click('Save', '#file_edit_save');
         $I->amOnPage('/bolt/file/edit/config/contenttypes.yml');
         $I->see('name: Resources');
         $I->see('singular_name: Resource');
@@ -327,7 +327,7 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->fillField('#slug',  'not-found');
         $I->fillField('#body',  $body);
 
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->see('Well, this is kind of embarrassing!');
         $I->see('You have what we call in the business, a 404.');
@@ -385,7 +385,7 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->click('New Showcase');
 
         $I->fillField('#title', 'A Strange Drop Bear');
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->see('The new Showcase has been saved.');
         $I->seeLink('A Strange Drop Bear', '/bolt/editcontent/showcases/');
@@ -405,8 +405,8 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->amOnPage('/bolt/file/edit/config/permissions.yml');
 
         $yaml = $I->getUpdatedPermissions();
-        $I->fillField('#form_contents', $yaml);
-        $I->click('Save', '#saveeditfile');
+        $I->fillField('#file_edit_contents', $yaml);
+        $I->click('Save', '#file_edit_save');
 
         $I->amOnPage('/bolt/file/edit/config/permissions.yml');
         $I->see('change-ownership: [ ]');
@@ -426,8 +426,8 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->amOnPage('/bolt/file/edit/config/taxonomy.yml');
 
         $yaml = $I->getUpdatedTaxonomy();
-        $I->fillField('#form_contents', $yaml);
-        $I->click('Save', '#saveeditfile');
+        $I->fillField('#file_edit_contents', $yaml);
+        $I->click('Save', '#file_edit_save');
 
         $I->amOnPage('/bolt/file/edit/config/taxonomy.yml');
         $I->see('options: [books, events, fun, life, love, movies, music, news]');
@@ -447,8 +447,8 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->amOnPage('/bolt/file/edit/config/menu.yml');
 
         $yaml = $I->getUpdatedMenu();
-        $I->fillField('#form_contents', $yaml);
-        $I->click('Save', '#saveeditfile');
+        $I->fillField('#file_edit_contents', $yaml);
+        $I->click('Save', '#file_edit_save');
 
         $I->amOnPage('/bolt/file/edit/config/menu.yml');
         $I->see('Showcases Listing');
@@ -469,8 +469,8 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->amOnPage('/bolt/file/edit/config/routing.yml');
 
         $yaml = $I->getUpdatedRouting();
-        $I->fillField('#form_contents', $yaml);
-        $I->click('Save', '#saveeditfile');
+        $I->fillField('#file_edit_contents', $yaml);
+        $I->click('Save', '#file_edit_save');
 
         $I->amOnPage('/bolt/file/edit/config/routing.yml');
         $I->see('pagebinding:');

--- a/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
+++ b/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
@@ -82,7 +82,7 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->fillField('#teaser', 'Woop woop woop! Crazy nice stuff inside!');
         $I->fillField('#body',   'Take it, take it! I have three more of these!');
 
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
         $I->see('The new Page has been saved.');
 
         $I->see('A page I made');
@@ -109,7 +109,7 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->dontSeeInField('#statusselect', 'published');
 
         // Save the page and return to the overview
-        $I->click('Save & return to overview');
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save_return' => 1]]);
         $I->see('Actions for Pages', '.panel-heading');
 
         // Check the 'Publish page' context menu option isn't shown
@@ -159,7 +159,7 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->fillField('#teaser', $teaser);
         $I->fillField('#body',   $body);
 
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->see('The new Page has been saved.');
         $I->see("Easy for editors, and a developer's dream cms");
@@ -188,7 +188,7 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->fillField('#slug',        'contact');
         $I->selectOption('#template', 'extrafields.twig');
 
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
         $I->see('The new Page has been saved.');
         $I->click('Contact Page');
 
@@ -196,7 +196,7 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->see('Template', 'a[data-toggle=tab]');
 
         $I->fillField('#templatefields-section_1', 'This is the contact text');
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->click('Contact Page');
         /*
@@ -206,6 +206,6 @@ class BackendEditorCest extends AbstractAcceptanceTest
          * pretend that seeing the data is good enough…
          */
         $I->seeInSource('This is the contact text');
-//         $I->seeInField('#templatefields-section_1', 'This is the contact text');
+        $I->seeInField('#templatefields-section_1', 'This is the contact text');
     }
 }

--- a/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
+++ b/tests/codeception/acceptance/102-BackendDeveloper/BackendDeveloperCest.php
@@ -102,21 +102,22 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         $I->see('<footer class="row">', 'textarea');
 
         // Edit the field
-        $twig = $I->grabTextFrom('#form_contents', 'textarea');
+        $twig = $I->grabTextFrom('#file_edit_contents', 'textarea');
         $twig = str_replace('Built with Bolt', 'Built with Bolt, tested with Codeception', $twig);
-        $I->fillField('#form_contents', $twig);
+        $I->fillField('#file_edit_contents', $twig);
 
         // Save it
-        $token = $I->grabValueFrom('#form__token');
+        $token = $I->grabValueFrom('#file_edit__token');
         $I->sendAjaxPostRequest('/bolt/file/edit/themes/base-2016/partials/_footer.twig', [
-            'form' => [
-                '_token'   => $token,
+            'file_edit' => [
                 'contents' => $twig,
+                '_token'   => $token,
+                'save'     => true,
             ],
         ]);
 
         $I->amOnPage('/bolt/file/edit/themes/base-2016/partials/_footer.twig');
-        $I->see('Built with Bolt, tested with Codeception', '#form_contents');
+        $I->see('Built with Bolt, tested with Codeception', '#file_edit_contents');
     }
 
     /**
@@ -136,15 +137,15 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         $I->see('page.login.button.forgot-password', 'textarea');
 
         // Edit the field
-        $twig = $I->grabTextFrom('#form_contents', 'textarea');
+        $twig = $I->grabTextFrom('#file_edit_contents', 'textarea');
         $twig = '"Built with Bolt, tested with Codeception" : "Built with Bolt, tested with Codeception"' . PHP_EOL . $twig;
-        $I->fillField('#form_contents', $twig);
+        $I->fillField('#file_edit_contents', $twig);
 
         // Save it
-        $I->click('Save', '#form_submit');
+        $I->submitForm('form[name="file_edit"]', ['file_edit' => ['save' => 1]]);
 
         $I->amOnPage('/bolt/tr');
-        $I->see('Built with Bolt, tested with Codeception', '#form_contents');
+        $I->see('Built with Bolt, tested with Codeception', '#file_edit_contents');
     }
 
     /**
@@ -162,12 +163,12 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
 
         // Go into edit mode
         $I->see('Use this field to upload a photo or image', 'textarea');
-        $twig = $I->grabTextFrom('#form_contents', 'textarea');
+        $twig = $I->grabTextFrom('#file_edit_contents', 'textarea');
         $twig = str_replace('Use this field to upload a photo or image', 'Use this field to upload a photo of a kitten', $twig);
-        $I->fillField('#form_contents', $twig);
+        $I->fillField('#file_edit_contents', $twig);
 
         // Save it
-        $I->click('Save', '#form_submit');
+        $I->submitForm('form[name="file_edit"]', ['file_edit' => ['save' => 1]]);
 
         $I->amOnPage('/bolt/tr/infos');
         $I->see('Use this field to upload a photo of a kitten', 'textarea');
@@ -190,12 +191,12 @@ class BackendDeveloperCest extends AbstractAcceptanceTest
         $I->see('contenttypes.entries.text.recent-changes-one', 'textarea');
         $I->see('The Entry you were looking for does not exist.', 'textarea');
 
-        $twig = $I->grabTextFrom('#form_contents', 'textarea');
+        $twig = $I->grabTextFrom('#file_edit_contents', 'textarea');
         $twig = str_replace('The Entry you were looking for does not exist.', 'These are not the Entries you are looking for.', $twig);
-        $I->fillField('#form_contents', $twig);
+        $I->fillField('#file_edit_contents', $twig);
 
         // Save it
-        $I->click('Save', '#form_submit');
+        $I->submitForm('form[name="file_edit"]', ['file_edit' => ['save' => 1]]);
 
         $I->amOnPage('/bolt/tr/contenttypes');
         $I->see('These are not the Entries you are looking for.', 'textarea');

--- a/tests/codeception/acceptance/103-BackendManager/BackendManagerCest.php
+++ b/tests/codeception/acceptance/103-BackendManager/BackendManagerCest.php
@@ -40,7 +40,7 @@ class BackendManagerCest extends AbstractAcceptanceTest
 
         $I->selectOption('#statusselect', 'published');
 
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->see('The changes to the Page have been saved.');
     }
@@ -63,7 +63,7 @@ class BackendManagerCest extends AbstractAcceptanceTest
 
         $I->selectOption('#statusselect', 'published');
 
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->see('The changes to the Page have been saved.');
     }
@@ -85,7 +85,7 @@ class BackendManagerCest extends AbstractAcceptanceTest
 
         $I->selectOption('#statusselect', 'published');
 
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->see('The changes to the Page have been saved.');
     }

--- a/tests/codeception/acceptance/104-BackendAuthor/BackendAuthorCest.php
+++ b/tests/codeception/acceptance/104-BackendAuthor/BackendAuthorCest.php
@@ -39,7 +39,7 @@ class BackendAuthorCest extends AbstractAcceptanceTest
         $I->see('Edit', 'a');
         $I->click('Edit', 'a');
 
-        $I->submitForm('#editcontent', []);
+        $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->see('The changes to the Page have been saved.');
     }

--- a/tests/codeception/acceptance/105-BackendLemmings/BackendLemmingsCest.php
+++ b/tests/codeception/acceptance/105-BackendLemmings/BackendLemmingsCest.php
@@ -44,9 +44,9 @@ class BackendLemmingsCest extends AbstractAcceptanceTest
 
         $yaml = $I->getLemmingsPermissions();
 
-        $I->fillField('#form_contents', $yaml);
+        $I->fillField('#file_edit_contents', $yaml);
 
-        $I->click('Save', '#saveeditfile');
+        $I->click('Save', '#file_edit_save');
 
         $I->reloadApp();
 

--- a/tests/phpunit/unit/Form/Validator/Constraints/YamlConstraintsTest.php
+++ b/tests/phpunit/unit/Form/Validator/Constraints/YamlConstraintsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Bolt\Tests\Form\Validator\Constraints;
+
+use Bolt\Form\Validator\Constraints\Yaml;
+use Bolt\Form\Validator\Constraints\YamlValidator;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
+
+/**
+ * @covers \Bolt\Form\Validator\Constraints\YamlValidator
+ * @covers \Bolt\Form\Validator\Constraints\Yaml
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class YamlConstraintsTest extends TestCase
+{
+    public function testValid()
+    {
+        $constraint = new Yaml();
+        $validator = $this->getValidator();
+        $data = 'valid: true';
+
+        $result = $validator->validate($data, $constraint);
+        $this->assertFalse($result);
+    }
+
+    public function providerNotYamlString()
+    {
+        return [
+            ['valid false'],
+            ["Welcome to Koala Country\nDrop Bear Alert High"],
+            ["a\nb\nc"],
+            [['valid' => false]],
+        ];
+    }
+
+    /**
+     * @dataProvider providerNotYamlString
+     */
+    public function testNotYamlString($data)
+    {
+        $constraint = new Yaml();
+        $validator = $this->getValidator();
+
+        $result = $validator->validate($data, $constraint);
+        $this->assertTrue($result);
+    }
+
+    public function testInValidYaml()
+    {
+        $constraint = new Yaml();
+        $validator = $this->getValidator();
+        $data = 'valid: [false';
+
+        $result = $validator->validate($data, $constraint);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @return YamlValidator
+     */
+    private function getValidator()
+    {
+        $validator = new YamlValidator();
+        $mockValidator = $this->getMockBuilder(ConstraintViolationBuilder::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setParameter', 'addViolation'])
+            ->getMock()
+        ;
+        $mockValidator->method('setParameter')
+            ->willReturn($mockValidator)
+        ;
+        /** @var ExecutionContext|MockObject $mockContext */
+        $mockContext = $this->getMockBuilder(ExecutionContext::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['buildViolation'])
+            ->getMock()
+        ;
+        $mockContext->method('buildViolation')
+            ->willReturn($mockValidator)
+        ;
+        $validator->initialize($mockContext);
+
+        return $validator;
+    }
+}


### PR DESCRIPTION
Talk about a 5 minute fix that took three weeks to get over the line :disappointed: 

OK, so this PR:
* Implements SF forms for file editing
* Implements SF forms for file upload form
* Starts the implementation of SF Forms for content editing :tada: 
  - `<form>`  & `</form>` 
  - Most buttons
  - *Not* fields … yet! Another PR, and a big lot of work
* Fixes a bug that prevents multiple buttons from being distinguished
* Migrate the base form to SF's `bootstrap_3_horizontal_layout.html.twig` template as a starting point, removing a lot of crud from ours
* The "Duplicate `{ContentType}`" link in listings will now take you to a new edit page, with the copied content rather than the edit page of the original
* Most useless fragment are gone from editing URLs … some I couldn't find … yet
* Cleans up an utter truck load of jQuery selectors in the areas I was touching … 
  - Rage Level 11 :wink: 
  - Temptation to not rip the whole layer out while I was there … **strong**! :wink: 
* Legitimate JavaScript errors we want included on console, will now appear on the console and not removed by ESLint … ones we do not need, :fire: 
