### PR TITLE
[3.3] Performance: Replace slow |excerpt use with |slice

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -186,9 +186,9 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
             <td class="username hidden-sm hidden-xs">
                 <i class="fa fa-user fa-fw"></i>
                 {% if content.user.displayname is defined %}
-                {{ content.user.displayname|excerpt(15) }}
+                {{ content.user.displayname|slice(0, 15) }}
             {% else %}
-                <s>{{ content.values.ownerid|excerpt(15) }}</s>
+                <s>{{ content.values.ownerid }}</s>
                 {% endif %}<br>
                 {% if content.status == 'timed' %}
                     <i class="fa fa-clock-o status-timed fa-fw"></i> {{ buic_moment(content.datepublish) }}<br>
@@ -269,7 +269,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                         <a class="nolink">
                             {{ __('general.phrase.author-colon') }} <strong><i class="fa fa-user"></i>
                                 {% if content.user.displayname is defined %}
-                                    {{ content.user.displayname|excerpt(15) }}
+                                    {{ content.user.displayname|slice(0, 15) }}
                                 {% else %}
                                     <s>user {{ content.values.ownerid }}</s>
                                 {% endif %}</strong>
@@ -280,7 +280,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                     </li>
                     <li>
                         <a class="nolink">{{ __('general.phrase.slug-colon') }}
-                            <code title="{{ content.slug }}">{{ content.slug|excerpt(24) }}</code>
+                            <code title="{{ content.slug }}">{{ content.slug|slice(0, 24) }}</code>
                         </a>
                     </li>
                     <li>
@@ -302,13 +302,13 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                         {% if values|length > 1 %}
                             <li>
                                 <a class="nolink">{{ config.get('taxonomy')[taxonomyslug].name }}:
-                                    <i class="fa fa-tag"></i> {{ values|join(", ")|excerpt(24) }}
+                                    <i class="fa fa-tag"></i> {{ values|join(", ")|slice(0, 24) }}
                                 </a>
                             </li>
                         {% else %}
                             <li>
                                 <a class="nolink">{{ config.get('taxonomy')[taxonomyslug].singular_name }}:
-                                    <i class="fa fa-tag"></i> {{ values|first|excerpt(24) }}
+                                    <i class="fa fa-tag"></i> {{ values|first|slice(0, 24) }}
                                 </a>
                             </li>
                         {% endif %}

--- a/app/view/twig/_macro/_macro.twig
+++ b/app/view/twig/_macro/_macro.twig
@@ -17,8 +17,8 @@
  #}
 {% macro contentlink_by_id(contenttype, title, content_id) %}
     {% spaceless %}
-        <a href="{{ path('editcontent', {'contenttypeslug': contenttype.slug, 'id': content_id}) }}">
-            {{- title|excerpt(70)|default("<em>(" ~ __('general.phrase.no-title') ~ ")</em>")|raw -}}
+        <a href="{{ path('editcontent', { 'contenttypeslug': contenttype.slug, 'id': content_id }) }}">
+            {{- title|striptags|slice(0, 70)|default("<em>(" ~ __('general.phrase.no-title') ~ ")</em>")|raw -}}
         </a>
     {% endspaceless %}
 {% endmacro %}

