### PR TITLE
[RFC] Twig relationship/taxonomy functions & filters

### DIFF
--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -172,6 +172,7 @@ class StorageServiceProvider implements ServiceProviderInterface
             Entity\LogChange::class  => Repository\LogChangeRepository::class,
             Entity\LogSystem::class  => Repository\LogSystemRepository::class,
             Entity\Relations::class  => Repository\RelationsRepository::class,
+            Entity\Taxonomy::class   => Repository\TaxonomyRepository::class,
             Entity\Users::class      => Repository\UsersRepository::class,
         ];
 

--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -171,6 +171,7 @@ class StorageServiceProvider implements ServiceProviderInterface
             Entity\FieldValue::class => Repository\FieldValueRepository::class,
             Entity\LogChange::class  => Repository\LogChangeRepository::class,
             Entity\LogSystem::class  => Repository\LogSystemRepository::class,
+            Entity\Relations::class  => Repository\RelationsRepository::class,
             Entity\Users::class      => Repository\UsersRepository::class,
         ];
 

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -61,6 +61,7 @@ class TwigServiceProvider implements ServiceProviderInterface
                 $app['request_stack'],
                 $app['pager'],
                 $app['filesystem']->getDir('theme://' . $app['config']->get('theme/template_directory')),
+                $app['storage'],
                 $app['config']->get('theme/templateselect/templates', []),
                 $app['config']->get('general/compatibility/twig_globals', true)
             );

--- a/src/Storage/Repository/RelationsRepository.php
+++ b/src/Storage/Repository/RelationsRepository.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Bolt\Storage\Repository;
+
+use Bolt\Collection\Bag;
+use Bolt\Collection\ImmutableBag;
+use Bolt\Storage\Collection;
+use Bolt\Storage\Entity;
+use Bolt\Storage\Repository;
+
+/**
+ * A Repository class that handles storage operations for the relations table.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class RelationsRepository extends Repository
+{
+    /**
+     * Fetches the related entities for a given ContentType & ID.
+     *
+     * @param string     $contentTypeKey
+     * @param int        $id
+     * @param array|null $options
+     *
+     * @return Collection\Relations
+     */
+    public function getRelatedEntities($contentTypeKey, $id, $options = null)
+    {
+        $default = Bag::from([
+            'types'      => null,
+            'status'     => null,
+            'limit'      => null,
+            'filter_ids' => null,
+        ]);
+        $options = $default->merge($options);
+        $query = $this->getRelationsQuery($contentTypeKey, $id, $options);
+        $base = $this->findWith($query);
+        if (!$base) {
+            return new Collection\Relations();
+        }
+        $collection = new Collection\Relations($base);
+        $grouped = $collection->getGrouped();
+        foreach ($grouped as $type => $relationsEntities) {
+            $filters = null;
+            foreach ($relationsEntities as $relationsEntity) {
+                /** @var Entity\Relations $relationsEntity */
+                $filters[] = $relationsEntity->get('to_id');
+            }
+            $options->set('filter_ids', $filters);
+            $grouped[$type] = $this->findRelatedEntities($type, $options);
+        }
+
+        return new Collection\Relations($grouped, $this->em);
+    }
+
+    public function getRelationsQuery($contentTypeKey, $id, $options)
+    {
+        $qb = $this->createQueryBuilder();
+        $qb->select('*')
+            ->where('from_contenttype = :from_contenttype')
+            ->andWhere('from_id = :from_id')
+            ->setParameter('from_contenttype', $contentTypeKey)
+            ->setParameter('from_id', $id)
+        ;
+        if ($options['types']) {
+            $expr = $qb->expr();
+            $or = null;
+            foreach ((array) $options['types'] as $type) {
+                $or[] = $expr->eq('to_contenttype', ':to_contenttype_' . $type);
+                $qb->setParameter('to_contenttype_' . $type, $type);
+            }
+            $qb->andWhere(call_user_func_array([$expr, 'orX'], $or));
+        }
+
+        return $qb;
+    }
+
+    /**
+     * @param string       $contentTypeKey
+     * @param ImmutableBag $options
+     *
+     * @return Entity\Content[]|null
+     */
+    private function findRelatedEntities($contentTypeKey, ImmutableBag $options)
+    {
+        $repo = $this->em->getRepository($contentTypeKey);
+        $query = $repo->createQueryBuilder();
+        $query->select('*');
+
+        // Status
+        if ($options->get('status')) {
+            $query->andWhere('status = :status')
+                ->setParameter('status', $options->get('status'))
+            ;
+        }
+        // Selected IDs
+        if ($options->get('filter_ids')) {
+            $expr = $query->expr();
+            $or = null;
+            foreach ((array) $options->get('filter_ids') as $id) {
+                $or[] = $expr->eq('content.id', ':id_' . $id);
+                $query->setParameter('id_' . $id, $id);
+            }
+            $query->andWhere(call_user_func_array([$expr, 'orX'], $or));
+        }
+        // Maximum number of results
+        if ($options->get('limit')) {
+            $query->setMaxResults((int) $options->get('limit'));
+        }
+
+        return $repo->findWith($query) ?: null;
+    }
+}

