### PR TITLE
[3.2] Translation file header

### DIFF
--- a/app/resources/translations/cs_CZ/contenttypes.cs_CZ.yml
+++ b/app/resources/translations/cs_CZ/contenttypes.cs_CZ.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/cs_CZ/contenttypes.cs_CZ.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  44 untranslated keyword based messages
-#  no translations
-# 101 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  44 Untranslated messages
+#   0 Legacy translation messages
+# 101 Translation messages
 
-#--- 44 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -64,7 +63,7 @@ contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase'
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 contenttypes.showcases.text.recent-changes-one: # "Recent change to this Showcase"
 
-#--- 101 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.description: "Typ obsahu **Novinky** může být použit pro obsah typu _'Novinky'_ nebo _'Blog'_. Mají teaser, který může být použít jako přehled / anotace na stránkách s výpisy, umožňujíc nášvštěvníkům procházet zbytek příspěvku. Obsahuje také obrázek či volitelně video. Pro změnu, přidání či odstranění polí obsahu je potřeba upravit soubor `contenttypes.yml` ve složce `app/config/`. Můžete použít svůj oblínbený editor nebo vestavěný v hlavní nabídce 'Konfigurace' » 'Typy obsahu' na levé straně."
 contenttypes.entries.group.content: "Obsah"

--- a/app/resources/translations/cs_CZ/messages.cs_CZ.yml
+++ b/app/resources/translations/cs_CZ/messages.cs_CZ.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/cs_CZ/messages.cs_CZ.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  12 untranslated messages
-#  92 untranslated keyword based messages
-#  80 translations
-# 439 keyword based translations
+#   0 Unused messages
+#  12 Legacy untranslated messages
+#  92 Untranslated messages
+#  80 Legacy translation messages
+# 439 Translation messages
 
-#--- 12 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Dependencies": #
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": #
@@ -29,7 +28,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "Video": #
 
-#--- 92 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.group.meta: # "Meta"
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
@@ -134,7 +133,7 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 
 permissions.roles.label.anonymous: # "Anonymous"
 
-#--- 80 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(standardní šablona)"
 "(no category)": "(bez kategorie)"
@@ -217,7 +216,7 @@ permissions.roles.label.anonymous: # "Anonymous"
 "You've been logged on successfully.": "Byl jste úspěšně přihlášen/a."
 "filtered by <em>'%filter%'</em>": "filtrováno dle <em>'%filter%'</em>"
 
-#--- 439 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Akce pro %contenttypes%"
 contenttypes.generic.actions-one: "Akce pro %contenttype%"

--- a/app/resources/translations/de_DE/contenttypes.de_DE.yml
+++ b/app/resources/translations/de_DE/contenttypes.de_DE.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/de_DE/contenttypes.de_DE.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  no untranslated keyword based messages
-#  no translations
-# 145 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#   0 Untranslated messages
+#   0 Legacy translation messages
+# 145 Translation messages
 
-#--- 145 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.blocks.description: "Der **Blöcke** Datentyp ist ein Hilfs-Datentyp. Er kann verwendet werden um kleinere Inhaltsbereiche zu verwalten, wie z.B. die Bereiche „Über uns“ und „Unsere Adresse“ im Footer oder andere Inhalts-Schnipsel."
 contenttypes.blocks.group.block: "Block"

--- a/app/resources/translations/de_DE/messages.de_DE.yml
+++ b/app/resources/translations/de_DE/messages.de_DE.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/de_DE/messages.de_DE.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  no untranslated keyword based messages
-#  92 translations
-# 531 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#   0 Untranslated messages
+#  92 Legacy translation messages
+# 531 Translation messages
 
-#--- 92 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(Standardvorlage)"
 "(no category)": "(keine Kategorie vergeben)"
@@ -109,7 +108,7 @@
 "You've been logged on successfully.": "Erfolgreich eingeloggt!"
 "filtered by <em>'%filter%'</em>": "gefiltert nach <em>'%filter%'</em>"
 
-#--- 531 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Aktionen für %contenttypes%"
 contenttypes.generic.actions-one: "Aktionen für %contenttype%"

--- a/app/resources/translations/el/contenttypes.el.yml
+++ b/app/resources/translations/el/contenttypes.el.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/el/contenttypes.el.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  44 untranslated keyword based messages
-#  no translations
-# 101 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  44 Untranslated messages
+#   0 Legacy translation messages
+# 101 Translation messages
 
-#--- 44 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -64,7 +63,7 @@ contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase'
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 contenttypes.showcases.text.recent-changes-one: # "Recent change to this Showcase"
 
-#--- 101 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.description: "Der Datentyp **Einträge** kann beispielsweise für _„News“_ oder _„Blogpostings“_ verwendet werden. Er hat einen Teaser, der für eine Inhaltsangabe in den Auflistungsseiten verwendet werden kann und den Besucher zum Rest des Eintrages führt. Er verfügt auch über Felder für ein Bild oder wahlweise ein Video. Um die Felder dieses Datentyps zu ändern, bearbeiten Sie die Datei `contenttypes.yml` im Verzeichnis `app/config/` mit dem Editor Ihrer Wahl, oder nutzen Sie den Menüpunkt „Konfiguration“ » „Datentypen“ im Menü auf der linken Seite."
 contenttypes.entries.group.content: "Inhalt"

--- a/app/resources/translations/el/messages.el.yml
+++ b/app/resources/translations/el/messages.el.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/el/messages.el.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  72 untranslated messages
-# 345 untranslated keyword based messages
-#  20 translations
-# 186 keyword based translations
+#   0 Unused messages
+#  72 Legacy untranslated messages
+# 345 Untranslated messages
+#  20 Legacy translation messages
+# 186 Translation messages
 
-#--- 72 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "(none)": #
 "Add a brief, optional comment to describe what's changed.": #
@@ -89,7 +88,7 @@
 "View (saved version) on site": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 345 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.created: # "This %contenttype% was created"
 contenttypes.generic.group.meta: # "Meta"
@@ -471,7 +470,7 @@ permissions.roles.description.everyone: # "Built-in role, automatically granted 
 permissions.roles.description.owner: # "Built-in role, only valid in the context of a resource, and automatically assigned to the owner of that resource."
 permissions.roles.description.root: # "Built-in superuser role, automatically grants all permissions"
 
-#--- 20 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(standardní šablona)"
 "(no category)": "(χωρίς κατηγορία)"
@@ -494,7 +493,7 @@ permissions.roles.description.root: # "Built-in superuser role, automatically gr
 "Title": "Τίτλος"
 "You've been logged on successfully.": "Συνδεθήκατε επιτυχώς."
 
-#--- 186 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Ενέργειες για %contenttypes%"
 contenttypes.generic.actions-one: "Ενέργεις για %contenttype%"

--- a/app/resources/translations/en_GB/contenttypes.en_GB.yml
+++ b/app/resources/translations/en_GB/contenttypes.en_GB.yml
@@ -1,24 +1,19 @@
 # app/resources/translations/en_GB/contenttypes.en_GB.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#   1 unused messages
