### PR TITLE
[3.4] Allow for consecutive prefills. 

### DIFF
--- a/app/resources/translations/cs_CZ/messages.cs_CZ.yml
+++ b/app/resources/translations/cs_CZ/messages.cs_CZ.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  10 Legacy untranslated messages
-# 116 Untranslated messages
-#  34 Legacy translation messages
-# 436 Translation messages
+#   8 Legacy untranslated messages
+# 120 Untranslated messages
+#  33 Legacy translation messages
+# 437 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -21,9 +21,7 @@
 "Finding packages that require this one…": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
 #--- Untranslated messages ----------------------------------------------------
@@ -65,6 +63,7 @@ general.phrase.selection: # "Selection"
 general.phrase.status-explanation: # "The status defines whether or not this record is published. Select 'Timed publish' to automatically publish on the set Publication Date."
 general.phrase.thumbnail: # "Thumbnail"
 general.phrase.tip-colon: # "Tip:"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
 general.phrase.value-minimum-variable: # "The value has to be at least “%MINVAL%”!"
 
@@ -155,7 +154,11 @@ page.extend.options: # "Extension Options"
 page.extend.pagetitle: # "Extend %BOLTNAME%"
 page.extend.theme.generation.failure: # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 permissions.roles.label.anonymous: # "Anonymous"
 
@@ -178,7 +181,6 @@ permissions.roles.label.anonymous: # "Anonymous"
 "Image": "Obrázek"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "V menu je nastavená špatná cesta (%PATH%). Neodpovídá žádnému z nastavených typů obsahu ani souačsnému routingu. Zkontrolujte soubor menu.yml."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "V menu menu.yml je nastavená špatná cesta (%PATH%). Mělo by tam pravděpodobně být link: !\""
-"Skipped <tt>%key%</tt> (already has records)": "Vynecháno <tt>%key%</tt> (již existuje)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "Identifikátor a trvalý odkaz pro '%taxonomytype%' se neshoduji ('%slug%' vs. '%taxonomytype%'). Upravte prosím taxonomy.yml, aby se shodovali. Zabráníte tím zmatkům mezi databází a vaší šablonou."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "Nastavení uživatelský práv a rolí je v <code>%permissions%</code>."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "Trvalý odkaz '%slug%' je využíván více typy obsahu. Odliště je v konfiguračním souboru contenttypes.yml."
@@ -648,6 +650,8 @@ page.login.password-reset-link-sent: "Odkaz na obnovení hesla byl odeslán '%us
 page.login.password-show: "Zobrazit"
 page.login.placeholder.password: "Vaše uživatelské jméno"
 page.login.title: "Přihlášení do Boltu"
+
+page.prefill.skipped-existing: "Vynecháno <code>%key%</code> (již existuje)"
 
 panel.latest-activity.button.more: "více aktivit"
 panel.latest-activity.by: "od"

--- a/app/resources/translations/de_DE/messages.de_DE.yml
+++ b/app/resources/translations/de_DE/messages.de_DE.yml
@@ -8,18 +8,16 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#   5 Legacy untranslated messages
-#  20 Untranslated messages
-#  39 Legacy translation messages
-# 532 Translation messages
+#   3 Legacy untranslated messages
+#  24 Untranslated messages
+#  38 Legacy translation messages
+# 533 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
 "Added records to the ContentType <tt>%CONTENTYPE%</tt> titled": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 
 #--- Untranslated messages ----------------------------------------------------
 
@@ -32,6 +30,7 @@ general.phrase.changelog-not-enabled: # "The changelog is not enabled. If you en
 general.phrase.changelog-note: # "Note: The database table will continue to grow as the editors keep adding content. If you enable this functionality in a production environment the table may end up taking up a lot of space."
 general.phrase.extensions-overview: # "Extensions Overview"
 general.phrase.folder: # "Folder"
+general.phrase.upload-progress: # "Current uploads"
 
 menu.configuration.checks: # "Set-up checks"
 
@@ -49,6 +48,11 @@ page.edit-users.error.password-long: # "This value is too long. It should have 1
 page.extend.headline.bundled: # "Bundled Extensions"
 page.extend.listheader.class: # "Class"
 page.extend.listheader.name: # "Name"
+
+page.file-management.actions-for-files: # "Actions for files"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 #--- Legacy translation messages ----------------------------------------------
 
@@ -72,7 +76,6 @@ page.extend.listheader.name: # "Name"
 "Image": "Bild"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Ungültiger Menüpfad (%PATH%) in menu.yml gesetzt. Dieser stimmt mit keinem konfigurierten Datentyp oder einer Route überein."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Ungültiger Menüpfad (%PATH%) in menu.yml gesetzt. Vielleichst sollte stattdessen link: benutzt werden!"
-"Skipped <tt>%key%</tt> (already has records)": "Überspringe <tt>%key%</tt> (bereits Einträge vorhanden)"
 "The field %field% has been changed to \"%newValue%\"": "Das Feld %field% wurde auf \"%newValue%\" geändert"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "Die ID und das Kürzel für '%taxonomytype%' sind nicht die selben ('%slug%' und '%taxonomytype%'). Bitte editieren Sie taxonomy.yml, um eventuelle Inkonsistenzen in Templates oder der Datenbank zu verhindern."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "Die Einstellungen und Berechtigungen werden in <code>%permissions%</code> gespeichert."
@@ -642,6 +645,8 @@ page.login.password-reset-link-sent: "Ein Link zum Zurücksetzen des Passworts w
 page.login.password-show: "Anzeigen"
 page.login.placeholder.password: "Ihr Benutzername"
 page.login.title: "In Bolt anmelden"
+
+page.prefill.skipped-existing: "Überspringe <code>%key%</code> (bereits Einträge vorhanden)"
 
 panel.latest-activity.button.more: "weitere Aktivitäten"
 panel.latest-activity.by: "von"

--- a/app/resources/translations/el/messages.el.yml
+++ b/app/resources/translations/el/messages.el.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  32 Legacy untranslated messages
-# 371 Untranslated messages
-#  12 Legacy translation messages
-# 181 Translation messages
+#  30 Legacy untranslated messages
+# 375 Untranslated messages
+#  11 Legacy translation messages
+# 182 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -29,14 +29,12 @@
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": #
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": #
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": # "The slug '%slug%' is used in more than one ContentType. Please edit contenttypes.yml, and make them distinct."
 "The translations file '%s' can't be created. You will have to use your own editor to make modifications to this file.": #
 "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
@@ -244,6 +242,7 @@ general.phrase.time-format-24-12: # "Time in 24h/12h format"
 general.phrase.toggle-all: # "Check/Uncheck all"
 general.phrase.upload-file-to-directory: # "Upload a file to this folder"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.used-libraries: # "Used Libraries / Components"
 general.phrase.users-none-create-first: # "There are no users in the database. Please create the first user."
 general.phrase.users-none-create-first-extended: # "There are no users present in the system. Please create the first user, which will be granted root privileges."
@@ -422,6 +421,7 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: # "Theme successfully generated. You can now edit it directly from your theme folder."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.label.create-folder: # "Create folder"
 page.file-management.message.create-file: # "Please enter the new file name"
@@ -440,6 +440,9 @@ page.login.password-hide: # "Hide"
 page.login.password-show: # "Show"
 page.login.placeholder.password: # "Your username"
 page.login.title: # "Sign in to Bolt"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.button.more: # "more activity"
 panel.latest-activity.change: # "Latest changes"
@@ -469,7 +472,6 @@ permissions.roles.description.root: # "Built-in superuser role, automatically gr
 "Everybody": "Όλοι"
 "Excerpt": "Απόσπασμα"
 "Image": "Εικόνα"
