### PR TITLE
[3.4] Requirement & recommended setting checks on first user

### DIFF
--- a/app/view/twig/firstuser/firstuser.twig
+++ b/app/view/twig/firstuser/firstuser.twig
@@ -10,6 +10,42 @@
 
 {% block page_main %}
 
+    <div class="row">
+        {% if context.required %}
+            <div class="panel panel-danger">
+                <div class="panel-heading"><i class="fa fa-close"> </i> Failed System and/or PHP requirements:</div>
+                <div class="panel-body bg-danger">
+                    {% for failed in context.required %}
+                        <p>{{ loop.index }}. {{ failed.testMessage }}</p>
+                        <p>{{ failed.helpHtml|raw }}</p>
+                    {% endfor %}
+                </div>
+            </div>
+        {% else %}
+            <div class="panel panel-success">
+                <div class="panel-heading"><i class="fa fa-check"> </i> No outstanding system or PHP requirements</div>
+            </div>
+        {% endif %}
+    </div>
+    <div class="row">
+        {% if context.recommended %}
+            <div class="panel panel-warning">
+                <div class="panel-heading"><i class="fa fa-close"> </i> Recommended updates:</div>
+                <div class="panel-body bg-warning">
+                    {% for failed in context.recommended %}
+                        <p>{{ loop.index }}. {{ failed.testMessage }}</p>
+                        <p>{{ failed.helpHtml|raw }}</p>
+                    {% endfor %}
+                </div>
+            </div>
+        {% else %}
+            <div class="panel panel-success">
+                <div class="panel-heading"><i class="fa fa-check"> </i> No recommended updates</div>
+            </div>
+        {% endif %}
+    </div>
+
+
     <p class="first-user">
         {{ __('general.phrase.users-none-create-first-extended') }}
     </p>

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -5,6 +5,7 @@ namespace Bolt\Controller\Backend;
 use Bolt\AccessControl\Permissions;
 use Bolt\Events\AccessControlEvent;
 use Bolt\Form\FormType;
+use Bolt\Requirement\BoltRequirements;
 use Bolt\Storage\Entity;
 use Bolt\Translation\Translator as Trans;
 use Silex\ControllerCollection;
@@ -197,7 +198,10 @@ class Users extends BackendBase
             }
         }
 
+        $requirements = new BoltRequirements($this->app['path_resolver']->resolve('%root%'));
         $context = [
+            'required'    => $requirements->getFailedRequirements() ?: null,
+            'recommended' => $requirements->getFailedRecommendations() ?: null,
             'kind'        => 'create',
             'form'        => $form->createView(),
             'note'        => $note,


### PR DESCRIPTION
This PR adds the results of required & recommended checks from `bolt/requirements` to first user screen.

If everything is good:
![first user good](https://user-images.githubusercontent.com/1427081/27475915-1bbdd432-5807-11e7-8425-4a8f66857273.png)

An example of a recommendation failure, i.e. not super critical, but well advised:
![first user problem](https://user-images.githubusercontent.com/1427081/27475914-1bbd8f4a-5807-11e7-9bb0-72e9d6c02928.png)

An example of a required setting failure:
![first user failure](https://user-images.githubusercontent.com/1427081/27506022-d4f7d2ec-58af-11e7-9885-e8a8e53b4780.png)

---

We obviously need to tweak the heck out of `bolt/requirements` … but that is also dependency of the Nut `setup:run` command, so linked requirements … just puts the motivation in front of a few more eyes :wink: 

Also, I am re-enforcing my disclaimer about Gawain + Visuals … I suck at them … so if we like the "feature", send it in and the UI team can do their magic to make the interface for this kick butt :tada: 