### PR TITLE
[3.4] Menus … 

### DIFF
--- a/app/resources/translations/cs_CZ/messages.cs_CZ.yml
+++ b/app/resources/translations/cs_CZ/messages.cs_CZ.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  10 Legacy untranslated messages
 # 116 Untranslated messages
-#  35 Legacy translation messages
-# 435 Translation messages
+#  34 Legacy translation messages
+# 436 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -168,7 +168,6 @@ permissions.roles.label.anonymous: # "Anonymous"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Přidat ukázku <a href='%url%' class='btn btn-default'>Záznam s Lorem ipsum</a>"
 "Added to <tt>%key%</tt> '%title%'": "Přidáno do <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Během aktualizace `%TABLE%` došlo k chybě: %ERROR%"
-"Content": "Obsah"
 "Current (saved) status:": "Současný (uložený) stav:"
 "Do you really want to delete %FOLDERNAME%?": "Opravdu smazat %FOLDERNAME%?"
 "Error reading extensions/composer.json file: %ERROR%": "Chyba při čtení souboru extensions/composer.json: %ERROR%"
@@ -327,6 +326,7 @@ general.phrase.confirm-remove-files: "Určitě chete odstranit tyto soubory?"
 general.phrase.confirm-remove-image: "Určitě chcete odstranit tento obrázek?"
 general.phrase.confirm-remove-images: "Určitě chcete odstranit tyto obrázky?"
 general.phrase.confirm-remove-record: "Určitě chcete odstranit tento záznam? Změny není možné vrátit zpět."
+general.phrase.content: "Obsah"
 general.phrase.content-type-permissions: "Oprávnění typu obsahu"
 general.phrase.content-types: "Typy obsahu"
 general.phrase.create-user-first: "Založení prvního uživatele"

--- a/app/resources/translations/de_DE/messages.de_DE.yml
+++ b/app/resources/translations/de_DE/messages.de_DE.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #   5 Legacy untranslated messages
 #  20 Untranslated messages
-#  40 Legacy translation messages
-# 531 Translation messages
+#  39 Legacy translation messages
+# 532 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -59,7 +59,6 @@ page.extend.listheader.name: # "Name"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Einige Beispieldatensätze mit <a href='%url%' class='btn btn-default'>mit Loripsum Text</a> hinzufügen."
 "Added to <tt>%key%</tt> '%title%'": "Hinzugefügt zu <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Es gab einen Fehler beim Updaten von `%TABLE%`. Der Error lautet %ERROR%"
-"Content": "Inhalt"
 "Current (saved) status:": "Momentaner (gespeicherter) Status:"
 "Dependencies": "Abhängigkeiten"
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": "Änderung der Bolt-Version zu <b>%VERSION%</b> erkannt, der Cache wurde gelöscht. Wenn noch nicht geschehen, bitte <a href=\"%URI%\">Datenbank überprüfen</a>."
@@ -232,6 +231,7 @@ general.phrase.confirm-remove-files: "Bist du dir sicher, dass du diese Dateien 
 general.phrase.confirm-remove-image: "Sind Sie sicher, dass Sie dieses Bild entfernen möchten?"
 general.phrase.confirm-remove-images: "Sind Sie sicher, dass Sie diese Bilder entfernen möchten?"
 general.phrase.confirm-remove-record: "Sind Sie sicher, dass Sie diesen Eintrag löschen möchten? Dies kann nicht rückgängig gemacht werden."
+general.phrase.content: "Inhalt"
 general.phrase.content-type-permissions: "Datentyp-Berechtigungen"
 general.phrase.content-types: "Datentypen"
 general.phrase.create-user-first: "Den ersten Benutzer erstellen"

--- a/app/resources/translations/el/messages.el.yml
+++ b/app/resources/translations/el/messages.el.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  32 Legacy untranslated messages
 # 371 Untranslated messages
-#  13 Legacy translation messages
-# 180 Translation messages
+#  12 Legacy translation messages
+# 181 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -465,7 +465,6 @@ permissions.roles.description.root: # "Built-in superuser role, automatically gr
 "(no group)": "(χωρίς ομάδα)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "<a href='%url%' class='btn btn-default'>Προσθέστε</a> εγγραφές με χαζό περιεχόμενο Lorem Ipsum."
 "Added to <tt>%key%</tt> '%title%'": "Προστεθηκε στο <tt>%key%</tt> '%title%'"
-"Content": "Περιεχόμενο"
 "Current (saved) status:": "Τρέχουσα (αποθηκευμένη) κατάσταση:"
 "Everybody": "Όλοι"
 "Excerpt": "Απόσπασμα"
@@ -531,6 +530,7 @@ general.phrase.clear-filter-sort: "Καθαρισμός ταξινόμησης/�
 general.phrase.code-colon: "Κώδικας:"
 general.phrase.configuration: "Παραμετροποίηση"
 general.phrase.confirm-delete-user: "Είστε σίγουροι ότι θέλετε να διαγραφεί ο/η %username%?"
+general.phrase.content: "Περιεχόμενο"
 general.phrase.create-user-first: "Δημιουργία του πρώτου χρήστη"
 general.phrase.created-on-colon: "Δημιουργήθηκε στις:"
 general.phrase.current-session-plural: "Τρέχων sessions"

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #   2 Legacy untranslated messages
 #   0 Untranslated messages
-#  43 Legacy translation messages
-# 551 Translation messages
+#  42 Legacy translation messages
+# 552 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -28,7 +28,6 @@
 "Added records to the ContentType <tt>%CONTENTYPE%</tt> titled": "Added records to the ContentType <tt>%CONTENTYPE%</tt> titled"
 "Added to <tt>%key%</tt> '%title%'": "Added to <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "An error occured while updating `%TABLE%`. The error is %ERROR%"
-"Content": "Content"
 "Current (saved) status:": "Current (saved) status:"
 "Dependencies": "Dependencies"
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already."
@@ -210,6 +209,7 @@ general.phrase.confirm-remove-files: "Are you sure you want to remove these file
 general.phrase.confirm-remove-image: "Are you sure you want to remove this image?"
 general.phrase.confirm-remove-images: "Are you sure you want to remove these images?"
 general.phrase.confirm-remove-record: "Are you sure you wish to delete this record? There is no undo."
+general.phrase.content: "Content"
 general.phrase.content-type-permissions: "ContentType Permissions"
 general.phrase.content-types: "ContentTypes"
 general.phrase.create-user-first: "Create the first user"

--- a/app/resources/translations/es_ES/messages.es_ES.yml
+++ b/app/resources/translations/es_ES/messages.es_ES.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #   5 Legacy untranslated messages
 #  27 Untranslated messages
-#  40 Legacy translation messages
-# 524 Translation messages
+#  39 Legacy translation messages
+# 525 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -69,7 +69,6 @@ page.extend.options: # "Extension Options"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Agregar algunas <a href='%url%' class='btn btn-default'>entradas con texto Loripsum</a> de ejemplo"
 "Added to <tt>%key%</tt> '%title%'": "Agregado a <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Se ha producido un error al actualizar '%TABLE%'. El error es %ERROR%"
-"Content": "Contenido"
 "Current (saved) status:": "Estado actual (guardado):"
 "Dependencies": "Dependencia"
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": "Detectado cambio de versión de Bolt a <b>%VERSION%</b>, la caché ha sido limpiada. Por favor <a href=\"%URI%\">comprueba la base de datos</a>, si no lo has hecho todavía."
@@ -240,6 +239,7 @@ general.phrase.confirm-remove-files: "¿Está seguro que desea eliminar estos ar
 general.phrase.confirm-remove-image: "¿Seguro que quieres borrar esta imagen?"
 general.phrase.confirm-remove-images: "¿Seguro que quieres borrar estas imágenes?"
 general.phrase.confirm-remove-record: "¿Está seguro que desea eliminar este registro? No se puede deshacer."
+general.phrase.content: "Contenido"
 general.phrase.content-type-permissions: "Permisos por tipo de contenido"
 general.phrase.content-types: "Tipos de contenido"
 general.phrase.create-user-first: "Crear el primer usuario"

--- a/app/resources/translations/fi/messages.fi.yml
+++ b/app/resources/translations/fi/messages.fi.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  14 Legacy untranslated messages
 # 169 Untranslated messages
-#  31 Legacy translation messages
-# 382 Translation messages
+#  30 Legacy translation messages
+# 383 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -227,7 +227,6 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "(none)": "(ei mitään)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Lisää hieman <a href='%url%' class='btn btn-default'>mallisisältöä täytetekstillä</a>"
 "Added to <tt>%key%</tt> '%title%'": "Lisätty <tt>%key%</tt> '%title%'"
-"Content": "Sisältö"
 "Current (saved) status:": "Nykyinen (tallennettu) tila:"
 "Do you really want to delete %FOLDERNAME%?": "Haluatko varmasti poistaa kansion '%FOLDERNAME%'?"
 "Everybody": "Kaikki"
@@ -369,6 +368,7 @@ general.phrase.confirm-remove-file: "Haluatko varmasti poistaa tämän tiedoston
 general.phrase.confirm-remove-image: "Haluatko varmasti poistaa tämän kuvan?"
 general.phrase.confirm-remove-images: "Haluatko varmasti poistaa nämä kuvat?"
 general.phrase.confirm-remove-record: "Halautko varmasti poistaa tämän tietueen? Sitä ei voi palauttaa."
+general.phrase.content: "Sisältö"
 general.phrase.content-type-permissions: "Sisätötyyppien oikeudet"
 general.phrase.content-types: "Sisältötyypit"
 general.phrase.create-user-first: "Luo ensimmäinen käyttäjä"

--- a/app/resources/translations/fr/messages.fr.yml
+++ b/app/resources/translations/fr/messages.fr.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #   7 Legacy untranslated messages
 #  26 Untranslated messages
-#  38 Legacy translation messages
-# 525 Translation messages
+#  37 Legacy translation messages
+# 526 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -71,7 +71,6 @@ page.extend.options: # "Extension Options"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "<a href='%url%' class='btn btn-default'>Ajouter des enregistrements de démonstration</a>"
 "Added to <tt>%key%</tt> '%title%'": "Contenu '%title%' ajouté à <tt>%key%</tt>"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Une erreur s'est produite lors de la mise à jour de `%TABLE%`. L'erreur est %ERROR%"