-"Skipped <tt>%key%</tt> (already has records)": "Παράληψη <tt>%key%</tt> (Έχει ήδη εγγραφές)"
 "Title": "Τίτλος"
 "You've been logged on successfully.": "Συνδεθήκατε επιτυχώς."
 
@@ -669,6 +671,8 @@ page.file-management.message.upload-success: "Το αρχείο '%file%' φορ�
 page.file-management.title: "Αρχεία"
 
 page.login.password-reset-link-sent: "Σύνδεσμος για καινούριο κωδικό πρόσβασης στάλθηκε στον '%user%'."
+
+page.prefill.skipped-existing: "Παράληψη <code>%key%</code> (Έχει ήδη εγγραφές)"
 
 panel.latest-activity.by: "απο"
 

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -10,8 +10,8 @@
 #   0 Unused messages
 #   2 Legacy untranslated messages
 #   0 Untranslated messages
-#  42 Legacy translation messages
-# 552 Translation messages
+#  39 Legacy translation messages
+# 557 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -41,15 +41,12 @@
 "Image": "Image"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured ContentTypes or routes."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!"
-"Skipped <tt>%key%</tt> (already has records)": "Skipped <tt>%key%</tt> (already has records)"
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 "The field %field% has been changed to \"%newValue%\"": "The field %field% has been changed to \"%newValue%\""
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "The settings for roles and permissions are stored in <code>%permissions%</code>."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "The slug '%slug%' is used in more than one ContentType. Please edit contenttypes.yml, and make them distinct."
 "The translations file '%s' can't be created. You will have to use your own editor to make modifications to this file.": "The translations file '%s' can't be created. You will have to use your own editor to make modifications to this file."
 "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.": "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>."
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
 "Title": "Title"
 "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page.": "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page."
 "Unable to create directory: %DIR%": "Unable to create directory: %DIR%"
@@ -638,6 +635,10 @@ page.login.password-reset-link-sent: "A password reset link has been sent to '%u
 page.login.password-show: "Show"
 page.login.placeholder.password: "Your username"
 page.login.title: "Sign in to Bolt"
+
+page.prefill.connection-timeout: "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
+page.prefill.skipped-existing: "Skipped <code>%key%</code> (already has records)"
 
 panel.latest-activity.button.more: "more activity"
 panel.latest-activity.by: "by"

--- a/app/resources/translations/es_ES/messages.es_ES.yml
+++ b/app/resources/translations/es_ES/messages.es_ES.yml
@@ -8,18 +8,16 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#   5 Legacy untranslated messages
-#  27 Untranslated messages
-#  39 Legacy translation messages
-# 525 Translation messages
+#   3 Legacy untranslated messages
+#  31 Untranslated messages
+#  38 Legacy translation messages
+# 526 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
 "Added records to the ContentType <tt>%CONTENTYPE%</tt> titled": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 
 #--- Untranslated messages ----------------------------------------------------
 
@@ -37,6 +35,7 @@ general.phrase.depublish-explanation: # "If set, the record will be automaticall
 general.phrase.extensions-overview: # "Extensions Overview"
 general.phrase.folder: # "Folder"
 general.phrase.status-explanation: # "The status defines whether or not this record is published. Select 'Timed publish' to automatically publish on the set Publication Date."
+general.phrase.upload-progress: # "Current uploads"
 
 menu.configuration.checks: # "Set-up checks"
 
@@ -60,6 +59,11 @@ page.extend.listheader.class: # "Class"
 page.extend.listheader.name: # "Name"
 page.extend.options: # "Extension Options"
 
+page.file-management.actions-for-files: # "Actions for files"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
+
 #--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(plantilla predeterminada)"
@@ -82,7 +86,6 @@ page.extend.options: # "Extension Options"
 "Image": "Imagen"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Ruta no válida para el menú (%PATH%), establecida en menu.yml. No coincide con ningún tipo de contenido o ruta configurada."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Ruta no válida para el menú (%PATH%), establecida en menu.yml. Probablemente debería ser un enlace en su lugar"
-"Skipped <tt>%key%</tt> (already has records)": "Omitida <tt>%key%</tt> (ya tiene registros)"
 "The field %field% has been changed to \"%newValue%\"": "El campo %field% ha sido cambiado a \"%newValue%\""
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "El identificador y el slug para '%taxonomytype%' no son el mismo ('%slug%' vs. '%taxonomytype%'). Por favor edita taxonomy.yml y haz que los dos sean el mismo para prevenir inconsistencias entre la base de datos y tus plantillas"
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "Los ajustes de los roles y permisos están almacenados en <code>%permissions%</code>."
@@ -643,6 +646,8 @@ page.login.password-reset-link-sent: "Se ha enviado un enlace para reiniciar la 
 page.login.password-show: "Mostrar"
 page.login.placeholder.password: "Tu usuario"
 page.login.title: "Iniciar Sesión en Bolt"
+
+page.prefill.skipped-existing: "Omitida <code>%key%</code> (ya tiene registros)"
 
 panel.latest-activity.button.more: "más actividad"
 panel.latest-activity.by: "por"

--- a/app/resources/translations/fi/messages.fi.yml
+++ b/app/resources/translations/fi/messages.fi.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  14 Legacy untranslated messages
-# 169 Untranslated messages
-#  30 Legacy translation messages
-# 383 Translation messages
+#  12 Legacy untranslated messages
+# 173 Untranslated messages
+#  29 Legacy translation messages
+# 384 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -23,9 +23,7 @@
 "Finding packages that require this one…": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unable to create file: %FILE%": #
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
@@ -109,6 +107,7 @@ general.phrase.status-explanation: # "The status defines whether or not this rec
 general.phrase.system-config-checks: # "System Configuration Checks"
 general.phrase.thumbnail: # "Thumbnail"
 general.phrase.toggle-all: # "Check/Uncheck all"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
 general.phrase.value-minimum-variable: # "The value has to be at least “%MINVAL%”!"
 
@@ -216,8 +215,12 @@ page.extend.options: # "Extension Options"
 page.extend.pagetitle: # "Extend %BOLTNAME%"
 page.extend.theme.generation.failure: # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 #--- Legacy translation messages ----------------------------------------------
 
@@ -236,7 +239,6 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "Image": "Kuva"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Viallinen valikkopolku (%PATH%) tiedostossa menu.yml. Ei vastaa määritettyjä sisältötyyppejä tai reittejä."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Viallinen valikkopolku (%PATH%) tiedostossa menu.yml. Luultavasti sen pitäisi olla 'link:'!"
-"Skipped <tt>%key%</tt> (already has records)": "Ohitettiin <tt>%key%</tt> (sisältää jo tietoja)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "Tyypin '%taxonomytype%' tunnus ja tunniste eivät ole samat ('%slug%' vs. '%taxonomytype%'). Muokkaa ne samoiksi tiedostossa taxonomy.yml estääksesi ristiriidat tietokannan ja sivupohjiesi välillä."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "Roolien ja oikeuksien asetukset on tallennettu <code>%permissions%</code>."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "Tunniste '%slug%' on käytössä usealle tietotyypille. Muokkaa contenttype.yml erotellaksesi ne toisistaan."
@@ -647,6 +649,8 @@ page.login.password-reset-link-sent: "Salasanan palautuslinkki lähetettiin käy
 page.login.password-show: "Näytä"
 page.login.placeholder.password: "Käyttäjätunnuksesi"
 page.login.title: "Bolt sisäänkirjautuminen"
+
+page.prefill.skipped-existing: "Ohitettiin <code>%key%</code> (sisältää jo tietoja)"
 
 panel.latest-activity.button.more: "Lisää tapahtumia"
 panel.latest-activity.by: "@"

