### PR TITLE
Fix for queries where fields have the same name as contenttype

### DIFF
--- a/src/Storage/Field/Type/FieldTypeBase.php
+++ b/src/Storage/Field/Type/FieldTypeBase.php
@@ -284,7 +284,7 @@ abstract class FieldTypeBase implements FieldTypeInterface, FieldInterface
         $reflected->setAccessible(true);
         $originalParts = $reflected->getValue($originalExpression);
         foreach ($originalParts as &$part) {
-            $part = str_replace($query->getContenttype().".".$field, $field.".".$column, $part);
+            $part = str_replace("_" . $query->getContenttype().".".$field, $field.".".$column, $part);
         }
         $reflected->setValue($originalExpression, $originalParts);
 

--- a/src/Storage/Query/Handler/SearchQueryHandler.php
+++ b/src/Storage/Query/Handler/SearchQueryHandler.php
@@ -27,7 +27,7 @@ class SearchQueryHandler
 
         foreach ($contentQuery->getContentTypes() as $contentType) {
             $repo = $contentQuery->getEntityManager()->getRepository($contentType);
-            $query->setQueryBuilder($repo->createQueryBuilder($contentType));
+            $query->setQueryBuilder($repo->createQueryBuilder("_" . $contentType));
             $query->setContentType($contentType);
 
             $searchParam = $contentQuery->getParameter('filter');

--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -25,7 +25,7 @@ class SelectQueryHandler
 
         foreach ($contentQuery->getContentTypes() as $contentType) {
             $repo = $contentQuery->getEntityManager()->getRepository($contentType);
-            $query->setQueryBuilder($repo->createQueryBuilder($contentType));
+            $query->setQueryBuilder($repo->createQueryBuilder('_' . $contentType));
             $query->setContentType($contentType);
 
             /** Run the parameters through the whitelister. If we get a false back from this method it's because there

--- a/src/Storage/Query/SelectQuery.php
+++ b/src/Storage/Query/SelectQuery.php
@@ -239,7 +239,7 @@ class SelectQuery implements QueryInterface
     {
         $this->filters = [];
         foreach ($this->params as $key => $value) {
-            $this->parser->setAlias($this->contentType);
+            $this->parser->setAlias('_' . $this->contentType);
             $filter = $this->parser->getFilter($key, $value);
             if ($filter) {
                 $this->addFilter($filter);

--- a/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
@@ -103,7 +103,7 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb = new ContentQueryParser($app['storage'], $app['query.select']);
         $qb->setQuery('entries');
         $qb->setParameters(['order' => '-datepublish', 'id' => '!1', 'printquery' => true]);
-        $this->expectOutputString('SELECT entries.* FROM bolt_entries entries WHERE entries.id <> :id_1 ORDER BY datepublish DESC');
+        $this->expectOutputString('SELECT _entries.* FROM bolt_entries _entries WHERE _entries.id <> :id_1 ORDER BY datepublish DESC');
         $qb->fetch();
     }
 
@@ -115,7 +115,7 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb->setParameters(['order' => '-datepublish', 'id' => '!1', 'getquery' => function ($query) {
             echo $query;
         }]);
-        $this->expectOutputString('SELECT pages.* FROM bolt_pages pages WHERE pages.id <> :id_1 ORDER BY datepublish DESC');
+        $this->expectOutputString('SELECT _pages.* FROM bolt_pages _pages WHERE _pages.id <> :id_1 ORDER BY datepublish DESC');
         $qb->fetch();
     }
 
@@ -127,7 +127,7 @@ class ContentQueryParserTest extends BoltUnitTest
         $qb->setParameters(['order' => '-datepublish, title', 'getquery' => function ($query) {
             echo $query;
         }]);
-        $this->expectOutputString('SELECT entries.* FROM bolt_entries entries ORDER BY datepublish DESC, title ASC');
+        $this->expectOutputString('SELECT _entries.* FROM bolt_entries _entries ORDER BY datepublish DESC, title ASC');
         $qb->fetch();
     }
 
@@ -278,7 +278,7 @@ class ContentQueryParserTest extends BoltUnitTest
         $this->assertEquals('namedselect', $qb->getOperation());
         $this->assertEquals('5', $qb->getIdentifier());
 
-        $this->expectOutputString('SELECT pages.* FROM bolt_pages pages WHERE pages.id = :id_1');
+        $this->expectOutputString('SELECT _pages.* FROM bolt_pages _pages WHERE _pages.id = :id_1');
         $res = $qb->fetch();
         $this->assertInstanceOf('Bolt\Storage\Entity\Content', $res);
     }

--- a/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SearchQueryTest.php
@@ -22,7 +22,7 @@ class SearchQueryTest extends BoltUnitTest
         $query->setContentType('pages');
         $query->setSearch($filter);
         $expr = $query->getWhereExpression();
-        $this->assertEquals('((pages.title LIKE :title_1) OR (pages.title LIKE :title_2)) OR ((pages.teaser LIKE :teaser_1) OR (pages.teaser LIKE :teaser_2)) OR ((pages.body LIKE :body_1) OR (pages.body LIKE :body_2)) OR ((pages.groups LIKE :groups_1) OR (pages.groups LIKE :groups_2))', $expr);
+        $this->assertEquals('((_pages.title LIKE :title_1) OR (_pages.title LIKE :title_2)) OR ((_pages.teaser LIKE :teaser_1) OR (_pages.teaser LIKE :teaser_2)) OR ((_pages.body LIKE :body_1) OR (_pages.body LIKE :body_2)) OR ((_pages.groups LIKE :groups_1) OR (_pages.groups LIKE :groups_2))', $expr);
         $params = $query->getWhereParameters();
         $this->assertArrayHasKey('title_1', $params);
         $this->assertArrayHasKey('title_2', $params);
@@ -44,7 +44,7 @@ class SearchQueryTest extends BoltUnitTest
         $query->setContentType('pages');
         $query->setSearch($filter);
         $expr = $query->getWhereExpression();
-        $this->assertEquals('((pages.title LIKE :title_1) AND (pages.title LIKE :title_2)) OR ((pages.teaser LIKE :teaser_1) AND (pages.teaser LIKE :teaser_2)) OR ((pages.body LIKE :body_1) AND (pages.body LIKE :body_2)) OR ((pages.groups LIKE :groups_1) AND (pages.groups LIKE :groups_2))', $expr);
+        $this->assertEquals('((_pages.title LIKE :title_1) AND (_pages.title LIKE :title_2)) OR ((_pages.teaser LIKE :teaser_1) AND (_pages.teaser LIKE :teaser_2)) OR ((_pages.body LIKE :body_1) AND (_pages.body LIKE :body_2)) OR ((_pages.groups LIKE :groups_1) AND (_pages.groups LIKE :groups_2))', $expr);
         $params = $query->getWhereParameters();
         $this->assertArrayHasKey('title_1', $params);
         $this->assertArrayHasKey('title_2', $params);

--- a/tests/phpunit/unit/Storage/Query/SelectQueryTest.php
+++ b/tests/phpunit/unit/Storage/Query/SelectQueryTest.php
@@ -22,7 +22,7 @@ class SelectQueryTest extends BoltUnitTest
         $query->setContentType('pages');
         $query->setParameters(($filters));
         $expr = $query->getWhereExpression();
-        $this->assertEquals('(pages.username LIKE :username_1) AND (pages.email LIKE :email_1) AND (pages.status = :status_1)', $expr->__toString());
+        $this->assertEquals('(_pages.username LIKE :username_1) AND (_pages.email LIKE :email_1) AND (_pages.status = :status_1)', $expr->__toString());
         $this->assertEquals(['%fred%', '%fred', 'published'], array_values($query->getWhereParameters()));
     }
 }


### PR DESCRIPTION
Fixes #6691

Whenever we build queries in the new storage engine, this prepends a `_` to the contenttype alias which prevents clashes with field names defined in `contenttypes.yml`

Tests also updated to add the underscore.