### PR TITLE
Always reset null templatefields to an empty array instead

### DIFF
--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -363,6 +363,9 @@ class Content extends Entity
 
     public function setTemplatefields($value)
     {
+        if ($value === null) {
+            $value = [];
+        }
         $this->templatefields = $value;
     }
 


### PR DESCRIPTION
Fixes #6790

Because we don't send null values to the database to save, we end up not persisting templatefields if all the values are cleared.

This ensures that a null templatefields is converted to an empty array instead and then will get saved to the db.