--- a/app/resources/translations/fr/messages.fr.yml
+++ b/app/resources/translations/fr/messages.fr.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#   7 Legacy untranslated messages
-#  26 Untranslated messages
-#  37 Legacy translation messages
-# 526 Translation messages
+#   5 Legacy untranslated messages
+#  30 Untranslated messages
+#  36 Legacy translation messages
+# 527 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -20,8 +20,6 @@
 "Finding packages that require this one…": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 
 #--- Untranslated messages ----------------------------------------------------
 
@@ -39,6 +37,7 @@ general.phrase.changelog-note: # "Note: The database table will continue to grow
 general.phrase.clashing-relation: # "In the ContentType for '%contenttype%', both a field and a relation are named '%relation%' which will prevent the relation from working. Please edit contenttypes.yml, and correct this."
 general.phrase.extensions-overview: # "Extensions Overview"
 general.phrase.folder: # "Folder"
+general.phrase.upload-progress: # "Current uploads"
 
 menu.configuration.checks: # "Set-up checks"
 
@@ -62,6 +61,11 @@ page.extend.listheader.class: # "Class"
 page.extend.listheader.name: # "Name"
 page.extend.options: # "Extension Options"
 
+page.file-management.actions-for-files: # "Actions for files"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
+
 #--- Legacy translation messages ----------------------------------------------
 
 "(default template)": "(modèle par défaut)"
@@ -82,7 +86,6 @@ page.extend.options: # "Extension Options"
 "Image": "Image"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Une entrée de menu invalide (%PATH%) est présente dans le fichier `menu.yml` : aucun type de contenu ou route correspondant."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Une entrée de menu invalide (%PATH%) est présente dans le fichier `menu.yml` : cela devrait certainement être un lien de type link"
-"Skipped <tt>%key%</tt> (already has records)": "Type de contenu <tt>%key%</tt> non traité (des enregistrements sont déjà présents)"
 "The field %field% has been changed to \"%newValue%\"": "Le champ %field% a été modifié pour \"%newValue%\""
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "L'identifiant et le slug pour '%taxonomytype%' sont différents ('%slug%' et '%taxonomytype%') Veuillez modifier le fichier taxonomy.yml et le corriger pour prévenir des incohérences entre la base de données et le thème."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "La configuration des rôles et des droits est stockée dans le fichier <code>%permissions%</code>."
@@ -644,6 +647,8 @@ page.login.password-reset-link-sent: "Un lien pour réinitialiser le mot de pass
 page.login.password-show: "Afficher"
 page.login.placeholder.password: "Votre identifiant"
 page.login.title: "Connexion à Bolt"
+
+page.prefill.skipped-existing: "Type de contenu <code>%key%</code> non traité (des enregistrements sont déjà présents)"
 
 panel.latest-activity.button.more: "Afficher plus"
 panel.latest-activity.by: "par"

--- a/app/resources/translations/hu/messages.hu.yml
+++ b/app/resources/translations/hu/messages.hu.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  12 Legacy untranslated messages
-# 101 Untranslated messages
-#  32 Legacy translation messages
-# 451 Translation messages
+#  10 Legacy untranslated messages
+# 105 Untranslated messages
+#  31 Legacy translation messages
+# 452 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -22,9 +22,7 @@
 "Finding packages that require this one…": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
@@ -94,6 +92,7 @@ general.phrase.slug-colon: # "Slug:"
 general.phrase.something-went-wrong-after-first-user: # "Something went wrong with logging in after first user creation!"
 general.phrase.status-explanation: # "The status defines whether or not this record is published. Select 'Timed publish' to automatically publish on the set Publication Date."
 general.phrase.toggle-all: # "Check/Uncheck all"
+general.phrase.upload-progress: # "Current uploads"
 
 general.visit-bolt: # "Visit Bolt.cm"
 
@@ -142,7 +141,11 @@ page.extend.message.package-dependencies: # "Packages that depend on this"
 page.extend.message.package-install-info-fail: # "Unable to get installation information for %PACKAGE% %VERSION%."
 page.extend.message.running-update-all: # "Running updates"
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.change: # "Latest changes"
 panel.latest-activity.created: # "Created"
@@ -167,7 +170,6 @@ panel.latest-activity.system: # "Latest system activity"
 "Image": "Kép"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Érvénytelen menü útvonal (%PATH%) beállítás a menu.yml-ben. Nincs egyező tartalomtípus vagy az útvonalválasztó."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Érvénytelen menü útvonal (%PATH%) beállítás a menu.yml-ben. Talán 'link' mezőre lenne inkább szükség?"
-"Skipped <tt>%key%</tt> (already has records)": "<tt>%key%</tt> kihagyva (már tartalmaz bejegyzéseket)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "A '%taxonomytype%' azonosítója és slug-ja nem egyezik ('%slug%' vs. '%taxonomytype%'). Szerkeszd úgy a taxonomy.yml fájlt, hogy egyezzenek, így megelőzhető az adatbázis és a sablonok közötti inkonzisztencia."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "A szerepek és az engedélyek beállításai tárolva a %permissions% fájlban."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "A '%slug%' slug több, mint egy tartalomtípusban használt. Szerkeszd úgy a contenttypes.yml fájlt, hogy különbözzenek."
@@ -652,6 +654,8 @@ page.login.password-reset-link-sent: "Jelszó visszaállítási link elküldve a
 page.login.password-show: "Mutat"
 page.login.placeholder.password: "A felhasználóneved"
 page.login.title: "Bejelentkezés"
+
+page.prefill.skipped-existing: "<code>%key%</code> kihagyva (már tartalmaz bejegyzéseket)"
 
 panel.latest-activity.button.more: "további aktivitások"
 panel.latest-activity.by: "általa:"

--- a/app/resources/translations/id/messages.id.yml
+++ b/app/resources/translations/id/messages.id.yml
@@ -8,8 +8,8 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  38 Legacy untranslated messages
-# 405 Untranslated messages
+#  35 Legacy untranslated messages
+# 410 Untranslated messages
 #   6 Legacy translation messages
 # 147 Translation messages
 
@@ -33,15 +33,12 @@
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
 "Menu": #
 "Search": #
-"Skipped <tt>%key%</tt> (already has records)": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": #
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": #
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": # "The slug '%slug%' is used in more than one ContentType. Please edit contenttypes.yml, and make them distinct."
 "The translations file '%s' can't be created. You will have to use your own editor to make modifications to this file.": #
 "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
@@ -279,6 +276,7 @@ general.phrase.toggle-all: # "Check/Uncheck all"
 general.phrase.types: # "Types"
 general.phrase.upload-file-to-directory: # "Upload a file to this folder"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.used-libraries: # "Used Libraries / Components"
 general.phrase.users-none-create-first: # "There are no users in the database. Please create the first user."
 general.phrase.users-none-create-first-extended: # "There are no users present in the system. Please create the first user, which will be granted root privileges."
@@ -459,6 +457,7 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: # "Theme successfully generated. You can now edit it directly from your theme folder."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.label.create-folder: # "Create folder"
 page.file-management.message.create-file: # "Please enter the new file name"
@@ -478,6 +477,10 @@ page.login.password-hide: # "Hide"
 page.login.password-show: # "Show"
 page.login.placeholder.password: # "Your username"
 page.login.title: # "Sign in to Bolt"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
+page.prefill.skipped-existing: # "Skipped <code>%key%</code> (already has records)"
 
 panel.latest-activity.button.more: # "more activity"
 panel.latest-activity.change: # "Latest changes"

--- a/app/resources/translations/it/messages.it.yml
+++ b/app/resources/translations/it/messages.it.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  33 Legacy untranslated messages
-# 353 Untranslated messages
-#  11 Legacy translation messages
-# 199 Translation messages
+#  31 Legacy untranslated messages
+# 357 Untranslated messages
+#  10 Legacy translation messages
+# 200 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -34,10 +34,8 @@
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
@@ -248,6 +246,7 @@ general.phrase.upload: # "Upload"
 general.phrase.upload-file: # "Upload file"
 general.phrase.upload-file-to-directory: # "Upload a file to this folder"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.users-none-create-first-extended: # "There are no users present in the system. Please create the first user, which will be granted root privileges."
 general.phrase.users-permissions: # "Users & Permissions"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