--- a/src/Storage/Repository/TaxonomyRepository.php
+++ b/src/Storage/Repository/TaxonomyRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Bolt\Storage\Repository;
+
+use Bolt\Storage\Collection;
+use Bolt\Storage\Repository;
+
+/**
+ * A Repository class that handles storage operations for the taxonomy table.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class TaxonomyRepository extends Repository
+{
+    /**
+     * Fetches the taxonomy entities for a given ContentType & ID.
+     *
+     * @param string            $contentTypeKey
+     * @param int               $id
+     * @param array|string|null $types
+     *
+     * @return Collection\Taxonomy
+     */
+    public function getTaxonomies($contentTypeKey, $id, $types = null)
+    {
+        $query = $this->getTaxonomiesQuery($contentTypeKey, $id, (array) $types);
+
+        $base = $this->findWith($query);
+        if (!$base) {
+            return new Collection\Taxonomy();
+        }
+        $collection = new Collection\Taxonomy($base);
+        $grouped = $collection->getGrouped();
+        foreach ($grouped as $type => $taxonomyEntities) {
+            $grouped[$type] = $taxonomyEntities;
+        }
+
+        return new Collection\Taxonomy($grouped);
+    }
+
+    public function getTaxonomiesQuery($contentTypeKey, $id, array $types)
+    {
+        $qb = $this->createQueryBuilder();
+        $qb->select('*')
+            ->where('contenttype = :contenttype')
+            ->andWhere('content_id = :content_id')
+            ->setParameter('contenttype', $contentTypeKey)
+            ->setParameter('content_id', $id)
+        ;
+        if ($types) {
+            $expr = $qb->expr();
+            $or = null;
+            foreach ($types as $type) {
+                $or[] = $expr->eq('taxonomytype', ':taxonomytype_' . $type);
+                $qb->setParameter('taxonomytype_' . $type, $type);
+            }
+            $qb->andWhere(call_user_func_array([$expr, 'orX'], $or));
+        }
+
+        return $qb;
+    }
+}