-#  no untranslated messages
-#   4 untranslated keyword based messages
-#  no translations
-# 141 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#   4 Untranslated messages
+#   0 Legacy translation messages
+# 141 Translation messages
 
-#--- 1 unused messages --------------------------------------------------------
-
-"contenttypes.showcases.group.template": "Template"
-
-#--- 4 untranslated keyword based messages ------------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.text.invalid-hyphen: # "In the ContentType for 'Block', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -28,7 +23,7 @@ contenttypes.pages.text.invalid-hyphen: # "In the ContentType for 'Page', you ha
 
 contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
-#--- 141 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.blocks.description: "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: "Block"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -1,27 +1,26 @@
 # app/resources/translations/en_GB/messages.en_GB.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#   4 untranslated messages
-#  no untranslated keyword based messages
-#  88 translations
-# 531 keyword based translations
+#   0 Unused messages
+#   4 Legacy untranslated messages
+#   0 Untranslated messages
+#  88 Legacy translation messages
+# 531 Translation messages
 
-#--- 4 untranslated messages --------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Dependencies": #
 "Finding packages that require this one…": #
 "Group": #
 "Groups": #
 
-#--- 88 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(default template)"
 "(no category)": "(no category)"
@@ -112,7 +111,7 @@
 "You've been logged on successfully.": "You've been logged on successfully."
 "filtered by <em>'%filter%'</em>": "filtered by <em>'%filter%'</em>"
 
-#--- 531 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Actions for %contenttypes%"
 contenttypes.generic.actions-one: "Actions for this %contenttype%"

--- a/app/resources/translations/es_ES/contenttypes.es_ES.yml
+++ b/app/resources/translations/es_ES/contenttypes.es_ES.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/es_ES/contenttypes.es_ES.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#   4 untranslated keyword based messages
-#  no translations
-# 141 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#   4 Untranslated messages
+#   0 Legacy translation messages
+# 141 Translation messages
 
-#--- 4 untranslated keyword based messages ------------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.text.invalid-hyphen: # "In the ContentType for 'Block', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -24,7 +23,7 @@ contenttypes.pages.text.invalid-hyphen: # "In the ContentType for 'Page', you ha
 
 contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
-#--- 141 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.blocks.description: "El Tipo de Contenido **Bloques** es también llamado como un 'recurso de Tipo de Contenido'. Esto significa que puede ser utilizado para gestionar pequeños trozos de contenido, como el texto 'sobre nosotros' y 'nuestra dirección' en el pie de la página web o textos cortos de propaganda similares."
 contenttypes.blocks.group.block: "Bloque"

--- a/app/resources/translations/es_ES/messages.es_ES.yml
+++ b/app/resources/translations/es_ES/messages.es_ES.yml
@@ -1,24 +1,19 @@
 # app/resources/translations/es_ES/messages.es_ES.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#   1 unused messages
-#  no untranslated messages
-#   7 untranslated keyword based messages
-#  92 translations
-# 524 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#   7 Untranslated messages
+#  92 Legacy translation messages
+# 524 Translation messages
 
-#--- 1 unused messages --------------------------------------------------------
-
-"general.phrase.page": "Página"
-
-#--- 7 untranslated keyword based messages ------------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -32,7 +27,7 @@ nut.version: # "version"
 
 page.extend.options: # "Extension Options"
 
-#--- 92 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(plantilla predeterminada)"
 "(no category)": "(sin categoría)"
@@ -127,7 +122,7 @@ page.extend.options: # "Extension Options"
 "You've been logged on successfully.": "Has iniciado sesión exitosamente"
 "filtered by <em>'%filter%'</em>": "filtrado por <em>'%filter%'</em>"
 
-#--- 524 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Acciones para %contenttypes%"
 contenttypes.generic.actions-one: "Acciones para %contenttype%"

--- a/app/resources/translations/fi/contenttypes.fi.yml
+++ b/app/resources/translations/fi/contenttypes.fi.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/fi/contenttypes.fi.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  47 untranslated keyword based messages
-#  no translations
-#  98 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  47 Untranslated messages
+#   0 Legacy translation messages
+#  98 Translation messages
 
-#--- 47 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -67,7 +66,7 @@ contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase'
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 contenttypes.showcases.text.recent-changes-one: # "Recent change to this Showcase"
 
-#--- 98 keyword based translations --------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.description: "**Merkinnät** sisältötyyppiä voidaan käyttää esimerkiksi _'uutisina'_ tai _'blogimerkintöinä'_. Niillä on näyte, jota voidaan käyttää lyhyenä otteena listauksissa, sallien kävijän klikata lukeakseen loput Merkintästa. Siinä on myös kentät kuvalle ja valinnaiselle videolle. Vaihtaaksesi sisältötyypin kenttiä, muokkaa tiedostoa `contenttypes.yml` kansiossa `app/config`, joko käyttäen haluamaasi editoria, tai menemällä 'Asetukset' » 'Sisältötyypit' vasemmalla olevassa valikossa."
 contenttypes.entries.group.content: "Sisältö"

--- a/app/resources/translations/fi/messages.fi.yml
+++ b/app/resources/translations/fi/messages.fi.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/fi/messages.fi.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  27 untranslated messages
-# 143 untranslated keyword based messages
-#  65 translations
-# 388 keyword based translations
+#   0 Unused messages
+#  27 Legacy untranslated messages
+# 143 Untranslated messages
+#  65 Legacy translation messages
+# 388 Translation messages
 
-#--- 27 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "An error occured while updating `%TABLE%`. The error is %ERROR%": #
 "Are you sure you want to do this for %NUMBER% records?": #
@@ -44,7 +43,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "Video": #
 
-#--- 143 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.group.meta: # "Meta"
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
@@ -204,7 +203,7 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.file-management.label.create-file: # "Create File"
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
 
-#--- 65 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(oletussivupohja)"
 "(no category)": "(ei kategoriaa)"
@@ -272,7 +271,7 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "You've been logged on successfully.": "Uloskirjautuminen onnistui."
 "filtered by <em>'%filter%'</em>": "suodatettu <em>'%filter%'</em>"
 
-#--- 388 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Sisältötyyppien toiminnot"
 contenttypes.generic.actions-one: "Tämän sisältötyypin toiminnot"

--- a/app/resources/translations/fr/contenttypes.fr.yml
+++ b/app/resources/translations/fr/contenttypes.fr.yml
@@ -1,24 +1,19 @@
 # app/resources/translations/fr/contenttypes.fr.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#   1 unused messages
-#  no untranslated messages
-#   4 untranslated keyword based messages
-#  no translations
-# 141 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#   4 Untranslated messages
+#   0 Legacy translation messages
+# 141 Translation messages
 
-#--- 1 unused messages --------------------------------------------------------
-
-"contenttypes.showcases.group.template": "Gabarit"
-
-#--- 4 untranslated keyword based messages ------------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.text.invalid-hyphen: # "In the ContentType for 'Block', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -28,7 +23,7 @@ contenttypes.pages.text.invalid-hyphen: # "In the ContentType for 'Page', you ha
 
 contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
