### PR TITLE
[3.2] Set maximum PHP version to be < 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "nesbot/carbon": "^1.20",
         "paragonie/random_compat": "^1.4",
         "passwordlib/passwordlib": "^1.0@beta",
-        "php": "^5.5.9 || ^7.0",
+        "php": "^5.5.9 || ^7.0, <7.2",
         "silex/silex": "^1.3",
         "silex/web-profiler": "^1.0",
         "siriusphp/upload": "^1.2",


### PR DESCRIPTION
Dear watchers & internet historians,

- PHP 7.2-beta3 was released yesterday, and will likely be the last beta before RC and planned release in November
- Bolt 3.2 is scheduled to be End Of Life (EoL) on the 24th of August but will have a final release tagged before the EoL is final
- Bolt 3.3 is now in stable release cycle and will EoL with the upcoming release of 3.4 stable next month

For all these reasons we've collectively decided to make the require change to Bolt to have it safely run on PHP 7.2 as part of the upcoming Bolt 3.4 release. This is due to some changes needed being a little more than we're comfortable to put into a (currently) stable release.

When PHP 7.2.0 GA ships in November, stable Bolt releases will support it.