@@ -407,6 +406,7 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: # "Theme successfully generated. You can now edit it directly from your theme folder."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.label.create-folder: # "Create folder"
 page.file-management.message.create-file: # "Please enter the new file name"
@@ -418,6 +418,9 @@ page.login.button.log-on: # "Log on"
 page.login.cookies-required: # "Note: Cookies are required to log on to Bolt. Please allow cookies."
 page.login.label.password: # "Password"
 page.login.title: # "Sign in to Bolt"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.by: # "by"
 panel.latest-activity.change: # "Latest changes"
@@ -444,7 +447,6 @@ permissions.roles.label.owner: # "Owner"
 "Add some sample <a href='%url%' class='btn btn-default'>Records with Loripsum text</a>": "Aggiungi un po di <a href='%url%' class='btn btn-default'>Contenuti con il testo Loripsum</a>"
 "Added to <tt>%key%</tt> '%title%'": "Aggiunto a <tt>%key%</tt> '%title%'"
 "Excerpt": "Estratto"
-"Skipped <tt>%key%</tt> (already has records)": "Saltato <tt>%key%</tt> (ha già contenuti)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "L'identificatore e lo slug per '%taxonomytype%' non sono lo stesso ('%slug%' vs. '%taxonomytype%'). Modifica taxonomy.yml, e rendili uguali per prevenire inconsistenze tra la memorizzazione nel database storage e i tuoi template."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "Lo slug '%slug%' è utilizzato in più di un tipo di contenuto. Modifica contenttypes.yml e rendili differenti."
 "The translations file '%s' can't be created. You will have to use your own editor to make modifications to this file.": "Il file di traduzione '%s' non può essere creato. Dovrai utilizzare un editor sul server per creare il file."
@@ -672,6 +674,8 @@ page.login.password-hide: "Nascondi"
 page.login.password-reset-link-sent: "Un link per il reset della password è stato inviato a '%user%'."
 page.login.password-show: "Mostra"
 page.login.placeholder.password: "Il tuo nome utente"
+
+page.prefill.skipped-existing: "Saltato <code>%key%</code> (ha già contenuti)"
 
 panel.latest-activity.button.more: "ulteriori attività"
 

--- a/app/resources/translations/ja/messages.ja.yml
+++ b/app/resources/translations/ja/messages.ja.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  26 Legacy untranslated messages
-# 289 Untranslated messages
-#  18 Legacy translation messages
-# 263 Translation messages
+#  24 Legacy untranslated messages
+# 293 Untranslated messages
+#  17 Legacy translation messages
+# 264 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -28,9 +28,7 @@
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
@@ -191,6 +189,7 @@ general.phrase.time-format-24-12: # "Time in 24h/12h format"
 general.phrase.toggle-all: # "Check/Uncheck all"
 general.phrase.upload-file-to-directory: # "Upload a file to this folder"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.users-none-create-first-extended: # "There are no users present in the system. Please create the first user, which will be granted root privileges."
 general.phrase.users-permissions: # "Users & Permissions"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
@@ -345,6 +344,7 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: # "Theme successfully generated. You can now edit it directly from your theme folder."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.message.create-file: # "Please enter the new file name"
 page.file-management.message.save-failed-invalid-form: # "File '%s' could not be saved, because the form wasn't valid."
@@ -352,6 +352,9 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 
 page.login.cookies-required: # "Note: Cookies are required to log on to Bolt. Please allow cookies."
 page.login.title: # "Sign in to Bolt"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.by: # "by"
 panel.latest-activity.change: # "Latest changes"
@@ -373,7 +376,6 @@ panel.user-actions.button.add: # "Add a new user"
 "Excerpt": "概要"
 "File '%file%' could not be uploaded (wrong/disallowed file type). Make sure the file extension is one of the following:": "ファイル '%file%' をアップロードできませんでした（間違っている/許可されていない ファイルの種類）。 ファイルの拡張子が以下に含まれるかご確認ください:"
 "Image": "画像"
-"Skipped <tt>%key%</tt> (already has records)": "<tt>%key%</tt>をスキップしました (すでにレコードが存在します)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "'%taxonomytype%' の識別名とスラッグが同じではありません('%slug%' vs. '%taxonomytype%')。taxonomy.xml を編集して、２つを一致させ、データベースとテンプレートの不整合を解消してください。"
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "ロールとパーミッションの設定は<code>%permissions%</code>に保存されています。"
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "スラッグ '%slug%' は２つ以上のコンテンツで利用されています。contenttypes.ymlを編集して、別々のスラッグにしてください。"
@@ -658,6 +660,8 @@ page.login.password-hide: "隠す"
 page.login.password-reset-link-sent: "パスワードリセット用のリンクが '%user%'に送信されました"
 page.login.password-show: "表示"
 page.login.placeholder.password: "ユーザー名"
+
+page.prefill.skipped-existing: "<code>%key%</code>をスキップしました (すでにレコードが存在します)"
 
 panel.latest-activity.button.more: "ほかの操作"
 panel.latest-activity.logged-in: "ログイン"

--- a/app/resources/translations/nb/messages.nb.yml
+++ b/app/resources/translations/nb/messages.nb.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  28 Legacy untranslated messages
-# 373 Untranslated messages
-#  16 Legacy translation messages
-# 179 Translation messages
+#  26 Legacy untranslated messages
+# 377 Untranslated messages
+#  15 Legacy translation messages
+# 180 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -30,9 +30,7 @@
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Try logging in with your ftp-client and make the file readable. Else try to go <a>back</a> to the last page.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
@@ -244,6 +242,7 @@ general.phrase.toggle-all: # "Check/Uncheck all"
 general.phrase.types: # "Types"
 general.phrase.upload-file-to-directory: # "Upload a file to this folder"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.users-none-create-first-extended: # "There are no users present in the system. Please create the first user, which will be granted root privileges."
 general.phrase.users-permissions: # "Users & Permissions"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
@@ -420,6 +419,7 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: # "Theme successfully generated. You can now edit it directly from your theme folder."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.label.create-folder: # "Create folder"
 page.file-management.message.create-file: # "Please enter the new file name"
@@ -439,6 +439,9 @@ page.login.password-hide: # "Hide"
 page.login.password-show: # "Show"
 page.login.placeholder.password: # "Your username"
 page.login.title: # "Sign in to Bolt"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.button.more: # "more activity"
 panel.latest-activity.change: # "Latest changes"
@@ -462,7 +465,6 @@ panel.user-actions.button.add: # "Add a new user"
 "Everybody": "Alle"
 "Excerpt": "Utdrag"
 "Image": "Bilde"
-"Skipped <tt>%key%</tt> (already has records)": "Hoppet over <tt>%key%</tt> (har allerede poster)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "Identifikator og slug for '%taxonomytype%' er ikke det samme ('%slug%' vs. '%taxonomytype%'). Endre taxonomy.yml slik at de samsvarer for å hindre inkonsistens mellom databaselager og dine maler."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "Innstillinger for roller og rettigheter lagres i %permissions%."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "Slug-en '%slug%' brukes i mer enn en innholdstype. Rediger contenttypes.yml slik at alle er forskjellige."
@@ -665,6 +667,8 @@ page.file-management.message.save-success: "Fila «%s» er lagret."
 page.file-management.message.upload-success: "Fila «%file%» er lastet opp."
 
 page.login.password-reset-link-sent: "En lenke for nullstilling av passord er sendt til «%user%»."
