### PR TITLE
More descriptive exception when the bundled-extension class does not exist 

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -169,12 +169,12 @@ class Bootstrap
                                 throw new LogicException(sprintf('Extension class name "%s" is defined in .bolt.yml or .bolt.php, but the class name is misspelled or not loadable by Composer.', $extensionClass));
                             }
                             if (!is_a($extensionClass, ExtensionInterface::class, true)) {
-                                throw new LogicException("$extensionClass needs to implement " . ExtensionInterface::class);
+                                throw new LogicException(sprintf('Extension class "%s" must implement %s', $extensionClass, ExtensionInterface::class));
                             }
                             $extensionClass = new $extensionClass();
                         }
                         if (!$extensionClass instanceof ExtensionInterface) {
-                            throw new LogicException(get_class($extensionClass) . ' needs to be an instance of ' . ExtensionInterface::class);
+                            throw new LogicException(sprintf('Extension class "%s" must be an instance of %s', get_class($extensionClass), ExtensionInterface::class));
                         }
                         $extensions->add($extensionClass);
                     }

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -165,6 +165,9 @@ class Bootstrap
                 function ($extensions) use ($config) {
                     foreach ((array) $config['extensions'] as $extensionClass) {
                         if (is_string($extensionClass)) {
+                            if (!class_exists($extensionClass)) {
+                                throw new LogicException(sprintf('Extension class name "%s" is defined in .bolt.yml or .bolt.php, but the class name is misspelled or not loadable by Composer.', $extensionClass));
+                            }
                             if (!is_a($extensionClass, ExtensionInterface::class, true)) {
                                 throw new LogicException("$extensionClass needs to implement " . ExtensionInterface::class);
                             }

--- a/tests/phpunit/unit/Bootstrap/BootstrapTest.php
+++ b/tests/phpunit/unit/Bootstrap/BootstrapTest.php
@@ -337,7 +337,7 @@ EOF;
 
     /**
      * @expectedException \LogicException
-     * @expectedExceptionMessage stdClass needs to implement Bolt\Extension\ExtensionInterface
+     * @expectedExceptionMessage Extension class "stdClass" must implement Bolt\Extension\ExtensionInterface
      */
     public function testRunExtensionStringInvalid()
     {
@@ -404,7 +404,7 @@ EOF;
 
     /**
      * @expectedException \LogicException
-     * @expectedExceptionMessage stdClass needs to be an instance of Bolt\Extension\ExtensionInterface
+     * @expectedExceptionMessage Extension class "stdClass" must be an instance of Bolt\Extension\ExtensionInterface
      */
     public function testRunExtensionObjectInvalid()
     {

--- a/tests/phpunit/unit/Bootstrap/BootstrapTest.php
+++ b/tests/phpunit/unit/Bootstrap/BootstrapTest.php
@@ -358,6 +358,29 @@ EOF;
         $this->assertInstanceOf(NormalExtension::class, $ext);
     }
 
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Extension class name "DropBear\Ninja" is defined in .bolt.yml or .bolt.php, but the class name is misspelled or not loadable by Composer.
+     */
+    public function testRunExtensionStringNotFound()
+    {
+        $config = [
+            'extensions' => [
+                'DropBear\Ninja',
+            ],
+        ];
+
+        $yaml = (new Dumper())->dump($config, 4, 0, true);
+        $fs = new Filesystem();
+        $fs->dumpFile($this->rootPath . '/.bolt.yml', $yaml);
+
+        $app = Bootstrap::run($this->rootPath);
+        $extensions = $app['extensions'];
+
+        $ext = $extensions->get('Bolt/Normal');
+        $this->assertInstanceOf(NormalExtension::class, $ext);
+    }
+
     public function testRunExtensionObject()
     {
         $config = <<<EOF


### PR DESCRIPTION
A class thatt doesn't exist can't implement an interface, so this should be checked first.
