### PR TITLE
[3.2] Select fields … The sage continues

### DIFF
--- a/app/src/lib/Versions.md
+++ b/app/src/lib/Versions.md
@@ -11,3 +11,6 @@
 
 + ``jquery-hotkeys`` ⇒
   **[jQuery Hotkeys Plugin](https://github.com/jeresig/jquery.hotkeys) 1.10.3**
+
+* `select2.sortable`  ⇒
+  **[select2-sortable](https://github.com/reduxframework/select2-sortable) (Patched for older Select2)**

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -12,40 +12,13 @@
 
 {#=== INIT ===========================================================================================================#}
 
-{% if option.values is iterable %}
-    {% set values = option.values %}
-{% else %}
-    {% set lookuptype = option.values|split('/')|slice(0,1)|first %}
-    {% set lookupfield = option.values|split('/')|slice(1,1)|first %}
-    {% if ',' in lookupfield %}
-        {% set lookupfieldlist = lookupfield|split(',') %}
-    {% endif %}
-    {% set sortingorder = field.sort|default(lookupfieldlist|default([])|first)|default(lookupfield)|default('id') %}
-    {% set querylimit = field.limit|default(500) %}
-    {% set wherefilter = field.filter|default({}) %}
-    {% setcontent lookups = lookuptype where wherefilter order sortingorder nohydrate limit querylimit %}
-    {% set valuefield = lookupfieldlist|default(lookupfield)|default('id') %}
-    {% set values = lookups|selectfield(valuefield, option.multiple, field.keys|default('id')) %}
-{% endif %}
+{% set values = context.values.select_choices[contentkey]|default([]) %}
 
 {# Get the current selection. Either a single value, or an array. #}
 {% set selection = context.content.get(contentkey)|default(option.default) %}
 {# Make sure the value is either `null` (for empty), or cast to an array for a string. Prevent breakage when switching from 'single' to 'mulptiple' #}
 {% if selection is not iterable and selection is not empty  %}
     {% set selection = [ selection ] %}
-{% endif %}
-
-{# if we have (sorted) options present already, make sure their order is
-   maintained. We do this by first selecting the current values, and then
-   merging that with the entire array of values. See #6332. #}
-{% if option.sortable %}
-    {% set leadingvalues = [] %}
-    {% for key, sel in selection %}
-        {% for value_key, value_sel in values if value_key == sel %}
-            {% set leadingvalues = leadingvalues|merge({ (value_key): value_sel}) %}
-        {% endfor %}
-    {% endfor %}
-    {% set values = unique(leadingvalues, values) %}
 {% endif %}
 
 {# If the current selection contains an existing id, we must use _only_ the id, and not accept a fallback. #}

--- a/app/view/twig/editcontent/fields/_select.twig
+++ b/app/view/twig/editcontent/fields/_select.twig
@@ -24,14 +24,26 @@
 {# If the current selection contains an existing id, we must use _only_ the id, and not accept a fallback. #}
 {% set onlyids = selection|first in values|keys %}
 
-{# Build the select options array #}
+{# Build the select options array, in two steps. #}
 {% set options = [] %}
-{% for id, value in values %}
-    {% set is_array = (value is iterable and (value | length) > 1) %}
+
+{# Step 1: If we have a current selection, we need to add these _first_, maintaining their order #}
+{% for id in selection %}
+    {% if values[id]|default() %}
+        {% set options = options|merge([{
+            'value':     id,
+            'text':      values[id],
+            'selected':  true,
+        }]) %}
+    {% endif %}
+{% endfor %}
+
+{# Step 2: Next, add all the values, _not_ in the selection. For new records, or records with no selection, this will add them all. #}
+{% for id, value in values if (id not in selection) %}
     {% set options = options|merge([{
-        value:     id,
-        text:      is_array ? value[0:]|join(' / ') : value,
-        selected:  id in selection or (not onlyids and (is_array ? value[0] : value) in selection),
+        'value':     id,
+        'text':      value,
+        'selected':  false,
     }]) %}
 {% endfor %}
 

--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Bolt\Form\Resolver;
+
+use Bolt\Storage\Entity\Content;
+use Bolt\Storage\EntityManager;
+use Bolt\Storage\Mapping\ContentType;
+use Bolt\Storage\Query\Query;
+use Bolt\Storage\Query\QueryResultset;
+
+/**
+ * Choice resolver.
+ *
+ * @internal DO NOT USE. Will be replaced circa Bolt 3.5.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class Choice
+{
+    /** @var EntityManager */
+    private $em;
+    /** @var Query */
+    private $query;
+
+    /**
+     * Constructor.
+     *
+     * @param EntityManager $em
+     * @param Query         $query
+     */
+    public function __construct(EntityManager $em, Query $query)
+    {
+        $this->em = $em;
+        $this->query = $query;
+    }
+
+    /**
+     * @param ContentType $contentType
+     *
+     * @return array
+     */
+    public function get(ContentType $contentType)
+    {
+        $select = null;
+        foreach ($contentType->getFields() as $name => $field) {
+            if ($field['type'] !== 'select') {
+                continue;
+            }
+            $field += [
+                'values'   => [],
+                'limit'    => null,
+                'sortable' => false,
+                'filter'   => null,
+            ];
+            $values = $field['values'];
+            $limit = $field['limit'];
+            $sortable = $field['sortable'];
+            $filter = $field['filter'];
+
+            // Get the appropriate values
+            $values = is_string($values)
+                ? $this->getEntityValues($values, $limit, $sortable, $filter)
+                : $this->getYamlValues($values, $limit, $sortable)
+            ;
+
+            $select[$name] = $values;
+        }
+
+        return $select;
+    }
+
+    /**
+     * Return a YAML defined array of select field value options.
+     *
+     * @param array $values
+     * @param int   $limit
+     * @param bool  $sortable
+     *
+     * @return array
+     */
+    private function getYamlValues(array $values, $limit, $sortable)
+    {
+        if ($values !== null) {
+            $values = array_slice($values, 0, $limit);
+        }
+        if ($sortable) {
+            asort($values, SORT_REGULAR);
+        }
+
+        return $values;
+    }
+
+    /**
+     * Return select field value options from a ContentType's records.
+     *
+     * @param string $queryString
+     * @param int    $limit
+     * @param bool   $sortable
+     * @param array  $filter
+     *
+     * @return array
+     */
+    private function getEntityValues($queryString, $limit, $sortable, $filter)
+    {
+        $baseParts = explode('/', $queryString);
+        if (count($baseParts) < 2) {
+            throw new \InvalidArgumentException(sprintf('The "values" key for a ContentType select must be in the form of ContentType/field_name but "%s" given', $queryString));
+        }
+
+        $contentType = $baseParts[0];
+        $queryFields = explode(',', $baseParts[1]);
+        foreach ($queryFields as $queryField) {
+            if ($queryField === '') {
+                throw new \InvalidArgumentException(sprintf('The "values" key for a ContentType select must include a single field, or comma separated fields, "%s" given', $queryString));
+            }
+        }
+        $orderBy = $sortable ? [$queryFields[0], 'ASC'] : ['id', 'ASC'];
+
+        $values = [];
+        if ($filter === null) {
+            $repo = $this->em->getRepository($contentType);
+            $entities = $repo->findBy([], $orderBy, $limit);
+        } else {
+            /** @var QueryResultset $entities */
+            $entities = $this->query->getContent('pages', $filter);
+        }
+        if (!$entities) {
+            return $values;
+        }
+
+        /** @var Content $entity */
+        foreach ($entities as $entity) {
+            $id = $entity->getId();
+            $values[$id] = $entity->get($queryFields[0]);
+            if (isset($queryFields[1])) {
+                $values[$id] .= ' / ' . $entity->get($queryFields[1]);
+            }
+        }
+
+        return $values;
+    }
+}

--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -230,6 +230,8 @@ class StorageServiceProvider implements ServiceProviderInterface
                     $app['logger.system'],
                     $app['logger.flash']
                 );
+                // @deprecated Temporary and to be removed circa Bolt 3.5.
+                $cr->setQueryHandler($app['query']);
 
                 return $cr;
             }

--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -5,12 +5,14 @@ namespace Bolt\Storage\ContentRequest;
 use Bolt\Config;
 use Bolt\Filesystem\Exception\IOException;
 use Bolt\Filesystem\Manager;
+use Bolt\Form\Resolver;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Storage\Entity\Content;
 use Bolt\Storage\Entity\Relations;
 use Bolt\Storage\Entity\TemplateFields;
 use Bolt\Storage\EntityManager;
 use Bolt\Storage\Mapping\ContentType;
+use Bolt\Storage\Query\Query;
 use Bolt\Storage\Repository;
 use Bolt\Translation\Translator as Trans;
 use Bolt\Users;
@@ -28,6 +30,8 @@ class Edit
 {
     /** @var EntityManager */
     protected $em;
+    /** @var Query */
+    private $query;
     /** @var Config */
     protected $config;
     /** @var Users */
@@ -63,6 +67,17 @@ class Edit
         $this->filesystem = $filesystem;
         $this->loggerSystem = $loggerSystem;
         $this->loggerFlash = $loggerFlash;
+    }
+
+    /**
+     * @internal DO NOT USE.
+     * @deprecated Temporary and to be removed circa 3.5.
+     *
+     * @param Query $query
+     */
+    public function setQueryHandler(Query $query)
+    {
+        $this->query = $query;
     }
 
     /**
@@ -141,6 +156,8 @@ class Edit
         if ($templateFields instanceof TemplateFields && $templateFieldsData = $templateFields->getContenttype()->getFields()) {
             $templateFields->getContenttype()['fields'] = $this->setCanUpload($templateFields->getContenttype()->getFields());
         }
+        // Temporary choice option resolver. Will be removed with Forms work circa Bolt 3.5.
+        $choiceResolver = new Resolver\Choice($this->em, $this->query);
 
         // Build context for Twig.
         $contextCan = [
@@ -159,6 +176,7 @@ class Edit
         $contextValues = [
             'datepublish'        => $this->getPublishingDate($content->getDatepublish(), true),
             'datedepublish'      => $this->getPublishingDate($content->getDatedepublish()),
+            'select_choices'     => $choiceResolver->get($contentType)
         ];
         $context = [
             'incoming_not_inv' => $incomingNotInverted,

--- a/src/Twig/Handler/ArrayHandler.php
+++ b/src/Twig/Handler/ArrayHandler.php
@@ -109,20 +109,26 @@ class ArrayHandler
     }
 
     /**
-     * Takes two arrays and returns a compiled array of unique, sorted values
+     * Takes two arrays and returns a compiled array of unique, sorted values.
      *
-     * @param $arr1
-     * @param $arr2
+     * @deprecated Deprecated since 3.2, to be removed in 4.0.
+     *
+     * @param array $arr1
+     * @param array $arr2
      *
      * @return array
      */
-    public function unique($arr1, $arr2)
+    public function unique(array $arr1, array $arr2)
     {
         $merged = array_unique(array_merge($arr1, $arr2), SORT_REGULAR);
         $compiled = [];
 
-        foreach ($merged as $val) {
-            $compiled[$val[0]] = $val;
+        foreach ($merged as $key => $val) {
+            if (is_array($val) && array_values($val) === $val) {
+                $compiled[$key] = $val;
+            } else {
+                $compiled[$val] = $val;
+            }
         }
 
         return $compiled;

--- a/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
+++ b/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Bolt\Tests\Form\Resolver;
+
+use Bolt\Form\Resolver\Choice;
+use Bolt\Storage\Entity\Content;
+use Bolt\Storage\EntityManager;
+use Bolt\Storage\Mapping\ContentType;
+use Bolt\Storage\Query\Query;
+use Bolt\Storage\Repository\ContentRepository;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * @covers \Bolt\Form\Resolver\Choice
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ChoiceTest extends TestCase
+{
+    public function testGetYamlNoSelect()
+    {
+        $resolver = $this->getResolver();
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'text_field' => ['type'   => 'text'],
+            ],
+        ]);
+        $result = $resolver->get($contentType);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetYamlIndexArray()
+    {
+        $resolver = $this->getResolver();
+        $values = ['foo', 'bar', 'koala', 'drop bear'];
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $result = $resolver->get($contentType);
+
+        $this->assertSame(['select_array' => $values], $result);
+    }
+
+    public function testGetYamlIndexArraySorted()
+    {
+        $resolver = $this->getResolver();
+        $values = ['foo', 'bar', 'koala', 'drop bear'];
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'     => 'select',
+                    'sortable' => true,
+                    'values'   => $values,
+                ],
+            ],
+        ]);
+        $result = $resolver->get($contentType);
+        asort($values, SORT_REGULAR);
+
+        $this->assertSame(['select_array' => $values], $result);
+    }
+
+    public function testGetYamlIndexArrayLimit()
+    {
+        $resolver = $this->getResolver();
+        $values = ['foo', 'bar', 'koala', 'drop bear'];
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'limit'  => 2,
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $result = $resolver->get($contentType);
+
+        $this->assertSame(['select_array' => array_slice($values, 0, 2)], $result);
+    }
+
+    public function testGetYamlHashArray()
+    {
+        $resolver = $this->getResolver();
+        $values = ['foo' => 'Foo Magoo', 'bar' => 'Iron Bar', 'koala' => 'Kenny', 'drop bear' => 'Danger Danger'];
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $result = $resolver->get($contentType);
+
+        $this->assertSame(['select_array' => $values], $result);
+    }
+
+    public function testGetYamlHashArraySorted()
+    {
+        $resolver = $this->getResolver();
+        $values = ['foo' => 'Foo Magoo', 'bar' => 'Iron Bar', 'koala' => 'Kenny', 'drop bear' => 'Danger Danger'];
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'     => 'select',
+                    'sortable' => true,
+                    'values'   => $values,
+                ],
+            ],
+        ]);
+        $result = $resolver->get($contentType);
+        asort($values, SORT_REGULAR);
+
+        $this->assertSame(['select_array' => $values], $result);
+    }
+
+    public function testGetYamlHashArrayLimit()
+    {
+        $resolver = $this->getResolver();
+        $values = ['foo' => 'Foo Magoo', 'bar' => 'Iron Bar', 'koala' => 'Kenny', 'drop bear' => 'Danger Danger'];
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'limit'  => 2,
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $result = $resolver->get($contentType);
+
+        $this->assertSame(['select_array' => array_slice($values, 0, 2)], $result);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The "values" key for a ContentType select must be in the form of ContentType/field_name but "contenttype" given
+     */
+    public function testGetEntityInvalidQuery()
+    {
+        $resolver = $this->getResolver();
+        $values = 'contenttype';
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $resolver->get($contentType);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The "values" key for a ContentType select must include a single field, or comma separated fields, "contenttype/" given
+     */
+    public function testGetEntityInvalidQueryFields()
+    {
+        $resolver = $this->getResolver();
+        $values = 'contenttype/';
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $resolver->get($contentType);
+    }
+
+    public function testGetEntitiesNotFound()
+    {
+        // Not passing entities into the mock will return a false inside the
+        // SUT, which should become an empty array.
+        $resolver = $this->getResolver();
+        $values = 'contenttype/field_1';
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $result = $resolver->get($contentType);
+
+        $this->assertSame(['select_array' => []], $result);
+    }
+
+    public function testGetEntityOneField()
+    {
+        $resolver = $this->getResolver($this->getEntities());
+        $values = 'contenttype/field_1';
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $expect = [
+            'select_array' => [
+                10 => 'Foo Magoo',
+                22 => 'Iron Bar',
+                33 => 'Kenny Koala',
+                42 => 'Drop Bear',
+            ],
+        ];
+        $result = $resolver->get($contentType);
+
+        $this->assertSame($expect, $result);
+    }
+
+    public function testGetEntityTwoFields()
+    {
+        $resolver = $this->getResolver($this->getEntities());
+        $values = 'contenttype/field_1,field_2';
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                ],
+            ],
+        ]);
+        $expect = [
+            'select_array' => [
+                10 => 'Foo Magoo / Magoo Foo',
+                22 => 'Iron Bar / Bar Iron',
+                33 => 'Kenny Koala / Koala Kenny',
+                42 => 'Drop Bear / Danger Danger',
+            ],
+        ];
+        $result = $resolver->get($contentType);
+
+        $this->assertSame($expect, $result);
+    }
+
+    public function testGetEntityFiltered()
+    {
+        $resolver = $this->getResolver(null, $this->getEntities());
+        $values = 'contenttype/field_1,field_2';
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                    'filter' => ['category' => 'test']
+                ],
+            ],
+        ]);
+        $expect = [
+            'select_array' => [
+                10 => 'Foo Magoo / Magoo Foo',
+                22 => 'Iron Bar / Bar Iron',
+                33 => 'Kenny Koala / Koala Kenny',
+                42 => 'Drop Bear / Danger Danger',
+            ],
+        ];
+        $result = $resolver->get($contentType);
+
+        $this->assertSame($expect, $result);
+    }
+
+    /**
+     * @return Content[]
+     */
+    private function getEntities()
+    {
+        return [
+            new Content(['id' => 10, 'field_1' => 'Foo Magoo', 'field_2' => 'Magoo Foo']),
+            new Content(['id' => 22, 'field_1' => 'Iron Bar', 'field_2' => 'Bar Iron']),
+            new Content(['id' => 33, 'field_1' => 'Kenny Koala', 'field_2' => 'Koala Kenny']),
+            new Content(['id' => 42, 'field_1' => 'Drop Bear', 'field_2' => 'Danger Danger']),
+        ];
+    }
+
+    /**
+     * @param array $repoReturn
+     * @param array $queryReturn
+     *
+     * @return Choice
+     */
+    private function getResolver($repoReturn = null, $queryReturn = null)
+    {
+        /** @var ContentRepository|MockObject $mockRepo */
+        $mockRepo = $this->getMockBuilder(ContentRepository::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['findBy'])
+            ->getMock()
+        ;
+        if ($repoReturn) {
+            $mockRepo
+                ->expects($this->atLeastOnce())
+                ->method('findBy')
+                ->willReturn($repoReturn)
+            ;
+        }
+        /** @var EntityManager|MockObject $mockEntityManager */
+        $mockEntityManager = $this->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getRepository'])
+            ->getMock()
+        ;
+        $mockEntityManager
+            ->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($mockRepo)
+        ;
+        /** @var Query|MockObject $mockQuery */
+        $mockQuery = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getContent'])
+            ->getMock()
+        ;
+        if ($queryReturn) {
+            $mockQuery
+                ->expects($this->atLeastOnce())
+                ->method('getContent')
+                ->willReturn($queryReturn)
+            ;
+        }
+
+        return new Choice($mockEntityManager, $mockQuery);
+    }
+}