+
+page.prefill.skipped-existing: "Hoppet over <code>%key%</code> (har allerede poster)"
 
 panel.latest-activity.by: "av"
 

--- a/app/resources/translations/nl_NL/messages.nl_NL.yml
+++ b/app/resources/translations/nl_NL/messages.nl_NL.yml
@@ -8,16 +8,14 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#   3 Legacy untranslated messages
-#  13 Untranslated messages
-#  41 Legacy translation messages
-# 539 Translation messages
+#   1 Legacy untranslated messages
+#  17 Untranslated messages
+#  40 Legacy translation messages
+# 540 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
 "Added records to the ContentType <tt>%CONTENTYPE%</tt> titled": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 
 #--- Untranslated messages ----------------------------------------------------
 
@@ -25,6 +23,8 @@ field.block.label.add-new: # "Add new..."
 field.block.label.add-set: # "Add new %label% set"
 
 field.repeater.label.add-set: # "Add new %label% set"
+
+general.phrase.upload-progress: # "Current uploads"
 
 menu.configuration.checks: # "Set-up checks"
 
@@ -38,6 +38,11 @@ page.checks.system-problem: # "System configuration check found problems!"
 page.edit-users.error.email-invalid: # "This email address is not valid."
 page.edit-users.error.password-different-email: # "Password must not match the email address."
 page.edit-users.error.password-long: # "This value is too long. It should have 128 characters or less."
+
+page.file-management.actions-for-files: # "Actions for files"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 #--- Legacy translation messages ----------------------------------------------
 
@@ -63,7 +68,6 @@ page.edit-users.error.password-long: # "This value is too long. It should have 1
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Ongeldige menu pad (%PATH%) ingesteld in menu.yml. Waarschijnlijk had deze een link moeten zijn!"
 "Menu": "Menu"
 "Search": "Zoek"
-"Skipped <tt>%key%</tt> (already has records)": "Overgeslagen: <tt>%key%</tt> (deze heeft al records)"
 "The field %field% has been changed to \"%newValue%\"": "Het veld %field% is aangepast naar \"%newValue%\""
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "De identifier en slug voor '%taxonomytype%' zijn niet hetzelfde ('%slug%' vs. '%taxonomytype%'). Bewerk taxonomy.yml, en laat ze overeenkomen om inconsistenties tussen de database-opslag en je templates te voorkomen."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "De instellingen voor rollen en permissies zijn opgeslagen in <code>%permissions%</code>."
@@ -640,6 +644,8 @@ page.login.password-reset-link-sent: "Een link om het wachtwoord te resetten is 
 page.login.password-show: "Toon"
 page.login.placeholder.password: "Je inlognaam"
 page.login.title: "Inloggen"
+
+page.prefill.skipped-existing: "Overgeslagen: <code>%key%</code> (deze heeft al records)"
 
 panel.latest-activity.button.more: "meer activiteit"
 panel.latest-activity.by: "door"

--- a/app/resources/translations/pl_PL/messages.pl_PL.yml
+++ b/app/resources/translations/pl_PL/messages.pl_PL.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  18 Legacy untranslated messages
-# 167 Untranslated messages
-#  26 Legacy translation messages
-# 385 Translation messages
+#  16 Legacy untranslated messages
+# 171 Untranslated messages
+#  25 Legacy translation messages
+# 386 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -22,9 +22,7 @@
 "Finding packages that require this one…": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
 "Unable to delete directory: %DIR%": #
@@ -114,6 +112,7 @@ general.phrase.status-explanation: # "The status defines whether or not this rec
 general.phrase.system-config-checks: # "System Configuration Checks"
 general.phrase.thumbnail: # "Thumbnail"
 general.phrase.toggle-all: # "Check/Uncheck all"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
 general.phrase.value-minimum-variable: # "The value has to be at least “%MINVAL%”!"
 general.phrase.warning: # "Warning"
@@ -221,7 +220,11 @@ page.extend.options: # "Extension Options"
 page.extend.pagetitle: # "Extend %BOLTNAME%"
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 #--- Legacy translation messages ----------------------------------------------
 
@@ -241,7 +244,6 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "Image": "Obraz"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Nieprawidłowa ścieżka menu (%PATH%) ustawiona w menu.yml. Nie pasuje do żadnych skonfigurowanych typów zawartości ani trasy."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Nieprawidłowa ścieżka menu (%PATH%) ustawiona w menu.yml. Prawdopodobnie powinien być link: zamiast tego!"
-"Skipped <tt>%key%</tt> (already has records)": "Pominięty <tt>%key%</tt> (posiada rekordy)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "Identyfikator i slug dla '%taxonomytype%' to nie to samo ('%slug%' w porównaniu z '%taxonomytype%'). Proszę tak edytować taxonomy.yml, aby je dopasować, żeby zapobiec niespójności między bazą danych i szablonami."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "Ustawienia dla ról i uprawnień są przechowywane w <code>%permissions%</code>."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "Slug '%slug%' jest używany w więcej niż jednym typie zawartości. Proszę przeedytować contenttypes.yml, i uczynić je różnymi."
@@ -648,6 +650,8 @@ page.login.password-reset-link-sent: "Link resetowania hasła został wysłany d
 page.login.password-show: "Pokaż"
 page.login.placeholder.password: "Twoja nazwa użytkownika"
 page.login.title: "Zaloguj się\\_do Bolt"
+
+page.prefill.skipped-existing: "Pominięty <code>%key%</code> (posiada rekordy)"
 
 panel.latest-activity.button.more: "więcej aktywności"
 panel.latest-activity.by: "przez"

--- a/app/resources/translations/pt/messages.pt.yml
+++ b/app/resources/translations/pt/messages.pt.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  11 Legacy untranslated messages
-#  59 Untranslated messages
-#  33 Legacy translation messages
-# 493 Translation messages
+#   9 Legacy untranslated messages
+#  63 Untranslated messages
+#  32 Legacy translation messages
+# 494 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -21,10 +21,8 @@
 "Finding packages that require this one…": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
 "This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
 #--- Untranslated messages ----------------------------------------------------
@@ -54,6 +52,7 @@ general.phrase.redirect-detected: # "Redirect detected. Check if you are still l
 general.phrase.related-content: # "Related content"
 general.phrase.selection: # "Selection"
 general.phrase.status-explanation: # "The status defines whether or not this record is published. Select 'Timed publish' to automatically publish on the set Publication Date."
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.warning-templatefields-loss: # "You may lose some of your template fields with this change. Go to the template section and note down the values before doing this."
 
 menu.configuration.checks: # "Set-up checks"
@@ -98,7 +97,11 @@ page.extend.message.running-update-all: # "Running updates"
 page.extend.options: # "Extension Options"
 page.extend.theme.generation.failure: # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 #--- Legacy translation messages ----------------------------------------------
 
@@ -119,7 +122,6 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "Image": "Imagem"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Caminho de menu inválido (%PATH%) definido no ficheiro menu.yml. Não coincide com qualquer tipo de conteúdo ou roteamentos configurados."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Caminho de menu inválido (%PATH%) definido no ficheiro menu.yml. Provavelmente deveria ser uma hiperligação!"
-"Skipped <tt>%key%</tt> (already has records)": "Ignorado <tt>%key%</tt> (já possui um registo)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "O identificador e o nome curto para '%taxonomytype%' não são iguais ('%slug%' vs. '%taxonomytype%'). Edite o ficheiro taxonomy.yml, e faça-os coincidir para evitar inconsistências entre o armazenamento da base de dados e dos seus temas."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "As definições para papéis e permissões são armazenadas em <code>%permissions%</code>."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "O slug '%slug%' é usado em mais de um tipo de conteúdo. Edite contenttypes.yml, para torná-los distintos."
@@ -645,6 +647,8 @@ page.login.password-reset-link-sent: "Foi enviada uma ligação ao '%user%' para
 page.login.password-show: "Exibir"
 page.login.placeholder.password: "O seu nome de utilizador"
 page.login.title: "Iniciar sessão"