--- a/src/Twig/Extension/RecordExtension.php
+++ b/src/Twig/Extension/RecordExtension.php
@@ -27,6 +27,7 @@ class RecordExtension extends AbstractExtension
 
         return [
             // @codingStandardsIgnoreStart
+            new TwigFunction('contenttype',   [Runtime\RecordRuntime::class, 'contentType'], $safe),
             new TwigFunction('current',       [Runtime\RecordRuntime::class, 'current']),
             new TwigFunction('excerpt',       [Runtime\RecordRuntime::class, 'excerpt'], $safe),
             new TwigFunction('fields',        [Runtime\RecordRuntime::class, 'fields'], $env + $safe),
@@ -49,6 +50,7 @@ class RecordExtension extends AbstractExtension
 
         return [
             // @codingStandardsIgnoreStart
+            new TwigFilter('contenttype', [Runtime\RecordRuntime::class, 'contentType'], $safe),
             new TwigFilter('current',     [Runtime\RecordRuntime::class, 'current']),
             new TwigFilter('excerpt',     [Runtime\RecordRuntime::class, 'excerpt'], $safe),
             new TwigFilter('selectfield', [Runtime\RecordRuntime::class, 'selectField']),

--- a/src/Twig/Extension/RecordExtension.php
+++ b/src/Twig/Extension/RecordExtension.php
@@ -32,6 +32,8 @@ class RecordExtension extends AbstractExtension
             new TwigFunction('fields',        [Runtime\RecordRuntime::class, 'fields'], $env + $safe),
             new TwigFunction('listtemplates', [Runtime\RecordRuntime::class, 'listTemplates']),
             new TwigFunction('pager',         [Runtime\RecordRuntime::class, 'pager'], $env + $safe),
+            new TwigFunction('related',       [Runtime\RecordRuntime::class, 'related'], $safe),
+            new TwigFunction('taxonomy',      [Runtime\RecordRuntime::class, 'taxonomy'], $safe),
             new TwigFunction('trimtext',      [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
             // @codingStandardsIgnoreEnd
         ];
@@ -50,6 +52,8 @@ class RecordExtension extends AbstractExtension
             new TwigFilter('current',     [Runtime\RecordRuntime::class, 'current']),
             new TwigFilter('excerpt',     [Runtime\RecordRuntime::class, 'excerpt'], $safe),
             new TwigFilter('selectfield', [Runtime\RecordRuntime::class, 'selectField']),
+            new TwigFilter('related',     [Runtime\RecordRuntime::class, 'related'], $safe),
+            new TwigFilter('taxonomy',    [Runtime\RecordRuntime::class, 'taxonomy'], $safe),
             new TwigFilter('trimtext',    [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
             // @codingStandardsIgnoreEnd
         ];

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Twig\Runtime;
 
+use Bolt\Collection\ImmutableBag;
 use Bolt\Filesystem\Handler\DirectoryInterface;
 use Bolt\Filesystem\Handler\FileInterface;
 use Bolt\Helpers\Deprecated;
@@ -324,6 +325,26 @@ class RecordRuntime
             }
         }
         return $retval;
+    }
+
+    /**
+     * @param Entity\Content|Legacy\Content $record The record to fetch related records for
+     *
+     * @return ImmutableBag
+     */
+    public function contentType($record)
+    {
+        if ($record instanceof Entity\Content) {
+            $contentTypeKey = (string) $record['contenttype'];
+        } elseif ($record instanceof Legacy\Content) {
+            Deprecated::warn('Passing legacy content object to the Twig "contenttype" function or filter', 3.4);
+            $contentTypeKey = $record->contenttype['slug'];
+        } else {
+            throw new \BadMethodCallException(sprintf('The Twig function "contenttype" requires a %s as the first parameter', Entity\Content::class));
+        }
+        $contentType = $this->em->getContentType($contentTypeKey);
+
+        return ImmutableBag::fromRecursive($contentType);
     }
 
     /**


### PR DESCRIPTION
OK, so I had some time to waste waiting on PRs to get merged, and I got thinking about the debate at the last meeting regarding decoupling relationships & taxonomy objects from an entity in v4.

The point of contention was how we would approach that, so this is a PoC RFC … that I am **either** happy to see though to merge if we all like the approach, or just close the RFC and delete the branch if we think not … really, it wasn't a lot of work and I was bored! :rofl: 

Have a look, talk to me! 

**EDIT:** It is worth noting that these are registered as filters & functions, the examples below are done using the Twig functions, 'cause personal taste.

## {{ related }}

```twig
    {# Get all related, published, entities to "record" #}
    {% set related = related(record) %}

    {# Get only "pages" ContentType records related to this record #}
    {% set related_pages = related(record, 'pages') %}

    {# Get a maximum of 5 *each* of related "entries" & "pages" #}
    {% set related_selection = related(record, ['entries', 'pages'], 5) %}
```
### Example use:
```twig
    {% set related = related(record) %}
    <ul>
    {% for entity in related.pages %}
        <li>{{ entity.title }}</li>
    {% endfor %}
    </ul>
```

```twig
    {% set related = related(record) %}
    {% for type, entities in related %}
        <p>{{ type }} related to this record:</p>
        <ul>
        {% for entity in entities %}
            <li>{{ entity.title }}</li>
        {% endfor %}
        </ul>
    {% endfor %}
```
## {{ taxonomy }}
```twig
    {# Get all taxonomy entries for this "record" #}
    {% set taxonomy = taxonomy(record) %}

    {# Get only "categories" taxonomy entries for this "record" #}
    {% set taxonomy_by_type = taxonomy(record, 'categories') %}

    {# Get only "tags" & "categories" taxonomy entries for this "record" #}
    {% set taxonomy_by_types = taxonomy(record, ['tags', 'categories']) %}
```
### Example use:
```twig
    {% set taxonomy = taxonomy(record) %}
    <ul>
    {% for entities in taxonomy.tags %}
        <li>{{ entity.name }}</li>
    {% endfor %}
    </ul>
```
```twig
    {% set taxonomy = taxonomy(record) %}
    {% for type, entities in taxonomy %}
        <p>{{ type }} taxonomy of this record:</p>
        <ul>
            {% for entity in entities %}
                <li>{{ entity.name }}</li>
            {% endfor %}
        </ul>
    {% endfor %}
```

