### PR TITLE
[3.2] base-2016 fixes and facepalms

### DIFF
--- a/theme/base-2016/partials/_sub_field_blocks.twig
+++ b/theme/base-2016/partials/_sub_field_blocks.twig
@@ -1,0 +1,85 @@
+{# If 'allowtwig' is true for this field, we'll need to parse it as
+   Twig here. Note, that we're doing this inside a block, so the
+   snippet has a limited scope. No global variables, etc. #}
+{% block parse_text_field %}
+    {% if contenttype.fields[key].allowtwig|default(false) %}
+        {% set value = value|twig %}
+    {% endif %}
+    {% if fieldtype == "markdown" %}
+        {% set value = value|markdown %}
+    {% endif %}
+    {% autoescape false %}
+    <div {% if key is not empty %}data-bolt-field="{{key}}"{% endif %}>{{ value }}</div>
+    {% endautoescape %}
+{% endblock %}
+
+{% block imagelist_field %}
+    <div class="bolt-imagelist">
+        {% for image in images %}
+            <div class="bolt-imageholder">
+                {{ popup(image.filename, 200, 0) }}
+            </div>
+        {% endfor %}
+    </div>
+{% endblock %}
+
+{# Block for "basic" fields like HTML, Markdown, Textarea and Text #}
+{% block common_fields %}
+
+        {# HTML, Markdown, Textarea, Text fields #}
+        {% if fieldtype in ['html', 'markdown', 'textarea', 'text'] %}
+            {{ block('parse_text_field') }}
+        {% endif %}
+
+        {# Image fields #}
+        {% if fieldtype == "image" %}
+            {{ popup(value, 1200, 0) }}
+        {% endif %}
+
+        {# Video fields #}
+        {% if fieldtype == "video" and value.responsive|default is not empty %}
+            <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
+                {{ value.responsive }}
+            </div>
+        {% endif %}
+
+{% endblock %}
+
+{# Block for other field types, like Geo, Select, Checkbox and others. #}
+{% block extended_fields %}
+
+        {# Geolocation field #}
+        {% if fieldtype == "geolocation" and value.latitude is defined %}
+            <img src="http://maps.googleapis.com/maps/api/staticmap?center={{ value.latitude }},{{ value.longitude }}&amp;zoom=14&amp;size=617x300&amp;sensor=false&amp;markers={{ value.latitude }},{{ value.longitude }}">
+        {% endif %}
+
+        {# Special case for 'select' fields: if it's a multiple select, the value is an array. #}
+        {% if fieldtype == "select" and value is not empty %}
+            <p><strong>{{ key }}: </strong>
+                {{ value|join(", ") }}
+            </p>
+        {% endif %}
+
+        {# Checkbox fields #}
+        {% if fieldtype == "checkbox" %}
+                <p>Checkbox {{ key }}: {{value ? "checked" : "not checked"}}</p>
+        {% endif %}
+
+        {# Imagelist fields #}
+        {% if fieldtype == "imagelist" and value is not empty %}
+            {{ block('imagelist_field') }}
+        {% endif %}
+
+        {# No special case defined for this type of field. We just output them, if it's
+           a simple scalar, and 'dump' them otherwise. #}
+        {% if fieldtype in [ 'filelist', 'datetime', 'date', 'integer', 'float' ] and value is not empty  %}
+            <p><strong>{{ key }}: </strong>
+                {% if value is iterable %}
+                    {{ dump(value) }}
+                {% else %}
+                    {{ value }}
+                {% endif %}
+            </p>
+        {% endif %}
+
+{% endblock %}

--- a/theme/base-2016/partials/_sub_fields.twig
+++ b/theme/base-2016/partials/_sub_fields.twig
@@ -34,7 +34,7 @@
    Twig here. Note, that we're doing this inside a macro, so the
    snippet has a limited scope. No global variables, etc. #}
 {% macro parsetextfield(key, value, contenttype) %}
-    {% if contenttype.fields[key].allowtwig is defined and contenttype.fields[key].allowtwig == true %}
+    {% if contenttype.fields[key].allowtwig|default(false) %}
         {% set value = value|twig %}
     {% endif %}
 
@@ -71,8 +71,8 @@
         {% endif %}
 
         {# Video fields #}
-        {% if fieldtype == "video" and value.responsive %}
-            <div class="flex-video {{ value.ratio > 1.5 ? 'widescreen' }}">
+        {% if fieldtype == "video" and value.responsive|default is not empty %}
+            <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
                 {{ value.responsive }}
             </div>
         {% endif %}

--- a/theme/base-2016/partials/_sub_fields.twig
+++ b/theme/base-2016/partials/_sub_fields.twig
@@ -1,16 +1,23 @@
-{# This file specifies the default output for the `fields()` tag. This file is
-   split into three parts:
+{# Default output for the `fields()` tag.
+   This file is contains the 'sub_fields' Twig block tag.
+
+   The 'sub_fields' Twig block is split into two parts:
     - The first section initializes the variables and settings, both from the
-      contenttype definitions as well as passed in variables.
-    - The second section defines the macros that are used to output the desired
-      fields in succession.
-    - The last section is where the actual looping is done for the 'contenttype
-      fields', 'repeater fields' and 'template fields' in turn.
+      ContentType definitions as well as passed in variables.
+    - The last section is where the actual looping is done, and the relevant
+      {{ block() }} function is called, for the 'ContentType fields',
+      'repeater fields' and 'template fields' in turn.
 
-    Read the relevant section in the documentation on usage of this
-    functionality: https://docs.bolt.cm/master/fields-tag
+   Read the relevant section in the documentation on usage of this
+   functionality: https://docs.bolt.cm/master/fields-tag
+
+   For more information on using blocks, see the Twig documentation at:
+    - https://twig.sensiolabs.org/doc/1.x/tags/block.html
+    - https://twig.sensiolabs.org/doc/1.x/functions/block.html
 #}
+{% use 'partials/_sub_field_blocks.twig' %}
 
+{% block sub_fields %}
 {# SECTION 1: INITIALIZATION #}
 
 {# Set up the array of fieldnames that should be iterated. We do this by looping
@@ -19,131 +26,39 @@
 
 {# Skip over the fields that are used in the slug, unless explicitly told not to,
    using the `skip_uses` parameter. #}
-{% if (record.contenttype.fields.slug.uses|default(null) is iterable) and (skip_uses == true) %}
+{% if (record.contenttype.fields.slug.uses|default(null) is iterable) and skip_uses|default(true) %}
     {% set omittedkeys = omittedkeys|merge(record.contenttype.fields.slug.uses) %}
 {% endif %}
 
 {# We also skip over the fields that are explicitly excluded. #}
-{% if exclude is iterable %}
+{% if exclude|default is iterable %}
     {% set omittedkeys = omittedkeys|merge(exclude) %}
 {% endif %}
 
-{# SECTION 2: MACROS #}
-
-{# If 'allowtwig' is true for this field, we'll need to parse it as
-   Twig here. Note, that we're doing this inside a macro, so the
-   snippet has a limited scope. No global variables, etc. #}
-{% macro parsetextfield(key, value, contenttype) %}
-    {% if contenttype.fields[key].allowtwig|default(false) %}
-        {% set value = value|twig %}
-    {% endif %}
-
-    <div {% if key is not empty %}data-bolt-field="{{key}}"{% endif %}>{{ value }}</div>
-{% endmacro %}
-
-{% macro imagelistfield(images) %}
-    <div class="bolt-imagelist">
-        {% for image in images %}
-            <div class="bolt-imageholder">
-                {{ popup(image.filename, 200, 0) }}
-            </div>
-        {% endfor %}
-    </div>
-{% endmacro %}
-
-{# Macro for "basic" fields like HTML, Markdown, Textarea and Text #}
-{% macro commonfields(key, value, fieldtype, contenttype) %}
-        {% import _self as macro %}
-
-        {# HTML, Textarea, Text fields #}
-        {% if fieldtype in ['html', 'textarea', 'text'] %}
-            {{ macro.parsetextfield(key, value, contenttype) }}
-        {% endif %}
-
-        {# Markdown fields #}
-        {% if fieldtype == "markdown" %}
-            {{ macro.parsetextfield(key, value|markdown, contenttype) }}
-        {% endif %}
-
-        {# Image fields #}
-        {% if fieldtype == "image" %}
-            {{ popup(value, 1200, 0) }}
-        {% endif %}
-
-        {# Video fields #}
-        {% if fieldtype == "video" and value.responsive|default is not empty %}
-            <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
-                {{ value.responsive }}
-            </div>
-        {% endif %}
-
-{% endmacro %}
-
-{# Macro for other field types, like Geo, Select, Checkbox and others. #}
-{% macro extendedfields(key, value, fieldtype) %}
-
-        {# Geolocation field #}
-        {% if fieldtype == "geolocation" and value.latitude is defined %}
-            <img src="http://maps.googleapis.com/maps/api/staticmap?center={{ value.latitude }},{{ value.longitude }}&amp;zoom=14&amp;size=617x300&amp;sensor=false&amp;markers={{ value.latitude }},{{ value.longitude }}">
-        {% endif %}
-
-        {# Special case for 'select' fields: if it's a multiple select, the value is an array. #}
-        {% if fieldtype == "select" and value is not empty %}
-            <p><strong>{{ key }}: </strong>
-                {{ value|join(", ") }}
-            </p>
-        {% endif %}
-
-        {# Checkbox fields #}
-        {% if fieldtype == "checkbox" %}
-                <p>Checkbox {{ key }}: {{value ? "checked" : "not checked"}}</p>
-        {% endif %}
-
-        {# Imagelist fields #}
-        {% if fieldtype == "imagelist" and value is not empty %}
-            {{ macro.imagelistfield(value) }}
-        {% endif %}
-
-        {# No special case defined for this type of field. We just output them, if it's
-           a simple scalar, and 'dump' them otherwise. #}
-        {% if fieldtype in [ 'filelist', 'datetime', 'date', 'integer', 'float' ] and value is not empty  %}
-            <p><strong>{{ key }}: </strong>
-                {% if value is iterable %}
-                    {{ dump(value) }}
-                {% else %}
-                    {{ value }}
-                {% endif %}
-            </p>
-        {% endif %}
-
-{% endmacro %}
-
-{% import _self as macro %}
-
-{# SECTION 3: LOOPING AND ITERATION #}
+{# SECTION 2: LOOPING AND ITERATION #}
 
 {# The actual looping is done here. #}
 {% for key, value in record.values if (key not in omittedkeys) %}
 
     {# Fields that are considered 'common': 'html', 'markdown', 'textarea',
        'text', 'image', 'video' and 'imagelist' #}
-    {% if common == true %}
+    {% if common|default(true) %}
 
         {% set fieldtype = record.fieldtype(key) %}
-        {{ macro.commonfields(key, value, fieldtype, record.contenttype) }}
+        {{ block('common_fields') }}
 
     {% endif %}
 
     {# The rest of the built-in fieldtypes #}
-    {% if extended == true %}
+    {% if extended|default(false) %}
 
         {% set fieldtype = record.fieldtype(key) %}
-        {{ macro.extendedfields(key, value, fieldtype) }}
+        {{ block('extended_fields') }}
 
     {% endif %}
 
     {# Finally, the repeaters #}
-    {% if repeaters == true and record.fieldtype(key) == "repeater" %}
+    {% if repeaters|default(true) and record.fieldtype(key) == "repeater" %}
 
         {% for repeater in value %}
 
@@ -151,8 +66,8 @@
 
                 {% set fieldtype = repeaterfield.getFieldtype() %}
                 {% set value = repeaterfield.getValue() %}
-                {{ macro.commonfields('', value, fieldtype, record.contenttype) }}
-                {{ macro.extendedfields('', value, fieldtype) }}
+                {{ block('common_fields') }}
+                {{ block('extended_fields') }}
 
             {% endfor %}
 
@@ -168,14 +83,15 @@
 
     {# Note: This needs to be expanded upon!! For better detection the 'virtual'
        contenttype for the templatefields should know about the types of fields. #}
-    {% set templatefieldsfieldtypes = attribute(record.contenttype.templatefields|first, 'fields') %}
+    {% set templatefields_field_types = attribute(record.contenttype.templatefields|first, 'fields') %}
 
     {% for key, value in templatefields if (key not in omittedkeys) %}
 
-        {% set fieldtype = attribute(attribute(templatefieldsfieldtypes, key), 'type')  %}
-        {{ macro.commonfields(key, value, fieldtype, record.contenttype) }}
-        {{ macro.extendedfields(key, value, fieldtype) }}
+        {% set fieldtype = attribute(attribute(templatefields_field_types, key), 'type')  %}
+        {{ block('common_fields') }}
+        {{ block('extended_fields') }}
 
     {% endfor %}
 
 {% endif %}
+{% endblock sub_fields %}


### PR DESCRIPTION
## Bugs

* With `strict variables: true` and an empty video field, `{{ fields() }}` will exception
* HTML is escaped

## Macros :fire:

The macros were flat out — text book style — abusing the the purpose of them, so I have moved them to blocks.

Honestly after looking at the code in Twig & PHP for this, I am proposing we rip out `{{ fields() }}` in v4 … **Seriously!**