-"Content": "Contenu"
 "Current (saved) status:": "Statut courant"
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": "La version détectée de Bolt est modifiée en <b>%VERSION%</b>, et le cache a été effacé. Veuillez <a href=\"%URI%\">vérifier la base de données</a>, si vous ne l'avez déjà fait."
 "Do you really want to delete %FOLDERNAME%?": "Etes-vous certain de vouloir supprimer le répertoire %FOLDERNAME% ?"
@@ -239,6 +238,7 @@ general.phrase.confirm-remove-files: "Etes-vous certain de vouloir retirer ces f
 general.phrase.confirm-remove-image: "Etes-vous certain de vouloir retirer cette image ?"
 general.phrase.confirm-remove-images: "Etes-vous certain de vouloir retirer ces images ?"
 general.phrase.confirm-remove-record: "Etes-vous certain de vouloir supprimer cet enregistrement ? Cette action est irréversible."
+general.phrase.content: "Contenu"
 general.phrase.content-type-permissions: "Droits par types de contenu"
 general.phrase.content-types: "Types de contenu"
 general.phrase.create-user-first: "Créer l'utilisateur initial"

--- a/app/resources/translations/hu/messages.hu.yml
+++ b/app/resources/translations/hu/messages.hu.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  12 Legacy untranslated messages
 # 101 Untranslated messages
-#  33 Legacy translation messages
-# 450 Translation messages
+#  32 Legacy translation messages
+# 451 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -158,7 +158,6 @@ panel.latest-activity.system: # "Latest system activity"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Néhány <a href='%url%' class='btn btn-default'>Lorem ipsum bejegyzés</a> felvétele"
 "Added to <tt>%key%</tt> '%title%'": "Hozzáadva a <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Hiba történt `%TABLE%` frissítése közben. A hiba: %ERROR%"
-"Content": "Tartalom"
 "Current (saved) status:": "Jelenlegi (mentett) státusz:"
 "Do you really want to delete %FOLDERNAME%?": "Valóban törölni szeretnéd a %FOLDERNAME% mappát?"
 "Everybody": "Mindenki"
@@ -306,6 +305,7 @@ general.phrase.confirm-remove-files: "Biztosan törölni szeretné ezeket a fáj
 general.phrase.confirm-remove-image: "Valóban törölni szeretnéd ezt a képet?"
 general.phrase.confirm-remove-images: "Valóban törölni szeretnéd ezeket a képeket?"
 general.phrase.confirm-remove-record: "Biztos törlöd ezt a rekordot? Később már nemlehet visszavonni."
+general.phrase.content: "Tartalom"
 general.phrase.content-type-permissions: "Tartalomtípus Engedélyek"
 general.phrase.content-types: "Tartalomtípusok"
 general.phrase.create-user-first: "Első felhasználó létrehozása"

--- a/app/resources/translations/id/messages.id.yml
+++ b/app/resources/translations/id/messages.id.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  38 Legacy untranslated messages
 # 405 Untranslated messages
-#   7 Legacy translation messages
-# 146 Translation messages
+#   6 Legacy translation messages
+# 147 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -501,7 +501,6 @@ permissions.roles.label.anonymous: # "Anonymous"
 
 "(no group)": "(Tidak ada kelompok)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Tambah contoh<a href='%url%' class='btn btn-default'>Isian dengan teks Loripsum</a>"
-"Content": "Konten"
 "Everybody": "Semua"
 "Excerpt": "Ringkasan"
 "Image": "Citra"
@@ -546,6 +545,7 @@ general.phrase.clear-filter-sort: "Bersihkan urutan/saringan"
 general.phrase.code-colon: "Kode"
 general.phrase.configuration: "Konfigurasi"
 general.phrase.confirm-delete-user: "Anda yakin menghapus %username%?"
+general.phrase.content: "Konten"
 general.phrase.content-types: "Tipe Konten"
 general.phrase.create-user-first: "Buat pengguna pertama"
 general.phrase.created-on-colon: "Dibuat pada:"

--- a/app/resources/translations/it/messages.it.yml
+++ b/app/resources/translations/it/messages.it.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  33 Legacy untranslated messages
 # 353 Untranslated messages
-#  12 Legacy translation messages
-# 198 Translation messages
+#  11 Legacy translation messages
+# 199 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -443,7 +443,6 @@ permissions.roles.label.owner: # "Owner"
 "(no group)": "(nessun gruppo)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Aggiungi un po di <a href='%url%' class='btn btn-default'>Contenuti con il testo Loripsum</a>"
 "Added to <tt>%key%</tt> '%title%'": "Aggiunto a <tt>%key%</tt> '%title%'"
-"Content": "Contenuto"
 "Excerpt": "Estratto"
 "Skipped <tt>%key%</tt> (already has records)": "Saltato <tt>%key%</tt> (ha già contenuti)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "L'identificatore e lo slug per '%taxonomytype%' non sono lo stesso ('%slug%' vs. '%taxonomytype%'). Modifica taxonomy.yml, e rendili uguali per prevenire inconsistenze tra la memorizzazione nel database storage e i tuoi template."
@@ -521,6 +520,7 @@ general.phrase.clear-cache-again: "Svuota ancora la cache"
 general.phrase.clear-filter-sort: "Svuota ordine/filtro"
 general.phrase.configuration: "Configurazione"
 general.phrase.confirm-delete-user: "Sei sicuro di voler rimuovere %username%?"
+general.phrase.content: "Contenuto"
 general.phrase.content-types: "Tipi di Contenuto"
 general.phrase.create-user-first: "Crea il primo utente"
 general.phrase.created-on-colon: "Creato il:"

--- a/app/resources/translations/ja/messages.ja.yml
+++ b/app/resources/translations/ja/messages.ja.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  26 Legacy untranslated messages
 # 289 Untranslated messages
-#  19 Legacy translation messages
-# 262 Translation messages
+#  18 Legacy translation messages
+# 263 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -368,7 +368,6 @@ panel.user-actions.button.add: # "Add a new user"
 "(no group)": "（グループなし）"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "サンプルを追加<a href='%url%' class='btn btn-default'>ダミーテキスト（Loripsum）のレコード</a>"
 "Added to <tt>%key%</tt> '%title%'": "<tt>%key%</tt> '%title%' に追加しました"
-"Content": "コンテンツ"
 "Current (saved) status:": "現在の（保存された）ステータス："
 "Everybody": "みなさん"
 "Excerpt": "概要"
@@ -466,6 +465,7 @@ general.phrase.clear-filter-sort: "並び替え/フィルタをクリア"
 general.phrase.code-colon: "コード："
 general.phrase.configuration: "全般設定"
 general.phrase.confirm-delete-user: "本当に '%username%' を"
+general.phrase.content: "コンテンツ"
 general.phrase.content-type-permissions: "コンテンツタイプのパーミッション"
 general.phrase.content-types: "コンテンツタイプ"
 general.phrase.create-user-first: "最初のユーザを作成"

--- a/app/resources/translations/nb/messages.nb.yml
+++ b/app/resources/translations/nb/messages.nb.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  28 Legacy untranslated messages
 # 373 Untranslated messages
-#  17 Legacy translation messages
-# 178 Translation messages
+#  16 Legacy translation messages
+# 179 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -459,7 +459,6 @@ panel.user-actions.button.add: # "Add a new user"
 "(no group)": "(ingen gruppe)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Legg til litt <a href='%url%' class='btn btn-default'>eksempelinnhold med Loripsum-tekst</a>"
 "Added to <tt>%key%</tt> '%title%'": "La til i <tt>%key%</tt> «%title%»"
-"Content": "Innhold"
 "Everybody": "Alle"
 "Excerpt": "Utdrag"
 "Image": "Bilde"
@@ -519,6 +518,7 @@ general.phrase.clear-cache-again: "Tøm mellomlager igjen"
 general.phrase.clear-filter-sort: "Tøm sortering/filter"
 general.phrase.code-colon: "Kode:"
 general.phrase.configuration: "Oppsett"
+general.phrase.content: "Innhold"
 general.phrase.content-type-permissions: "Rettigheter etter innholdstype"
 general.phrase.content-types: "Innholdstyper"
 general.phrase.create-user-first: "Lag den første brukeren"

--- a/app/resources/translations/nl_NL/messages.nl_NL.yml
+++ b/app/resources/translations/nl_NL/messages.nl_NL.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #   3 Legacy untranslated messages
 #  13 Untranslated messages
-#  42 Legacy translation messages
-# 538 Translation messages
+#  41 Legacy translation messages
+# 539 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -48,7 +48,6 @@ page.edit-users.error.password-long: # "This value is too long. It should have 1
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Voeg een aantal <a href='%url%' class='btn btn-default'>Records met Loripsum tekst toe</a>"
 "Added to <tt>%key%</tt> '%title%'": "Toegevoegd aan <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Er is een fout opgetreden tijdens het bijwerken van de '%TABLE%'. De fout is %ERROR%"
-"Content": "Content"
 "Current (saved) status:": "Huidige (opgeslagen) status"
 "Dependencies": "Afhankelijkheden"
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": "Bolt versie <b>%VERSION%</b> gedetecteerd en de cache is gewist. <a href=\\\"%URI%\\\">Controleer de database</a>, als je dat nog niet gedaan hebt.\""
@@ -225,6 +224,7 @@ general.phrase.confirm-remove-files: "Weet je zeker dat je deze bestanden wil ve
 general.phrase.confirm-remove-image: "Weet je zeker dat je deze afbeelding wil verwijderen?"
 general.phrase.confirm-remove-images: "Weet je zeker dat je deze afbeeldingen wil verwijderen?"
 general.phrase.confirm-remove-record: "Weet je zeker dat je dit gegeven wil verwijderen? Dit kan je niet ongedaan maken."
+general.phrase.content: "Content"
 general.phrase.content-type-permissions: "Content type permissies"
 general.phrase.content-types: "Contenttypen"
 general.phrase.create-user-first: "Maak de eerste gebruiker aan"

--- a/app/resources/translations/pl_PL/messages.pl_PL.yml
+++ b/app/resources/translations/pl_PL/messages.pl_PL.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  18 Legacy untranslated messages
 # 167 Untranslated messages
-#  27 Legacy translation messages
-# 384 Translation messages
+#  26 Legacy translation messages
+# 385 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -232,7 +232,6 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Dodaj trochę przykładowych <a href='%url%' class='btn btn-default'>wpisów z tekstem Loripsum</a>"
 "Added to <tt>%key%</tt> '%title%'": "Dodano do <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Wystąpił błąd podczas aktualizowania `%TABLE%`. Błąd %ERROR%"
