### PR TITLE
[WIP] Select fields should keep all items, even when using a "string" as value.

### DIFF
--- a/app/view/twig/_buic/_select.twig
+++ b/app/view/twig/_buic/_select.twig
@@ -84,7 +84,7 @@
                             {% endif %}
 
                             {# option #}
-                            {% set opttext = option.text|default(option.value)|striptags %}
+                            {% set opttext = option.text|default(option.value)|join()|striptags %}
                             {# for details on why 'disabled' is in here, see https://github.com/bolt/bolt/pull/6590 #}
                             {% set optattr = {
                                 'value!':   option.value,

--- a/src/Twig/Handler/RecordHandler.php
+++ b/src/Twig/Handler/RecordHandler.php
@@ -286,7 +286,7 @@ class RecordHandler
                 }
                 $retval[$element] = $row;
             } elseif (isset($c->values[$fieldName])) {
-                $retval[$element] = $c->values[$fieldName];
+                $retval[$element] = [$c->values[$fieldName]];
             }
         }
 


### PR DESCRIPTION
Currently, `type: select` will not work correctly, if you use `values: entries/title`, instead of a compound value like `values: entries/id,title`. This will cause items that start with the same letter to "vanish".

We fix this by making sure the intermediate array of values always consists of an array, keeping the keys unique. 

Works correctly for these cases: 

```
        selectentry:
            type: select
            values: entries/id,title
            postfix: "Select an entry"
            autocomplete: true
            sort: title
            multiple: true
            sortable: true
        selectentry2:
            type: select
            values: entries/title
            autocomplete: true
            sort: title
            multiple: true
            sortable: true
        selectentry:
            type: select
            values: entries/id,title
            autocomplete: true
            sort: title
            multiple: true
            sortable: true
        selectentry3:
            type: select
            values: entries/title
            autocomplete: false
        selectentry4:
            type: select
            values: entries/id,title
            autocomplete: false
```

Screenshot: 

![screen shot 2017-07-19 at 14 05 42](https://user-images.githubusercontent.com/1833361/28366069-68d325cc-6c8b-11e7-82ed-19376627b90a.png)

Marked as `[WIP]`, because this area of the code has been changed often, and is very brittle. Seemingly "simple" fixes in this part have so far always caused side effects and introduced new bugs. 