-#--- 141 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.blocks.description: "Les **Blocs** sont assimilés à un 'type de contenu ressource'. Cela signifie qu'ils peuvent être utilisés pour gérer les petits morceaux de contenu, comme le texte 'qui sommes-nous', un 'notre adresse' dans le pied de page ou n'importe quel autre petit texte."
 contenttypes.blocks.group.block: "Bloc"

--- a/app/resources/translations/fr/messages.fr.yml
+++ b/app/resources/translations/fr/messages.fr.yml
@@ -1,27 +1,26 @@
 # app/resources/translations/fr/messages.fr.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#   4 untranslated messages
-#   6 untranslated keyword based messages
-#  88 translations
-# 525 keyword based translations
+#   0 Unused messages
+#   4 Legacy untranslated messages
+#   6 Untranslated messages
+#  88 Legacy translation messages
+# 525 Translation messages
 
-#--- 4 untranslated messages --------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Dependencies": #
 "Finding packages that require this one…": #
 "Group": #
 "Groups": #
 
-#--- 6 untranslated keyword based messages ------------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -35,7 +34,7 @@ nut.version: # "version"
 
 page.extend.options: # "Extension Options"
 
-#--- 88 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(modèle par défaut)"
 "(no category)": "(aucune catégorie)"
@@ -126,7 +125,7 @@ page.extend.options: # "Extension Options"
 "You've been logged on successfully.": "Connexion réussie."
 "filtered by <em>'%filter%'</em>": "filtré par <em>'%filter%'</em>"
 
-#--- 525 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Actions pour les %contenttypes%"
 contenttypes.generic.actions-one: "Actions pour ce(tte) %contenttype%"

--- a/app/resources/translations/hu/contenttypes.hu.yml
+++ b/app/resources/translations/hu/contenttypes.hu.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/hu/contenttypes.hu.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-# 102 untranslated keyword based messages
-#  no translations
-#  43 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+# 102 Untranslated messages
+#   0 Legacy translation messages
+#  43 Translation messages
 
-#--- 102 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -122,7 +121,7 @@ contenttypes.showcases.text.show-more: # "More Showcases"
 contenttypes.showcases.text.view: # "View Showcases"
 contenttypes.showcases.text.wrong-use-field: # "In the ContentType for 'Showcase', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
 
-#--- 43 keyword based translations --------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.group.content: "Tartalom"
 contenttypes.entries.group.media: "Média"

--- a/app/resources/translations/hu/messages.hu.yml
+++ b/app/resources/translations/hu/messages.hu.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/hu/messages.hu.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  19 untranslated messages
-#  79 untranslated keyword based messages
-#  73 translations
-# 452 keyword based translations
+#   0 Unused messages
+#  19 Legacy untranslated messages
+#  79 Untranslated messages
+#  73 Legacy translation messages
+# 452 Translation messages
 
-#--- 19 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Body": #
 "Dependencies": #
@@ -36,7 +35,7 @@
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
-#--- 79 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 contenttypes.generic.invalid-relation: # "In the ContentType for '%contenttype%', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
@@ -132,7 +131,7 @@ panel.latest-activity.created: # "Created"
 panel.latest-activity.deleted: # "Deleted"
 panel.latest-activity.system: # "Latest system activity"
 
-#--- 73 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(alapértelmezett sablon)"
 "(no category)": "(nincs kategória)"
@@ -208,7 +207,7 @@ panel.latest-activity.system: # "Latest system activity"
 "You've been logged on successfully.": "Sikeresen bejelentkezett."
 "filtered by <em>'%filter%'</em>": "szűrés: <em>'%filter%'</em>"
 
-#--- 452 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Műveletek a(z) %contenttypes% tartalomtípusokhoz"
 contenttypes.generic.actions-one: "Műveletek a(z) %contenttype% tartalomtípushoz"

--- a/app/resources/translations/id/contenttypes.id.yml
+++ b/app/resources/translations/id/contenttypes.id.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/id/contenttypes.id.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-# 142 untranslated keyword based messages
-#  no translations
-#   3 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+# 142 Untranslated messages
+#   0 Legacy translation messages
+#   3 Translation messages
 
-#--- 142 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -162,7 +161,7 @@ contenttypes.showcases.text.show-more: # "More Showcases"
 contenttypes.showcases.text.view: # "View Showcases"
 contenttypes.showcases.text.wrong-use-field: # "In the ContentType for 'Showcase', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
 
-#--- 3 keyword based translations ---------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.group.content: "Konten"
 contenttypes.entries.name.singular: "Catatan"

--- a/app/resources/translations/id/messages.id.yml
+++ b/app/resources/translations/id/messages.id.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/id/messages.id.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  78 untranslated messages
-# 380 untranslated keyword based messages
-#  14 translations
-# 151 keyword based translations
+#   0 Unused messages
+#  78 Legacy untranslated messages
+# 380 Untranslated messages
+#  14 Legacy translation messages
+# 151 Translation messages
 
-#--- 78 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "(default template)": #
 "(no category)": #
@@ -95,7 +94,7 @@
 "You've been logged on successfully.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 380 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.actions-all: # "Actions for %contenttypes%"
 contenttypes.generic.actions-one: # "Actions for this %contenttype%"
@@ -511,7 +510,7 @@ permissions.roles.description.owner: # "Built-in role, only valid in the context
 permissions.roles.description.root: # "Built-in superuser role, automatically grants all permissions"
 permissions.roles.label.anonymous: # "Anonymous"
 
-#--- 14 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(no group)": "(Tidak ada kelompok)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Tambah contoh<a href='%url%' class='btn btn-default'>Isian dengan teks Loripsum</a>"
@@ -528,7 +527,7 @@ permissions.roles.label.anonymous: # "Anonymous"
 "This is a checkbox": "Ini kotak centang"
 "Title": "Judul"
 
-#--- 151 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.group.taxonomy: "Taksonomi"
 

--- a/app/resources/translations/it/contenttypes.it.yml
+++ b/app/resources/translations/it/contenttypes.it.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/it/contenttypes.it.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  96 untranslated keyword based messages
-#  no translations
-#  49 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  96 Untranslated messages
+#   0 Legacy translation messages
+#  49 Translation messages
 
-#--- 96 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -116,7 +115,7 @@ contenttypes.showcases.text.show-more: # "More Showcases"
 contenttypes.showcases.text.view: # "View Showcases"
 contenttypes.showcases.text.wrong-use-field: # "In the ContentType for 'Showcase', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
 
-#--- 49 keyword based translations --------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.group.content: "Contenuto"
 contenttypes.entries.name.plural: "Notizie"

--- a/app/resources/translations/it/messages.it.yml
+++ b/app/resources/translations/it/messages.it.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/it/messages.it.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  72 untranslated messages
-# 326 untranslated keyword based messages
-#  20 translations
-# 205 keyword based translations
+#   0 Unused messages
+#  72 Legacy untranslated messages
+# 326 Untranslated messages
+#  20 Legacy translation messages
+# 205 Translation messages
 
-#--- 72 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "(default template)": #
 "(no category)": #
@@ -89,7 +88,7 @@
 "View (saved version) on site": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 326 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.group.meta: # "Meta"
 contenttypes.generic.group.template: # "Template"
