### PR TITLE
[3.4] More menus

### DIFF
--- a/app/view/twig/_nav/_secondary.twig
+++ b/app/view/twig/_nav/_secondary.twig
@@ -33,6 +33,9 @@
         {% if menus.has('files') %}{{ include('@bolt/_nav/_secondary-filemanagement.twig') }}{% endif %}
         {% if menus.has('translations') %}{{ include('@bolt/_nav/_secondary-translations.twig') }}{% endif %}
         {% if menus.has('extensions') %}{{ include('@bolt/_nav/_secondary-extensions.twig') }}{% endif %}
+        {% if menus.has('custom') %}
+            {% for menu in menus.get('custom').children %}{{ nav.submenu(null, null, [menu]) }}{% endfor %}
+        {% endif %}
 
         {{ nav.collapse() }}
     {% else %}

--- a/src/Extension/MenuTrait.php
+++ b/src/Extension/MenuTrait.php
@@ -36,16 +36,16 @@ trait MenuTrait
     {
         $app = $this->getContainer();
 
-        $app['menu.admin'] = $app->share(
+        $app['menu.admin_builder'] = $app->share(
             $app->extend(
-                'menu.admin',
+                'menu.admin_builder',
                 function (MenuEntry $menus) {
-                    if (!$menus->has('extensions')) {
+                    if (!$menus->has('custom')) {
                         return $menus;
                     }
 
                     /** @var MenuEntry $menus */
-                    $extendMenu = $menus->get('extensions');
+                    $extendMenu = $menus->get('custom');
 
                     foreach ($this->registerMenuEntries() as $menuEntry) {
                         if (!$menuEntry instanceof MenuEntry) {

--- a/src/Menu/Builder/AdminMenu.php
+++ b/src/Menu/Builder/AdminMenu.php
@@ -143,7 +143,7 @@ final class AdminMenu
                 ->setRoute('checks')
                 ->setLabel(Trans::__('menu.configuration.checks'))
                 ->setIcon('fa:support')
-                ->setPermission('files:config')
+                ->setPermission('checks')
         );
     }
 

--- a/src/Menu/Builder/AdminMenu.php
+++ b/src/Menu/Builder/AdminMenu.php
@@ -226,5 +226,12 @@ final class AdminMenu
                 ->setIcon('fa:cubes')
                 ->setPermission('extensions')
         );
+
+        // Extension supplied entries
+        $root->add(
+            MenuEntry::create('custom')
+                ->setRoute('extensions')
+                ->setPermission('settings')
+        );
     }
 }

--- a/src/Menu/Resolver/RecentlyEdited.php
+++ b/src/Menu/Resolver/RecentlyEdited.php
@@ -79,7 +79,7 @@ final class RecentlyEdited
                 MenuEntry::create($entity->getSlug())
                     ->setRoute('editcontent', ['contenttypeslug' => $contentTypeKey, 'id' => $entity->getId()])
                     ->setLabel($label)
-                    ->setIcon($contentType->get('icon_one', 'fa:file-text-o'))
+                    ->setIcon($contentType->getPath($contentTypeKey . '/icon_one', 'fa:file-text-o'))
             );
         }
     }

--- a/src/Provider/MenuServiceProvider.php
+++ b/src/Provider/MenuServiceProvider.php
@@ -30,38 +30,40 @@ class MenuServiceProvider implements ServiceProviderInterface
         /**
          * @internal Backwards compatibility not guaranteed on this provider presently.
          */
+        $app['menu.admin_builder'] = function ($app) {
+            $baseUrl = '';
+            if (($request = $app['request_stack']->getCurrentRequest()) !== null) {
+                $baseUrl = $request->getBasePath();
+            }
+            $baseUrl .= '/' . trim($app['controller.backend.mount_prefix'], '/');
+
+            $rootEntry = MenuEntry::createRoot($app['url_generator'], $baseUrl);
+
+            $builder = new Builder\AdminMenu();
+            $builder->build($rootEntry);
+
+            $contentTypes = Bag::fromRecursive($app['config']->get('contenttypes'));
+            $builder = new Builder\AdminContent($contentTypes);
+            $builder->build($rootEntry);
+
+            return $rootEntry;
+        };
+
+        /**
+         * @internal Backwards compatibility not guaranteed on this provider presently.
+         */
         $app['menu.admin'] = $app->share(
             function ($app) {
-                // This service should not be invoked until request cycle since it depends
-                // on url generation and request base path. Probably should be refactored somehow.
-                $baseUrl = '';
-                if (($request = $app['request_stack']->getCurrentRequest()) !== null) {
-                    $baseUrl = $request->getBasePath();
-                }
-                $baseUrl .= '/' . trim($app['controller.backend.mount_prefix'], '/');
-
-                $rootEntry = MenuEntry::createRoot($app['url_generator'], $baseUrl);
                 $token = $app['session']->get('authentication');
                 if (!$token instanceof Token) {
-                    return $rootEntry;
+                    return MenuEntry::create('root');
                 }
                 $user = $token->getUser();
 
                 /** @var Stopwatch $watch */
                 $watch = $app['stopwatch'];
-
-                // ~ 1 ms
-                $watch->start('menu.build.admin');
-                $builder = new Builder\AdminMenu();
-                $builder->build($rootEntry);
-                $watch->stop('menu.build.admin');
-
-                // ~ 2 ms
-                $watch->start('menu.build.admin_content');
-                $contentTypes = Bag::fromRecursive($app['config']->get('contenttypes'));
-                $builder = new Builder\AdminContent($contentTypes);
-                $builder->build($rootEntry);
-                $watch->stop('menu.build.admin_content');
+                $rootEntry = $app['menu.admin_builder'];
+                $contentTypes = Bag::from($app['config']->get('contenttypes'));
 
                 // ~ 100 ms
                 $watch->start('menu.resolve.recent');

--- a/tests/phpunit/unit/Extension/MenuTraitTest.php
+++ b/tests/phpunit/unit/Extension/MenuTraitTest.php
@@ -45,7 +45,7 @@ class MenuTraitTest extends BoltUnitTest
         $ext->setContainer($app);
         $ext->register($app);
         /** @var MenuEntry $extendMenu */
-        $extendMenu = $app['menu.admin']->get('extensions');
+        $extendMenu = $app['menu.admin']->get('custom');
         $children = $extendMenu->children();
 
         $this->assertSame('koala', $children['koala']->getName());


### PR DESCRIPTION
- Follow-up to #6895
- Fixes _Set-up Checks_ menu item showing when when `files:check` permission is given, but the route will deny access
- Fixes recently edited icons
- Allows extension driven menus to appear for the correct permission. Failing continued requests for a decision on this, none came … I'll give it the evening and then :shipit: 