--- a/tests/phpunit/unit/Twig/Handler/ArrayHandlerTest.php
+++ b/tests/phpunit/unit/Twig/Handler/ArrayHandlerTest.php
@@ -143,4 +143,74 @@ class ArrayHandlerTest extends BoltUnitTest
         $handler = new ArrayHandler($app);
         $handler->shuffle(['shuffle', 'board']);
     }
+
+    public function dataProviderUnique()
+    {
+        return [
+            'Same keys in different orders 1' => [
+                ['abc', 'bcd', 'cde'], ['abc', 'bcd', 'cde'], ['abc' => 'abc', 'bcd' => 'bcd', 'cde' => 'cde'],
+            ],
+            'Same keys in different orders 2' => [
+                ['bcd', 'cde', 'abc'], ['abc', 'bcd', 'cde'], ['bcd' => 'bcd', 'cde' => 'cde', 'abc' => 'abc'],
+            ],
+            'Same keys in different orders 3' => [
+                ['cde', 'abc', 'bcd'], ['abc', 'bcd', 'cde'], ['cde' => 'cde', 'abc' => 'abc', 'bcd' => 'bcd'],
+            ],
+
+            'Single additional key in different orders 1' => [
+                ['abc', 'bcd', 'cde'], ['abc', 'bcd', 'def'], ['abc' => 'abc', 'bcd' => 'bcd', 'cde' => 'cde', 'def' => 'def']
+            ],
+            'Single additional key in different orders 2' => [
+                ['bcd', 'cde', 'abc'], ['def', 'abc', 'bcd'], ['bcd' => 'bcd', 'cde' => 'cde', 'abc' => 'abc', 'def' => 'def']
+            ],
+            'Single additional key in different orders 3' => [
+                ['cde', 'abc', 'bcd'], ['bcd', 'cde', 'def'], ['cde' => 'cde', 'abc' => 'abc', 'bcd' => 'bcd', 'def' => 'def']
+            ],
+
+            'Multiple additional keys in different orders 1' => [
+                ['abc', 'bcd', 'cde'], ['abc', 'def', 'fgh'], ['abc' => 'abc', 'bcd' => 'bcd', 'cde' => 'cde', 'def' => 'def', 'fgh' => 'fgh']
+            ],
+            'Multiple additional keys in different orders 2' => [
+                ['abc', 'bcd', 'cde'], ['fgh', 'cde', 'def'], ['abc' => 'abc', 'bcd' => 'bcd', 'cde' => 'cde', 'fgh' => 'fgh', 'def' => 'def']
+            ],
+            'Multiple additional keys in different orders 3' => [
+                ['abc', 'bcd', 'cde'], ['fgh', 'def', 'efg'], ['abc' => 'abc', 'bcd' => 'bcd', 'cde' => 'cde', 'fgh' => 'fgh', 'def' => 'def', 'efg' => 'efg']
+            ],
+
+            'Indexed array of values' => [
+                [
+                    ['abc', 'bcd', 'cde'], ['fgh', 'def', 'efg']
+                ],
+                [
+                    ['fgh', 'def', 'efg'], ['abc', 'bcd', 'cde']
+                ],
+                [
+                    ['abc', 'bcd', 'cde'], ['fgh', 'def', 'efg']
+                ],
+            ],
+
+            'Mapped array of values' => [
+                [
+                    'map1' => ['abc', 'bcd', 'cde'], 'map2' => ['fgh', 'def', 'efg']
+                ],
+                [
+                    'map2' => ['fgh', 'def', 'efg'], 'map1' => ['abc', 'bcd', 'cde']
+                ],
+                [
+                    'map1' => ['abc', 'bcd', 'cde'], 'map2' => ['fgh', 'def', 'efg']
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderUnique
+     */
+    public function testUnique($arr1, $arr2, $expected)
+    {
+        $app = $this->getApp();
+        $handler = new ArrayHandler($app);
+
+        $this->assertSame($expected, $handler->unique($arr1, $arr2));
+    }
 }


### PR DESCRIPTION
Closes #6834
Closes #6835

Related: #4865, #5441, #6096, #6291, #6332, #6355, #6561, #6610, #6638, #6834

Test coverage on `ArrayHandler::unique` & `Bolt\Form\Resolver\Choice` at 100% LoC … More data input use-cases needed, but this get a lot of them.