@@ -448,7 +447,7 @@ permissions.roles.description.root: # "Built-in superuser role, automatically gr
 permissions.roles.label.anonymous: # "Anonymous"
 permissions.roles.label.owner: # "Owner"
 
-#--- 20 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(no group)": "(nessun gruppo)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Aggiungi un po di <a href='%url%' class='btn btn-default'>Contenuti con il testo Loripsum</a>"
@@ -471,7 +470,7 @@ permissions.roles.label.owner: # "Owner"
 "Title": "Titolo"
 "You've been logged on successfully.": "Accesso effettuato con successo."
 
-#--- 205 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Azioni per contenuti %contenttypes%"
 contenttypes.generic.actions-one: "Azioni per questo contenuto %contenttype%"

--- a/app/resources/translations/ja/contenttypes.ja.yml
+++ b/app/resources/translations/ja/contenttypes.ja.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/ja/contenttypes.ja.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  96 untranslated keyword based messages
-#  no translations
-#  49 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  96 Untranslated messages
+#   0 Legacy translation messages
+#  49 Translation messages
 
-#--- 96 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -116,7 +115,7 @@ contenttypes.showcases.text.show-more: # "More Showcases"
 contenttypes.showcases.text.view: # "View Showcases"
 contenttypes.showcases.text.wrong-use-field: # "In the ContentType for 'Showcase', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
 
-#--- 49 keyword based translations --------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.group.content: "コンテンツ"
 contenttypes.entries.name.plural: "投稿"

--- a/app/resources/translations/ja/messages.ja.yml
+++ b/app/resources/translations/ja/messages.ja.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/ja/messages.ja.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  51 untranslated messages
-# 260 untranslated keyword based messages
-#  41 translations
-# 271 keyword based translations
+#   0 Unused messages
+#  51 Legacy untranslated messages
+# 260 Untranslated messages
+#  41 Legacy translation messages
+# 271 Translation messages
 
-#--- 51 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "(none)": #
 "Add a brief, optional comment to describe what's changed.": #
@@ -68,7 +67,7 @@
 "View (saved version) on site": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 260 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.group.ungrouped: # "Ungrouped"
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
@@ -355,7 +354,7 @@ panel.latest-activity.system: # "Latest system activity"
 
 panel.user-actions.button.add: # "Add a new user"
 
-#--- 41 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "（デフォルトテンプレート）"
 "(no category)": "（カテゴリなし）"
@@ -399,7 +398,7 @@ panel.user-actions.button.add: # "Add a new user"
 "Video": "動画"
 "You've been logged on successfully.": "正常にログインしました。"
 
-#--- 271 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "%contenttypes%の操作"
 contenttypes.generic.actions-one: "この%contenttype%の操作"

--- a/app/resources/translations/nb/contenttypes.nb.yml
+++ b/app/resources/translations/nb/contenttypes.nb.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/nb/contenttypes.nb.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-# 143 untranslated keyword based messages
-#  no translations
-#   2 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+# 143 Untranslated messages
+#   0 Legacy translation messages
+#   2 Translation messages
 
-#--- 143 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -163,7 +162,7 @@ contenttypes.showcases.text.show-more: # "More Showcases"
 contenttypes.showcases.text.view: # "View Showcases"
 contenttypes.showcases.text.wrong-use-field: # "In the ContentType for 'Showcase', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
 
-#--- 2 keyword based translations ---------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.group.content: "Innhold"
 