+
+page.prefill.skipped-existing: "Ignorado <code>%key%</code> (já possui um registo)"
 
 panel.latest-activity.button.more: "mais atividades"
 panel.latest-activity.by: "por"

--- a/app/resources/translations/pt_BR/messages.pt_BR.yml
+++ b/app/resources/translations/pt_BR/messages.pt_BR.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  22 Legacy untranslated messages
-# 249 Untranslated messages
-#  22 Legacy translation messages
-# 303 Translation messages
+#  20 Legacy untranslated messages
+# 253 Untranslated messages
+#  21 Legacy translation messages
+# 304 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -26,9 +26,7 @@
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
 "Unable to delete directory: %DIR%": #
@@ -154,6 +152,7 @@ general.phrase.system-config-checks: # "System Configuration Checks"
 general.phrase.thumbnail: # "Thumbnail"
 general.phrase.upload: # "Upload"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.users-permissions: # "Users & Permissions"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
 general.phrase.value-minimum-variable: # "The value has to be at least “%MINVAL%”!"
@@ -302,11 +301,15 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: # "Theme successfully generated. You can now edit it directly from your theme folder."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.message.save-failed-invalid-form: # "File '%s' could not be saved, because the form wasn't valid."
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
 
 page.login.label.password: # "Password"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.change: # "Latest changes"
 panel.latest-activity.created: # "Created"
@@ -327,7 +330,6 @@ panel.latest-activity.system: # "Latest system activity"
 "Expand sidebar": "Expandir barra lateral"
 "File '%file%' could not be uploaded (wrong/disallowed file type). Make sure the file extension is one of the following:": "O arquivo '%file%' não pode ser carregado (erro/tipo de arquivo não permitido). Certifique-se que a extensão é uma das seguintes:"
 "Image": "Imagem"
-"Skipped <tt>%key%</tt> (already has records)": "Ignorado <tt>%key%</tt> (já possui um registro)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "O identificador e o slug para '%taxonomytype%' não são os mesmos ('%slug%' vs. '%taxonomytype%'). Edite taxonomy.yml, e faça-os coincidirem para evitar inconsistências entre o armazenamento do banco de dados e seus templates."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "As definições para papéis e permissões são armazenadas em <code>%permissions%</code>."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "O slug '%slug%' é usado em mais de um tipo de conteúdo. Edite contenttypes.yml, para torná-los distintos."
@@ -654,6 +656,8 @@ page.login.password-reset-link-sent: "Um link para redefinir a senha foi enviado
 page.login.password-show: "Mostar"
 page.login.placeholder.password: "Seu nome de usuário"
 page.login.title: "Registrar no Bolt"
+
+page.prefill.skipped-existing: "Ignorado <code>%key%</code> (já possui um registro)"
 
 panel.latest-activity.button.more: "mais atividades"
 panel.latest-activity.by: "por"

--- a/app/resources/translations/ru/messages.ru.yml
+++ b/app/resources/translations/ru/messages.ru.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#   9 Legacy untranslated messages
-# 184 Untranslated messages
-#  35 Legacy translation messages
-# 368 Translation messages
+#   7 Legacy untranslated messages
+# 188 Untranslated messages
+#  34 Legacy translation messages
+# 369 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -21,9 +21,7 @@
 "Finding packages that require this one…": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 
 #--- Untranslated messages ----------------------------------------------------
 
@@ -127,6 +125,7 @@ general.phrase.thumbnail: # "Thumbnail"
 general.phrase.time-format-24-12: # "Time in 24h/12h format"
 general.phrase.toggle-all: # "Check/Uncheck all"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.users-permissions: # "Users & Permissions"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
 general.phrase.value-minimum-variable: # "The value has to be at least “%MINVAL%”!"
@@ -230,8 +229,12 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: # "Theme successfully generated. You can now edit it directly from your theme folder."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.message.save-failed-invalid-form: # "File '%s' could not be saved, because the form wasn't valid."
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.by: # "by"
 
@@ -254,7 +257,6 @@ panel.latest-activity.by: # "by"
 "Image": "Изображение"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Неправильный путь menu (%PATH%) в menu.yml. Он не соответствует ни одному настроенному contenttypes или routes."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Неправильный путь menu (%PATH%) в menu.yml. Скорее всего должен быть link:."
-"Skipped <tt>%key%</tt> (already has records)": "Пропущено <tt>%key%</tt> (уже имеется записи)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "Идентификатор для slug '%taxonomytype%' не может быть идентичным ('%slug%' и '%taxonomytype%'). Пожалуйста, отредактируйте taxonomy.yml, и сделать их соответствие для предотвращения несоответствий между хранением баз данных и шаблонов."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "Настройки для роли и права доступа сохранены в <code>%permissions%</code>."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "Slug '%slug%' уже используется для одной из сущностей. Пожалуйста, отредактируйте contenttypes.yml, и сделайте их различным друг от друга."
@@ -651,6 +653,8 @@ page.login.password-reset-link-sent: "Ссылка для сброса паро�
 page.login.password-show: "Показать"
 page.login.placeholder.password: "Ваше имя пользователя"
 page.login.title: "Войти в Bolt"
+
+page.prefill.skipped-existing: "Пропущено <code>%key%</code> (уже имеется записи)"
 
 panel.latest-activity.button.more: "Больше активностей"
 panel.latest-activity.change: "Последние изменения"

--- a/app/resources/translations/sv_SE/messages.sv_SE.yml
+++ b/app/resources/translations/sv_SE/messages.sv_SE.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  12 Legacy untranslated messages
-#  72 Untranslated messages
-#  32 Legacy translation messages
-# 480 Translation messages
+#  10 Legacy untranslated messages
+#  76 Untranslated messages
+#  31 Legacy translation messages
+# 481 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -22,9 +22,7 @@
 "Finding packages that require this one…": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unable to duplicate file: %FILE%": #
 "Unfortunately, no content could be found. Try another page, or go to the <a href=\"%paths_root%\">homepage</a>.": #
 
@@ -70,6 +68,7 @@ general.phrase.selection: # "Selection"
 general.phrase.show-proposed-alterations: # "Show proposed alterations"
 general.phrase.status-explanation: # "The status defines whether or not this record is published. Select 'Timed publish' to automatically publish on the set Publication Date."
 general.phrase.toggle-all: # "Check/Uncheck all"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
 general.phrase.value-minimum-variable: # "The value has to be at least “%MINVAL%”!"
 
@@ -114,7 +113,11 @@ page.extend.message.package-install-info-fail: # "Unable to get installation inf
 page.extend.message.running-update-all: # "Running updates"
 page.extend.options: # "Extension Options"
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 #--- Legacy translation messages ----------------------------------------------
 
@@ -134,7 +137,6 @@ page.file-management.message.upload-not-writable: # "Unable to write to upload d
 "Image": "Bild"
 "Invalid menu path (%PATH%) set in menu.yml. Does not match any configured contenttypes or routes.": "Ogiltig meny sökväg (%PATH%) i menu.yml. Matchar inte några konfigurerade innehållstyper eller rutter."
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": "Ogiltig menyn sökväg (%PATH%) i menu.yml. Borde nog vara en 'link:' istället!"
-"Skipped <tt>%key%</tt> (already has records)": "Hoppade över <tt>%key%</tt> (har redan innehåll)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "Identifieraren och permalänken för '%taxonomytype%' är inte samma ('%slug%' vs. '%taxonomytype%'). Redigera taxonomy.yml för att förebygga motsägelser mellan databas och mall."
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "Inställningarna för roller och rättigheter lagras i <code>%permissions%</code>."
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "Permalänken '%slug%' används i mer än en innehållstyp. Redigera contenttypes.yml så att de är unika."
@@ -646,6 +648,8 @@ page.login.password-reset-link-sent: "En återställningslänk för lösenord ha
 page.login.password-show: "Visa"
 page.login.placeholder.password: "Ditt användarnamn"
 page.login.title: "Logga in till bolt"