--- a/app/view/twig/_nav/_primary.twig
+++ b/app/view/twig/_nav/_primary.twig
@@ -48,7 +48,7 @@
     <li class="dropdown">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">
             {# FIXME DTO: When the session hits the check timer, the user object can be empty #}
-            <i class="fa fa-fw fa-user"></i> <span>{{ user.displayname|default()|excerpt(16) }}</span> <i class="fa fa-caret-down"></i>
+            <i class="fa fa-fw fa-user"></i> <span>{{ user.displayname|default()|slice(0, 16) }}</span> <i class="fa fa-caret-down"></i>
         </a>
         <ul class="dropdown-menu dropdown-user" role="menu" >
             <li>

--- a/app/view/twig/async/browse.twig
+++ b/app/view/twig/async/browse.twig
@@ -20,11 +20,11 @@
                 {# dir \Bolt\Filesystem\Handler\DirectoryInterface #}
                 {%- if not loop.last or loop.first -%}
                     <a href="#" data-fbrowser-chdir="{{ path('asyncbrowse', {'namespace': dir.mountPoint, 'path': dir.path}) }}">
-                        {{- (dir.filename ?: dir.mountPoint)|excerpt(40)|shy -}}
+                        {{- (dir.filename ?: dir.mountPoint)|slice(0, 40)|shy -}}
                     </a>
                     {{- loop.first ? '://' : '/' -}}
                 {%- else -%}
-                    {{- (dir.filename ?: dir.mountPoint)|excerpt(40)|shy -}}
+                    {{- (dir.filename ?: dir.mountPoint)|slice(0, 40)|shy -}}
                 {%- endif -%}
             {% endfor %}
         </h4>

--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -5,12 +5,12 @@
             {% if v is iterable %}
                 <em>(object / array)</em>
             {% else %}
-                {{ v|excerpt(200)|default('<em>(empty)</em>')|raw }}
+                {{ v|slice(0, 200)|default('<em>(empty)</em>')|raw }}
             {% endif %}
             {% if not loop.last %}<br>{% endif %}
         {% endfor %}
     {% else %}
-        {{ value|excerpt(200)|default('<em>(empty)</em>')|raw }}
+        {{ value|slice(0, 200)|default('<em>(empty)</em>')|raw }}
     {% endif %}
 {% endmacro %}
 

--- a/app/view/twig/files/_files.twig
+++ b/app/view/twig/files/_files.twig
@@ -22,7 +22,7 @@
                         <a href="{{ file.path|thumbnail(1000, 1000, 'r') }}"
                            class="magnific"
                            title="Image: {{ file.filename }}">
-                            <b>{{ file.filename|excerpt(80)|shy }}</b>
+                            <b>{{ file.filename|slice(0, 80)|shy }}</b>
                         </a>
 
                     {% elseif file.extension in ['twig', 'txt', 'html', 'md', 'markdown', 'json', 'htm', 'scss', 'css', 'less', 'js', 'yml'] %}
@@ -30,18 +30,18 @@
                         <i class="fa fa-fw fa-file-code-o"></i>
 
                         <a href="{{ path('fileedit', {'namespace': file.mountPoint, 'file': file.path}) }}">
-                            <b>{{ file.filename|excerpt(80)|shy }}</b>
+                            <b>{{ file.filename|slice(0, 80)|shy }}</b>
                         </a>
 
                     {% else %}
                         {% if file.hasUrl %}
                             <i class="fa fa-fw fa-link"></i>
                             <a href="{{ file.url }}" target="_blank">
-                                <b>{{ file.filename|excerpt(80)|shy }}</b>
+                                <b>{{ file.filename|slice(0, 80)|shy }}</b>
                             </a>
                         {% else %}
                             <i class="fa fa-fw fa-file-o disabled"></i>
-                            <b class="disabled">{{ file.filename|excerpt(80)|shy }}</b>
+                            <b class="disabled">{{ file.filename|slice(0, 80)|shy }}</b>
                         {% endif %}
                     {% endif %}
                 </td>

--- a/app/view/twig/files/_folders.twig
+++ b/app/view/twig/files/_folders.twig
@@ -22,7 +22,7 @@
                 <td class="filename">
                     <i class="fa fa-fw fa-folder-open-o"></i>
                     <a href="{{ path('files', pathoptions|default({})|merge({'path': directory.path, 'namespace': directory.mountPoint})) }}">
-                        <b>{{ directory.filename|excerpt(60)|shy }}</b>
+                        <b>{{ directory.filename|slice(0, 60)|shy }}</b>
                     </a>
                 </td>
                 <td class="folder-meta">

--- a/app/view/twig/files_ck/_files.twig
+++ b/app/view/twig/files_ck/_files.twig
@@ -16,11 +16,11 @@
                     {% if file.hasUrl %}
                         <i class="fa fa-fw fa-file-image-o"></i>
                         <a class="filebrowserCallbackLink" href="{{ file.url }}">
-                            <b>{{ file.filename|excerpt(60)|shy }}</b>
+                            <b>{{ file.filename|slice(0, 60)|shy }}</b>
                         </a>
                     {% else %}
                         <i class="fa fa-fw fa-file-image-o disabled"></i>
-                        <b class="disabled">{{ file.filename|excerpt(60)|shy }}</b>
+                        <b class="disabled">{{ file.filename|slice(0, 60)|shy }}</b>
                     {% endif %}
                 </td>
                 <td class="listthumb">


### PR DESCRIPTION
So while debugging some performance regressions that need to be addressed, the first one to pop up was in `Bolt\Helpers\Excerpt` … it's really slow :disappointed: 

The simple test below shows it to consistently be **5 - 7 times slower** that the native Twig function (+20ms on listing pages with only 5 records).

This PR just replaces its use where it make sense. More PRs to come :wink: 

```php
#!/usr/bin/env php
<?php
include_once __DIR__ . '/vendor/autoload.php';

function excerpt($content, $length = 200, $focus = null)
{
    $excerpter = new Excerpt($content);
    $excerpt = $excerpter->getExcerpt($length, false, $focus);

    return $excerpt;
}

$env = new Twig_Environment();
$subject = 'Bolt is an open source Content Management Tool, which strives to be as simple and straightforward as possible. It is quick to set up, easy to configure, uses elegant templates, and above all: It’s a joy to use.';
$length = 20;

$start = microtime(true);
for ($i = 0; $i <= 1000000; ++$i) {
    $result = twig_slice($env, $subject, 0, $length);
}
$run = microtime(true) - $start;
echo "twig_slice took $run seconds\n";

$start = microtime(true);
for ($i = 0; $i <= 1000000; ++$i) {
    $result = excerpt($subject, $length);
}
$run = microtime(true) - $start;
echo "Excerpt took $run seconds\n";
```