### PR TITLE
[3.2] Cache directory group permissions

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -2,7 +2,7 @@
 
 namespace Bolt;
 
-use Bolt\Filesystem\AggregateFilesystemInterface;
+use Bolt\Filesystem\CompositeFilesystemInterface;
 use Bolt\Filesystem\Exception\IOException;
 use Bolt\Filesystem\Handler\DirectoryInterface;
 use Bolt\Filesystem\Handler\HandlerInterface;
@@ -23,7 +23,7 @@ class Cache extends FilesystemCache
     /** Default cache file extension. */
     const EXTENSION = '.data';
 
-    /** @var AggregateFilesystemInterface */
+    /** @var CompositeFilesystemInterface */
     private $filesystem;
     /** @var int */
     private $umask;
@@ -34,9 +34,9 @@ class Cache extends FilesystemCache
      * @param string                       $directory
      * @param string                       $extension
      * @param int                          $umask
-     * @param AggregateFilesystemInterface $filesystem
+     * @param CompositeFilesystemInterface $filesystem
      */
-    public function __construct($directory, $extension = self::EXTENSION, $umask = 0002, AggregateFilesystemInterface $filesystem = null)
+    public function __construct($directory, $extension = self::EXTENSION, $umask = 0002, CompositeFilesystemInterface $filesystem = null)
     {
         parent::__construct($directory, $extension, $umask);
         $this->filesystem = $filesystem;
@@ -70,7 +70,7 @@ class Cache extends FilesystemCache
         // Clear Doctrine's folder.
         $result = parent::doFlush();
 
-        if ($this->filesystem instanceof AggregateFilesystemInterface) {
+        if ($this->filesystem instanceof CompositeFilesystemInterface) {
             $cacheFs = $this->filesystem->getFilesystem('cache');
             // Clear our cached configuration
             if ($cacheFs->has('config-cache.json')) {

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -38,9 +38,10 @@ class Cache extends FilesystemCache
      */
     public function __construct($directory, $extension = self::EXTENSION, $umask = 0002, CompositeFilesystemInterface $filesystem = null)
     {
-        parent::__construct($directory, $extension, $umask);
+        umask($umask);
         $this->filesystem = $filesystem;
         $this->umask = $umask;
+        parent::__construct($directory, $extension, $umask);
     }
 
     /**


### PR DESCRIPTION
Closes #6562

This is just a hacky workaround for systems with poorly configured umasks … 'nuf said. We'll pick the rest of this up when we re-do caching soon.

Grabbed the deprecation on `Bolt\Filesystem\AggregateFilesystemInterface` while I was there.