+
+page.prefill.skipped-existing: "Hoppade över <code>%key%</code> (har redan innehåll)"
 
 panel.latest-activity.button.more: "Mer aktivitet"
 panel.latest-activity.by: "av"

--- a/app/resources/translations/zh_CN/messages.zh_CN.yml
+++ b/app/resources/translations/zh_CN/messages.zh_CN.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  23 Legacy untranslated messages
-# 230 Untranslated messages
-#  21 Legacy translation messages
-# 322 Translation messages
+#  21 Legacy untranslated messages
+# 234 Untranslated messages
+#  20 Legacy translation messages
+# 323 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -27,9 +27,7 @@
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
 "Unable to delete directory: %DIR%": #
@@ -159,6 +157,7 @@ general.phrase.thumbnail: # "Thumbnail"
 general.phrase.time-format-24-12: # "Time in 24h/12h format"
 general.phrase.toggle-all: # "Check/Uncheck all"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.users-permissions: # "Users & Permissions"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
 general.phrase.value-minimum-variable: # "The value has to be at least “%MINVAL%”!"
@@ -283,9 +282,13 @@ page.extend.theme.generation.failure: # "We were unable to generate the theme. I
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 page.extend.theme.generation.success: # "Theme successfully generated. You can now edit it directly from your theme folder."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.message.save-failed-invalid-form: # "File '%s' could not be saved, because the form wasn't valid."
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.change: # "Latest changes"
 panel.latest-activity.created: # "Created"
@@ -310,7 +313,6 @@ permissions.roles.description.root: # "Built-in superuser role, automatically gr
 "Expand sidebar": "展开"
 "File '%file%' could not be uploaded (wrong/disallowed file type). Make sure the file extension is one of the following:": "无法上传文件 '%file%' (错误的/不允许的文件类型)。确保文件扩展名是以下类型之一："
 "Image": "图像"
-"Skipped <tt>%key%</tt> (already has records)": "跳过 <tt>%key%</tt> (已有记录)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "'%taxonomytype%' 的标识符和 slug 不同。('%slug%' 与 '%taxonomytype%')。请编辑 taxonomy.yml 保持一致，避免数据库存储和模板不一致。"
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "角色和权限设置保存在 <code>%permissions%</code> 文件中。"
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "slug '%slug%'用在了多个内容格式中。请编辑 contenttypes.yml 区分它们。"
@@ -659,6 +661,8 @@ page.login.password-reset-link-sent: "密码重置链接已发送到 '%user%'。
 page.login.password-show: "显示"
 page.login.placeholder.password: "你的用户名"
 page.login.title: "登录 Bolt"
+
+page.prefill.skipped-existing: "跳过 <code>%key%</code> (已有记录)"
 
 panel.latest-activity.button.more: "更多活动日志"
 panel.latest-activity.by: "由"

--- a/app/resources/translations/zh_TW/messages.zh_TW.yml
+++ b/app/resources/translations/zh_TW/messages.zh_TW.yml
@@ -8,10 +8,10 @@
 #          re-map your translations.
 
 #   0 Unused messages
-#  23 Legacy untranslated messages
-# 214 Untranslated messages
-#  21 Legacy translation messages
-# 338 Translation messages
+#  21 Legacy untranslated messages
+# 218 Untranslated messages
+#  20 Legacy translation messages
+# 339 Translation messages
 
 #--- Legacy untranslated messages ---------------------------------------------
 
@@ -27,9 +27,7 @@
 "Invalid menu path (%PATH%) set in menu.yml. Probably should be a link: instead!": #
 "Menu": #
 "Search": #
-"Table not found for ContentType %CONTENTTYPE%, a database update is probably required.": #
 "The field %field% has been changed to \"%newValue%\"": #
-"Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content.": #
 "Unable to create directory: %DIR%": #
 "Unable to create file: %FILE%": #
 "Unable to delete directory: %DIR%": #
@@ -155,6 +153,7 @@ general.phrase.system-config-checks: # "System Configuration Checks"
 general.phrase.thumbnail: # "Thumbnail"
 general.phrase.toggle-all: # "Check/Uncheck all"
 general.phrase.upload-not-allowed: # "Upload not allowed"
+general.phrase.upload-progress: # "Current uploads"
 general.phrase.users-permissions: # "Users & Permissions"
 general.phrase.value-maximum-variable: # "The value must not be greater than “%MAXVAL%”!"
 general.phrase.value-minimum-variable: # "The value has to be at least “%MINVAL%”!"
@@ -269,9 +268,13 @@ page.extend.pagetitle: # "Extend %BOLTNAME%"
 page.extend.theme.generation.failure: # "We were unable to generate the theme. It is likely that your theme directory is not writable by Bolt. Check the permissions and try reinstalling."
 page.extend.theme.generation.missing.name: # "No theme name found. Theme is not generated."
 
+page.file-management.actions-for-files: # "Actions for files"
 page.file-management.label.create-file: # "Create file"
 page.file-management.message.save-failed-invalid-form: # "File '%s' could not be saved, because the form wasn't valid."
 page.file-management.message.upload-not-writable: # "Unable to write to upload destination. Check permissions on %TARGET%"
+
+page.prefill.connection-timeout: # "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
+page.prefill.database-update-required: # "Table not found for ContentType %CONTENTTYPE%, a database update is probably required."
 
 panel.latest-activity.change: # "Latest changes"
 panel.latest-activity.created: # "Created"
@@ -291,7 +294,6 @@ panel.latest-activity.system: # "Latest system activity"
 "Expand sidebar": "展開"
 "File '%file%' could not be uploaded (wrong/disallowed file type). Make sure the file extension is one of the following:": "無法上傳檔案 '%file%' (錯誤的/不允許的檔案類型)。確保副檔名是以下類型之一："
 "Image": "影象"
-"Skipped <tt>%key%</tt> (already has records)": "跳過 <tt>%key%</tt> (已有記錄)"
 "The identifier and slug for '%taxonomytype%' are the not the same ('%slug%' vs. '%taxonomytype%'). Please edit taxonomy.yml, and make them match to prevent inconsistencies between database storage and your templates.": "'%taxonomytype%' 的標識符和 slug 不同。('%slug%' 與 '%taxonomytype%')。請編輯 taxonomy.yml 保持一致，避免資料庫存儲和模板不一致。"
 "The settings for roles and permissions are stored in <code>%permissions%</code>.": "角色和許可權設定儲存在 <code>%permissions%</code> 檔案中。"
 "The slug '%slug%' is used in more than one contenttype. Please edit contenttypes.yml, and make them distinct.": "slug '%slug%'用在了多個內容格式中。請編輯 contenttypes.yml 區分它們。"
@@ -653,6 +655,8 @@ page.login.password-reset-link-sent: "密碼重置連結已發送到 '%user%'。
 page.login.password-show: "顯示"
 page.login.placeholder.password: "你的使用者名"
 page.login.title: "登入 Bolt"
+
+page.prefill.skipped-existing: "跳過 <code>%key%</code> (已有記錄)"
 
 panel.latest-activity.button.more: "更多活動日誌"
 panel.latest-activity.by: "由"

--- a/app/view/twig/dbcheck/dbcheck.twig
+++ b/app/view/twig/dbcheck/dbcheck.twig
@@ -47,7 +47,10 @@
 
                 {{ list(__('general.phrase.hints-colon'), hints) }}
 
