### PR TITLE
Include Slack channel count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ page.
 
 ---
 
-[![Build Status][travis-badge]][travis] [![Scrutinizer Continuous Inspections][codeclimate-badge]][codeclimate] [![SensioLabsInsight][sensio-badge]][sensio-insight]
+[![Build Status][travis-badge]][travis] [![Scrutinizer Continuous Inspections][codeclimate-badge]][codeclimate] [![SensioLabsInsight][sensio-badge]][sensio-insight] [![Slack][slack-badge]](https://slack.bolt.cm)
 
 [bolt-cm]: https://bolt.cm
 [MIT-license]: http://opensource.org/licenses/mit-license.php
@@ -50,4 +50,5 @@ page.
 [codeclimate-badge]: https://lima.codeclimate.com/github/bolt/bolt/badges/gpa.svg
 [sensio-insight]: https://insight.sensiolabs.com/projects/4d1713e3-be44-4c2e-ad92-35f65eee6bd5
 [sensio-badge]: https://insight.sensiolabs.com/projects/4d1713e3-be44-4c2e-ad92-35f65eee6bd5/mini.png
+[slack-badge]: https://slack.bolt.cm/badge/ratio
 [contributing]: https://github.com/bolt/bolt/blob/master/.github/CONTRIBUTING.md


### PR DESCRIPTION
Tagging as an RFC as I have no great opinion on this one, just having fun and seeing what we can do.

The currently implemented options are:
  * ![](https://slack.bolt.cm/badge/active) — Active users
  * ![](https://slack.bolt.cm/badge/ratio) — Active/total ratio 
  * ![](https://slack.bolt.cm/badge/total) — Total user count