### PR TITLE
[BUG/CR] 3.2 - Quick fix for content with large lists of incoming relations

### DIFF
--- a/src/Helpers/Input.php
+++ b/src/Helpers/Input.php
@@ -12,7 +12,7 @@ class Input
      * @param bool  $stripslashes
      * @param bool  $stripControlChars
      *
-     * @return string
+     * @return string|array
      */
     public static function cleanPostedData($var, $stripslashes = true, $stripControlChars = false)
     {

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -112,6 +112,8 @@ class Edit
 
         // Build list of incoming non inverted related records.
         $incomingNotInverted = [];
+        $count = 0;
+        $limit = $this->config->get('general/edit_incomingrelations_limit', false);
         foreach ($content->getRelation()->incoming($content) as $relation) {
             if ($relation->isInverted()) {
                 continue;
@@ -121,6 +123,12 @@ class Edit
 
             if ($record) {
                 $incomingNotInverted[$fromContentType][] = $record;
+            }
+
+            // Do not try to load more than X records or db will fail
+            ++$count;
+            if ($limit && $count > $limit) {
+                break;
             }
         }
 

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -7,6 +7,7 @@ use Bolt\Filesystem\Exception\IOException;
 use Bolt\Filesystem\Manager;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Storage\Entity\Content;
+use Bolt\Storage\Entity\Relations;
 use Bolt\Storage\Entity\TemplateFields;
 use Bolt\Storage\EntityManager;
 use Bolt\Storage\Mapping\ContentType;
@@ -115,6 +116,7 @@ class Edit
         $count = 0;
         $limit = $this->config->get('general/edit_incomingrelations_limit', false);
         foreach ($content->getRelation()->incoming($content) as $relation) {
+            /** @var Relations $relation */
             if ($relation->isInverted()) {
                 continue;
             }
@@ -134,6 +136,7 @@ class Edit
 
         // Test write access for uploadable fields.
         $contentType['fields'] = $this->setCanUpload($contentType['fields']);
+        /** @var Content $templateFields */
         $templateFields = $content->getTemplatefields();
         if ($templateFields instanceof TemplateFields && $templateFieldsData = $templateFields->getContenttype()->getFields()) {
             $templateFields->getContenttype()['fields'] = $this->setCanUpload($templateFields->getContenttype()->getFields());

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -447,8 +447,8 @@ trait ContentValuesTrait
     /**
      * Set a ContentType record values from a HTTP POST.
      *
-     * @param array  $values
-     * @param string $contenttype
+     * @param array $values
+     * @param array $contenttype
      *
      * @throws \Exception
      *
@@ -560,6 +560,8 @@ trait ContentValuesTrait
 
     /**
      * Get the title, name, caption or subject.
+     *
+     * @param bool $allowBasicTags
      *
      * @return string
      */


### PR DESCRIPTION
The current Bolt 3.2 Edit action loads each incoming related record in it's own DB query. If you have more than a couple hundred objects, the edit page will no longer load as you get memory and execution time problems.

After some discussions with @GawainLynch, it seems a "proper" solution using the new storage layers is already available but might not be portable as fast as needed. This quick fix is intended as a temporary solution until the loading is refactored to the new mechanism. (Also keep in mind that rendering 10000 related objects in twig might still not be advisable ;) )