--- a/app/resources/translations/nb/infos.nb.yml
+++ b/app/resources/translations/nb/infos.nb.yml
@@ -1,1 +1,81 @@
----
+info:
+    upload:
+        image: |
+            Use this field to upload a photo or image. Click the button to upload a file from your
+            computer, or if you're using a recent version of Chrome or Firefox, you can simply drag'n'drop the file
+            from your desktop or from a different browser window.<br>
+            Alternatively, you can use a previously uploaded image. To select a previously uploaded file, just
+            type (part) of the file name in the input area, and it will be autocompleted.
+        file: |
+            Use this field to upload a file to include as a download or to use inside a page on the
+            website. Click the button to upload a file from your computer, or if you're using a recent version
+            of Chrome or Firefox, you can simply drag'n'drop the file from your desktop or from a different
+            browser window.<br>
+            Alternatively, you can use a previously uploaded file. To select a previously uploaded file, just
+            type (part) of the file name in the input area, and it will be autocompleted.
+        filelist: |
+            Use this field to upload multiple files and some descriptions. Like with the singular "file" field, recent
+            browser versions are able to understand you dragging a file into the input field. Maybe give it a try?
+        filesmall: |
+            Use the button to upload a file. To select a previously uploaded file, you can
+            type (part) of the file name in the input area, and it will be autocompleted.
+        imagelist: |
+            Use this field to upload a set of photos or image. Click the button to upload a file from your
+                computer, or if you're using a recent version of Chrome or Firefox, you can simply drag'n'drop the file
+                from your desktop or from a different browser window.<br>
+                Alternatively, you can use a previously uploaded image.<br>
+                You can rearrange the images using drag'n'drop, and change the descriptions of the images.
+        video: |
+            Use this field to embed a video inside a page on the website. Just copy/paste the
+                  URL of a video-page on Youtube, Vimeo or almost any other video sharing website.<br>
+                  Bolt will automatically fetch the &lt;embed&gt;-code, with the correct width, height and the original
+                  title. If you change the width or height, the other value will change accordingly, to maintain the
+                  aspect ratio.
+    geolocation: |
+        Use this field to get the geolocation of any address, or place the marker
+            manually by dragging the pin. First, enter an (approximate) address in the 'address'-field,
+            and the corresponding latitude and longitude will be retrieved using the Google Maps API,
+            together with the closest matching address, according to Google.<br>
+            If you want to move the marker to a different location, just drag'n'drop the pin on the
+            mini-map. The latitude and longitude will be updated automatically.
+    markdown: |
+        Markdown is a text-to-HTML conversion tool for web writers.
+            <p>Markdown allows you to write using an easy-to-read, easy-to-write plain text format,
+            which is then converted to structurally valid HTML.</p>
+            <p><strong>Quick reference:</strong><br>
+            # This is an &lt;h1&gt;-tag<br>
+            ## This is an &lt;h2&gt;-tag<br>
+            ###### This is an &lt;h6&gt;-tag</p>
+            <p>This _<em>is italic</em>_, this __<strong>is bold</strong>__, and this
+            ___<em><strong>is both</strong></em>___. You can also use asterisks: This *<em>is italic</em>*,
+            this **<strong>is bold</strong>**.
+            <p>Create <a href='#'>links</a> like this:<br>
+            An [exciting website](http://example.org/ &quot;Title of link&quot;)</p>
+            <p>&nbsp; * This is an unordered list<br>
+            &nbsp; * Item 2</p>
+            <p>&nbsp; 1 This is an ordered list<br>
+            &nbsp; 2 Item 2</p>
+    relationships: |
+        By selecting other records as a 'relation', you are actually
+            creating a link between this record, and the one you selected. On the
+            website, this can by used for 'related articles', 'see also' or to display
+            how this record fits into a certain structure.
+    taxonomy: |
+        By selecting one or more taxonomies for this record,
+                  you are classifying this record to have those properties. On the
+                  website this can be used to group certain records together, or
+                  to automatically create links to records that share a
+                  classification.
+about:
+    bolt: |
+        <p>Bolt is a CMS that strives to be simple, fast, straightforward and enjoyable to use. Both for
+        developers and content-editors. Bolt is Open Source, and as such it uses other Open Source
+        components. If you are a developer you're very welcome to help in the further development of Bolt.</p>
+    licence: |
+        <p>All parts of Bolt are free to use under the open-source MIT license. The full licensing text can be
+        found here, in the included <a href="https://docs.bolt.cm/other/license">LICENSE.md</a>.</p>
+prefill:
+    short_help: |
+        <p>Check the ContentTypes for which you want to automatically generate some records that are filled with Lorem Ipsum dummy content.</p>
+        <p>If all checkboxes are left unchecked, Bolt will only prefill the ContentTypes that have no content yet.</p>
+

--- a/app/resources/translations/nb/messages.nb.yml
+++ b/app/resources/translations/nb/messages.nb.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/nb/messages.nb.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  65 untranslated messages
-# 346 untranslated keyword based messages
-#  27 translations
-# 185 keyword based translations
+#   0 Unused messages
+#  65 Legacy untranslated messages
+# 346 Untranslated messages
+#  27 Legacy translation messages
+# 185 Translation messages
 
-#--- 65 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "(none)": #
 "Add a brief, optional comment to describe what's changed.": #
@@ -82,7 +81,7 @@
 "View (saved version) on site": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 346 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.actions-all: # "Actions for %contenttypes%"
 contenttypes.generic.actions-one: # "Actions for this %contenttype%"
@@ -461,7 +460,7 @@ panel.latest-activity.unknown: # "unknown"
 
 panel.user-actions.button.add: # "Add a new user"
 
-#--- 27 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(standard mal)"
 "(no category)": "(ingen kategori)"
@@ -491,7 +490,7 @@ panel.user-actions.button.add: # "Add a new user"
 "Title": "Tittel"
 "You've been logged on successfully.": "Du er vellykket logget ut."
 
-#--- 185 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.group.relations: "Relasjoner"
 contenttypes.generic.group.taxonomy: "Taksonomi"

--- a/app/resources/translations/nl_NL/contenttypes.nl_NL.yml
+++ b/app/resources/translations/nl_NL/contenttypes.nl_NL.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/nl_NL/contenttypes.nl_NL.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  16 untranslated keyword based messages
-#  no translations
-# 129 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  16 Untranslated messages
+#   0 Legacy translation messages
+# 129 Translation messages
 
-#--- 16 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.text.invalid-field: # "Can't set %field% in Block: Not a valid field."
@@ -36,7 +35,7 @@ contenttypes.pages.text.invalid-relation: # "In the ContentType for 'Page', the 
 contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 
-#--- 129 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.blocks.group.block: "Blok"
 contenttypes.blocks.name.plural: "Blokken"

--- a/app/resources/translations/nl_NL/messages.nl_NL.yml
+++ b/app/resources/translations/nl_NL/messages.nl_NL.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/nl_NL/messages.nl_NL.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  12 untranslated messages
-#  27 untranslated keyword based messages
-#  80 translations
-# 504 keyword based translations
+#   0 Unused messages
+#  12 Legacy untranslated messages
+#  27 Untranslated messages
+#  80 Legacy translation messages
+# 504 Translation messages
 
-#--- 12 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Dependencies": #
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": #
@@ -29,7 +28,7 @@
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
-#--- 27 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -62,7 +61,7 @@ page.extend.options: # "Extension Options"
 
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
 
-#--- 80 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(standaard template)"
 "(no category)": "(geen categorie)"
@@ -145,7 +144,7 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "You've been logged on successfully.": "Je bent succesvol ingelogd."
 "filtered by <em>'%filter%'</em>": "gefilterd door <em>'%filter%'</em>"
 
-#--- 504 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Handelingen voor %contenttypes%"
 contenttypes.generic.actions-one: "Handelingen voor deze %contenttype%"

--- a/app/resources/translations/pl_PL/contenttypes.pl_PL.yml
+++ b/app/resources/translations/pl_PL/contenttypes.pl_PL.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/pl_PL/contenttypes.pl_PL.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  42 untranslated keyword based messages
-#  no translations
-# 103 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  42 Untranslated messages
+#   0 Legacy translation messages
+# 103 Translation messages
 
-#--- 42 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -62,7 +61,7 @@ contenttypes.showcases.group.repeater: # "Repeater"
 contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 
-#--- 103 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.description: "**Wpisy** mogą być stosowane do takich rzeczy jak _'aktualności'_ lub _'wiadomości'_. Mają zajawkę, która może być stosowana dla krótkich notek na listach, dzięki czemu użytkownicy mogą przejść szybko do reszty zawartości. Posiada również pola dla obrazu oraz opcjonalnie wideo. Aby zmienić pola, które są w tym typie zawartości, zmodyfikuj plik `contenttypes.yml` w folderze `app/config/`, za pomocą własnego edytora, lub przechodząc do \"Konfiguracja\" » \"Typy zawartości\" w menu po lewej."
 contenttypes.entries.group.content: "Zawartość"

--- a/app/resources/translations/pl_PL/messages.pl_PL.yml
+++ b/app/resources/translations/pl_PL/messages.pl_PL.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/pl_PL/messages.pl_PL.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  28 untranslated messages
-# 144 untranslated keyword based messages
-#  64 translations
-# 387 keyword based translations
+#   0 Unused messages
+#  28 Legacy untranslated messages
+# 144 Untranslated messages
+#  64 Legacy translation messages
+# 387 Translation messages
 
-#--- 28 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Dependencies": #
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": #
@@ -45,7 +44,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 144 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 contenttypes.generic.invalid-relation: # "In the ContentType for '%contenttype%', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
@@ -208,7 +207,7 @@ page.extend.theme.generation.missing.name: # "No theme name found. Theme is not 
 
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
 
-#--- 64 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(domyślny szablon)"
 "(no category)": "(bez kategorii)"
@@ -275,7 +274,7 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "View (saved version) on site": "Przeglądaj (zapisaną wersję) na witrynie"
 "You've been logged on successfully.": "Zostałeś zalogowany."
 
-#--- 387 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Akcje dla %contenttypes%"
 contenttypes.generic.actions-one: "Akcje dla tego %contenttype%"

--- a/app/resources/translations/pt/contenttypes.pt.yml
+++ b/app/resources/translations/pt/contenttypes.pt.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/pt/contenttypes.pt.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#   7 untranslated keyword based messages
-#  no translations
-# 138 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#   7 Untranslated messages
+#   0 Legacy translation messages
+# 138 Translation messages
 
-#--- 7 untranslated keyword based messages ------------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.text.invalid-hyphen: # "In the ContentType for 'Block', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -27,7 +26,7 @@ contenttypes.pages.text.invalid-hyphen: # "In the ContentType for 'Page', you ha
 contenttypes.showcases.description: # "The **Showcases** ContentType is used to show all of the available common field types. In practice, its uses are limited, but be sure to take a look to see which fields are available for use. To change (or delete) the fields that are in this ContentType, edit the file `contenttypes.yml` in the folder `app/config/`, using the editor of your choice, or by going to 'Configuration' » 'ContentTypes' in the menu on the left."
 contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
-#--- 138 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.blocks.description: "O tipo de conteúdo BLOCO é chamado um 'recurso de tipo de conteúdo'. Isto significa que pode ser usado para gerir pequenos pedaços de conteúdo, como o texto 'sobre nós', um 'nosso endereço' no rodapé ou em pequenos segmentos de texto similares."
 contenttypes.blocks.group.block: "Bloco"

--- a/app/resources/translations/pt/messages.pt.yml
+++ b/app/resources/translations/pt/messages.pt.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/pt/messages.pt.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#   8 untranslated messages
-#  35 untranslated keyword based messages
-#  84 translations
-# 496 keyword based translations
+#   0 Unused messages
+#   8 Legacy untranslated messages
+#  35 Untranslated messages
+#  84 Legacy translation messages
+# 496 Translation messages
 
-#--- 8 untranslated messages --------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Dependencies": #
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": #
@@ -25,7 +24,7 @@
 "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
-#--- 35 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -70,7 +69,7 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
 
-#--- 84 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(tema padrão)"
 "(no category)": "(sem categoria)"
@@ -157,7 +156,7 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "You've been logged on successfully.": "Autenticação realizada com sucesso!"
 "filtered by <em>'%filter%'</em>": "filtrados por <em>'%filter%'</em>"
 
-#--- 496 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Ações para %contenttypes%"
 contenttypes.generic.actions-one: "Ações para %contenttype%"

--- a/app/resources/translations/pt_BR/contenttypes.pt_BR.yml
+++ b/app/resources/translations/pt_BR/contenttypes.pt_BR.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/pt_BR/contenttypes.pt_BR.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  78 untranslated keyword based messages
-#  no translations
-#  67 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  78 Untranslated messages
+#   0 Legacy translation messages
+#  67 Translation messages
 
-#--- 78 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -98,7 +97,7 @@ contenttypes.showcases.text.saved-new: # "The new Showcase has been saved."
 contenttypes.showcases.text.saving-impossible: # "Could not save Showcase."
 contenttypes.showcases.text.wrong-use-field: # "In the ContentType for 'Showcase', the field '%field%' has 'uses: %uses%', but the field '%uses%' does not exist. Please edit contenttypes.yml, and correct this."
 
-#--- 67 keyword based translations --------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.group.content: "Conteúdo"
 contenttypes.entries.group.media: "Midia"

--- a/app/resources/translations/pt_BR/messages.pt_BR.yml
+++ b/app/resources/translations/pt_BR/messages.pt_BR.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/pt_BR/messages.pt_BR.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  45 untranslated messages
-# 217 untranslated keyword based messages
-#  47 translations
-# 314 keyword based translations
+#   0 Unused messages
+#  45 Legacy untranslated messages
+# 217 Untranslated messages
+#  47 Legacy translation messages
+# 314 Translation messages
 
-#--- 45 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "An error occured while updating `%TABLE%`. The error is %ERROR%": #
 "Are you sure you want to delete %FILENAME%?": #
@@ -62,7 +61,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 217 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.group.meta: # "Meta"
 contenttypes.generic.group.template: # "Template"
@@ -303,7 +302,7 @@ panel.latest-activity.created: # "Created"
 panel.latest-activity.deleted: # "Deleted"
 panel.latest-activity.system: # "Latest system activity"
 
-#--- 47 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(template padrão)"
 "(no category)": "(sem categoria)"
@@ -353,7 +352,7 @@ panel.latest-activity.system: # "Latest system activity"
 "View (saved version) on site": "Visualizar (versão salva) no site"
 "You've been logged on successfully.": "Autenticação realizada com sucesso!"
 
-#--- 314 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Ações para %contenttypes%"
 contenttypes.generic.actions-one: "Ações para %contenttype%"

--- a/app/resources/translations/ru/contenttypes.ru.yml
+++ b/app/resources/translations/ru/contenttypes.ru.yml
@@ -1,59 +1,19 @@
 # app/resources/translations/ru/contenttypes.ru.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  36 unused messages
-#  no untranslated messages
-#  53 untranslated keyword based messages
-#  no translations
-#  92 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  53 Untranslated messages
+#   0 Legacy translation messages
+#  92 Translation messages
 
-#--- 36 unused messages -------------------------------------------------------
-
-"contenttypes.blocks.description\"": #
-"contenttypes.blocks.group.block\"": #
-"contenttypes.blocks.name.plural\"": #
-"contenttypes.blocks.name.singular\"": #
-"contenttypes.blocks.text.actions-all\"": #
-"contenttypes.blocks.text.actions-one\"": #
-"contenttypes.blocks.text.created\"": #
-"contenttypes.blocks.text.delete\"": #
-"contenttypes.blocks.text.duplicate\"": #
-"contenttypes.blocks.text.duplicated-finalize\"": #
-"contenttypes.blocks.text.edit\"": #
-"contenttypes.blocks.text.invalid-field\"": #
-"contenttypes.blocks.text.invalid-relation\"": #
-"contenttypes.blocks.text.last-modified\"": #
-"contenttypes.blocks.text.new\"": #
-"contenttypes.blocks.text.no-latest\"": #
-"contenttypes.blocks.text.none-available\"": #
-"contenttypes.blocks.text.not-saved-yet\"": #
-"contenttypes.blocks.text.overview\"": #
-"contenttypes.blocks.text.publish\"": #
-"contenttypes.blocks.text.recent\"": #
-"contenttypes.blocks.text.recent-changes-one\"": #
-"contenttypes.blocks.text.recently-edited\"": #
-"contenttypes.blocks.text.save\"": #
-"contenttypes.blocks.text.saved-changes\"": #
-"contenttypes.blocks.text.saved-new\"": #
-"contenttypes.blocks.text.saving-impossible\"": #
-"contenttypes.blocks.text.show-more\"": #
-"contenttypes.blocks.text.view\"": #
-"contenttypes.blocks.text.wrong-use-field\"": #
-"contenttypes.showcases.group.files\"": #
-"contenttypes.showcases.group.media\"": #
-"contenttypes.showcases.group.other\"": #
-"contenttypes.showcases.group.repeater\"": #
-"contenttypes.showcases.group.text\"": #
-"contenttypes.showcases.text.recent-changes-one\"": #
-
-#--- 53 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -112,7 +72,7 @@ contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase'
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 contenttypes.showcases.text.recent-changes-one: # "Recent change to this Showcase"
 
-#--- 92 keyword based translations --------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.group.content: "Контент"
 contenttypes.entries.name.plural: "Записи"

--- a/app/resources/translations/ru/messages.ru.yml
+++ b/app/resources/translations/ru/messages.ru.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/ru/messages.ru.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  11 untranslated messages
-# 164 untranslated keyword based messages
-#  81 translations
-# 367 keyword based translations
+#   0 Unused messages
+#  11 Legacy untranslated messages
+# 164 Untranslated messages
+#  81 Legacy translation messages
+# 367 Translation messages
 
-#--- 11 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": #
 "Dependencies": #
@@ -28,7 +27,7 @@
 "Testing connection to extension server failed: %errormessage%": #
 "The field %field% has been changed to \"%newValue%\"": #
 
-#--- 164 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.group.ungrouped: # "Ungrouped"
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
@@ -216,7 +215,7 @@ page.file-management.message.save-failed-invalid-form: # "File '%s' could not be
 
 panel.latest-activity.by: # "by"
 
-#--- 81 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(шаблон по умолчанию)"
 "(no category)": "(без категории)"
@@ -300,7 +299,7 @@ panel.latest-activity.by: # "by"
 "You've been logged on successfully.": "Вы успешно вошли."
 "filtered by <em>'%filter%'</em>": "фильтровано через <em>'%filter%'</em>"
 
-#--- 367 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Действия для %contenttypes%"
 contenttypes.generic.actions-one: "Действия для этой %contenttype%"

--- a/app/resources/translations/sv_SE/contenttypes.sv_SE.yml
+++ b/app/resources/translations/sv_SE/contenttypes.sv_SE.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/sv_SE/contenttypes.sv_SE.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  45 untranslated keyword based messages
-#  no translations
-# 100 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  45 Untranslated messages
+#   0 Legacy translation messages
+# 100 Translation messages
 
-#--- 45 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -65,7 +64,7 @@ contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase'
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 contenttypes.showcases.text.recent-changes-one: # "Recent change to this Showcase"
 
-#--- 100 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.description: "**Entries** innehållstypen kan användas för bolggar eller nyheter. Den har en teaser, som kan användas för att visa en kort sammanfattning i flöden och listningar, och besökare kan klicka vidare för att se hela inlägget. Det har också fält för en bild och en video. För att ändra fälten redigera filen `contenttypes.yml` i mappen `app/config/` med din textredigerare eller gå till 'Konfiguration' » 'Innehållstyper' i vänstermenyn."
 contenttypes.entries.group.content: "Innehåll"

--- a/app/resources/translations/sv_SE/messages.sv_SE.yml
+++ b/app/resources/translations/sv_SE/messages.sv_SE.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/sv_SE/messages.sv_SE.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  16 untranslated messages
-#  48 untranslated keyword based messages
-#  76 translations
-# 483 keyword based translations
+#   0 Unused messages
+#  16 Legacy untranslated messages
+#  48 Untranslated messages
+#  76 Legacy translation messages
+# 483 Translation messages
 
-#--- 16 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "Dependencies": #
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": #
@@ -33,7 +32,7 @@
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
-#--- 48 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 
@@ -92,7 +91,7 @@ page.extend.options: # "Extension Options"
 
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
 
-#--- 76 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(standardmall)"
 "(no category)": "(ingen kategori)"
@@ -171,7 +170,7 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "You've been logged on successfully.": "Du är nu inloggad."
 "filtered by <em>'%filter%'</em>": "filtrerat efter <em>\"%filter%\"</em>"
 
-#--- 483 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "Åtgärder för %contenttypes%"
 contenttypes.generic.actions-one: "Åtgärder för denna %contenttype%"

--- a/app/resources/translations/zh_CN/contenttypes.zh_CN.yml
+++ b/app/resources/translations/zh_CN/contenttypes.zh_CN.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/zh_CN/contenttypes.zh_CN.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  45 untranslated keyword based messages
-#  no translations
-# 100 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  45 Untranslated messages
+#   0 Legacy translation messages
+# 100 Translation messages
 
-#--- 45 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -65,7 +64,7 @@ contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase'
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 contenttypes.showcases.text.recent-changes-one: # "Recent change to this Showcase"
 
-#--- 100 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.description: "内容格式**条目**可用在类似于_'新闻'_或者_'博客文章'_这样的模型。这些模型都含有可用于列表页显示的梗概，允许访客点击，跳转到各个条目页面。同时，它还有图片和可选的视频字段。要更改这项内容格式的内部字段，请用自己喜欢的编辑器编辑 `app/config/` 文件夹下的 `contenttypes.yml` 文件，或者打开左侧的 '配置' » '内容格式' 菜单。"
 contenttypes.entries.group.content: "内容"

--- a/app/resources/translations/zh_CN/messages.zh_CN.yml
+++ b/app/resources/translations/zh_CN/messages.zh_CN.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/zh_CN/messages.zh_CN.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  43 untranslated messages
-# 197 untranslated keyword based messages
-#  49 translations
-# 334 keyword based translations
+#   0 Unused messages
+#  43 Legacy untranslated messages
+# 197 Untranslated messages
+#  49 Legacy translation messages
+# 334 Translation messages
 
-#--- 43 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "An error occured while updating `%TABLE%`. The error is %ERROR%": #
 "Are you sure you want to delete %FILENAME%?": #
@@ -60,7 +59,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 197 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 contenttypes.generic.invalid-relation: # "In the ContentType for '%contenttype%', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
@@ -283,7 +282,7 @@ permissions.roles.description.everyone: # "Built-in role, automatically granted 
 permissions.roles.description.owner: # "Built-in role, only valid in the context of a resource, and automatically assigned to the owner of that resource."
 permissions.roles.description.root: # "Built-in superuser role, automatically grants all permissions"
 
-#--- 49 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(默认模板)"
 "(no category)": "(没有分类)"
@@ -335,7 +334,7 @@ permissions.roles.description.root: # "Built-in superuser role, automatically gr
 "View (saved version) on site": "观看站点中(保存的版本)"
 "You've been logged on successfully.": "你已成功登录。"
 
-#--- 334 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "对%contenttypes%的操作"
 contenttypes.generic.actions-one: "对%contenttype%的操作"

--- a/app/resources/translations/zh_TW/contenttypes.zh_TW.yml
+++ b/app/resources/translations/zh_TW/contenttypes.zh_TW.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/zh_TW/contenttypes.zh_TW.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  no untranslated messages
-#  45 untranslated keyword based messages
-#  no translations
-# 100 keyword based translations
+#   0 Unused messages
+#   0 Legacy untranslated messages
+#  45 Untranslated messages
+#   0 Legacy translation messages
+# 100 Translation messages
 
-#--- 45 untranslated keyword based messages -----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.blocks.description: # "The **Blocks** ContentType is a so-called 'resource ContentType'. This means that it can be used to manage smaller pieces of content, like the 'about us' text, an 'our address' in the footer, or similar short blurbs of text."
 contenttypes.blocks.group.block: # "Block"
@@ -65,7 +64,7 @@ contenttypes.showcases.text.invalid-hyphen: # "In the ContentType for 'Showcase'
 contenttypes.showcases.text.invalid-relation: # "In the ContentType for 'Showcase', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
 contenttypes.showcases.text.recent-changes-one: # "Recent change to this Showcase"
 
-#--- 100 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.entries.description: "內容格式**條目**可用在類似於_'新聞'_或者_'部落格文章'_這樣的模型。這些模型都含有可用於列表頁顯示的梗概，允許訪客點選，跳轉到各個條目頁面。同時，它還有圖片和可選的視訊欄位。要更改這項內容格式的內部欄位，請用自己喜歡的編輯器編輯 `app/config/` 資料夾下的 `contenttypes.yml` 檔案，或者開啟左側的 '配置' » '內容格式' 選單。"
 contenttypes.entries.group.content: "內容"

--- a/app/resources/translations/zh_TW/messages.zh_TW.yml
+++ b/app/resources/translations/zh_TW/messages.zh_TW.yml
@@ -1,20 +1,19 @@
 # app/resources/translations/zh_TW/messages.zh_TW.yml
 
-# Warning: Translations are in the process of being moved to a new keyword-based translation
-#          at the moment. This is an ongoing process. Translations currently in the
-#          repository are automatically mapped to the new scheme. Be aware that there
-#          can be a race condition between that process and your PR so that it's
-#          eventually necessary to remap your translations. If you're planning on
-#          updating your translations, it's best to ask on IRC to time your contribution
-#          in order to prevent merge conflicts.
+# Warning: Translations are in the process of being moved to a new keyword
+#          based translation messages. This is an ongoing process. Translations
+#          currently in the repository are automatically mapped to the new
+#          scheme. Be aware that there can be a race condition between that
+#          process and your PR so that it will eventually be necessary to
+#          re-map your translations.
 
-#  no unused messages
-#  43 untranslated messages
-# 181 untranslated keyword based messages
-#  49 translations
-# 350 keyword based translations
+#   0 Unused messages
+#  43 Legacy untranslated messages
+# 181 Untranslated messages
+#  49 Legacy translation messages
+# 350 Translation messages
 
-#--- 43 untranslated messages -------------------------------------------------
+#--- Legacy untranslated messages ---------------------------------------------
 
 "An error occured while updating `%TABLE%`. The error is %ERROR%": #
 "Are you sure you want to delete %FILENAME%?": #
@@ -60,7 +59,7 @@
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 "filtered by <em>'%filter%'</em>": #
 
-#--- 181 untranslated keyword based messages ----------------------------------
+#--- Untranslated messages ----------------------------------------------------
 
 contenttypes.generic.invalid-hyphen: # "In the ContentType for '%contenttype%', you have used a hyphen in the definition which is not supported. Please edit contenttypes.yml and remove the hyphen or alternatively replace with an underscore."
 contenttypes.generic.invalid-relation: # "In the ContentType for '%contenttype%', the relation '%relation%' is defined, which is not a valid ContentType. Please edit contenttypes.yml, and correct this."
@@ -264,7 +263,7 @@ panel.latest-activity.created: # "Created"
 panel.latest-activity.deleted: # "Deleted"
 panel.latest-activity.system: # "Latest system activity"
 
-#--- 49 translations ----------------------------------------------------------
+#--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(默認模板)"
 "(no category)": "(沒有分類)"
@@ -316,7 +315,7 @@ panel.latest-activity.system: # "Latest system activity"
 "View (saved version) on site": "觀看站點中(儲存的版本)"
 "You've been logged on successfully.": "你已成功登入。"
 
-#--- 350 keyword based translations -------------------------------------------
+#--- Translation messages -----------------------------------------------------
 
 contenttypes.generic.actions-all: "對%contenttypes%的操作"
 contenttypes.generic.actions-one: "對%contenttype%的操作"

--- a/src/Translation/TranslationFile.php
+++ b/src/Translation/TranslationFile.php
@@ -288,11 +288,11 @@ class TranslationFile
         // Presort
         $unusedTranslations = $savedTranslations;
         $transByType = [
-            'Unused'   => [' unused messages', []],
-            'TodoReal' => [' untranslated messages', []],
-            'TodoKey'  => [' untranslated keyword based messages', []],
-            'DoneReal' => [' translations', []],
-            'DoneKey'  => [' keyword based translations', []],
+            'Unused'   => [' Unused messages', []],
+            'TodoReal' => [' Legacy untranslated messages', []],
+            'TodoKey'  => [' Untranslated messages', []],
+            'DoneReal' => [' Legacy translation messages', []],
+            'DoneKey'  => [' Translation messages', []],
         ];
         foreach ($newTranslations as $key => $translation) {
             $set = ['trans' => $translation];
@@ -315,13 +315,12 @@ class TranslationFile
         // Build List
         $indent = '    ';
         $status = '# ' . $this->relPath . "\n\n" .
-            '# Warning: Translations are in the process of being moved to a new keyword-based translation' . "\n" .
-            '#          at the moment. This is an ongoing process. Translations currently in the' . "\n" .
-            '#          repository are automatically mapped to the new scheme. Be aware that there' . "\n" .
-            '#          can be a race condition between that process and your PR so that it\'s' . "\n" .
-            '#          eventually necessary to remap your translations. If you\'re planning on' . "\n" .
-            '#          updating your translations, it\'s best to ask on IRC to time your contribution' . "\n" .
-            '#          in order to prevent merge conflicts.' . "\n\n";
+            '# Warning: Translations are in the process of being moved to a new keyword' . "\n" .
+            '#          based translation messages. This is an ongoing process. Translations' . "\n" .
+            '#          currently in the repository are automatically mapped to the new' . "\n" .
+            '#          scheme. Be aware that there can be a race condition between that' . "\n" .
+            '#          process and your PR so that it will eventually be necessary to' . "\n" .
+            '#          re-map your translations.' . "\n\n";
         $content = '';
 
         // Set this to true to get nested output.
@@ -330,10 +329,10 @@ class TranslationFile
         foreach ($transByType as $type => $transData) {
             list($text, $translations) = $transData;
             // Header
-            $count = (count($translations) > 0 ? sprintf('%3s', count($translations)) : ' no');
+            $count = (count($translations) > 0 ? sprintf('%3s', count($translations)) : '  0');
             $status .= '# ' . $count . $text . "\n";
             if (count($translations) > 0) {
-                $content .= "\n" . '#--- ' . str_pad(ltrim($count) . $text . ' ', 74, '-') . "\n\n";
+                $content .= "\n" . '#--- ' . str_pad(ltrim($text) . ' ', 74, '-') . "\n\n";
             }
             // List
             $lastKey = [];


### PR DESCRIPTION
After a couple of days of rebasing fun, chasing endless merge conflicts due to these headers, it has become obvious we need to move away from this approach a.s.a.p.

First step, pending the refresh of the PHP layer, is to keep the changing "dynamic" headers at the top of the translation file, and stick with static headers in the body of the file.

Aiming at 3.2 as there is zero functional changes in this PR … and did I mention merge conflicts? :wink: 

P.S. Anyone bored, and interested; with time available, I'd really not mind if someone wants to help me with chasing down and replacing the remaining full text strings and converting to keywords. 

It is **one** of the remaining blockers to get this pushed to a translation service for people to use, who don't need/want to be bothered with the keywords & YAML files, but instead want to get on with the job of maintaining a language's translations. :+1: 