### PR TITLE
[4.0] Reverse asset sort priority so higher numbers have higher priority

### DIFF
--- a/src/Asset/AssetSortTrait.php
+++ b/src/Asset/AssetSortTrait.php
@@ -28,7 +28,7 @@ trait AssetSortTrait
             }
         );
 
-        sort($assets);
+        rsort($assets);
 
         array_walk(
             $assets,


### PR DESCRIPTION
Closes #6751
Relevant bolt/docs#746

Note that this is a BC break, documentation update to follow.