### PR TITLE
Fix for specific ContentType translations being ignored

### DIFF
--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -139,7 +139,7 @@ class Translator
         $transFallback = self::trans($key, $encParams, 'contenttypes', reset($localeFallbacks), false);
 
         // We don't want fallback translation here
-        if ($trans === $transFallback) {
+        if ($trans === $transFallback && !in_array($app['locale'], $localeFallbacks)) {
             $trans = false;
         }
 


### PR DESCRIPTION
Via a bug reported in Slack channel, if your locale is set to en_gb then we don't want it to count as a fallback locale.

The `transcontenttype` method finds a specific ContentType translation before moving down to the generic one but if your locale is set to en_gb then the specific translation always appears as to be a fallback one and thus gets ignored in favour of the generic.