-"Content": "Zawartość"
 "Current (saved) status:": "Aktualny (zapisany) status:"
 "Do you really want to delete %FOLDERNAME%?": "Czy naprawdę chcesz usunąć %FOLDERNAME%?"
 "Everybody": "Wszyscy"
@@ -371,6 +370,7 @@ general.phrase.confirm-remove-files: "Czy na pewno chcesz usunąć te pliki?"
 general.phrase.confirm-remove-image: "Czy na pewno chcesz usunąć ten obraz?"
 general.phrase.confirm-remove-images: "Czy na pewno chcesz usunąć te obrazy?"
 general.phrase.confirm-remove-record: "Czy na pewno chcesz usunąć ten rekord? Operacja jest nieodwracalna."
+general.phrase.content: "Zawartość"
 general.phrase.content-type-permissions: "Uprawnienia do Typu zawartości"
 general.phrase.content-types: "Typy zawartości"
 general.phrase.create-user-first: "Utwórz pierwszego użytkownika"

--- a/app/resources/translations/pt/messages.pt.yml
+++ b/app/resources/translations/pt/messages.pt.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  11 Legacy untranslated messages
 #  59 Untranslated messages
-#  34 Legacy translation messages
-# 492 Translation messages
+#  33 Legacy translation messages
+# 493 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -109,7 +109,6 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Adicionar registos de amostra com texto <a href='%url%' class='btn btn-default'>Loripsum</a>"
 "Added to <tt>%key%</tt> '%title%'": "Adicionado a <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Ocorreu um erro ao atualizar a '%TABLE%'. O erro é %ERROR%"
-"Content": "Conteúdo"
 "Current (saved) status:": "Estado atual (guardado):"
 "Do you really want to delete %FOLDERNAME%?": "Deseja mesmo eliminar %FOLDERNAME%?"
 "Error reading extensions/composer.json file: %ERROR%": "Erro ao ler o ficheiro extensions/composer.json: %ERROR%"
@@ -273,6 +272,7 @@ general.phrase.confirm-remove-files: "Tem a certeza que deseja eliminar estes fi
 general.phrase.confirm-remove-image: "Tem a certeza que deseja eliminar esta imagem?"
 general.phrase.confirm-remove-images: "Tem a certeza que quer eliminar estas imagens?"
 general.phrase.confirm-remove-record: "Tem a certeza que deseja eliminar este registo? Não será possível reverter."
+general.phrase.content: "Conteúdo"
 general.phrase.content-type-permissions: "Permissões de tipos de conteúdo"
 general.phrase.content-types: "Tipos de conteúdo"
 general.phrase.create-user-first: "Criar o primeiro utilizador"

--- a/app/resources/translations/pt_BR/messages.pt_BR.yml
+++ b/app/resources/translations/pt_BR/messages.pt_BR.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  22 Legacy untranslated messages
 # 249 Untranslated messages
-#  23 Legacy translation messages
-# 302 Translation messages
+#  22 Legacy translation messages
+# 303 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -321,7 +321,6 @@ panel.latest-activity.system: # "Latest system activity"
 "(none)": "(nenhum)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Adicionar uma amostra <a href='%url%' class='btn btn-default'>de registro com Loripsum text</a>"
 "Added to <tt>%key%</tt> '%title%'": "Adicionado a <tt>%key%</tt> '%title%'"
-"Content": "Conteúdo"
 "Current (saved) status:": "Status atual (salvo):"
 "Everybody": "Todos"
 "Excerpt": "Resumo"
@@ -438,6 +437,7 @@ general.phrase.collapse-sidebar: "Minimizar barra lateral"
 general.phrase.configuration: "Configurações"
 general.phrase.configuration-main: "Principais Configurações"
 general.phrase.confirm-delete-user: "Tem certeza que deseja excluir %username%?"
+general.phrase.content: "Conteúdo"
 general.phrase.content-type-permissions: "Permissões de Tipos de Conteúdo"
 general.phrase.content-types: "Tipos de conteúdo"
 general.phrase.create-user-first: "Criar o primeiro usuário"

--- a/app/resources/translations/ru/messages.ru.yml
+++ b/app/resources/translations/ru/messages.ru.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #   9 Legacy untranslated messages
 # 184 Untranslated messages
-#  36 Legacy translation messages
-# 367 Translation messages
+#  35 Legacy translation messages
+# 368 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -243,7 +243,6 @@ panel.latest-activity.by: # "by"
 "(none)": "(отсутствует)"
 "Added to <tt>%key%</tt> '%title%'": "Добавлено <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Произошла ошибка при попытке обновить `%TABLE%`. Ошибка: %ERROR%"
-"Content": "Контент"
 "Current (saved) status:": "Текущий (сохранённый) статус:"
 "Detected Bolt version change to <b>%VERSION%</b>, and the cache has been cleared. Please <a href=\"%URI%\">check the database</a>, if you haven't done so already.": "Обнаружена смена версии Bolt на <b>%VERSION%</b>, кэш был отчищен. Пожалуйста <a href=\"%URI%\">проверьте базу данных</a>, если вы уже этого не сделали."
 "Do you really want to delete %FOLDERNAME%?": "Вы действительно хотите удалить папку %FILENAME%?"
@@ -383,6 +382,7 @@ general.phrase.confirm-remove-files: "Вы действительно хотит
 general.phrase.confirm-remove-image: "Вы действительно хотите удалить это изображение?"
 general.phrase.confirm-remove-images: "Вы действительно хотите удалить эти изображения?"
 general.phrase.confirm-remove-record: "Вы действительно хотите удалить эту запись? Вы не сможете ее восстановить."
+general.phrase.content: "Контент"
 general.phrase.content-type-permissions: "Разрешения для сущности"
 general.phrase.content-types: "Сущности"
 general.phrase.create-user-first: "Создание первого пользователя"

--- a/app/resources/translations/sv_SE/messages.sv_SE.yml
+++ b/app/resources/translations/sv_SE/messages.sv_SE.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  12 Legacy untranslated messages
 #  72 Untranslated messages
-#  33 Legacy translation messages
-# 479 Translation messages
+#  32 Legacy translation messages
+# 480 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -125,7 +125,6 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Lägg till <a href='%url%' class='btn btn-default'>exempeldokument med Lorem Ipsum text</a>"
 "Added to <tt>%key%</tt> '%title%'": "Tillagt i <tt>%key%</tt> '%title%'"
 "An error occured while updating `%TABLE%`. The error is %ERROR%": "Ett fel inträffade under uppdateringen av '%TABLE%'. Felet är %ERROR%"
-"Content": "Innehåll"
 "Current (saved) status:": "Nuvarande (sparad) status:"
 "Do you really want to delete %FOLDERNAME%?": "Vill du verkligen ta bort %FOLDERNAME%?"
 "Everybody": "Alla"
@@ -282,6 +281,7 @@ general.phrase.confirm-remove-files: "Är du säker du vill ta bort dessa filer?
 general.phrase.confirm-remove-image: "Är du säker på att du vill ta bort denna bild?"
 general.phrase.confirm-remove-images: "Är du säker du vill ta bort dessa bilder?"
 general.phrase.confirm-remove-record: "Är du säker du vill ta bort detta inlägg? Det går inte att ångra."
+general.phrase.content: "Innehåll"
 general.phrase.content-type-permissions: "Innehållsrättigheter"
 general.phrase.content-types: "Innehållstyper"
 general.phrase.create-user-first: "Skapa första användaren"

--- a/app/resources/translations/zh_CN/messages.zh_CN.yml
+++ b/app/resources/translations/zh_CN/messages.zh_CN.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  23 Legacy untranslated messages
 # 230 Untranslated messages
-#  22 Legacy translation messages
-# 321 Translation messages
+#  21 Legacy translation messages
+# 322 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -305,7 +305,6 @@ permissions.roles.description.root: # "Built-in superuser role, automatically gr
 "(none)": "(无)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "可以添加一些 <a href='%url%' class='btn btn-default'>带有 Loripsum 示例文本</a> 的记录"
 "Added to <tt>%key%</tt> '%title%'": "添加到 <tt>%key%</tt> '%title%'"
-"Content": "内容"
 "Current (saved) status:": "当前(保存的)状态:"
 "Excerpt": "摘要"
 "Expand sidebar": "展开"
@@ -421,6 +420,7 @@ general.phrase.collapse-sidebar: "折叠侧边栏"
 general.phrase.configuration: "配置"
 general.phrase.configuration-main: "主配置文件"
 general.phrase.confirm-delete-user: "确定要删除 %username% 吗？"
+general.phrase.content: "内容"
 general.phrase.content-type-permissions: "内容格式的权限"
 general.phrase.content-types: "内容格式"
 general.phrase.create-user-first: "创建第一个用户"

--- a/app/resources/translations/zh_TW/messages.zh_TW.yml
+++ b/app/resources/translations/zh_TW/messages.zh_TW.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #  23 Legacy untranslated messages
 # 214 Untranslated messages
-#  22 Legacy translation messages
-# 337 Translation messages
+#  21 Legacy translation messages
+# 338 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -286,7 +286,6 @@ panel.latest-activity.system: # "Latest system activity"
 "(none)": "(無)"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "可以添加一些 <a href='%url%' class='btn btn-default'>帶有 Loripsum 示例文字</a> 的記錄"
 "Added to <tt>%key%</tt> '%title%'": "添加到 <tt>%key%</tt> '%title%'"
-"Content": "內容"
 "Current (saved) status:": "當前(儲存的)狀態:"
 "Excerpt": "摘要"
 "Expand sidebar": "展開"
@@ -403,6 +402,7 @@ general.phrase.collapse-sidebar: "摺疊側邊欄"
 general.phrase.configuration: "配置"
 general.phrase.configuration-main: "主配置檔案"
 general.phrase.confirm-delete-user: "確定要刪除 %username% 嗎？"
+general.phrase.content: "內容"
 general.phrase.content-type-permissions: "內容格式的許可權"
 general.phrase.content-types: "內容格式"
 general.phrase.create-user-first: "創建第一個使用者"

--- a/app/view/twig/_nav/_macros.twig
+++ b/app/view/twig/_nav/_macros.twig
@@ -32,7 +32,7 @@
     {% set allowedamount = 0 %}
     {% set allowedsingle = "" %}
     {% for item in subitems %}
