### PR TITLE
[3.4] Catch InvalidFieldNameException in revokeSession()

### DIFF
--- a/src/AccessControl/AccessChecker.php
+++ b/src/AccessControl/AccessChecker.php
@@ -11,6 +11,7 @@ use Bolt\Storage\Entity;
 use Bolt\Storage\EntityManagerInterface;
 use Bolt\Storage\Repository;
 use Bolt\Translation\Translator as Trans;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -164,6 +165,8 @@ class AccessChecker
                 $this->getRepositoryAuthtoken()->deleteTokens($sessionAuth->getUser()->getId());
             } catch (TableNotFoundException $e) {
                 // Database tables have been dropped
+            } catch (InvalidFieldNameException $e) {
+                // Database tables need updating
             }
         }
 


### PR DESCRIPTION
Fixes #6915
Follow up to #6670