-                {% if isallowed('prefill') %}
+            {% endif %}
+
+            {% if isallowed('prefill') %}
+
                 <br>
                 <hr>
 
@@ -55,7 +58,6 @@
                     <b>{{ __('general.phrase.tip-colon') }}</b>
                     {{ __('Add some sample <a href=\'%url%\' class=\'btn btn-default\'>Records with Loripsum text</a>', {'%url%': path('prefill')}) }}
                 </p>
-                {% endif %}
 
             {% endif %}
 

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -194,15 +194,17 @@ class General extends BackendBase
 
         if ($request->isMethod('POST') || $request->query->getBoolean('force')) {
             $form->handleRequest($request);
-            if ($form->get('contenttypes')->has('contenttypes')) {
+            if (!empty($form->get('contenttypes')->getData())) {
                 $contentTypeNames = (array) $form->get('contenttypes')->getData();
+                $skipNonEmpty = false;
             } else {
                 $contentTypes = $this->app['config']->get('contenttypes');
                 $contentTypeNames = array_keys($contentTypes);
+                $skipNonEmpty = true;
             }
 
             $builder = $this->app['prefill.builder'];
-            $results = $builder->build($contentTypeNames, 5);
+            $results = $builder->build($contentTypeNames, 5, $skipNonEmpty);
             $this->session()->set('prefill_result', $results);
 
             return $this->redirectToRoute('prefill');

--- a/src/Controller/Backend/General.php
+++ b/src/Controller/Backend/General.php
@@ -194,17 +194,20 @@ class General extends BackendBase
 
         if ($request->isMethod('POST') || $request->query->getBoolean('force')) {
             $form->handleRequest($request);
-            if (!empty($form->get('contenttypes')->getData())) {
-                $contentTypeNames = (array) $form->get('contenttypes')->getData();
-                $skipNonEmpty = false;
-            } else {
-                $contentTypes = $this->app['config']->get('contenttypes');
-                $contentTypeNames = array_keys($contentTypes);
-                $skipNonEmpty = true;
+            $contentTypeNames = (array) $form->get('contenttypes')->getData();
+
+            // ✓ - If the DB is empty
+            // ✓ - If ContentType(s) *are* selected
+            // ✓ - If *no* ContentTypes are selected *and* a ContentType's record count < max
+            // X - If *no* ContentTypes are selected *and* a ContentType's record count >= max
+            $canExceedMax = true;
+            if (count($contentTypeNames) === 0) {
+                $contentTypeNames = $choices;
+                $canExceedMax = false;
             }
 
             $builder = $this->app['prefill.builder'];
-            $results = $builder->build($contentTypeNames, 5, $skipNonEmpty);
+            $results = $builder->build($contentTypeNames, 5, $canExceedMax);
             $this->session()->set('prefill_result', $results);
 
             return $this->redirectToRoute('prefill');

--- a/src/Storage/Database/Prefill/Builder.php
+++ b/src/Storage/Database/Prefill/Builder.php
@@ -52,7 +52,7 @@ class Builder
                 $existingCount = $this->storage->getRepository($contentTypeName)->count();
             } catch (TableNotFoundException $e) {
                 $response['errors'][$contentTypeName] = Trans::__(
-                    'Table not found for ContentType %CONTENTTYPE%, a database update is probably required.',
+                    'page.prefill.database-update-required',
                     ['%CONTENTTYPE%' => $contentTypeName]
                 );
 
@@ -62,7 +62,7 @@ class Builder
             // If we're over 'max' and we're not skipping "non empty" ContentTypes, show a notice and move on.
             if ($existingCount >= $this->maxCount && $skipNonEmpty) {
                 $response['errors'][$contentTypeName] = Trans::__(
-                    'Skipped <tt>%key%</tt> (already has records)',
+                    'page.prefill.skipped-existing',
                     ['%key%' => $contentTypeName]
                 );
 
@@ -79,9 +79,7 @@ class Builder
                 try {
                     $response['created'][$contentTypeName] = $recordContentGenerator->generate($count);
                 } catch (RequestException $e) {
-                    $response['errors'][$contentTypeName] = Trans::__(
-                        "Timeout attempting connection to the 'Lorem Ipsum' generator. Unable to add dummy content."
-                    );
+                    $response['errors'][$contentTypeName] = Trans::__('page.prefill.connection-timeout');
 
                     return $response;
                 }

--- a/src/Storage/Database/Prefill/Builder.php
+++ b/src/Storage/Database/Prefill/Builder.php
@@ -40,10 +40,11 @@ class Builder
      *
      * @param array $contentTypeNames
      * @param int   $count
+     * @param bool  $skipNonEmpty
      *
      * @return null
      */
-    public function build(array $contentTypeNames, $count)
+    public function build(array $contentTypeNames, $count, $skipNonEmpty)
     {
         $response = ['created' => null, 'errors' => null];
         foreach ($contentTypeNames as $contentTypeName) {
@@ -58,7 +59,8 @@ class Builder
                 continue;
             }
 
-            if ($existingCount >= $this->maxCount) {
+            // If we're over 'max' and we're not skipping "non empty" ContentTypes, show a notice and move on.
+            if ($existingCount >= $this->maxCount && $skipNonEmpty) {
                 $response['errors'][$contentTypeName] = Trans::__(
                     'Skipped <tt>%key%</tt> (already has records)',
                     ['%key%' => $contentTypeName]
@@ -67,7 +69,11 @@ class Builder
                 continue;
             }
 
-            $count -= $existingCount;
+            // Take the current amount of items into consideration, when adding more.
+            if ($skipNonEmpty) {
+                $count -= $existingCount;
+            }
+
             if ($count > 0) {
                 $recordContentGenerator = $this->createRecordContentGenerator($contentTypeName);
                 try {

--- a/tests/phpunit/unit/Storage/Database/Prefill/BuilderTest.php
+++ b/tests/phpunit/unit/Storage/Database/Prefill/BuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Tests\Storage\Database\Prefill;
 
+use Bolt\Common\Json;
 use Bolt\Storage\Database\Prefill;
 use Bolt\Storage\EntityManager;
 use Bolt\Storage\Repository\ContentRepository;
@@ -143,7 +144,35 @@ class BuilderTest extends TestCase
         $builder = new Prefill\Builder($this->em->reveal(), $this->generatorFactory, 5);
         $result = $builder->build(['pages'], 5);
 
+        $this->assertNotEmpty($result['errors'], 'No error messages returned from builder');
+        $this->assertArrayHasKey('pages', $result['errors'], 'Did not return error for "pages" ContentType');
         $this->assertRegExp('/(pages).+(already has records)/', $result['errors']['pages']);
+    }
+
+    public function testCountAllowExceeded()
+    {
+        $repo = $this->prophesize(ContentRepository::class);
+        $repo->count()->willReturn(9001);
+
+        $this->em
+            ->getRepository('pages')
+            ->willReturn($repo)
+        ;
+
+        $expected = [
+            'Kenny does Alice Springs',
+            'Up the gum tree without a paddle',
+        ];
+        $this->generator
+            ->generate(5)
+            ->willReturn($expected)
+        ;
+
+        $builder = new Prefill\Builder($this->em->reveal(), $this->generatorFactory, 5);
+        $result = $builder->build(['pages'], 5, true);
+
+        $this->assertNotNull($result['created'], 'Builder did not build anything');
+        $this->assertEmpty($result['errors'], 'Error messages were returned from builder: ' . Json::dump($result['errors'], Json::HUMAN));
     }
 
     public function testMaxCount()


### PR DESCRIPTION
 - Allow for consecutive prefills, with the Lorem Ipsum generator
 - Fix logic error in `$form->get('contenttypes')->has('contenttypes')`
 - Small UI change: show the "prefill with Lorem Ipsum" button not only after finished DB check.

Fixes #6917.

