### PR TITLE
[3.2] Keeping `keys:` intact for select fields. 

### DIFF
--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -80,10 +80,11 @@ final class Choice
         $limit = $field['limit'];
         $sortable = $field['sortable'];
         $filter = $field['filter'];
+        $key = isset($field['keys']) ? $field['keys'] : 'id';
 
         // Get the appropriate values
         return is_string($values)
-            ? $this->getEntityValues($values, $limit, $sortable, $filter)
+            ? $this->getEntityValues($values, $limit, $sortable, $filter, $key)
             : $this->getYamlValues($values, $limit, $sortable)
         ;
     }
@@ -116,10 +117,11 @@ final class Choice
      * @param int    $limit
      * @param bool   $sortable
      * @param array  $filter
+     * @param array  $key
      *
      * @return array
      */
-    private function getEntityValues($queryString, $limit, $sortable, $filter)
+    private function getEntityValues($queryString, $limit, $sortable, $filter, $key)
     {
         $baseParts = explode('/', $queryString);
         if (count($baseParts) < 2) {
@@ -149,7 +151,7 @@ final class Choice
 
         /** @var Content $entity */
         foreach ($entities as $entity) {
-            $id = $entity->getId();
+            $id = $entity->get($key);
             $values[$id] = $entity->get($queryFields[0]);
             if (isset($queryFields[1])) {
                 $values[$id] .= ' / ' . $entity->get($queryFields[1]);

--- a/tests/codeception/_support/YamlHelper.php
+++ b/tests/codeception/_support/YamlHelper.php
@@ -326,6 +326,17 @@ class YamlHelper extends \Codeception\Module
                 'values'       => 'pages/id,title',
                 'sort'         => 'title',
             ],
+            'select_record_single' => [
+                'type'         => 'select',
+                'values'       => 'pages/title',
+                'sort'         => 'title',
+            ],
+            'select_record_keys' => [
+                'type'         => 'select',
+                'values'       => 'pages/title',
+                'sort'         => 'title',
+                'keys'         => 'slug',
+            ],
             /**
              * Disabled as currently unsupported due to problems in extension
              * fields, and in test due to |first filter in base-2016:

--- a/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
+++ b/tests/codeception/acceptance/101-BackendEditor/BackendEditorCest.php
@@ -253,6 +253,8 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->selectOption('#templatefields-select_list', 'foo');
         $I->selectOption('#templatefields-select_multi', ['Donatello', 'Rafael']);
         $I->selectOption('#templatefields-select_record', '1');
+        $I->selectOption('#templatefields-select_record_single', '2');
+        $I->selectOption('#templatefields-select_record_keys', 'contact');
 
         $I->click('Save Page', '#savecontinuebutton');
 
@@ -275,5 +277,10 @@ class BackendEditorCest extends AbstractAcceptanceTest
         $I->seeInField('#templatefields-select_multi', 'Donatello');
         $I->seeInField('#templatefields-select_multi', 'Rafael');
         $I->seeInField('#templatefields-select_record', '1');
+        $I->seeOptionIsSelected("#templatefields-select_record", '1 / A Page I Made');
+        $I->seeInField('#templatefields-select_record_single', '2');
+        $I->seeOptionIsSelected("#templatefields-select_record_single", 'ABOUT');
+        $I->seeInField('#templatefields-select_record_keys', 'contact');
+        $I->seeOptionIsSelected("#templatefields-select_record_keys", 'Contact Page');
     }
 }

--- a/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
+++ b/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
@@ -272,6 +272,34 @@ class ChoiceTest extends TestCase
         $this->assertSame($expect, $result);
     }
 
+    public function testGetEntityKeys()
+    {
+        $resolver = $this->getResolver(null, $this->getEntities());
+        $values = 'contenttype/field_1';
+        $contentType = new ContentType('koala', [
+            'fields' => [
+                'select_array' => [
+                    'type'   => 'select',
+                    'values' => $values,
+                    'keys'   => 'field_2',
+                    'filter' => ['category' => 'test']
+                ],
+            ],
+        ]);
+        $expect = [
+            'select_array' => [
+                'Magoo Foo' => 'Foo Magoo',
+                'Bar Iron' => 'Iron Bar',
+                'Koala Kenny' => 'Kenny Koala',
+                'Danger Danger' => 'Drop Bear',
+            ],
+        ];
+        $result = $resolver->get($contentType, []);
+
+        $this->assertSame($expect, $result);
+    }
+
+
     public function testGetTemplateFieldsSelect()
     {
         $resolver = $this->getResolver();


### PR DESCRIPTION
Fixes #6858