-        {% if item != '-' and isallowed(item.isallowed|default('dashboard')) %}
+        {% if item != '-' %}
             {% set allowedany = true %}
             {% set allowedamount = allowedamount + 1 %}
             {% set allowedsingle = item %}
@@ -46,11 +46,11 @@
         <li{% if class %} class="{{ class }}"{% endif %}>
             {% if allowedamount == 1 and not force_submenu|default(false) %}
                 {% set item = allowedsingle %}
-                <a href="{{ item.link }}">
+                <a href="{{ item.uri }}">
                     {{ icon(item.icon, "icon") }}{{ item.label|default("<em>(" ~ __('general.phrase.no-content') ~ ")</em>")|raw }}
                 </a>
             {% else %}
-                <a  href="{% if popoveritems %}{{ popoveritems.0.link }}{% else %}#{% endif %}" class="menu-pop">
+                <a href="{% if popoveritems %}{{ popoveritems.0.uri|default('') }}{% else %}#{% endif %}" class="menu-pop">
                     {{ label(icon, label) }}
                 </a>
                 <ul class="nav submenu">
@@ -58,9 +58,9 @@
                     {% for item in popoveritems %}
                         {% if item == '-' %}
                             {% set divider = true %}
-                        {% elseif isallowed(item.isallowed|default('dashboard')) %}
+                        {% else %}
                             <li{% if divider %} class="subdivider"{% endif %}>
-                                <a href="{{ item.link }}">
+                                <a href="{{ item.uri|default('') }}">
                                     {{ icon(item.icon) }}{{ item.label|default("<em>(" ~ __('general.phrase.no-content') ~ ")</em>")|raw }}
                                 </a>
                             </li>

--- a/app/view/twig/_nav/_secondary-configuration.twig
+++ b/app/view/twig/_nav/_secondary-configuration.twig
@@ -1,67 +1,24 @@
 {% import '@bolt/_nav/_macros.twig' as nav %}
+{% spaceless %}
+    {% set menu = menus.get('config') %}
+    {% set sub = [] %}
 
-{% set config_menu = app['menu.admin'].get('config') %}
-{% set sub = [
-    {
-        icon: config_menu.get('users').icon,
-        label: config_menu.get('users').label,
-        link: config_menu.get('users').uri,
-        isallowed: config_menu.get('users').permission
-    }, {
-        icon: config_menu.get('config_main').icon,
-        label: config_menu.get('config_main').label,
-        link: config_menu.get('config_main').uri,
-        isallowed: config_menu.get('config_main').permission
-    }, {
-        icon: config_menu.get('config_contenttypes').icon,
-        label: config_menu.get('config_contenttypes').label,
-        link: config_menu.get('config_contenttypes').uri,
-        isallowed: config_menu.get('config_contenttypes').permission
-    }, {
-        icon: config_menu.get('config_taxonomy').icon,
-        label: config_menu.get('config_taxonomy').label,
-        link: config_menu.get('config_taxonomy').uri,
-        isallowed: config_menu.get('config_taxonomy').permission
-    },
-    '-',
-    {
-        icon: config_menu.get('config_menu').icon,
-        label: config_menu.get('config_menu').label,
-        link: config_menu.get('config_menu').uri,
-        isallowed: config_menu.get('config_menu').permission
-    }, {
-        icon: config_menu.get('config_routing').icon,
-        label: config_menu.get('config_routing').label,
-        link: config_menu.get('config_routing').uri,
-        isallowed: config_menu.get('config_routing').permission
-    },
-    '-',
-    {
-        icon: config_menu.get('dbcheck').icon,
-        label: config_menu.get('dbcheck').label,
-        link: config_menu.get('dbcheck').uri,
-        isallowed: config_menu.get('dbcheck').permission
-    }, {
-        icon: config_menu.get('clearcache').icon,
-        label: config_menu.get('clearcache').label,
-        link: config_menu.get('clearcache').uri,
-        isallowed: config_menu.get('clearcache').permission
-    }, {
-        icon: config_menu.get('log_change').icon,
-        label: config_menu.get('log_change').label,
-        link: config_menu.get('log_change').uri,
-        isallowed: config_menu.get('log_change').permission
-    }, {
-        icon: config_menu.get('log_system').icon,
-        label: config_menu.get('log_system').label,
-        link: config_menu.get('log_system').uri,
-        isallowed: config_menu.get('log_system').permission
-    }, {
-        icon: config_menu.get('setup_checks').icon,
-        label: config_menu.get('setup_checks').label,
-        link: config_menu.get('setup_checks').uri,
-        isallowed: config_menu.get('setup_checks').permission
-    }
-] %}
+    {% if menu.has('users') %}{% set sub = sub|merge([menu.get('users')]) %}{% endif %}
+    {% if menu.has('config_main') %}{% set sub = sub|merge([menu.get('config_main')]) %}{% endif %}
+    {% if menu.has('config_contenttypes') %}{% set sub = sub|merge([menu.get('config_contenttypes')]) %}{% endif %}
+    {% if menu.has('config_taxonomy') %}{% set sub = sub|merge([menu.get('config_taxonomy')]) %}{% endif %}
 
+    {% set sub = sub|merge(['-']) %}
+
+    {% if menu.has('config_menu') %}{% set sub = sub|merge([menu.get('config_menu')]) %}{% endif %}
+    {% if menu.has('config_routing') %}{% set sub = sub|merge([menu.get('config_routing')]) %}{% endif %}
+
+    {% set sub = sub|merge(['-']) %}
+
+    {% if menu.has('dbcheck') %}{% set sub = sub|merge([menu.get('dbcheck')]) %}{% endif %}
+    {% if menu.has('clearcache') %}{% set sub = sub|merge([menu.get('clearcache')]) %}{% endif %}
+    {% if menu.has('log_change') %}{% set sub = sub|merge([menu.get('log_change')]) %}{% endif %}
+    {% if menu.has('log_system') %}{% set sub = sub|merge([menu.get('log_system')]) %}{% endif %}
+    {% if menu.has('setup_checks') %}{% set sub = sub|merge([menu.get('setup_checks')]) %}{% endif %}
+{% endspaceless %}
 {{ nav.submenu('fa:cogs', __('general.phrase.configuration'), sub, (page_nav == 'Settings/Configuration')) }}

--- a/app/view/twig/_nav/_secondary-content.twig
+++ b/app/view/twig/_nav/_secondary-content.twig
@@ -1,68 +1,36 @@
 {% import '@bolt/_nav/_macros.twig' as nav %}
 
-{% set definedSubs = [] %}
+{% set content_menus = menus.get('content').children|default([]) %}
 
