### PR TITLE
[3.3] Deprecate {{ fields() }} and move to a block call

### DIFF
--- a/app/theme_defaults/_sub_field_blocks.twig
+++ b/app/theme_defaults/_sub_field_blocks.twig
@@ -9,7 +9,7 @@
         {% set value = value|markdown %}
     {% endif %}
     {% autoescape false %}
-    <div {% if key is not empty %}data-bolt-field="{{key}}"{% endif %}>{{ value }}</div>
+    <div {% if key is not empty %}data-bolt-field="{{ key }}"{% endif %}>{{ value }}</div>
     {% endautoescape %}
 {% endblock %}
 
@@ -39,23 +39,6 @@
     {# Video fields #}
     {% if fieldtype == "video" and value.responsive|default is not empty %}
         <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
-            {{ value.responsive }}
-        </div>
-    {% endif %}
-
-    {# HTML, Textarea, Text and Markdown fields #}
-    {% if fieldtype in ['html', 'textarea', 'text', 'markdown'] %}
-        {{ block('parse_text_field') }}
-    {% endif %}
-
-    {# Image fields #}
-    {% if fieldtype == "image" %}
-        {{ popup(value, 1200, 0) }}
-    {% endif %}
-
-    {# Video fields #}
-    {% if fieldtype == "video" and value.responsive|default %}
-        <div class="flex-video {{ value.ratio > 1.5 ? 'widescreen' }}">
             {{ value.responsive }}
         </div>
     {% endif %}

--- a/app/theme_defaults/_sub_fields.twig
+++ b/app/theme_defaults/_sub_fields.twig
@@ -55,7 +55,7 @@
         {% endif %}
 
         {# Finally, the repeaters #}
-        {% if repeaters == true and record.fieldtype(key) == "repeater" %}
+        {% if repeaters|default(false) == true and record.fieldtype(key) == "repeater" %}
             {% if (global.request.get('_route') != "preview") %}
                 {% for repeater in value %}
                     {% for key, repeaterfield in repeater %}

--- a/src/Twig/Extension/RecordExtension.php
+++ b/src/Twig/Extension/RecordExtension.php
@@ -27,7 +27,7 @@ class RecordExtension extends Extension
             // @codingStandardsIgnoreStart
             new \Twig_SimpleFunction('current',            [Runtime\RecordRuntime::class, 'current']),
             new \Twig_SimpleFunction('excerpt',            [Runtime\RecordRuntime::class, 'excerpt'], $safe),
-            new \Twig_SimpleFunction('fields',             [Runtime\RecordRuntime::class, 'fields'], $env + $safe),
+            new \Twig_SimpleFunction('fields',             [Runtime\RecordRuntime::class, 'fields'], $env + $safe + $deprecated + ['alternative' => 'block(\'sub_fields\')']),
             new \Twig_SimpleFunction('listtemplates',      [Runtime\RecordRuntime::class, 'listTemplates']),
             new \Twig_SimpleFunction('pager',              [Runtime\RecordRuntime::class, 'pager'], $env + $safe),
             new \Twig_SimpleFunction('trimtext',           [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -158,12 +158,8 @@ class RecordRuntime
         $exclude = null,
         $skip_uses = true
     ) {
-        if ($record === null) {
-            if (!$this->useTwigGlobals) {
-                throw new \BadMethodCallException('Twig function fields() requires a record to be passed in as either the first, or named \'record\' parameter');
-            }
-            Deprecated::warn('Twig function fields() requires a record parameter', 3.3, ' Passed one in as either the first, or named \'record\' parameter');
-        }
+        Deprecated::method('3.3');
+
         // If $record is empty, we must get it from the global scope in Twig.
         if (!$record instanceof \Bolt\Legacy\Content) {
             $globals = $env->getGlobals();

--- a/theme/base-2016/extrafields.twig
+++ b/theme/base-2016/extrafields.twig
@@ -1,10 +1,11 @@
 {% extends 'partials/_master.twig' %}
+{% use 'partials/_sub_fields.twig' %}
 
 {% block main %}
 
     <h1>{{ record.title }}</h1>
 
-    {{ fields(record = record, template = 'partials/_sub_fields.twig') }}
+    {{ block('sub_fields') }}
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}

--- a/theme/base-2016/notfound.twig
+++ b/theme/base-2016/notfound.twig
@@ -1,4 +1,5 @@
 {% extends 'partials/_master.twig' %}
+{% use 'partials/_sub_fields.twig' %}
 
 {% setcontent record = 'blocks/404-not-found' %}
 
@@ -7,6 +8,7 @@
 {% endblock title %}
 
 {% block main %}
+
     <div class="row">
         <div class="large-12 columns">
 
@@ -16,8 +18,8 @@
         {% else %}
             <h1>{{ record.title|default('404 not found') }}</h1>
 
-            {% if fields(record) %}
-                {{ fields(record) }}
+            {% if record %}
+                {{ block('sub_fields') }}
             {% else %}
                 <p>
                     The requested page was not found.

--- a/theme/base-2016/page.twig
+++ b/theme/base-2016/page.twig
@@ -1,4 +1,5 @@
 {% extends 'partials/_master.twig' %}
+{% use 'partials/_sub_fields.twig' %}
 
 {% block main %}
 
@@ -15,7 +16,9 @@
     {{ record.body }}
 
     {# If there are repeaters, we should output them. #}
-    {{ fields(record = record, template = 'partials/_sub_fields.twig', common = false, repeaters = true) }}
+    {% with {common: false, repeaters: true} %}
+    {{ block('sub_fields') }}
+    {% endwith %}
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}

--- a/theme/base-2016/partials/_sub_field_blocks.twig
+++ b/theme/base-2016/partials/_sub_field_blocks.twig
@@ -9,7 +9,7 @@
         {% set value = value|markdown %}
     {% endif %}
     {% autoescape false %}
-    <div {% if key is not empty %}data-bolt-field="{{key}}"{% endif %}>{{ value }}</div>
+    <div {% if key is not empty %}data-bolt-field="{{ key }}"{% endif %}>{{ value }}</div>
     {% endautoescape %}
 {% endblock %}
 
@@ -39,23 +39,6 @@
     {# Video fields #}
     {% if fieldtype == "video" and value.responsive|default is not empty %}
         <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
-            {{ value.responsive }}
-        </div>
-    {% endif %}
-
-    {# HTML, Textarea, Text and Markdown fields #}
-    {% if fieldtype in ['html', 'textarea', 'text', 'markdown'] %}
-        {{ block('parse_text_field') }}
-    {% endif %}
-
-    {# Image fields #}
-    {% if fieldtype == "image" %}
-        {{ popup(value, 1200, 0) }}
-    {% endif %}
-
-    {# Video fields #}
-    {% if fieldtype == "video" and value.responsive|default %}
-        <div class="flex-video {{ value.ratio > 1.5 ? 'widescreen' }}">
             {{ value.responsive }}
         </div>
     {% endif %}

--- a/theme/base-2016/partials/_sub_fields.twig
+++ b/theme/base-2016/partials/_sub_fields.twig
@@ -55,7 +55,7 @@
     {% endif %}
 
     {# Finally, the repeaters #}
-    {% if repeaters == true and record.fieldtype(key) == "repeater" %}
+    {% if repeaters|default(false) == true and record.fieldtype(key) == "repeater" %}
         {% if (global.request.get('_route') != "preview") %}
             {% for repeater in value %}
                 {% for key, repeaterfield in repeater %}
@@ -82,7 +82,7 @@
 
 {# We do the same for the templatefields, if set and not empty. #}
 {% set templatefields = record.values.templatefields.values|default() %}
-{% if templatefields is defined and templatefields is not empty %}
+{% if templatefields is not empty %}
     {# Note: This needs to be expanded upon!! For better detection the 'virtual'
        contenttype for the templatefields should know about the types of fields. #}
     {% set templatefields_field_types = attribute(record.contenttype.templatefields|first, 'fields') %}
@@ -90,7 +90,6 @@
         {% set fieldtype = attribute(attribute(templatefields_field_types, key), 'type')  %}
         {{ block('common_fields') }}
         {{ block('extended_fields') }}
-
     {% endfor %}
 {% endif %}
 {% endblock sub_fields %}

--- a/theme/base-2016/readme.md
+++ b/theme/base-2016/readme.md
@@ -121,12 +121,13 @@ For example, take a look at one of the simpler templates, `record.twig`:
 
 ```twig
 {% extends 'partials/_master.twig' %}
+{% use 'partials/_sub_fields.twig' %}
 
 {% block main %}
 
         <h1>{{ record.title }}</h1>
 
-        {{ fields(record = record, template = 'partials/_sub_fields.twig') }}
+        {{ block('sub_fields') }}
 
         {{ include('partials/_recordfooter.twig', { 'record': record }) }}
 
@@ -136,7 +137,7 @@ For example, take a look at one of the simpler templates, `record.twig`:
 You'll notice the first line that states that the template 'extends' the
 `_master.twig` partial. The rest of the template is the `{% block %}`, which
 overrides the 'main' block in the master template. Inside the block is just an
-`<h1>`-tag with the record's title, a `{{ fields() }}` tag that will output the
+`<h1>` element with the record title, a `subfields` block that will output the
 fields that are defined for this contenttype, and it closes with an include of
 `_recordfooter.twig` to display some meta data, like the author, date and
 permalink.

--- a/theme/base-2016/record.twig
+++ b/theme/base-2016/record.twig
@@ -1,4 +1,5 @@
 {% extends 'partials/_master.twig' %}
+{% use 'partials/_sub_fields.twig' %}
 
 {% block main %}
 
@@ -6,8 +7,8 @@
 
     {# Output all fields, in the order as defined in the contenttype.
        To change the generated html and configure the options, see:
-       https://docs.bolt.cm/templating/fields-tag #}
-    {{ fields(record = record, template = 'partials/_sub_fields.twig') }}
+       https://docs.bolt.cm/templating #}
+    {{ block('sub_fields', 'partials/_sub_fields.twig') }}
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}


### PR DESCRIPTION
Let's try again shall we :wink: 

This PR:
  - Fully deprecates the Twig function `{{ fields() }}`
  - Cut over to full use of blocks in `base-2016`
  - Derpy derp on copy/pasta

Matching v4 PR is #6781
