### PR TITLE
Use followLinks() on Finder

### DIFF
--- a/src/Composer/EventListener/PackageEventListener.php
+++ b/src/Composer/EventListener/PackageEventListener.php
@@ -120,6 +120,7 @@ class PackageEventListener
             ->name('composer.json')
             ->notPath('vendor/composer')
             ->depth(2)
+            ->followLinks()
         ;
         try {
             $finder->in(['vendor']);


### PR DESCRIPTION
Use [followLinks()](http://api.symfony.com/2.3/Symfony/Component/Finder/Finder.html#method_followLinks) on Finder, because on Linux dev environments composer creates symlinks instead copying source.