-{% for slug, contenttype in config.get('contenttypes')  %}
-    {% if isallowed('contenttype:' ~ slug) %}
-        {% set sub_view = {
-            icon: contenttype.icon_many|default(contenttype.show_in_menu ? 'fa:files-o' : 'fa:th-list'),
-            label: __('contenttypes.generic.view', {'%contenttypes%': contenttype.name}),
-            link: path('overview', {'contenttypeslug': slug})
-        } %}
-        {% set sub_new = {
-            icon: 'fa:plus',
-            label: __('contenttypes.generic.new', {'%contenttype%': contenttype.singular_name}),
-            link: path('editcontent', {'contenttypeslug': slug}),
-            isallowed: 'contenttype:' ~ slug ~ ':create'
-        } %}
-        {% set sub = [sub_view, sub_new, '-'] %}
+{# Each "main" ContentType menu and sub-menu #}
+{% if content_menus.main is defined %}
+    {% for name, menu in content_menus.main.children %}
+        {% set active = (page_nav == 'Content/*' and context.contenttype.slug|default == name) %}
+        {% set sub = [] %}
 
-        {# ContentTypes, where show_in_menu is set true #}
-        {% if contenttype.show_in_menu == "true" %}
+        {# View ContentType & New ContentType #}
+        {% if menu.has('view') %}{% set sub = sub|merge([menu.get('view')]) %}{% endif %}
+        {% if menu.has('new') %}{% set sub = sub|merge([menu.get('new')]) %}{% endif %}
+        {% set sub = sub|merge(['-']) %}
 
-            {% setcontent records = slug limit 4 nohydrate orderby '-datechanged' %}
-            {% for record in records %}
-                {% set sub = sub|merge([
-                    {
-                        icon: contenttype.icon_one|default('fa:file-text-o'),
-                        label: record.excerpt(80, true)|replace({"</b>": "&nbsp;</b>"})|trim,
-                        link: path('editcontent', {'contenttypeslug': slug, 'id': record.id})
-                    }
-                ]) %}
-            {% endfor %}
-
-            {% set label = __(['contenttypes', contenttype.slug, 'name', 'plural'], {DEFAULT: contenttype.name}) %}
-            {% set active = (page_nav == 'Content/*' and context.contenttype.slug|default == slug) %}
-
-            {{ nav.submenu(contenttype.icon_many|default(''), label, sub, active, true) }}
-
-        {# ContentTypes, where show_in_menu is set to a custom value or false #}
-        {% else %}
-
-            {% set sub_view = {
-                icon: contenttype.icon_many|default(contenttype.show_in_menu ? 'fa:files-o' : 'fa:th-list'),
-                label: __(['contenttypes', contenttype.slug, 'name', 'plural'], {DEFAULT: contenttype.name}),
-                link: path('overview', {'contenttypeslug': slug})
-            } %}
-
-            {% set key = contenttype.show_in_menu ?: __('general.phrase.other-content') %}
-            {% if definedSubs[key] is defined %}
-                {% for submenuName, submenudef in definedSubs %}
-                    {% if key == submenuName %}
-                        {% set submenudef = submenudef|merge([sub_view]) %}
-                        {% set definedSubs = definedSubs|merge({(submenuName) : submenudef}) %}
-                    {% endif %}
-                {% endfor %}
-            {% else %}
-                {% set definedSubs = definedSubs|merge({(key) : [sub_view]}) %}
-            {% endif %}
-
+        {# Recently edited records for this ContentType #}
+        {% if menu.has('recent') %}
+            {% for record_menu in menu.get('recent').children %}{% set sub = sub|merge([record_menu]) %}{% endfor %}
         {% endif %}
-    {% endif %}
-{% endfor %}
 
-{# Display contenttypes, that have show_in_menu set to false or a custom value in submenus #}
-{% for submenuName, submenudef in definedSubs %}
-    {# Create the submenu and force it to be a submenu #}
-    {{ nav.submenu('fa:th-list', submenuName, submenudef, false, false, false, true) }}
-{% endfor %}
+        {{ nav.submenu(menu.icon, menu.label, sub, active, true) }}
+    {% endfor %}
+{% endif %}
+
+{# "Other" ContentType menu and sub-menu #}
+{% if content_menus.other is defined %}
+    {% set menu = content_menus.other %}
+    {% set key = menu.label %}
+    {% set sub = [] %}
+
+    {% for sub_menu in menu.children %}
+        {% set sub = sub|merge([sub_menu]) %}
+    {% endfor %}
+
+    {{ nav.submenu(menu.icon, menu.label, sub, false, false, null, true) }}
+{% endif %}

--- a/app/view/twig/_nav/_secondary-extensions.twig
+++ b/app/view/twig/_nav/_secondary-extensions.twig
@@ -2,38 +2,27 @@
 
 {# Empty array for submenu #}
 {% set sub = [] %}
-{% set extend_menu = app['menu.admin'].get('extensions') %}
+{% set extend_menu = menus.get('extensions') %}
 
-{% if isallowed('extensions||extensions:config') %}
+{# Add the "view" and "configure" options #}
+{% set sub = sub|merge([{
+    icon: extend_menu.icon,
+    label: (extend_menu.children|length > 0) ? extend_menu.label : __('general.phrase.extensions'),
+    uri: extend_menu.uri
+}]) %}
 
-    {# Add the "view" and "configure" options #}
-    {% set sub = sub|merge([
-        {
-            icon: extend_menu.icon,
-            label: (extend_menu.children|length > 0) ? extend_menu.label : __('general.phrase.extensions'),
-            link: extend_menu.uri,
-            isallowed: extend_menu.permission
-        }
-    ]) %}
-
-    {# Add a divider, if there are any items to print. We don't want a divider with nothing below it #}
-    {% if extend_menu.children|length > 0 %}
-        {% set sub = sub|merge(['-']) %}
-    {% endif %}
-
-
+{# Add a divider, if there are any items to print. We don't want a divider with nothing below it #}
+{% if extend_menu.children|length > 0 %}
+    {% set sub = sub|merge(['-']) %}
 {% endif %}
 
 {# Add the available extensions that have added a menu-item. #}
 {% for extend_submenu in extend_menu.children %}
-    {% set sub = sub|merge([
-        {
-            icon: extend_submenu.icon|default('fa:briefcase'),
-            label: extend_submenu.label,
-            link: extend_submenu.uri,
-            isallowed: extend_submenu.permission
-        }
-    ]) %}
+    {% set sub = sub|merge([{
+        icon: extend_submenu.icon|default('fa:briefcase'),
+        label: extend_submenu.label,
+        uri: extend_submenu.uri
+    }]) %}
 {% endfor %}
 
 {{ nav.submenu('fa:cubes', __('general.phrase.extensions'), sub, (page_nav == 'Settings/ExtendBolt')) }}

--- a/app/view/twig/_nav/_secondary-filemanagement.twig
+++ b/app/view/twig/_nav/_secondary-filemanagement.twig
@@ -1,18 +1,9 @@
 {% import '@bolt/_nav/_macros.twig' as nav %}
+{% spaceless %}
+    {% set menu = menus.get('files') %}
+    {% set sub = [] %}
 
-{% set files_menu = app['menu.admin'].get('files') %}
-{% set sub = [
-    {
-        icon: files_menu.get('files_uploads').icon,
-        label: files_menu.get('files_uploads').label,
-        link: files_menu.get('files_uploads').uri,
-        isallowed: files_menu.get('files_uploads').permission
-    }, {
-        icon: files_menu.get('files_themes').icon,
-        label: files_menu.get('files_themes').label,
-        link: files_menu.get('files_themes').uri,
-        isallowed: files_menu.get('files_themes').permission
-    }
-] %}
-
+    {% if menu.has('files_uploads') %}{% set sub = sub|merge([menu.get('files_uploads')]) %}{% endif %}
+    {% if menu.has('files_themes') %}{% set sub = sub|merge([menu.get('files_themes')]) %}{% endif %}
+{% endspaceless %}
 {{ nav.submenu('fa:folder-open', __('general.phrase.file-management'), sub, (page_nav == 'Settings/FileManagement')) }}

--- a/app/view/twig/_nav/_secondary-search.twig
+++ b/app/view/twig/_nav/_secondary-search.twig
@@ -1,7 +1,0 @@
-<li class="search">
-    <form class="navbar-form">
-        <i class="icon fa fa-search"></i><div class="form-group has-feedback omnisearch" role="search">
-            <select class="form-control" data-omnisearch-url="{{ path('omnisearch') }}"></select>
-        </div>
-    </form>
-</li>

--- a/app/view/twig/_nav/_secondary-translations.twig
+++ b/app/view/twig/_nav/_secondary-translations.twig
@@ -1,18 +1,9 @@
 {% import '@bolt/_nav/_macros.twig' as nav %}
+{% spaceless %}
+    {% set menu = menus.get('translations') %}
+    {% set sub = [] %}
 
-{% set tr_menu = app['menu.admin'].get('translations') %}
-{% set sub = [
-    {
-        icon: tr_menu.get('tr_messages').icon,
-        label: tr_menu.get('tr_messages').label,
-        link: tr_menu.get('tr_messages').uri,
-        isallowed: tr_menu.get('tr_messages').permission
-    }, {
-        icon: tr_menu.get('tr_long_messages').icon,
-        label: tr_menu.get('tr_long_messages').label,
-        link: tr_menu.get('tr_long_messages').uri,
-        isallowed: tr_menu.get('tr_long_messages').permission
-    }
-] %}
-
+    {% if menu.has('tr_messages') %}{% set sub = sub|merge([menu.get('tr_messages')]) %}{% endif %}
+    {% if menu.has('tr_long_messages') %}{% set sub = sub|merge([menu.get('tr_long_messages')]) %}{% endif %}
+{% endspaceless %}
 {{ nav.submenu('fa:flag', __('general.phrase.translations'), sub, (page_nav == 'Settings/Translations')) }}

--- a/app/view/twig/_nav/_secondary.twig
+++ b/app/view/twig/_nav/_secondary.twig
@@ -1,10 +1,17 @@
 {% import '@bolt/_nav/_macros.twig' as nav %}
 
 <ul class="nav">
-    {% if app.session.get('authentication') is not null %}
+    {% if app.session.has('authentication') %}
+        {% set menus = app['menu.admin'] %}
 
         {# Omnisearch: one here for "extra small", the other in the header-navbar #}
-        {{ include('@bolt/_nav/_secondary-search.twig') }}
+        <li class="search">
+            <form class="navbar-form">
+                <i class="icon fa fa-search"></i><div class="form-group has-feedback omnisearch" role="search">
+                    <select class="form-control" data-omnisearch-url="{{ path('omnisearch') }}"></select>
+                </div>
+            </form>
+        </li>
 
         {# Dashboard #}
         {{ nav.link('fa:dashboard', __('general.phrase.dashboard'), 'dashboard', (page_nav == 'Dashboard')) }}
@@ -19,33 +26,16 @@
         {{ include('@bolt/_nav/_secondary-content.twig') }}
 
         {# Settings #}
-        {% if isallowed('settings') %}
-            {% set nav_config %}{{ include('@bolt/_nav/_secondary-configuration.twig') }}{% endset %}
-            {% set nav_files %}{{ include('@bolt/_nav/_secondary-filemanagement.twig') }}{% endset %}
-            {% set nav_trans %}{{ include('@bolt/_nav/_secondary-translations.twig') }}{% endset %}
-            {# Link to Extend Bolt #}
-            {% if app['menu.admin'].get('extensions').children or isallowed('extensions||extensions:config') %}
-                {% set nav_extend %}{{ include('@bolt/_nav/_secondary-extensions.twig') }}{% endset %}
-            {% else %}
-                {% set nav_extend = '' %}
-            {% endif %}
-
-            {% if nav_config|trim or nav_files|trim or nav_trans|trim or nav_extend|trim %}
-                {{ nav.heading(__('general.phrase.settings'), 'fa:wrench') }}
-
-                {{ nav_config }}
-                {{ nav_files }}
-                {{ nav_trans }}
-                {{ nav_extend }}
-            {% endif %}
-
+        {% if menus.has('config') or menus.has('files') or menus.has('translations') or menus.has('extensions') %}
+            {{ nav.heading(__('general.phrase.settings'), 'fa:wrench') }}
         {% endif %}
-
+        {% if menus.has('config') %}{{ include('@bolt/_nav/_secondary-configuration.twig') }}{% endif %}
+        {% if menus.has('files') %}{{ include('@bolt/_nav/_secondary-filemanagement.twig') }}{% endif %}
+        {% if menus.has('translations') %}{{ include('@bolt/_nav/_secondary-translations.twig') }}{% endif %}
+        {% if menus.has('extensions') %}{{ include('@bolt/_nav/_secondary-extensions.twig') }}{% endif %}
 
         {{ nav.collapse() }}
-
     {% else %}
-
         {# View site #}
         <li>
             <a href="{{ path('homepage') }}" target="_blank"><i class="fa fa-external-link-square"></i> {{ __('general.phrase.view-site') }}</a>

--- a/app/view/twig/_nav/_secondary.twig
+++ b/app/view/twig/_nav/_secondary.twig
@@ -15,7 +15,7 @@
         </li>
 
         {# ContentTypes #}
-        {{ nav.heading(__('Content'), 'fa:file-text') }}
+        {{ nav.heading(__('general.phrase.content'), 'fa:file-text') }}
         {{ include('@bolt/_nav/_secondary-content.twig') }}
 
         {# Settings #}

--- a/src/Extension/MenuTrait.php
+++ b/src/Extension/MenuTrait.php
@@ -40,6 +40,10 @@ trait MenuTrait
             $app->extend(
                 'menu.admin',
                 function (MenuEntry $menus) {
+                    if (!$menus->has('extensions')) {
+                        return $menus;
+                    }
+
                     /** @var MenuEntry $menus */
                     $extendMenu = $menus->get('extensions');
 

--- a/src/Helpers/Excerpt.php
+++ b/src/Helpers/Excerpt.php
@@ -2,8 +2,10 @@
 
 namespace Bolt\Helpers;
 
+use Bolt\Collection\MutableBag;
 use Bolt\Legacy\Content as LegacyContent;
 use Bolt\Storage\Entity\Content;
+use Parsedown;
 
 class Excerpt
 {
@@ -94,6 +96,40 @@ class Excerpt
         }
 
         return trim($excerpt);
+    }
+
+    /**
+     * @internal
+     *
+     * @param Content   $entity
+     * @param int       $length
+     * @param Parsedown $markdown
+     *
+     * @return string
+     */
+    public static function createFromEntity(Content $entity, $length, Parsedown $markdown)
+    {
+        $contentType = $entity->getContenttype();
+        $parts = new MutableBag();
+
+        foreach ($contentType->getFields() as $key => $field) {
+            // Skip empty fields, and fields used as 'title'.
+            $fieldValue = $entity->get($key);
+            if (!$fieldValue || $fieldValue === $entity->getTitle()) {
+                continue;
+            }
+            // Add 'text', 'html' and 'textarea' fields.
+            if (in_array($field['type'], ['text', 'html', 'textarea'])) {
+                $parts[] = $fieldValue;
+            }
+            // Add 'markdown' field
+            if ($field['type'] === 'markdown') {
+                $parts[] = $markdown->text($fieldValue);
+            }
+        }
+        $excerpt = new static($parts->join(' '), $entity->getTitle());
+
+        return $excerpt->getExcerpt($length, true, false);
     }
 
     /**

--- a/src/Menu/AdminMenuBuilder.php
+++ b/src/Menu/AdminMenuBuilder.php
@@ -40,7 +40,7 @@ final class AdminMenuBuilder
     {
         // Main configuration
         $configEntry = $root->add(
-            (new MenuEntry('config', 'config'))
+            MenuEntry::create('config', 'config')
                 ->setLabel(Trans::__('general.phrase.configuration'))
                 ->setIcon('fa:cogs')
                 ->setPermission('settings')
@@ -48,7 +48,7 @@ final class AdminMenuBuilder
 
         // Users & Permissions
         $configEntry->add(
-            (new MenuEntry('users'))
+            MenuEntry::create('users')
                 ->setRoute('users')
                 ->setLabel(Trans::__('general.phrase.users-permissions'))
                 ->setIcon('fa:group')
@@ -57,7 +57,7 @@ final class AdminMenuBuilder
 
         // Main configuration
         $configEntry->add(
-            (new MenuEntry('config_main'))
+            MenuEntry::create('config_main')
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'config.yml'])
                 ->setLabel(Trans::__('general.phrase.configuration-main'))
                 ->setIcon('fa:cog')
@@ -66,7 +66,7 @@ final class AdminMenuBuilder
 
         // ContentTypes
         $configEntry->add(
-            (new MenuEntry('config_contenttypes'))
+            MenuEntry::create('config_contenttypes')
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'contenttypes.yml'])
                 ->setLabel(Trans::__('general.phrase.content-types'))
                 ->setIcon('fa:paint-brush')
@@ -75,7 +75,7 @@ final class AdminMenuBuilder
 
         // Taxonomy
         $configEntry->add(
-            (new MenuEntry('config_taxonomy'))
+            MenuEntry::create('config_taxonomy')
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'taxonomy.yml'])
                 ->setLabel(Trans::__('general.phrase.taxonomy'))
                 ->setIcon('fa:tags')
@@ -84,7 +84,7 @@ final class AdminMenuBuilder
 
         // Menus
         $configEntry->add(
-            (new MenuEntry('config_menu'))
+            MenuEntry::create('config_menu')
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'menu.yml'])
                 ->setLabel(Trans::__('general.phrase.menu-setup'))
                 ->setIcon('fa:list')
@@ -93,7 +93,7 @@ final class AdminMenuBuilder
 
         // Routing
         $configEntry->add(
-            (new MenuEntry('config_routing'))
+            MenuEntry::create('config_routing')
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'routing.yml'])
                 ->setLabel(Trans::__('menu.configuration.routing'))
                 ->setIcon('fa:random')
@@ -102,7 +102,7 @@ final class AdminMenuBuilder
 
         // Database checks
         $configEntry->add(
-            (new MenuEntry('dbcheck'))
+            MenuEntry::create('dbcheck')
                 ->setRoute('dbcheck')
                 ->setLabel(Trans::__('general.phrase.check-database'))
                 ->setIcon('fa:database')
@@ -111,7 +111,7 @@ final class AdminMenuBuilder
 
         // Cache flush
         $configEntry->add(
-            (new MenuEntry('clearcache'))
+            MenuEntry::create('clearcache')
                 ->setRoute('clearcache')
                 ->setLabel(Trans::__('general.phrase.clear-cache'))
                 ->setIcon('fa:eraser')
@@ -120,7 +120,7 @@ final class AdminMenuBuilder
 
         // Change log
         $configEntry->add(
-            (new MenuEntry('log_change'))
+            MenuEntry::create('log_change')
                 ->setRoute('changelog')
                 ->setLabel(Trans::__('logs.change-log'))
                 ->setIcon('fa:archive')
@@ -129,7 +129,7 @@ final class AdminMenuBuilder
 
         // System log
         $configEntry->add(
-            (new MenuEntry('log_system'))
+            MenuEntry::create('log_system')
                 ->setRoute('systemlog')
                 ->setLabel(Trans::__('logs.system-log'))
                 ->setIcon('fa:archive')
@@ -138,7 +138,7 @@ final class AdminMenuBuilder
 
         // Set-up checks
         $configEntry->add(
-            (new MenuEntry('setup_checks'))
+            MenuEntry::create('setup_checks')
                 ->setRoute('checks')
                 ->setLabel(Trans::__('menu.configuration.checks'))
                 ->setIcon('fa:support')
@@ -154,7 +154,7 @@ final class AdminMenuBuilder
     private function addFileManagement(MenuEntry $root)
     {
         $fileEntry = $root->add(
-            (new MenuEntry('files', 'files'))
+            MenuEntry::create('files', 'files')
                 ->setLabel(Trans::__('general.phrase.extensions'))
                 ->setIcon('fa:cubes')
                 ->setPermission('extensions')
@@ -162,7 +162,7 @@ final class AdminMenuBuilder
 
         // Uploaded files
         $fileEntry->add(
-            (new MenuEntry('files_uploads'))
+            MenuEntry::create('files_uploads')
                 ->setRoute('files')
                 ->setLabel(Trans::__('general.phrase.general.phrase.uploaded-files'))
                 ->setIcon('fa:folder-open-o')
@@ -171,7 +171,7 @@ final class AdminMenuBuilder
 
         // Themes
         $fileEntry->add(
-            (new MenuEntry('files_themes'))
+            MenuEntry::create('files_themes')
                 ->setRoute('files', ['namespace' => 'themes'])
                 ->setLabel(Trans::__('general.phrase.view-edit-templates'))
                 ->setIcon('fa:desktop')
@@ -187,14 +187,14 @@ final class AdminMenuBuilder
     private function addTranslations(MenuEntry $root)
     {
         $translationEntry = $root->add(
-            (new MenuEntry('translations', 'tr'))
+            MenuEntry::create('translations', 'tr')
                 ->setLabel(Trans::__('general.phrase.translations'))
                 ->setPermission('translation')
         );
 
         // Messages
         $translationEntry->add(
-            (new MenuEntry('tr_messages'))
+            MenuEntry::create('tr_messages')
                 ->setRoute('translation', ['domain' => 'messages'])
                 ->setLabel(Trans::__('general.phrase.messages'))
                 ->setIcon('fa:flag')
@@ -203,7 +203,7 @@ final class AdminMenuBuilder
 
         // Long messages
         $translationEntry->add(
-            (new MenuEntry('tr_long_messages'))
+            MenuEntry::create('tr_long_messages')
                 ->setRoute('translation', ['domain' => 'infos'])
                 ->setLabel(Trans::__('general.phrase.long-messages'))
                 ->setIcon('fa:flag')
@@ -219,7 +219,7 @@ final class AdminMenuBuilder
     private function addExtend(MenuEntry $root)
     {
         $root->add(
-            (new MenuEntry('extensions', 'extensions'))
+            MenuEntry::create('extensions', 'extensions')
                 ->setLabel(Trans::__('general.phrase.extensions-overview'))
                 ->setIcon('fa:cubes')
                 ->setPermission('extensions')

--- a/src/Menu/Builder/AdminContent.php
+++ b/src/Menu/Builder/AdminContent.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Bolt\Menu\Builder;
+
+use Bolt\Collection\Bag;
+use Bolt\Menu\MenuEntry;
+use Bolt\Translation\Translator as Trans;
+
+/**
+ * Bolt admin (back-end) content menu builder.
+ *
+ * @internal Backwards compatibility not guaranteed on this class presently.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class AdminContent
+{
+    /** @var Bag */
+    private $contentTypes;
+
+    /**
+     * Constructor.
+     *
+     * @param Bag $contentTypes
+     */
+    public function __construct(Bag $contentTypes)
+    {
+        $this->contentTypes = $contentTypes;
+    }
+
+    /**
+     * Build the "Content" menu.
+     *
+     * @param MenuEntry $root
+     *
+     * @return MenuEntry
+     */
+    public function build(MenuEntry $root)
+    {
+        // Top level header for ContentTypes
+        $contentRoot = $root->add(
+            MenuEntry::create('content', '')
+                ->setLabel(Trans::__('general.phrase.content'))
+                ->setIcon('fa:file-text')
+                ->setPermission('dashboard')
+        );
+        $mainContentRoot = $contentRoot->add(
+            MenuEntry::create('main')
+                ->setPermission('dashboard')
+        );
+
+        // ContentTypes, where show_in_menu is set true
+        $contentTypes = $this->contentTypes->filter(function ($k, $v) {
+            return $v['show_in_menu'] === true;
+        });
+        foreach ($contentTypes as $name => $contentType) {
+            $this->addContentType($mainContentRoot, $name, $contentType);
+        }
+
+        // ContentTypes, where show_in_menu is set to a custom value or false
+        $this->addOtherContentTypes($contentRoot);
+
+        return $root;
+    }
+
+    /**
+     * Add a ContentType's menu and sub-menu.
+     *
+     * @param MenuEntry $contentRoot
+     * @param string    $contentTypeKey
+     * @param Bag       $contentType
+     */
+    private function addContentType(MenuEntry $contentRoot, $contentTypeKey, Bag $contentType)
+    {
+        // Named ContentType root
+        $contentTypeEntry = $contentRoot->add(
+            MenuEntry::create($contentTypeKey)
+                ->setRoute('overview', ['contenttypeslug' => $contentTypeKey])
+                ->setLabel($contentType->get('name'))
+                ->setIcon($contentType->get('icon_many'))
+                ->setPermission('contenttype:' . $contentTypeKey)
+        );
+        // View
+        $contentTypeEntry->add(
+            MenuEntry::create('view')
+                ->setRoute('overview', ['contenttypeslug' => $contentTypeKey])
+                ->setLabel(Trans::__('contenttypes.generic.view', ['%contenttypes%' => $contentType->get('name')]))
+                ->setIcon($contentType->get('icon_many', 'fa:files-o'))
+                ->setPermission('contenttype:' . $contentTypeKey)
+        );
+        // New
+        $contentTypeEntry->add(
+            MenuEntry::create('new')
+                ->setRoute('editcontent', ['contenttypeslug' => $contentTypeKey])
+                ->setLabel(Trans::__('contenttypes.generic.new', ['%contenttype%' => $contentType->get('singular_name')]))
+                ->setIcon('fa:plus')
+                ->setPermission('contenttype:' . $contentTypeKey . ':create')
+        );
+    }
+
+    /**
+     * Add the "Other content" menu.
+     *
+     * @param MenuEntry $contentRoot
+     */
+    private function addOtherContentTypes(MenuEntry $contentRoot)
+    {
+        $contentTypes = $this->contentTypes->filter(function ($k, $v) {
+            return $v['show_in_menu'] !== true;
+        });
+        if ($contentTypes->isEmpty()) {
+            return;
+        }
+
+        // Other content root
+        $otherEntry = $contentRoot->add(
+            MenuEntry::create('other')
+                ->setLabel(Trans::__('general.phrase.other-content'))
+                ->setIcon('fa:th-list')
+                ->setPermission('dashboard')
+        );
+
+        // Other content children
+        foreach ($contentTypes as $contentTypeKey => $contentType) {
+            /** @var Bag $contentType */
+            $otherEntry->add(
+                MenuEntry::create($contentTypeKey)
+                    ->setRoute('overview', ['contenttypeslug' => $contentTypeKey])
+                    ->setLabel($contentType->get('name'))
+                    ->setIcon($contentType->get('icon_many', 'fa:th-list'))
+                    ->setPermission('contenttype:' . $contentTypeKey)
+            );
+        }
+    }
+}

--- a/src/Menu/Builder/AdminMenu.php
+++ b/src/Menu/Builder/AdminMenu.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Bolt\Menu;
+namespace Bolt\Menu\Builder;
 
+use Bolt\Menu\MenuEntry;
 use Bolt\Translation\Translator as Trans;
 
 /**
@@ -12,7 +13,7 @@ use Bolt\Translation\Translator as Trans;
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
  */
-final class AdminMenuBuilder
+final class AdminMenu
 {
     /**
      * Build the menus.

--- a/src/Menu/Builder/AdminMenu.php
+++ b/src/Menu/Builder/AdminMenu.php
@@ -41,7 +41,7 @@ final class AdminMenu
     {
         // Main configuration
         $configEntry = $root->add(
-            MenuEntry::create('config', 'config')
+            MenuEntry::create('config')
                 ->setLabel(Trans::__('general.phrase.configuration'))
                 ->setIcon('fa:cogs')
                 ->setPermission('settings')
@@ -62,7 +62,7 @@ final class AdminMenu
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'config.yml'])
                 ->setLabel(Trans::__('general.phrase.configuration-main'))
                 ->setIcon('fa:cog')
-                ->setPermission('files:config')
+                ->setPermission('fileedit')
         );
 
         // ContentTypes
@@ -71,7 +71,7 @@ final class AdminMenu
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'contenttypes.yml'])
                 ->setLabel(Trans::__('general.phrase.content-types'))
                 ->setIcon('fa:paint-brush')
-                ->setPermission('files:config')
+                ->setPermission('fileedit')
         );
 
         // Taxonomy
@@ -80,7 +80,7 @@ final class AdminMenu
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'taxonomy.yml'])
                 ->setLabel(Trans::__('general.phrase.taxonomy'))
                 ->setIcon('fa:tags')
-                ->setPermission('files:config')
+                ->setPermission('fileedit')
         );
 
         // Menus
@@ -89,7 +89,7 @@ final class AdminMenu
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'menu.yml'])
                 ->setLabel(Trans::__('general.phrase.menu-setup'))
                 ->setIcon('fa:list')
-                ->setPermission('files:config')
+                ->setPermission('fileedit')
         );
 
         // Routing
@@ -98,7 +98,7 @@ final class AdminMenu
                 ->setRoute('fileedit', ['namespace' => 'config', 'file' => 'routing.yml'])
                 ->setLabel(Trans::__('menu.configuration.routing'))
                 ->setIcon('fa:random')
-                ->setPermission('files:config')
+                ->setPermission('fileedit')
         );
 
         // Database checks
@@ -155,10 +155,10 @@ final class AdminMenu
     private function addFileManagement(MenuEntry $root)
     {
         $fileEntry = $root->add(
-            MenuEntry::create('files', 'files')
-                ->setLabel(Trans::__('general.phrase.extensions'))
+            MenuEntry::create('files')
+                ->setLabel(Trans::__('general.phrase.file-management'))
                 ->setIcon('fa:cubes')
-                ->setPermission('extensions')
+                ->setPermission('files')
         );
 
         // Uploaded files
@@ -188,7 +188,7 @@ final class AdminMenu
     private function addTranslations(MenuEntry $root)
     {
         $translationEntry = $root->add(
-            MenuEntry::create('translations', 'tr')
+            MenuEntry::create('translations')
                 ->setLabel(Trans::__('general.phrase.translations'))
                 ->setPermission('translation')
         );
@@ -220,7 +220,8 @@ final class AdminMenu
     private function addExtend(MenuEntry $root)
     {
         $root->add(
-            MenuEntry::create('extensions', 'extensions')
+            MenuEntry::create('extensions')
+                ->setRoute('extensions')
                 ->setLabel(Trans::__('general.phrase.extensions-overview'))
                 ->setIcon('fa:cubes')
                 ->setPermission('extensions')

--- a/src/Menu/MenuEntry.php
+++ b/src/Menu/MenuEntry.php
@@ -64,7 +64,7 @@ class MenuEntry implements Serializable
      * @param string $name
      * @param string $uri
      */
-    public function __construct($name, $uri = '')
+    public function __construct($name, $uri = null)
     {
         $this->name = $name;
         $this->uri = $uri;
@@ -76,7 +76,7 @@ class MenuEntry implements Serializable
      *
      * @return MenuEntry
      */
-    public static function create($name, $uri = '')
+    public static function create($name, $uri = null)
     {
         return new static($name, $uri);
     }
@@ -127,7 +127,7 @@ class MenuEntry implements Serializable
             return $this->uri;
         }
 
-        return $this->parent->getUri() . '/' . $this->uri;
+        return $this->uri ? $this->parent->getUri() . '/' . $this->uri : $this->uri;
     }
 
     /**

--- a/src/Menu/MenuEntry.php
+++ b/src/Menu/MenuEntry.php
@@ -227,7 +227,11 @@ class MenuEntry implements Serializable
      */
     public function get($name)
     {
-        return $this->children[$name];
+        if (isset($this->children[$name])) {
+            return $this->children[$name];
+        }
+
+        throw new \InvalidArgumentException(sprintf('Menu entry %s does not have a child named "%s"', $this->name, $name));
     }
 
     /**

--- a/src/Menu/MenuEntry.php
+++ b/src/Menu/MenuEntry.php
@@ -235,6 +235,28 @@ class MenuEntry implements Serializable
     }
 
     /**
+     * Returns true if the child is defined.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function has($name)
+    {
+        return isset($this->children[$name]);
+    }
+
+    /**
+     * Remove a menu entry's named child.
+     *
+     * @param string $name
+     */
+    public function remove($name)
+    {
+        unset($this->children[$name]);
+    }
+
+    /**
      * Return the menu entry's children.
      *
      * @return MenuEntry[]

--- a/src/Menu/MenuEntry.php
+++ b/src/Menu/MenuEntry.php
@@ -69,6 +69,17 @@ class MenuEntry
     }
 
     /**
+     * @param string $name
+     * @param string $uri
+     *
+     * @return MenuEntry
+     */
+    public static function create($name, $uri = '')
+    {
+        return new static($name, $uri);
+    }
+
+    /**
      * Set the uri to be generated with given route name and params.
      *
      * @param string $routeName

--- a/src/Menu/MenuEntry.php
+++ b/src/Menu/MenuEntry.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Menu;
 
+use Bolt\Common\Serialization;
+use Serializable;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -12,7 +14,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  * @author Carson Full <carsonfull@gmail.com>
  */
-class MenuEntry
+class MenuEntry implements Serializable
 {
     /** @var MenuEntry|null */
     protected $parent;
@@ -236,5 +238,37 @@ class MenuEntry
     public function children()
     {
         return $this->children;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return Serialization::dump([
+            'parent'     => $this->parent,
+            'children'   => $this->children,
+            'name'       => $this->name,
+            'label'      => $this->label,
+            'icon'       => $this->icon,
+            'permission' => $this->getPermission(),
+            'uri'        => $this->getUri(),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        $data = Serialization::parse($serialized);
+
+        $this->parent = $data['parent'];
+        $this->children = $data['children'];
+        $this->name = $data['name'];
+        $this->label = $data['label'];
+        $this->icon = $data['icon'];
+        $this->permission = $data['permission'];
+        $this->uri = $data['uri'];
     }
 }

--- a/src/Menu/Resolver/Access.php
+++ b/src/Menu/Resolver/Access.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Bolt\Menu\Resolver;
+
+use Bolt\AccessControl\Permissions;
+use Bolt\Menu\MenuEntry;
+use Bolt\Storage\Entity;
+
+/**
+ * Menu access permission resolver.
+ *
+ * @internal
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class Access
+{
+    /** @var Permissions */
+    private $permissions;
+
+    /**
+     * Constructor.
+     *
+     * @param Permissions $permissions
+     */
+    public function __construct(Permissions $permissions)
+    {
+        $this->permissions = $permissions;
+    }
+
+    /**
+     * Resolve the access permissions on each menu child recursively, and
+     * remove the child if access is not granted. Should a parent have no
+     * remaining children & isn't routed, it should then be removed.
+     *
+     * @param MenuEntry    $menu
+     * @param Entity\Users $user
+     */
+    public function resolve(MenuEntry $menu, Entity\Users $user)
+    {
+        foreach ($menu->children() as $name => $child) {
+            $this->doResolve($menu, $child, $user);
+
+            if ($child->children() === [] && $child->getUri() === null) {
+                $menu->remove($name);
+            }
+        }
+    }
+
+    /**
+     * @param MenuEntry    $parent
+     * @param MenuEntry    $child
+     * @param Entity\Users $user
+     */
+    private function doResolve(MenuEntry $parent, MenuEntry $child, Entity\Users $user)
+    {
+        $perm = $child->getPermission();
+        if ($perm && !$this->permissions->isAllowed($perm, $user->toArray())) {
+            $parent->remove($child->getName());
+
+            return;
+        }
+        foreach ($child->children() as $grandchild) {
+            $this->doResolve($child, $grandchild, $user);
+        }
+    }
+}

--- a/src/Menu/Resolver/RecentlyEdited.php
+++ b/src/Menu/Resolver/RecentlyEdited.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Bolt\Menu\Resolver;
+
+use Bolt\Collection\Bag;
+use Bolt\Common\Str;
+use Bolt\Helpers\Excerpt;
+use Bolt\Menu\MenuEntry;
+use Bolt\Storage\Entity;
+use Bolt\Storage\EntityManager;
+use Doctrine\DBAL\Exception\TableNotFoundException;
+use Parsedown;
+
+/**
+ * Recently edited record resolver.
+ *
+ * @internal Backwards compatibility not guaranteed on this class presently.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class RecentlyEdited
+{
+    /** @var EntityManager */
+    private $em;
+    /** @var Parsedown */
+    private $markdown;
+
+    /**
+     * Constructor.
+     *
+     * @param EntityManager $em
+     * @param Parsedown     $markdown
+     */
+    public function __construct(EntityManager $em, Parsedown $markdown)
+    {
+        $this->em = $em;
+        $this->markdown = $markdown;
+    }
+
+    /**
+     * @param MenuEntry $menu
+     * @param Bag       $contentType
+     */
+    public function resolve(MenuEntry $menu, Bag $contentType)
+    {
+        $contentRoot = $menu->get('content');
+        if (!$contentRoot->has('main')) {
+            return;
+        }
+
+        foreach ($contentRoot->get('main')->children() as $name => $contentMenu) {
+            $this->addRecentlyEdited($contentMenu, $name, $contentType);
+        }
+    }
+
+    /**
+     * @param MenuEntry $contentMenu
+     * @param string    $contentTypeKey
+     * @param Bag       $contentType
+     */
+    private function addRecentlyEdited(MenuEntry $contentMenu, $contentTypeKey, Bag $contentType)
+    {
+        $entities = $this->getRecords($contentTypeKey, 4);
+        if (!$entities) {
+            return;
+        }
+        // Parent for this ContentType recently edited
+        $listingMenu = $contentMenu->add(
+            MenuEntry::create('recent')
+                ->setPermission('contenttype:' . $contentTypeKey)
+        );
+
+        // Each of the ContentType record entries.
+        foreach ($entities as $entity) {
+            $label = Str::replaceFirst(Excerpt::createFromEntity($entity, 80, $this->markdown), '</b>', '&nbsp;</b>');
+
+            /**@var Entity\Content $entity */
+            $listingMenu->add(
+                MenuEntry::create($entity->getSlug())
+                    ->setRoute('editcontent', ['contenttypeslug' => $contentTypeKey, 'id' => $entity->getId()])
+                    ->setLabel($label)
+                    ->setIcon($contentType->get('icon_one', 'fa:file-text-o'))
+            );
+        }
+    }
+
+    /**
+     * Fetch recently changed records for a given ContentType.
+     *
+     * @param string $contentTypeKey
+     * @param int    $limit
+     *
+     * @return Entity\Content[]
+     */
+    private function getRecords($contentTypeKey, $limit)
+    {
+        $repo = $this->em->getRepository($contentTypeKey);
+        $qb = $repo
+            ->createQueryBuilder()
+            ->setMaxResults($limit)
+            ->orderBy('datechanged', 'DESC')
+        ;
+
+        try {
+            return $repo->findWith($qb);
+        } catch (TableNotFoundException $e) {
+            return null;
+        }
+    }
+}

--- a/src/Omnisearch.php
+++ b/src/Omnisearch.php
@@ -2,6 +2,7 @@
 
 namespace Bolt;
 
+use Bolt\Menu\MenuEntry;
 use Bolt\Translation\Translator as Trans;
 use Silex;
 use Symfony\Component\Finder\Finder;
@@ -219,8 +220,13 @@ class Omnisearch
         if (!$this->showExtensions) {
             return;
         }
+        /** @var MenuEntry $menus */
+        $menus = $this->app['menu.admin'];
+        if (!$menus->has('extensions')) {
+            return;
+        }
+        $extensionsMenu = $menus->get('extensions')->children();
 
-        $extensionsMenu = $this->app['menu.admin']->get('extensions')->children();
         $index = 0;
         /** @var \Bolt\Menu\MenuEntry $extension */
         foreach ($extensionsMenu as $extension) {

--- a/src/Provider/MenuServiceProvider.php
+++ b/src/Provider/MenuServiceProvider.php
@@ -53,6 +53,9 @@ class MenuServiceProvider implements ServiceProviderInterface
                 $builder = new Builder\AdminContent($contentTypes);
                 $builder->build($rootEntry);
 
+                $resolver = new Resolver\RecentlyEdited($app['storage'], $app['markdown']);
+                $resolver->resolve($rootEntry, $contentTypes);
+
                 $resolver = new Resolver\Access($app['permissions']);
                 $resolver->resolve($rootEntry, $user);
 

--- a/src/Provider/MenuServiceProvider.php
+++ b/src/Provider/MenuServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Bolt\Provider;
 
+use Bolt\Collection\Bag;
+use Bolt\Menu\Builder;
 use Bolt\Menu\AdminMenuBuilder;
 use Bolt\Menu\MenuBuilder;
 use Bolt\Menu\MenuEntry;
@@ -39,6 +41,10 @@ class MenuServiceProvider implements ServiceProviderInterface
                 $rootEntry = MenuEntry::createRoot($app['url_generator'], $baseUrl);
 
                 $builder = new AdminMenuBuilder();
+                $builder->build($rootEntry);
+
+                $contentTypes = Bag::fromRecursive($app['config']->get('contenttypes'));
+                $builder = new Builder\AdminContent($contentTypes);
                 $builder->build($rootEntry);
 
                 return $rootEntry;

--- a/src/Provider/MenuServiceProvider.php
+++ b/src/Provider/MenuServiceProvider.php
@@ -4,7 +4,6 @@ namespace Bolt\Provider;
 
 use Bolt\Collection\Bag;
 use Bolt\Menu\Builder;
-use Bolt\Menu\AdminMenuBuilder;
 use Bolt\Menu\MenuBuilder;
 use Bolt\Menu\MenuEntry;
 use Silex\Application;
@@ -40,7 +39,7 @@ class MenuServiceProvider implements ServiceProviderInterface
 
                 $rootEntry = MenuEntry::createRoot($app['url_generator'], $baseUrl);
 
-                $builder = new AdminMenuBuilder();
+                $builder = new Builder\AdminMenu();
                 $builder->build($rootEntry);
 
                 $contentTypes = Bag::fromRecursive($app['config']->get('contenttypes'));

--- a/tests/phpunit/unit/Extension/MenuTraitTest.php
+++ b/tests/phpunit/unit/Extension/MenuTraitTest.php
@@ -2,7 +2,11 @@
 
 namespace Bolt\Tests\Extension;
 
+use Bolt\AccessControl\Permissions;
+use Bolt\AccessControl\Token\Token;
 use Bolt\Menu\MenuEntry;
+use Bolt\Storage\Entity\Authtoken;
+use Bolt\Storage\Entity\Users;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Tests\Extension\Mock\MenuExtension;
 use Bolt\Tests\Extension\Mock\NormalExtension;
@@ -17,6 +21,7 @@ class MenuTraitTest extends BoltUnitTest
     public function testEmptyMenus()
     {
         $app = $this->getApp();
+
         $ext = new NormalExtension();
         $baseDir = $app['filesystem']->getDir('extensions://local/bolt/menu');
         $ext->setBaseDirectory($baseDir);
@@ -54,5 +59,25 @@ class MenuTraitTest extends BoltUnitTest
         $this->assertSame('/bolt/extensions/look-up-live', $children['Drop Bear']->getUri());
         $this->assertSame('fa-thumbs-o-down', $children['Drop Bear']->getIcon());
         $this->assertSame('dangerous', $children['Drop Bear']->getPermission());
+    }
+
+    protected function getApp($boot = true)
+    {
+        $app = parent::getApp();
+        $token = new Token(New Users([]), new Authtoken([]));
+        $app['session']->set('authentication', $token);
+        $permissions = $this->getMockBuilder(Permissions::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['isAllowed'])
+            ->getMock()
+        ;
+        $permissions
+            ->expects($this->any())
+            ->method('isAllowed')
+            ->willReturn(true)
+        ;
+        $app['permissions'] = $permissions;
+
+        return $app;
     }
 }


### PR DESCRIPTION
* Fixes: #6896 — _"(No content.)"_ in recently edited menus
* Finishes: Admin menu generation in PHP instead of Twig 

So a bit more than I expected at this stage, but let's talk …

## Service definition

Is now overloaded and ugly. The menu construction itself needs a class of its own, but there are a few things to consider. Obviously happy for ideas, but the timer has started :wink: 

## Extension driven menus

This is a complete _CharlieFoxtrot_ currently, and we're not going back! :stuck_out_tongue_winking_eye: So we need to make some calls here. They're logically broken, let's get this right :smile: 

Extension driven menus require the `extensions` permission as a default in order for the parent menu to persist, and that makes no sense that to use MenuEditor a person should also have the level of access to add/remove extensions. 

Suggestions from me, either:
  - Create a new top-level menu group that requires the `settings` permission at the top-level, and then the extensions just define the menu's permission 
  - Stop kidding ourselves that extensions are going to flood the menu (#1694 & #3461), when it's easy enough to do with ContentTypes, e.g.

![image](https://user-images.githubusercontent.com/1427081/29269800-ca3979e8-80f3-11e7-8c6e-8dd346956ed9.png)

