### PR TITLE
[3.4] Refresh config checks page

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -481,6 +481,7 @@ logs.system-log: "System Log"
 logs.system-log.cleared: "The system log has been cleared."
 logs.system-log.trimmed: "The system log has been trimmed."
 
+menu.configuration.checks: "Set-up checks"
 menu.configuration.routing: "Routing set up"
 
 nut.greeting: "Welcome to Bolt!"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -488,10 +488,12 @@ nut.greeting: "Welcome to Bolt!"
 
 nut.version: "version"
 
-page.checks.run-all: "Run all checks"
-page.checks.run-directory-checks: "Run directory checks"
-page.checks.run-email-checks: "Run email checks"
-page.checks.run-php-ext-checks: "Run PHP extension checks"
+page.checks.show-all: "Show all checks"
+page.checks.show-failed: "Show only failed checks"
+page.checks.system-pass: "All system configuration checks pass!"
+page.checks.system-problem: "System configuration check found problems!"
+page.checks.php-pass: "All PHP configuration checks pass!"
+page.checks.php-problem: "PHP configuration check found problems!"
 
 page.ckeditor-browse-server.files: "Files"
 page.ckeditor-browse-server.modified: "Modified"

--- a/app/view/twig/_nav/_secondary-configuration.twig
+++ b/app/view/twig/_nav/_secondary-configuration.twig
@@ -56,6 +56,11 @@
         label: config_menu.get('log_system').label,
         link: config_menu.get('log_system').uri,
         isallowed: config_menu.get('log_system').permission
+    }, {
+        icon: config_menu.get('setup_checks').icon,
+        label: config_menu.get('setup_checks').label,
+        link: config_menu.get('setup_checks').uri,
+        isallowed: config_menu.get('setup_checks').permission
     }
 ] %}
 

--- a/app/view/twig/checks/_aside.twig
+++ b/app/view/twig/checks/_aside.twig
@@ -1,32 +1,22 @@
-{% import '@bolt/_macro/_panels.twig' as panels %}
+{% block check_aside_button %}
+    <a href="{{ check_path }}">
+        <button type="submit" class="btn btn-primary">
+            <i class="fa fa-flag"></i> {{ check_text }}
+        </button>
+    </a>
+{% endblock check_aside_button %}
 
