### PR TITLE
[3.3] Twig consistency

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -186,9 +186,9 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
             <td class="username hidden-sm hidden-xs">
                 <i class="fa fa-user fa-fw"></i>
                 {% if content.user.displayname is defined %}
-                {{ content.user.displayname|slice(0, 15) }}
-            {% else %}
-                <s>{{ content.values.ownerid }}</s>
+                    {{ content.user.displayname[:15] }}
+                {% else %}
+                    <s>{{ content.values.ownerid }}</s>
                 {% endif %}<br>
                 {% if content.status == 'timed' %}
                     <i class="fa fa-clock-o status-timed fa-fw"></i> {{ buic_moment(content.datepublish) }}<br>
@@ -269,7 +269,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                         <a class="nolink">
                             {{ __('general.phrase.author-colon') }} <strong><i class="fa fa-user"></i>
                                 {% if content.user.displayname is defined %}
-                                    {{ content.user.displayname|slice(0, 15) }}
+                                    {{ content.user.displayname[:15] }}
                                 {% else %}
                                     <s>user {{ content.values.ownerid }}</s>
                                 {% endif %}</strong>
@@ -280,7 +280,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                     </li>
                     <li>
                         <a class="nolink">{{ __('general.phrase.slug-colon') }}
-                            <code title="{{ content.slug }}">{{ content.slug|slice(0, 24) }}</code>
+                            <code title="{{ content.slug }}">{{ content.slug[:24] }}</code>
                         </a>
                     </li>
                     <li>
@@ -302,13 +302,13 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                         {% if values|length > 1 %}
                             <li>
                                 <a class="nolink">{{ config.get('taxonomy')[taxonomyslug].name }}:
-                                    <i class="fa fa-tag"></i> {{ values|join(", ")|slice(0, 24) }}
+                                    <i class="fa fa-tag"></i> {{ values|join(", ")[:24] }}
                                 </a>
                             </li>
                         {% else %}
                             <li>
                                 <a class="nolink">{{ config.get('taxonomy')[taxonomyslug].singular_name }}:
-                                    <i class="fa fa-tag"></i> {{ values|first|slice(0, 24) }}
+                                    <i class="fa fa-tag"></i> {{ values|first[:24] }}
                                 </a>
                             </li>
                         {% endif %}

--- a/app/view/twig/_base/_page.twig
+++ b/app/view/twig/_base/_page.twig
@@ -12,7 +12,7 @@
 {%- spaceless %}
 
 {% set page_locale_long = app.locale %}
-{% set page_locale_short = page_locale_long|slice(0, 2) %}
+{% set page_locale_short = page_locale_long[:2] %}
 {% set page_timezone_offset = app.timezone_offset %}
 
 {% if block('page_subtitle') is defined %}

--- a/app/view/twig/_macro/_macro.twig
+++ b/app/view/twig/_macro/_macro.twig
@@ -18,7 +18,7 @@
 {% macro contentlink_by_id(contenttype, title, content_id) %}
     {% spaceless %}
         <a href="{{ path('editcontent', { 'contenttypeslug': contenttype.slug, 'id': content_id }) }}">
-            {{- title|striptags|slice(0, 70)|default("<em>(" ~ __('general.phrase.no-title') ~ ")</em>")|raw -}}
+            {{- title|striptags[:70]|default("<em>(" ~ __('general.phrase.no-title') ~ ")</em>")|raw -}}
         </a>
     {% endspaceless %}
 {% endmacro %}

--- a/app/view/twig/_nav/_macros.twig
+++ b/app/view/twig/_nav/_macros.twig
@@ -117,7 +117,7 @@
     {% from _self import icon %}
 
     {% if icon is empty %}
-        <i class="icon">{{ label|slice(0, 1) }}</i>
+        <i class="icon">{{ label[:1] }}</i>
     {% elseif icon != '-' %}
         {{ icon(icon, true) }}
     {% endif %}
