### PR TITLE
[3.2+] More refactoring of fields blocks

### DIFF
--- a/app/theme_defaults/_sub_field_blocks.twig
+++ b/app/theme_defaults/_sub_field_blocks.twig
@@ -1,18 +1,22 @@
-{# If 'allowtwig' is true for this field, we'll need to parse it as
-   Twig here. Note, that we're doing this inside a block, so the
-   snippet has a limited scope. No global variables, etc. #}
-{% block parse_text_field %}
-    {% if contenttype.fields[key].allowtwig|default(false) %}
-        {% set value = value|twig %}
-    {% endif %}
-    {% if fieldtype == "markdown" %}
-        {% set value = value|markdown %}
-    {% endif %}
-    {% autoescape false %}
-    <div {% if key is not empty %}data-bolt-field="{{key}}"{% endif %}>{{ value }}</div>
-    {% endautoescape %}
+{# Sub-block for 'text' field such as 'text', 'textarea', or 'html' #}
+{% block text_field %}
+    <div {% if key is not empty %}data-bolt-field="{{ key }}"{% endif %}>
+        {%- autoescape false -%}
+            {# If 'allowtwig' is true for this field, we'll need to parse it as Twig here. #}
+            {% if allowtwig %}{{ value|twig }}{% else %}{{ value }}{% endif -%}
+        {%- endautoescape -%}
+    </div>
 {% endblock %}
 
+{# Sub-block for Markdown fields #}
+{% block markdown_field %}
+    <div {% if key is not empty %}data-bolt-field="{{ key }}"{% endif %}>
+        {# If 'allowtwig' is true for this field, we'll need to parse it as Twig here. #}
+        {% if allowtwig %}{{ value|twig|markdown }}{% else %}{{ value|markdown }}{% endif -%}
+    </div>
+{% endblock %}
+
+{# Sub-block for 'imagelist' fields #}
 {% block imagelist_field %}
     <div class="bolt-imagelist">
         {% for image in images %}
@@ -26,60 +30,65 @@
 {# Block for "basic" fields like HTML, Markdown, Textarea and Text #}
 {% block common_fields %}
 
-        {# HTML, Markdown, Textarea, Text fields #}
-        {% if fieldtype in ['html', 'markdown', 'textarea', 'text'] %}
-            {{ block('parse_text_field') }}
-        {% endif %}
+    {# HTML, Textarea, Text fields #}
+    {% if fieldtype in ['html', 'textarea', 'text'] %}
+        {{ block('text_field') }}
+    {% endif %}
 
-        {# Image fields #}
-        {% if fieldtype == "image" %}
-            {{ popup(value, 1200, 0) }}
-        {% endif %}
+    {# Markdown fields #}
+    {% if fieldtype == 'markdown' %}
+        {{ block('markdown_field') }}
+    {% endif %}
 
-        {# Video fields #}
-        {% if fieldtype == "video" and value.responsive|default is not empty %}
-            <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
-                {{ value.responsive }}
-            </div>
-        {% endif %}
+    {# Image fields #}
+    {% if fieldtype == "image" %}
+        {{ popup(value, 1200, 0) }}
+    {% endif %}
+
+    {# Video fields #}
+    {% if fieldtype == "video" and value.responsive|default is not empty %}
+        <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
+            {{ value.responsive }}
+        </div>
+    {% endif %}
 
 {% endblock %}
 
 {# Block for other field types, like Geo, Select, Checkbox and others. #}
 {% block extended_fields %}
 
-        {# Geolocation field #}
-        {% if fieldtype == "geolocation" and value.latitude is defined %}
-            <img src="http://maps.googleapis.com/maps/api/staticmap?center={{ value.latitude }},{{ value.longitude }}&amp;zoom=14&amp;size=617x300&amp;sensor=false&amp;markers={{ value.latitude }},{{ value.longitude }}">
-        {% endif %}
+    {# Geolocation field #}
+    {% if fieldtype == "geolocation" and value.latitude is defined %}
+        <img src="http://maps.googleapis.com/maps/api/staticmap?center={{ value.latitude }},{{ value.longitude }}&amp;zoom=14&amp;size=617x300&amp;sensor=false&amp;markers={{ value.latitude }},{{ value.longitude }}">
+    {% endif %}
 
-        {# Special case for 'select' fields: if it's a multiple select, the value is an array. #}
-        {% if fieldtype == "select" and value is not empty %}
-            <p><strong>{{ key }}: </strong>
-                {{ value|join(", ") }}
-            </p>
-        {% endif %}
+    {# Special case for 'select' fields: if it's a multiple select, the value is an array. #}
+    {% if fieldtype == "select" and value is not empty %}
+        <p><strong>{{ key }}: </strong>
+        {{ value|join(", ") }}
+        </p>
+    {% endif %}
 
-        {# Checkbox fields #}
-        {% if fieldtype == "checkbox" %}
-                <p>Checkbox {{ key }}: {{value ? "checked" : "not checked"}}</p>
-        {% endif %}
+    {# Checkbox fields #}
+    {% if fieldtype == "checkbox" %}
+        <p>Checkbox {{ key }}: {{value ? "checked" : "not checked"}}</p>
+    {% endif %}
 
-        {# Imagelist fields #}
-        {% if fieldtype == "imagelist" and value is not empty %}
-            {{ block('imagelist_field') }}
-        {% endif %}
+    {# Imagelist fields #}
+    {% if fieldtype == "imagelist" and value is not empty %}
+        {{ block('imagelist_field') }}
+    {% endif %}
 
-        {# No special case defined for this type of field. We just output them, if it's
-           a simple scalar, and 'dump' them otherwise. #}
-        {% if fieldtype in [ 'filelist', 'datetime', 'date', 'integer', 'float' ] and value is not empty  %}
-            <p><strong>{{ key }}: </strong>
-                {% if value is iterable %}
-                    {{ dump(value) }}
-                {% else %}
-                    {{ value }}
-                {% endif %}
-            </p>
+    {# No special case defined for this type of field. We just output them, if it's
+       a simple scalar, and 'dump' them otherwise. #}
+    {% if fieldtype in [ 'filelist', 'datetime', 'date', 'integer', 'float' ] and value is not empty  %}
+        <p><strong>{{ key }}: </strong>
+        {% if value is iterable %}
+            {{ dump(value) }}
+        {% else %}
+            {{ value }}
         {% endif %}
+        </p>
+    {% endif %}
 
 {% endblock %}

--- a/app/theme_defaults/_sub_fields.twig
+++ b/app/theme_defaults/_sub_fields.twig
@@ -1,4 +1,6 @@
-{# Default output for the `fields()` tag.
+{#
+   Default output for fields.
+
    This file is contains the 'sub_fields' Twig block tag.
 
    The 'sub_fields' Twig block is split into two parts:
@@ -9,89 +11,105 @@
       'repeater fields' and 'template fields' in turn.
 
    Read the relevant section in the documentation on usage of this
-   functionality: https://docs.bolt.cm/master/fields-tag
+   functionality: https://docs.bolt.cm/templating
 
    For more information on using blocks, see the Twig documentation at:
     - https://twig.sensiolabs.org/doc/1.x/tags/block.html
     - https://twig.sensiolabs.org/doc/1.x/functions/block.html
 #}
-{% use '@theme/_sub_field_blocks.twig' %}
+{% use 'partials/_sub_field_blocks.twig' %}
 
 {% block sub_fields %}
-{# SECTION 1: INITIALIZATION #}
+    {# SECTION 1: INITIALIZATION #}
+    {%- spaceless %}
+        {# Set up the array of fieldnames that should be iterated. We do this by looping
+           over _all_ the fields, and skipping those in the 'omittedkeys' array. #}
+        {% set omittedkeys = [ 'id', 'slug', 'datecreated', 'datechanged', 'datepublish',
+        'datedepublish', 'username', 'status', 'ownerid', 'templatefields' ] %}
 
-{# Set up the array of fieldnames that should be iterated. We do this by looping
-   over _all_ the fields, and skipping those in the 'omittedkeys' array. #}
-{% set omittedkeys = ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'ownerid', 'templatefields'] %}
+        {# Skip over the fields that are used in the slug, unless explicitly told not to,
+           using the `skip_uses` parameter. #}
+        {% if (record.contenttype.fields.slug.uses|default(null) is iterable) and skip_uses|default(true) %}
+            {% set omittedkeys = omittedkeys|merge(record.contenttype.fields.slug.uses) %}
+        {% endif %}
 
-{# Skip over the fields that are used in the slug, unless explicitly told not to,
-   using the `skip_uses` parameter. #}
-{% if (record.contenttype.fields.slug.uses|default(null) is iterable) and skip_uses|default(true) %}
-    {% set omittedkeys = omittedkeys|merge(record.contenttype.fields.slug.uses) %}
-{% endif %}
+        {# We also skip over the fields that are explicitly excluded. #}
+        {% if exclude|default is iterable %}
+            {% set omittedkeys = omittedkeys|merge(exclude) %}
+        {% endif %}
+    {% endspaceless -%}
 
-{# We also skip over the fields that are explicitly excluded. #}
-{% if exclude|default is iterable %}
-    {% set omittedkeys = omittedkeys|merge(exclude) %}
-{% endif %}
+    {# SECTION 2: LOOPING AND ITERATION - The actual looping is done here. #}
+    {% for key, value in record.values if (key not in omittedkeys) %}
 
-{# SECTION 2: LOOPING AND ITERATION #}
+        {# Is the field allowed to contain Twig functions #}
+        {% set allowtwig = record.contenttype.fields[key].allowtwig|default(false) %}
 
-{# The actual looping is done here. #}
-{% for key, value in record.values if (key not in omittedkeys) %}
+        {# Fields that are considered 'common': 'html', 'markdown', 'textarea',
+           'text', 'image', 'video' and 'imagelist' #}
+        {% if common|default(true) and (key not in exclude|default([])) %}
 
-    {# Fields that are considered 'common': 'html', 'markdown', 'textarea',
-       'text', 'image', 'video' and 'imagelist' #}
-    {% if common|default(true) %}
+            {% set fieldtype = record.fieldtype(key) %}
+            {% set value = record.get(key) %}
+            {{ block('common_fields') }}
 
-        {% set fieldtype = record.fieldtype(key) %}
-        {{ block('common_fields') }}
+        {% endif %}
 
-    {% endif %}
+        {# The rest of the built-in fieldtypes #}
+        {% if extended|default(false) and (key not in exclude|default([])) %}
 
-    {# The rest of the built-in fieldtypes #}
-    {% if extended|default(false) %}
+            {% set fieldtype = record.fieldtype(key) %}
+            {{ block('extended_fields') }}
 
-        {% set fieldtype = record.fieldtype(key) %}
-        {{ block('extended_fields') }}
+        {% endif %}
 
-    {% endif %}
+        {# Finally, the repeaters #}
+        {% if repeaters|default(false) == true and record.fieldtype(key) == "repeater" %}
 
-    {# Finally, the repeaters #}
-    {% if repeaters|default(true) and record.fieldtype(key) == "repeater" %}
+            {% if (app.request.get('_route') != "preview") %}
 
-        {% for repeater in value %}
+                {% for repeater in value %}
 
-            {% for repeaterfield in repeater %}
+                    {% for key, repeaterfield in repeater %}
 
-                {% set fieldtype = repeaterfield.getFieldtype() %}
-                {% set value = repeaterfield.getValue() %}
-                {{ block('common_fields') }}
-                {{ block('extended_fields') }}
+                        {% set fieldtype = repeaterfield.fieldtype() %}
+                        {% set value = repeaterfield.value() %}
+                        {{ block('common_fields') }}
+                        {{ block('extended_fields') }}
 
-            {% endfor %}
+                    {% endfor %}
+                {% endfor %}
+
+            {% else %}
+                {# @deprecated
+                `blocks()` does not work correctly when _previewing_ repeater fields. This will be
+                fixed properly for Bolt 4, but for now we just output a notice, and prevent crashes.
+                See also: https://github.com/bolt/bolt/issues/6605 #}
+                <p>
+                Unfortunately, Repeater fields do not work correctly with the generic
+                <code>block()</code> function, when using Preview. To view these fields, please
+                save the record, and view the page normally.
+                </p>
+            {% endif %}
+        {% endif %}
+
+    {% endfor %}
+
+    {# We do the same for the templatefields, if set and not empty. #}
+    {% set templatefields = record.values.templatefields.values|default() %}
+    {% if templatefields is not empty %}
+
+        {# Note: This needs to be expanded upon!! For better detection the 'virtual'
+           contenttype for the templatefields should know about the types of fields. #}
+        {% set templatefields_field_types = attribute(record.contenttype.templatefields|first, 'fields') %}
+
+        {% for key, value in templatefields if (key not in omittedkeys) %}
+
+            {% set fieldtype = attribute(attribute(templatefields_field_types, key), 'type')  %}
+            {{ block('common_fields') }}
+            {{ block('extended_fields') }}
 
         {% endfor %}
 
     {% endif %}
-
-{% endfor %}
-
-{# We do the same for the templatefields, if set and not empty. #}
-{% set templatefields = record.values.templatefields.values|default() %}
-{% if templatefields is defined and templatefields is not empty %}
-
-    {# Note: This needs to be expanded upon!! For better detection the 'virtual'
-       contenttype for the templatefields should know about the types of fields. #}
-    {% set templatefields_field_types = attribute(record.contenttype.templatefields|first, 'fields') %}
-
-    {% for key, value in templatefields if (key not in omittedkeys) %}
-
-        {% set fieldtype = attribute(attribute(templatefields_field_types, key), 'type')  %}
-        {{ block('common_fields') }}
-        {{ block('extended_fields') }}
-
-    {% endfor %}
-
-{% endif %}
 {% endblock sub_fields %}

--- a/theme/base-2016/extrafields.twig
+++ b/theme/base-2016/extrafields.twig
@@ -4,7 +4,9 @@
 
     <h1>{{ record.title }}</h1>
 
-    {{ fields(template = 'partials/_sub_fields.twig') }}
+    {% with { 'record': record, 'common': false, 'repeaters': true } %}
+        {{ block('sub_fields', 'partials/_sub_fields.twig') }}
+    {% endwith %}
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}

--- a/theme/base-2016/page.twig
+++ b/theme/base-2016/page.twig
@@ -6,7 +6,7 @@
 
     {{ record.teaser }}
 
-    {% if record.image!="" %}
+    {% if record.image != "" %}
         <a href="{{ image(record.image) }}">
             <img src="{{ thumbnail(record.image, 740, 560) }}">
         </a>
@@ -15,7 +15,10 @@
     {{ record.body }}
 
     {# If there are repeaters, we should output them. #}
-    {{ fields(common = false, extended = false, repeaters = true) }}
+    {% with { 'record': record, 'common': false, 'repeaters': true, 'exclude': ['teaser', 'body', 'image'] } %}
+        {{ block('sub_fields', 'partials/_sub_fields.twig') }}
+    {% endwith %}
+
 
     {# Uncomment this if you wish to dump the entire record to the client, for debugging purposes.
     {{ dump(record) }}

--- a/theme/base-2016/partials/_sub_field_blocks.twig
+++ b/theme/base-2016/partials/_sub_field_blocks.twig
@@ -1,18 +1,22 @@
-{# If 'allowtwig' is true for this field, we'll need to parse it as
-   Twig here. Note, that we're doing this inside a block, so the
-   snippet has a limited scope. No global variables, etc. #}
-{% block parse_text_field %}
-    {% if contenttype.fields[key].allowtwig|default(false) %}
-        {% set value = value|twig %}
-    {% endif %}
-    {% if fieldtype == "markdown" %}
-        {% set value = value|markdown %}
-    {% endif %}
-    {% autoescape false %}
-    <div {% if key is not empty %}data-bolt-field="{{key}}"{% endif %}>{{ value }}</div>
-    {% endautoescape %}
+{# Sub-block for 'text' field such as 'text', 'textarea', or 'html' #}
+{% block text_field %}
+    <div {% if key is not empty %}data-bolt-field="{{ key }}"{% endif %}>
+        {%- autoescape false -%}
+            {# If 'allowtwig' is true for this field, we'll need to parse it as Twig here. #}
+            {% if allowtwig|default(false) %}{{ value|twig }}{% else %}{{ value }}{% endif -%}
+        {%- endautoescape -%}
+    </div>
 {% endblock %}
 
+{# Sub-block for Markdown fields #}
+{% block markdown_field %}
+    <div {% if key is not empty %}data-bolt-field="{{ key }}"{% endif %}>
+        {# If 'allowtwig' is true for this field, we'll need to parse it as Twig here. #}
+        {% if allowtwig|default(false) %}{{ value|twig|markdown }}{% else %}{{ value|markdown }}{% endif -%}
+    </div>
+{% endblock %}
+
+{# Sub-block for 'imagelist' fields #}
 {% block imagelist_field %}
     <div class="bolt-imagelist">
         {% for image in images %}
@@ -26,60 +30,65 @@
 {# Block for "basic" fields like HTML, Markdown, Textarea and Text #}
 {% block common_fields %}
 
-        {# HTML, Markdown, Textarea, Text fields #}
-        {% if fieldtype in ['html', 'markdown', 'textarea', 'text'] %}
-            {{ block('parse_text_field') }}
-        {% endif %}
+    {# HTML, Textarea, Text fields #}
+    {% if fieldtype in ['html', 'textarea', 'text'] %}
+        {{ block('text_field') }}
+    {% endif %}
 
-        {# Image fields #}
-        {% if fieldtype == "image" %}
-            {{ popup(value, 1200, 0) }}
-        {% endif %}
+    {# Markdown fields #}
+    {% if fieldtype == 'markdown' %}
+        {{ block('markdown_field') }}
+    {% endif %}
 
-        {# Video fields #}
-        {% if fieldtype == "video" and value.responsive|default is not empty %}
-            <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
-                {{ value.responsive }}
-            </div>
-        {% endif %}
+    {# Image fields #}
+    {% if fieldtype == "image" %}
+        {{ popup(value, 1200, 0) }}
+    {% endif %}
+
+    {# Video fields #}
+    {% if fieldtype == "video" and value.responsive|default is not empty %}
+        <div class="flex-video {{ value.ratio|default(1) > 1.5 ? 'widescreen' }}">
+            {{ value.responsive }}
+        </div>
+    {% endif %}
 
 {% endblock %}
 
 {# Block for other field types, like Geo, Select, Checkbox and others. #}
 {% block extended_fields %}
 
-        {# Geolocation field #}
-        {% if fieldtype == "geolocation" and value.latitude is defined %}
-            <img src="http://maps.googleapis.com/maps/api/staticmap?center={{ value.latitude }},{{ value.longitude }}&amp;zoom=14&amp;size=617x300&amp;sensor=false&amp;markers={{ value.latitude }},{{ value.longitude }}">
-        {% endif %}
+    {# Geolocation field #}
+    {% if fieldtype == "geolocation" and value.latitude is defined %}
+        <img src="http://maps.googleapis.com/maps/api/staticmap?center={{ value.latitude }},{{ value.longitude }}&amp;zoom=14&amp;size=617x300&amp;sensor=false&amp;markers={{ value.latitude }},{{ value.longitude }}">
+    {% endif %}
 
-        {# Special case for 'select' fields: if it's a multiple select, the value is an array. #}
-        {% if fieldtype == "select" and value is not empty %}
-            <p><strong>{{ key }}: </strong>
-                {{ value|join(", ") }}
-            </p>
-        {% endif %}
+    {# Special case for 'select' fields: if it's a multiple select, the value is an array. #}
+    {% if fieldtype == "select" and value is not empty %}
+        <p><strong>{{ key }}: </strong>
+        {{ value|join(", ") }}
+        </p>
+    {% endif %}
 
-        {# Checkbox fields #}
-        {% if fieldtype == "checkbox" %}
-                <p>Checkbox {{ key }}: {{value ? "checked" : "not checked"}}</p>
-        {% endif %}
+    {# Checkbox fields #}
+    {% if fieldtype == "checkbox" %}
+        <p>Checkbox {{ key }}: {{value ? "checked" : "not checked"}}</p>
+    {% endif %}
 
-        {# Imagelist fields #}
-        {% if fieldtype == "imagelist" and value is not empty %}
-            {{ block('imagelist_field') }}
-        {% endif %}
+    {# Imagelist fields #}
+    {% if fieldtype == "imagelist" and value is not empty %}
+        {{ block('imagelist_field') }}
+    {% endif %}
 
-        {# No special case defined for this type of field. We just output them, if it's
-           a simple scalar, and 'dump' them otherwise. #}
-        {% if fieldtype in [ 'filelist', 'datetime', 'date', 'integer', 'float' ] and value is not empty  %}
-            <p><strong>{{ key }}: </strong>
-                {% if value is iterable %}
-                    {{ dump(value) }}
-                {% else %}
-                    {{ value }}
-                {% endif %}
-            </p>
+    {# No special case defined for this type of field. We just output them, if it's
+       a simple scalar, and 'dump' them otherwise. #}
+    {% if fieldtype in [ 'filelist', 'datetime', 'date', 'integer', 'float' ] and value is not empty  %}
+        <p><strong>{{ key }}: </strong>
+        {% if value is iterable %}
+            {{ dump(value) }}
+        {% else %}
+            {{ value }}
         {% endif %}
+        </p>
+    {% endif %}
 
 {% endblock %}

--- a/theme/base-2016/partials/_sub_fields.twig
+++ b/theme/base-2016/partials/_sub_fields.twig
@@ -1,4 +1,6 @@
-{# Default output for the `fields()` tag.
+{#
+   Default output for fields.
+
    This file is contains the 'sub_fields' Twig block tag.
 
    The 'sub_fields' Twig block is split into two parts:
@@ -9,7 +11,7 @@
       'repeater fields' and 'template fields' in turn.
 
    Read the relevant section in the documentation on usage of this
-   functionality: https://docs.bolt.cm/master/fields-tag
+   functionality: https://docs.bolt.cm/templating
 
    For more information on using blocks, see the Twig documentation at:
     - https://twig.sensiolabs.org/doc/1.x/tags/block.html
@@ -18,80 +20,96 @@
 {% use 'partials/_sub_field_blocks.twig' %}
 
 {% block sub_fields %}
-{# SECTION 1: INITIALIZATION #}
+    {# SECTION 1: INITIALIZATION #}
+    {%- spaceless %}
+        {# Set up the array of fieldnames that should be iterated. We do this by looping
+           over _all_ the fields, and skipping those in the 'omittedkeys' array. #}
+        {% set omittedkeys = [ 'id', 'slug', 'datecreated', 'datechanged', 'datepublish',
+        'datedepublish', 'username', 'status', 'ownerid', 'templatefields' ] %}
 
-{# Set up the array of fieldnames that should be iterated. We do this by looping
-   over _all_ the fields, and skipping those in the 'omittedkeys' array. #}
-{% set omittedkeys = ['id', 'slug', 'datecreated', 'datechanged', 'datepublish', 'datedepublish', 'username', 'status', 'ownerid', 'templatefields'] %}
+        {# Skip over the fields that are used in the slug, unless explicitly told not to,
+           using the `skip_uses` parameter. #}
+        {% if (record.contenttype.fields.slug.uses|default(null) is iterable) and skip_uses|default(true) %}
+            {% set omittedkeys = omittedkeys|merge(record.contenttype.fields.slug.uses) %}
+        {% endif %}
 
-{# Skip over the fields that are used in the slug, unless explicitly told not to,
-   using the `skip_uses` parameter. #}
-{% if (record.contenttype.fields.slug.uses|default(null) is iterable) and skip_uses|default(true) %}
-    {% set omittedkeys = omittedkeys|merge(record.contenttype.fields.slug.uses) %}
-{% endif %}
+        {# We also skip over the fields that are explicitly excluded. #}
+        {% if exclude|default is iterable %}
+            {% set omittedkeys = omittedkeys|merge(exclude) %}
+        {% endif %}
+    {% endspaceless -%}
 
-{# We also skip over the fields that are explicitly excluded. #}
-{% if exclude|default is iterable %}
-    {% set omittedkeys = omittedkeys|merge(exclude) %}
-{% endif %}
+    {# SECTION 2: LOOPING AND ITERATION - The actual looping is done here. #}
+    {% for key, value in record.values if (key not in omittedkeys) %}
 
-{# SECTION 2: LOOPING AND ITERATION #}
+        {# Is the field allowed to contain Twig functions #}
+        {% set allowtwig = record.contenttype.fields[key].allowtwig|default(false) %}
 
-{# The actual looping is done here. #}
-{% for key, value in record.values if (key not in omittedkeys) %}
+        {# Fields that are considered 'common': 'html', 'markdown', 'textarea',
+           'text', 'image', 'video' and 'imagelist' #}
+        {% if common|default(true) and (key not in exclude|default([])) %}
 
-    {# Fields that are considered 'common': 'html', 'markdown', 'textarea',
-       'text', 'image', 'video' and 'imagelist' #}
-    {% if common|default(true) %}
+            {% set fieldtype = record.fieldtype(key) %}
+            {% set value = record.get(key) %}
+            {{ block('common_fields') }}
 
-        {% set fieldtype = record.fieldtype(key) %}
-        {{ block('common_fields') }}
+        {% endif %}
 
-    {% endif %}
+        {# The rest of the built-in fieldtypes #}
+        {% if extended|default(false) and (key not in exclude|default([])) %}
 
-    {# The rest of the built-in fieldtypes #}
-    {% if extended|default(false) %}
+            {% set fieldtype = record.fieldtype(key) %}
+            {{ block('extended_fields') }}
 
-        {% set fieldtype = record.fieldtype(key) %}
-        {{ block('extended_fields') }}
+        {% endif %}
 
-    {% endif %}
+        {# Finally, the repeaters #}
+        {% if repeaters|default(false) == true and record.fieldtype(key) == "repeater" %}
 
-    {# Finally, the repeaters #}
-    {% if repeaters|default(true) and record.fieldtype(key) == "repeater" %}
+            {% if (app.request.get('_route') != "preview") %}
 
-        {% for repeater in value %}
+                {% for repeater in value %}
 
-            {% for repeaterfield in repeater %}
+                    {% for key, repeaterfield in repeater %}
 
-                {% set fieldtype = repeaterfield.getFieldtype() %}
-                {% set value = repeaterfield.getValue() %}
-                {{ block('common_fields') }}
-                {{ block('extended_fields') }}
+                        {% set fieldtype = repeaterfield.fieldtype() %}
+                        {% set value = repeaterfield.value() %}
+                        {{ block('common_fields') }}
+                        {{ block('extended_fields') }}
 
-            {% endfor %}
+                    {% endfor %}
+                {% endfor %}
+
+            {% else %}
+                {# @deprecated
+                `blocks()` does not work correctly when _previewing_ repeater fields. This will be
+                fixed properly for Bolt 4, but for now we just output a notice, and prevent crashes.
+                See also: https://github.com/bolt/bolt/issues/6605 #}
+                <p>
+                Unfortunately, Repeater fields do not work correctly with the generic
+                <code>block()</code> function, when using Preview. To view these fields, please
+                save the record, and view the page normally.
+                </p>
+            {% endif %}
+        {% endif %}
+
+    {% endfor %}
+
+    {# We do the same for the templatefields, if set and not empty. #}
+    {% set templatefields = record.values.templatefields.values|default() %}
+    {% if templatefields is not empty %}
+
+        {# Note: This needs to be expanded upon!! For better detection the 'virtual'
+           contenttype for the templatefields should know about the types of fields. #}
+        {% set templatefields_field_types = attribute(record.contenttype.templatefields|first, 'fields') %}
+
+        {% for key, value in templatefields if (key not in omittedkeys) %}
+
+            {% set fieldtype = attribute(attribute(templatefields_field_types, key), 'type')  %}
+            {{ block('common_fields') }}
+            {{ block('extended_fields') }}
 
         {% endfor %}
 
     {% endif %}
-
-{% endfor %}
-
-{# We do the same for the templatefields, if set and not empty. #}
-{% set templatefields = record.values.templatefields.values|default() %}
-{% if templatefields is defined and templatefields is not empty %}
-
-    {# Note: This needs to be expanded upon!! For better detection the 'virtual'
-       contenttype for the templatefields should know about the types of fields. #}
-    {% set templatefields_field_types = attribute(record.contenttype.templatefields|first, 'fields') %}
-
-    {% for key, value in templatefields if (key not in omittedkeys) %}
-
-        {% set fieldtype = attribute(attribute(templatefields_field_types, key), 'type')  %}
-        {{ block('common_fields') }}
-        {{ block('extended_fields') }}
-
-    {% endfor %}
-
-{% endif %}
 {% endblock sub_fields %}


### PR DESCRIPTION
## One good :bug: deserves another

So while tracking down a small bug in 3.3, I found several more all stemming from this area. I double checked and they were present from 3.2 onward, so I thought I'd back-port the "two-liner" to 3.2 … and all hell broke lose, wasting several hours of work nobody really has time to waste. :disappointed: 

The differences between 3.2 & 3.3 were substantial enough to make this a long and painful process, exacerbated by the fact that we have:

  - `theme/base-2016/partials/_sub_field_blocks.twig` supposed to be identical to `app/theme_defaults/_sub_fields.twig`
  - `theme/base-2016/partials/_sub_field_blocks.twig` supposed to be identical to `app/theme_defaults/_sub_field_blocks.twig`

… and #6810 inbound adding a third copy of each, to make this harder to track and keep up-to-date.

Which leave us with the following status:

| Principle  |    |
| ---------- | -- |
| D.R.Y.     | :x:
| S.O.L.I.D. | :x:
| W.E.T.     | :white_check_mark:

A check-mark on W.E.T. is not something we should aim for. It also makes changes to one branch too easily break newer release branches on merge cascade.

## PR Changes

- Adds an `exclude` array variable to the use of the `with` control statement 
- Separate out Markdown logic into own mini sub-block
- Re-sync `theme` & `theme_defaults`
- Remove vestige reference to `fields()` in comment blocks

**Important note:** One of the reasons this PR diff is so large is that :koala:s can't indent :rofl: … Nah, totally my fault.
