### PR TITLE
[Travis] Drop HHVM and add PHP nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
+  - nightly
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: hhvm
+    - php: nightly
 
 sudo: false
 


### PR DESCRIPTION
HHVM is basically untestable, and uninstallable  We owe Facebook tremendous thanks for it, as it has pushed the PHP core team to really make huge improvements over PHP 5. However it just sits there and fails testing, nobody except for me has ever tried to get past that, and having it in Travis is just a waste of resources.

This however enables testing against PHP "nightly" builds, which is probably something of a misnomer but is bleeding edge PHP nonetheless, giving us visibility on upcoming breakage faster than waiting on me to update my test environment 

![image](https://user-images.githubusercontent.com/1427081/29504016-d015b19e-863c-11e7-9ba4-91929f729497.png)