@@ -131,8 +131,8 @@
 {% macro icon(icon, box) %}
     {% set class = box|default(false) ? 'icon' : 'fa-fw' %}
     {# Font Awsome #}
-    {% if icon|slice(0,3) == 'fa:' %}
-        <i class="fa fa-{{ icon|slice(3) }} {{ class }}"></i>
+    {% if icon[:3] == 'fa:' %}
+        <i class="fa fa-{{ icon[3:] }} {{ class }}"></i>
     {# Defaults to (?) #}
     {% else %}
         <i class="fa fa-question-circle {{ class }}" title="{{ icon }}"></i>

--- a/app/view/twig/_nav/_primary.twig
+++ b/app/view/twig/_nav/_primary.twig
@@ -48,7 +48,7 @@
     <li class="dropdown">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#">
             {# FIXME DTO: When the session hits the check timer, the user object can be empty #}
-            <i class="fa fa-fw fa-user"></i> <span>{{ user.displayname|default()|slice(0, 16) }}</span> <i class="fa fa-caret-down"></i>
+            <i class="fa fa-fw fa-user"></i> <span>{{ user.displayname|default[:16] }}</span> <i class="fa fa-caret-down"></i>
         </a>
         <ul class="dropdown-menu dropdown-user" role="menu" >
             <li>

--- a/app/view/twig/async/browse.twig
+++ b/app/view/twig/async/browse.twig
@@ -20,11 +20,11 @@
                 {# dir \Bolt\Filesystem\Handler\DirectoryInterface #}
                 {%- if not loop.last or loop.first -%}
                     <a href="#" data-fbrowser-chdir="{{ path('asyncbrowse', {'namespace': dir.mountPoint, 'path': dir.path}) }}">
-                        {{- (dir.filename ?: dir.mountPoint)|slice(0, 40)|shy -}}
+                        {{- (dir.filename ?: dir.mountPoint)[:40]|shy -}}
                     </a>
                     {{- loop.first ? '://' : '/' -}}
                 {%- else -%}
-                    {{- (dir.filename ?: dir.mountPoint)|slice(0, 40)|shy -}}
+                    {{- (dir.filename ?: dir.mountPoint)[:40]|shy -}}
                 {%- endif -%}
             {% endfor %}
         </h4>

--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -5,12 +5,12 @@
             {% if v is iterable %}
                 <em>(object / array)</em>
             {% else %}
-                {{ v|slice(0, 200)|default('<em>(empty)</em>')|raw }}
+                {{ v[:200]|default('<em>(empty)</em>')|raw }}
             {% endif %}
             {% if not loop.last %}<br>{% endif %}
         {% endfor %}
     {% else %}
-        {{ value|slice(0, 200)|default('<em>(empty)</em>')|raw }}
+        {{ value[:200]|default('<em>(empty)</em>')|raw }}
     {% endif %}
 {% endmacro %}
 
@@ -21,9 +21,9 @@
     <tr>
         <th>{{ key }}</th>
         <td>
-            {% if key|slice(0, 13) in obfuscated %}<span class='obfuscated' data-value="{% endif %}
+            {% if key[:13] in obfuscated %}<span class='obfuscated' data-value="{% endif %}
             {{- macros.printvalue(value) -}}
-            {%- if key|slice(0, 13) in obfuscated -%}">(Click to reveal sensitive data)</span>{% endif %}
+            {%- if key[:13] in obfuscated -%}">(Click to reveal sensitive data)</span>{% endif %}
         </td>
     </tr>
 {% endmacro %}

--- a/app/view/twig/files/_files.twig
+++ b/app/view/twig/files/_files.twig
@@ -22,7 +22,7 @@
                         <a href="{{ file.path|thumbnail(1000, 1000, 'r') }}"
                            class="magnific"
                            title="Image: {{ file.filename }}">
-                            <b>{{ file.filename|slice(0, 80)|shy }}</b>
+                            <b>{{ file.filename[:80]|shy }}</b>
                         </a>
 
                     {% elseif file.extension in ['twig', 'txt', 'html', 'md', 'markdown', 'json', 'htm', 'scss', 'css', 'less', 'js', 'yml'] %}
@@ -30,18 +30,18 @@
                         <i class="fa fa-fw fa-file-code-o"></i>
 
                         <a href="{{ path('fileedit', {'namespace': file.mountPoint, 'file': file.path}) }}">
-                            <b>{{ file.filename|slice(0, 80)|shy }}</b>
+                            <b>{{ file.filename[:80]|shy }}</b>
                         </a>
 
                     {% else %}
                         {% if file.hasUrl %}
                             <i class="fa fa-fw fa-link"></i>
                             <a href="{{ file.url }}" target="_blank">
-                                <b>{{ file.filename|slice(0, 80)|shy }}</b>
+                                <b>{{ file.filename[:80]|shy }}</b>
                             </a>
                         {% else %}
                             <i class="fa fa-fw fa-file-o disabled"></i>
-                            <b class="disabled">{{ file.filename|slice(0, 80)|shy }}</b>
+                            <b class="disabled">{{ file.filename[:80]|shy }}</b>
                         {% endif %}
                     {% endif %}
                 </td>

--- a/app/view/twig/files/_folders.twig
+++ b/app/view/twig/files/_folders.twig
@@ -22,7 +22,7 @@
                 <td class="filename">
                     <i class="fa fa-fw fa-folder-open-o"></i>
                     <a href="{{ path('files', pathoptions|default({})|merge({'path': directory.path, 'namespace': directory.mountPoint})) }}">
-                        <b>{{ directory.filename|slice(0, 60)|shy }}</b>
+                        <b>{{ directory.filename[:60]|shy }}</b>
                     </a>
                 </td>
                 <td class="folder-meta">

--- a/app/view/twig/files_ck/_files.twig
+++ b/app/view/twig/files_ck/_files.twig
@@ -16,11 +16,11 @@
                     {% if file.hasUrl %}
                         <i class="fa fa-fw fa-file-image-o"></i>
                         <a class="filebrowserCallbackLink" href="{{ file.url }}">
-                            <b>{{ file.filename|slice(0, 60)|shy }}</b>
+                            <b>{{ file.filename[:60]|shy }}</b>
                         </a>
                     {% else %}
                         <i class="fa fa-fw fa-file-image-o disabled"></i>
-                        <b class="disabled">{{ file.filename|slice(0, 60)|shy }}</b>
+                        <b class="disabled">{{ file.filename[:60]|shy }}</b>
                     {% endif %}
                 </td>
                 <td class="listthumb">


### PR DESCRIPTION
While working on what ended up not being needed for #6904, I noticed that we already use `|slice` in several places with shorthand notation, so updated and committed there.

Seeing as nothing more was needed for #6904, I am just sending this in on its own to be included with 3.3.2 that I'll tag today or tomorrow.