### PR TITLE
Remove duplicated code in _sub_fields_blocks.twig

### DIFF
--- a/app/theme_defaults/_sub_field_blocks.twig
+++ b/app/theme_defaults/_sub_field_blocks.twig
@@ -43,23 +43,6 @@
         </div>
     {% endif %}
 
-    {# HTML, Textarea, Text and Markdown fields #}
-    {% if fieldtype in ['html', 'textarea', 'text', 'markdown'] %}
-        {{ block('text_field') }}
-    {% endif %}
-
-    {# Image fields #}
-    {% if fieldtype == "image" %}
-        {{ popup(value, 1200, 0) }}
-    {% endif %}
-
-    {# Video fields #}
-    {% if fieldtype == "video" and value.responsive|default %}
-        <div class="flex-video {{ value.ratio > 1.5 ? 'widescreen' }}">
-            {{ value.responsive }}
-        </div>
-    {% endif %}
-
 {% endblock %}
 
 {# Block for other field types, like Geo, Select, Checkbox and others. #}

--- a/theme/base-2016/partials/_sub_field_blocks.twig
+++ b/theme/base-2016/partials/_sub_field_blocks.twig
@@ -43,23 +43,6 @@
         </div>
     {% endif %}
 
-    {# HTML, Textarea, Text and Markdown fields #}
-    {% if fieldtype in ['html', 'textarea', 'text', 'markdown'] %}
-        {{ block('text_field') }}
-    {% endif %}
-
-    {# Image fields #}
-    {% if fieldtype == "image" %}
-        {{ popup(value, 1200, 0) }}
-    {% endif %}
-
-    {# Video fields #}
-    {% if fieldtype == "video" and value.responsive|default %}
-        <div class="flex-video {{ value.ratio > 1.5 ? 'widescreen' }}">
-            {{ value.responsive }}
-        </div>
-    {% endif %}
-
 {% endblock %}
 
 {# Block for other field types, like Geo, Select, Checkbox and others. #}


### PR DESCRIPTION
As a followup of db5a488. Looks like some code got duplicated in the merge-down to `release/3.3`, since `release/3.2` is OK. 
