### PR TITLE
Only add the label, when the label isn't empty

### DIFF
--- a/app/view/twig/_base/_fieldset.twig
+++ b/app/view/twig/_base/_fieldset.twig
@@ -31,7 +31,7 @@
 
 <fieldset{{ macro.attr(attributes_fieldset) }}>
     <legend class="sr-only">{% block fieldset_label_text %}{% endblock fieldset_label_text %}</legend>
-    {% if block('fieldset_label_text') is defined %}
+    {% if block('fieldset_label_text') is not empty %}
         <label{{ macro.attr(attributes_label) }}>{{ block('fieldset_label_text') }}: {{ field_info|default('') }}</label>
     {% endif %}
     {% block fieldset_controls %}{% endblock fieldset_controls %}


### PR DESCRIPTION
For 3.3 and up.

Fields of `type: hidden` would still output an "empty" label, showing up as a single semi-column:

![screen shot 2017-07-19 at 16 18 58](https://user-images.githubusercontent.com/1833361/28371964-c102b830-6c9e-11e7-899f-0de2217b24ce.png)