-{# No Javascript #}
-<noscript>
-    <section>
-        <h2>{{ __('generic.noscript.headline') }}</h2>
-        <p>{{ __('generic.noscript.message') }}</p>
-    </section>
-</noscript>
-
-<div class="panel panel-default panel-checks">
-    <div class="panel-body">
-        <button type="button" class="btn btn-primary">
-            <i class="fa fa-flag"></i> {{ __('page.checks.run-all') }}
-        </button>
+{% block check_aside %}
+    <div class="panel panel-default panel-checks">
+        <div class="panel-body">
+            {% if context.show_all %}
+                {% set check_path = path('checks') %}
+                {% set check_text = __('page.checks.show-failed') %}
+            {% else %}
+                {% set check_path = path('checks', {'all': true}) %}
+                {% set check_text = __('page.checks.show-all') %}
+            {% endif %}
+            {{ block('check_aside_button') }}
+        </div>
     </div>
-    <div class="panel-body">
-        <button type="button" class="btn btn-primary">
-            <i class="fa fa-flag"></i> {{ __('page.checks.run-directory-checks') }}
-        </button>
-    </div>
-    <div class="panel-body">
-        <button type="button" class="btn btn-primary">
-            <i class="fa fa-flag"></i> {{ __('page.checks.run-email-checks') }}
-        </button>
-    </div>
-    <div class="panel-body">
-        <button type="button" class="btn btn-primary">
-            <i class="fa fa-flag"></i> {{ __('page.checks.run-php-ext-checks') }}
-        </button>
-    </div>
-</div>
+{% endblock %}

--- a/app/view/twig/checks/checks.twig
+++ b/app/view/twig/checks/checks.twig
@@ -8,35 +8,99 @@
     Bolt {{ constant('Bolt\\Version::VERSION') }}
 {% endblock page_subtitle %}
 
+{% block checks_pass %}
+    <div class="panel-group">
+        <div class="panel panel-success">
+            <div class="panel-heading">Passed checks:</div>
+            <ul class="list-group">
+                {%- for result in results -%}
+                <li class="list-group-item">
+                    <i class="fa fa-check"></i> {{ result.testMessage }}
+                </li>
+                {%- endfor -%}
+            </ul>
+        </div>
+    </div>
+{% endblock checks_pass %}
+
+{% block checks_fail %}
+    <div class="panel-group">
+        {%- for result in results -%}
+            <div class="panel panel-{{ result.optional ? 'warning' : 'danger' }}">
+                <div class="panel-heading"><i class="fa fa-close"></i> {{ result.testMessage }}</div>
+                <div class="panel-body">{{ result.helpHtml|raw }}</div>
+            </div>
+        {%- endfor -%}
+    </div>
+{% endblock checks_fail %}
+
+{% block check_section %}
+    <div class="col-md-6">
+        <h4>System settings</h4>
+        {% if fails.system.empty %}
+            <div class="panel panel-success">
+                <div class="panel-heading"><i class="fa fa-star"></i> {{ __('page.checks.system-pass') }}</div>
+            </div>
+        {% else %}
+            <div class="panel panel-{{ required ? 'danger' : 'warning' }}">
+                <div class="panel-heading"><i class="fa fa-stop"></i> {{ __('page.checks.system-problem') }}</div>
+            </div>
+            {% with {'results': fails.system} %}{{ block('checks_fail') }}{% endwith %}
+        {% endif %}
+        {% if context.show_all %}
+            {% with {'results': passes.system} %}{{ block('checks_pass') }}{% endwith %}
+        {% endif %}
+    </div>
+
+    <div class="col-md-6">
+        <h4>PHP settings</h4>
+        {% if fails.php.empty %}
+            <div class="panel panel-success">
+                <div class="panel-heading"><i class="fa fa-star"></i> {{ __('page.checks.php-pass') }}</div>
+            </div>
+        {% else %}
+            <div class="panel panel-{{ required ? 'danger' : 'warning' }}">
+                <div class="panel-heading"><i class="fa fa-stop"></i> {{ __('page.checks.php-problem') }}</div>
+            </div>
+            {% with {'results': fails.php} %}{{ block('checks_fail') }}{% endwith %}
+        {% endif %}
+        {% if context.show_all %}
+            {% with {'results': passes.php} %}{{ block('checks_pass') }}{% endwith %}
+        {% endif %}
+    </div>
+{% endblock check_section %}
+
 {% block page_main %}
 
     <div class="row">
         <div class="col-md-8">
-
             <div class="row">
-                <div class="col-md-12">
-                    {{ dump(render(path('directories'))|json_decode) }}
-                </div>
+                <h3>Required settings</h3>
+                {%  with {
+                    'fails': context.checks.requirements.fail,
+                    'passes': context.checks.requirements.pass,
+                    'required': true
+                } %}
+                {{ block('check_section') }}
+                {% endwith %}
             </div>
 
             <div class="row">
-                <div class="col-md-12">
-                    {{ dump(render(path('email'))|json_decode) }}
-                </div>
+                <h3>Recommended settings</h3>
+                {%  with {
+                    'fails': context.checks.recommendations.fail,
+                    'passes': context.checks.recommendations.pass,
+                    'required': false
+                } %}
+                {{ block('check_section') }}
+                {% endwith %}
             </div>
-
-            <div class="row">
-                <div class="col-md-12">
-                    {{ dump(render(path('extensions'))|json_decode) }}
-                </div>
-            </div>
-
         </div>
 
         <aside class="col-md-4">
-            {{ include('@bolt/checks/_aside.twig') }}
+            {% use '@bolt/checks/_aside.twig' %}
+            {{ block('check_aside') }}
         </aside>
     </div>
-
 
 {% endblock page_main %}

--- a/src/Configuration/Check/BaseCheck.php
+++ b/src/Configuration/Check/BaseCheck.php
@@ -2,10 +2,13 @@
 
 namespace Bolt\Configuration\Check;
 
+use Bolt\Helpers\Deprecated;
 use Silex\Application;
 
 /**
  * Base class for checks.
+ *
+ * @deprecated Since 3.4, to be removed in 4.0
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
@@ -25,6 +28,7 @@ abstract class BaseCheck
      */
     public function __construct(Application $app)
     {
+        Deprecated::cls(__CLASS__, 3.4);
         $this->app = $app;
     }
 

--- a/src/Configuration/Check/ConfigurationCheckInterface.php
+++ b/src/Configuration/Check/ConfigurationCheckInterface.php
@@ -5,6 +5,8 @@ namespace Bolt\Configuration\Check;
 /**
  * System configuration check interface.
  *
+ * @deprecated Since 3.4, to be removed in 4.0
+ *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
 interface ConfigurationCheckInterface

--- a/src/Configuration/Check/DirectoryAccess.php
+++ b/src/Configuration/Check/DirectoryAccess.php
@@ -8,6 +8,8 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * Checks for writeable directories.
  *
+ * @deprecated Since 3.4, to be removed in 4.0
+ *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
 class DirectoryAccess extends BaseCheck implements ConfigurationCheckInterface

--- a/src/Configuration/Check/EmailSetup.php
+++ b/src/Configuration/Check/EmailSetup.php
@@ -5,6 +5,8 @@ namespace Bolt\Configuration\Check;
 /**
  * Checks for email configuration.
  *
+ * @deprecated Since 3.4, to be removed in 4.0
+ *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
 class EmailSetup extends BaseCheck implements ConfigurationCheckInterface

--- a/src/Configuration/Check/PhpExtensions.php
+++ b/src/Configuration/Check/PhpExtensions.php
@@ -5,6 +5,8 @@ namespace Bolt\Configuration\Check;
 /**
  * Checks for PHP extension configuration.
  *
+ * @deprecated Since 3.4, to be removed in 4.0
+ *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
 class PhpExtensions extends BaseCheck implements ConfigurationCheckInterface

--- a/src/Configuration/Check/Result.php
+++ b/src/Configuration/Check/Result.php
@@ -2,8 +2,12 @@
 
 namespace Bolt\Configuration\Check;
 
+use Bolt\Helpers\Deprecated;
+
 /**
  * A container class for a check result.
+ *
+ * @deprecated Since 3.4, to be removed in 4.0
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
@@ -15,6 +19,11 @@ class Result implements \JsonSerializable
     protected $message;
     /** @var \Exception */
     protected $exception;
+
+    public function __construct()
+    {
+        Deprecated::cls(__CLASS__, 3.4);
+    }
 
     /**
      * Check if the result is a pass or fail.

--- a/src/Menu/AdminMenuBuilder.php
+++ b/src/Menu/AdminMenuBuilder.php
@@ -135,6 +135,15 @@ final class AdminMenuBuilder
                 ->setIcon('fa:archive')
                 ->setPermission('systemlog')
         );
+
+        // Set-up checks
+        $configEntry->add(
+            (new MenuEntry('setup_checks'))
+                ->setRoute('checks')
+                ->setLabel(Trans::__('menu.configuration.checks'))
+                ->setIcon('fa:support')
+                ->setPermission('files:config')
+        );
     }
 
     /**


### PR DESCRIPTION
We've had this route, and the aysnc controller that isn't even used, since 3.0-dev, so this PR basically just adds it to the menu, and updates the admin route & templates to use `bolt/requirements`

Eye candy (_normal UI team disclaimer_):

![checks-menu](https://user-images.githubusercontent.com/1427081/27578796-7163321c-5b25-11e7-99d7-b3220c79d11e.png)

![checks-mixed](https://user-images.githubusercontent.com/1427081/27578798-71695c6e-5b25-11e7-8d81-fbc0e9a05bff.png)

![checks-all](https://user-images.githubusercontent.com/1427081/27578797-716342b6-5b25-11e7-88d7-873fc18d7b46.png)

**Edit:** The screenshot for #3602 (original PR) is, with hindsight, pretty funny; "Bolt 2.3.0 alpha 1" … 2 years ago 