### PR TITLE
[3.3] Fixes for .bolt.yml / .bolt.php custom path handling

### DIFF
--- a/src/Composer/Script/BootstrapYamlUpdater.php
+++ b/src/Composer/Script/BootstrapYamlUpdater.php
@@ -13,6 +13,13 @@ use Webmozart\PathUtil\Path;
 /**
  * Updates .bolt.yml paths for changes with PathResolver introduced in 3.3.
  *
+ * NOTE: If debugging this with with xdebug, you will need to run Composer from
+ * the vendor/bin/ directory, and set the COMPOSER_ALLOW_XDEBUG=1 environment
+ * variable, e.g.
+ * <pre>
+ * COMPOSER_ALLOW_XDEBUG=1 ./vendor/bin/composer run-script <script name>
+ * </pre>
+ *
  * @author Carson Full <carsonfull@gmail.com>
  */
 class BootstrapYamlUpdater

--- a/src/Composer/Script/BootstrapYamlUpdater.php
+++ b/src/Composer/Script/BootstrapYamlUpdater.php
@@ -162,6 +162,23 @@ class BootstrapYamlUpdater
             }
         }
 
+        if ($var = $paths['var']) {
+            if ($var === 'var') {
+                $paths->remove('var');
+            } elseif (strpos($var, '%site%') !== 0) {
+                $paths['var'] = '%site%/' . $var;
+            }
+        }
+        $var = $var ?: 'var';
+        $varLength = strlen($var . '/');
+
+        if ($cache = $paths['cache']) {
+            // Handle v4 style layouts
+            if (strpos($cache, $var . '/') === 0) {
+                $paths['cache'] = '%var%/' . substr($cache, $varLength);
+            }
+        }
+
         if ($paths->has('app')) {
             return $paths;
         }
@@ -170,7 +187,7 @@ class BootstrapYamlUpdater
         $appPaths = array_intersect_key($paths->toArray(), array_flip($appPathKeys));
         // Only paths without %app% alias in them.
         $appPaths = array_filter($appPaths, function ($path) {
-            return strpos($path, '%app%') === false && strpos($path, 'app') === 0;
+            return strpos($path, '%app%') === false || strpos($path, 'app') === 0;
         });
         if (empty($appPaths)) {
             return $paths;

--- a/src/Composer/Script/BootstrapYamlUpdater.php
+++ b/src/Composer/Script/BootstrapYamlUpdater.php
@@ -170,7 +170,7 @@ class BootstrapYamlUpdater
         $appPaths = array_intersect_key($paths->toArray(), array_flip($appPathKeys));
         // Only paths without %app% alias in them.
         $appPaths = array_filter($appPaths, function ($path) {
-            return strpos($path, '%app%') === false;
+            return strpos($path, '%app%') === false && strpos($path, 'app') === 0;
         });
         if (empty($appPaths)) {
             return $paths;

--- a/src/Configuration/PathResolver.php
+++ b/src/Configuration/PathResolver.php
@@ -37,6 +37,7 @@ class PathResolver
             'database'          => '%app%/database',
             'extensions'        => '%site%/extensions',
             'extensions_config' => '%config%/extensions',
+            'var'               => '%site%/var',
             'web'               => '%site%/public',
             'files'             => '%web%/files',
             'themes'            => '%web%/theme',

--- a/tests/phpunit/unit/Composer/Script/BootstrapYamlUpdaterTest.php
+++ b/tests/phpunit/unit/Composer/Script/BootstrapYamlUpdaterTest.php
@@ -60,7 +60,7 @@ class BootstrapYamlUpdaterTest extends TestCase
                 ],
                 [
                     'app'   => '%site%/myapp',
-                    'cache' => 'var/cache',
+                    'cache' => '%var%/cache',
                 ]
             ],
 
@@ -72,7 +72,7 @@ class BootstrapYamlUpdaterTest extends TestCase
                 ],
                 [
                     'app'   => '%site%/..',
-                    'cache' => 'var/cache',
+                    'cache' => '%var%/cache',
                 ]
             ],
 
@@ -83,7 +83,7 @@ class BootstrapYamlUpdaterTest extends TestCase
                     'database' => '../database',
                 ],
                 [
-                    'cache'    => 'var/cache',
+                    'cache'    => '%var%/cache',
                     'config'   => 'myapp/config',
                     'database' => '../database',
                 ]


### PR DESCRIPTION
Fixes #6797

OK, so this was a bit of fun to debug with a brain that is only coming back into business mode … not to mention keeping backward **and forward** compatibility working.  :rofl:

This PR addresses the first problem I hit with `BootstrapYamlUpdater` updating custom path handling:
  * Add forward-compatible path resolution for `var/` (it's in active use in the wild on 3.2+ sites)
  * Handle FC path updating for use of `var/`
  * Don't assume that a path that defaults to being under `app/` is actually under `app/`
  * Adds a note on debugging Composer for ageing princesses with memory recall problems :stuck_out_tongue_winking_eye: 
 
Bolt 3.2.x use/test case, taken from a production site:

```yaml
paths:
    var: var
    cache: var/cache
    config: app/config
    database: app/database
    web: web
    themebase: web/theme
    files: web/files
    view: web/bolt-web/view
```