### PR TITLE
Smack some sense into extension page failures

### DIFF
--- a/src/Controller/Backend/Extend.php
+++ b/src/Controller/Backend/Extend.php
@@ -275,7 +275,19 @@ class Extend extends BackendBase
      */
     public function installInfo(Request $request)
     {
-        $package = $request->get('package');
+        $package = $request->query->get('package');
+        if ($package === null) {
+            $message  = 'Extension browser request query was missing or invalid, check your web server configuration.';
+
+            return $this->getJsonException(new \Exception($message));
+        }
+        if ($package === '') {
+            $message = sprintf(
+                'No extension was selected. Try entering a name and press the "%s" button.',
+                Trans::__('page.extend.button.browse-versions')
+            );
+            return $this->getJsonException(new \Exception($message));
+        }
         $versions = ['dev' => [], 'beta' => [], 'RC' => [], 'stable' => []];
 
         try {

--- a/tests/phpunit/unit/Composer/PackageManagerTest.php
+++ b/tests/phpunit/unit/Composer/PackageManagerTest.php
@@ -333,38 +333,6 @@ class PackageManagerTest extends TestCase
         $packageManager->initJson('composer.json', []);
     }
 
-    public function testUseSsl()
-    {
-        $app = new Application();
-        $app['extend.writeable'] = false;
-        $app['guzzle.api_version'] = 6;
-
-        $app['extend.site'] = 'http://example.com';
-        $packageManager = new PackageManager($app);
-        $this->assertFalse($packageManager->useSsl());
-
-        $app['extend.site'] = 'https://example.com';
-        $packageManager = new PackageManager($app);
-        $this->assertTrue($packageManager->useSsl());
-        // Test early return
-        $this->assertTrue($packageManager->useSsl());
-    }
-
-    public function testUseInvalidCa()
-    {
-        $app = new Application();
-        $app['extend.writeable'] = false;
-        $app['guzzle.api_version'] = $app->share(function () {
-            throw new \RuntimeException('Drop bear alert');
-        });
-
-        $app['extend.site'] = 'https://example.com';
-        $packageManager = new PackageManager($app);
-
-        $this->assertFalse($packageManager->useSsl());
-        $this->assertSame(['Drop bear alert'], $packageManager->getMessages());
-    }
-
     /**
      * @param string $action
      * @param mixed  $returnValue


### PR DESCRIPTION
- Invalid AJAX package queries will be more informative, e.g. the Nginx problem that @bhrobinson hit yesterday 
- Use the Composer CaBundle to check for CA bundles … no more `open_basedir` :hankey: 

Yes, the whole Composer layer needs a redo … just not now!