### PR TITLE
[3.2] Fix doubled OL button in Markdown editor

### DIFF
--- a/app/view/js/uikit/marked.js
+++ b/app/view/js/uikit/marked.js
@@ -875,7 +875,7 @@ Renderer.prototype.link = function(href, title, text) {
     } catch (e) {
       return '';
     }
-    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0) {
+    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
       return '';
     }
   }
@@ -1094,7 +1094,7 @@ function escape(html, encode) {
 }
 
 function unescape(html) {
-	// explicitly match decimal, hex, and named HTML entities 
+	// explicitly match decimal, hex, and named HTML entities
   return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(?:\w+));?/g, function(_, n) {
     n = n.toLowerCase();
     if (n === 'colon') return ':';

--- a/app/view/twig/editcontent/fields/_markdown.twig
+++ b/app/view/twig/editcontent/fields/_markdown.twig
@@ -11,6 +11,7 @@
 
 {#=== INIT ===========================================================================================================#}
 
+{# NOTE: The toolbar option loop double taps the last array variable, hack around it here until we can replace #}
 {% set ukkit_conf = {
     height:         option.height,
     lblMarkedview:  __('field.markdown.label.markedview'),
@@ -19,7 +20,7 @@
     markedOptions:  {
                         breaks: false,
                     },
-    toolbar:        ['bold', 'italic', 'link', 'image', 'blockquote', 'listUl', 'listOl'],
+    toolbar:        ['bold', 'italic', 'link', 'image', 'blockquote', 'listUl', 'listOl', ''],
 } %}
 
 {% set attributes = {


### PR DESCRIPTION
The workaround to the issue reported on Slack is in the `_markdown.twig` commit, and yeah. As far as hacks go, this one really churns my stomach :disappointed: 

Also, while looking at the upstream project and its 350 open issues & 162 open PRs, I found the one commit that has landed in the last year was an XSS fix in the sanitise method … that the maintainer isn't interested in tagging as he's "out grown" the project and abandoned it for all intensive [sic/humour] purposes.

Granted we don't use the sanitise, but the project is now un-maintained and the project owner is unwilling to take fixed security issues seriously! :fire: 

For all the above reasons, we need to ditch this :hankey: pretty soon.