### PR TITLE
[4.0] Set minimum PHP requirement to 7.0.8

### DIFF
--- a/app/nut
+++ b/app/nut
@@ -4,7 +4,7 @@
  * This could be loaded on a very old version of PHP so no syntax/methods over 5.2 in this file.
  */
 
-$minVersion = '7.0.0';
+$minVersion = '7.0.8';
 if (version_compare(PHP_VERSION, $minVersion, '<')) {
     echo sprintf("\033[37;41mBolt requires PHP \033[1m%s\033[22m or higher. You have PHP \033[1m%s\033[22m, so Bolt will not run on your current setup.\033[39;49m%s", $minVersion, PHP_VERSION, PHP_EOL);
     exit(1);

--- a/app/web.php
+++ b/app/web.php
@@ -4,7 +4,7 @@
  */
 use Bolt\Exception\BootException;
 
-if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+if (version_compare(PHP_VERSION, '7.0.8', '<')) {
     require dirname(__DIR__) . '/src/Exception/BootException.php';
 
     BootException::earlyExceptionVersion();

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "jdorn/sql-formatter": "^1.2",
         "monolog/monolog": "^1.21",
         "nesbot/carbon": "^1.21",
-        "php": "^7.0",
+        "php": "^7.0.8",
         "silex/silex": "^2.2",
         "silex/web-profiler": "^2.0",
         "siriusphp/upload": "^1.3",

--- a/src/Application.php
+++ b/src/Application.php
@@ -28,7 +28,7 @@ class Application extends Silex\Application
         AppSingleton::set($this);
 
         /** @internal Parameter to track a deprecated PHP version */
-        $values['deprecated.php'] = version_compare(PHP_VERSION, '7.0.0', '<');
+        $values['deprecated.php'] = version_compare(PHP_VERSION, '7.0.8', '<');
 
         // Debug 1st phase: Register early error & exception handlers
         $this->register(new Provider\DebugServiceProvider());

--- a/src/Exception/BootException.php
+++ b/src/Exception/BootException.php
@@ -90,7 +90,7 @@ EOM;
     public static function earlyExceptionVersion()
     {
         $message = <<<EOM
-Bolt requires PHP <u>7.0.0</u>, or higher. 
+Bolt requires PHP <u>7.0.8</u>, or higher. 
 <br><br>
 You are running PHP <u>%s</u>, so Bolt will not run on your current setup.
 EOM;


### PR DESCRIPTION
Owing to a [`serialize()`](https://bugs.php.net/72229) bug, [Nicolas has bumped](https://github.com/symfony/symfony/pull/23703) the Symfony PHP 7.0 requirement to 7.0.8.

This just leaves an audit trail in our code :wink: 