### PR TITLE
Sortable select fields using content as the values

### DIFF
--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -42,10 +42,16 @@
     {% set leadingvalues = [] %}
     {% for key, sel in selection %}
         {% for value_key, value_sel in values if value_key == sel %}
-            {% set leadingvalues = leadingvalues|merge({ (value_key): value_sel}) %}
+            {# do an associative merge as PHP can't handle merging items with numeric keys but not sequential #}
+            {% set leadingvalues = leadingvalues|assocmerge({ (value_key): value_sel}) %}
         {% endfor %}
     {% endfor %}
-    {% set values = unique(leadingvalues, values) %}
+    {# check if the array is sequential or not and either do an associative merge based on key if associative or a list of unique values if it is sequential #}
+    {% if isseq(values) %}
+        {% set values = unique(leadingvalues, values) %}
+    {% else %}
+        {% set values = leadingvalues|assocmerge(values) %}
+    {% endif %}
 {% endif %}
 
 {# If the current selection contains an existing id, we must use _only_ the id, and not accept a fallback. #}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bolt/bolt",
+    "name": "smgdesign/bolt",
     "description": "Sophisticated, lightweight & simple CMS",
     "homepage": "http://bolt.cm",
     "keywords": [

--- a/src/Twig/Extension/ArrayExtension.php
+++ b/src/Twig/Extension/ArrayExtension.php
@@ -26,6 +26,7 @@ class ArrayExtension extends Extension
         return [
             // @codingStandardsIgnoreStart
             new \Twig_SimpleFunction('unique', [$this, 'unique'], $safe),
+            new \Twig_SimpleFunction('isseq', [$this, 'isSequential'], $safe),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -39,6 +40,7 @@ class ArrayExtension extends Extension
             // @codingStandardsIgnoreStart
             new \Twig_SimpleFilter('order',   [$this, 'order']),
             new \Twig_SimpleFilter('shuffle', [$this, 'shuffle']),
+            new \Twig_SimpleFilter('assocmerge', [$this, 'assocMerge']),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -170,5 +172,32 @@ class ArrayExtension extends Extension
         }
 
         return $compiled;
+    }
+    
+    /**
+     * Takes an array and detects whether the keys are sequential
+     * 
+     * @param array $arr
+     * 
+     * @return boolean
+     */
+    public function isSequential(array $arr)
+    {
+        if (array() === $arr) return true;
+        // get an array of all the keys and see if they match the expected list of keys for an indexed array of this length and in this order \\
+        return array_keys($arr) === range(0, count($arr) -1);
+    }
+    
+    /**
+     * Appends $arr2 to $arr1 keeping the original keys
+     * 
+     * @param array $arr1
+     * @param array $arr2
+     * 
+     * @return array
+     */
+    public function assocMerge(array $arr1, array $arr2)
+    {
+        return $arr1+$arr2;
     }
 }


### PR DESCRIPTION
This is a more comprehensive fix to complement the PR for issue #6638.
Twig filter for associative array merging `array|assocmerge(array)`

Twig function to check if an array is a sequential indexed array or an associative array `isseq(array)`

`_select.twig` now detects if a list of sortable values is indexed or associative and merges selected values with the full list accordingly

Fixes: #6832
Related to: #6638 