### PR TITLE
[3.3] Catch exceptions better, don't break layout.

### DIFF
--- a/app/view/css/bolt_exception.css
+++ b/app/view/css/bolt_exception.css
@@ -12,3 +12,15 @@ pre[data-line]{position:relative;padding:1em 0 1em 3em}.line-highlight{position:
     font-style: italic;
     cursor: pointer;
 }
+
+th {
+    width: 22%;
+}
+
+th.narrow {
+    width: 8%;
+}
+
+td {
+    word-break: break-all;
+}

--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -1,58 +1,52 @@
-{% macro printvalue(value) %}
-    {% if value is iterable and value is not empty %}
-        {% for k, v in value %}
-            {% if k is not same as(loop.index0) %} {{ k }} =&gt; {% endif %}
-            {% if v is iterable %}
-                <em>(object / array)</em>
-            {% else %}
-                {{ v[:200]|default('<em>(empty)</em>')|raw }}
-            {% endif %}
-            {% if not loop.last %}<br>{% endif %}
+{% block data_value %}
+    {% if value is empty %}
+        <em>(empty)</em>
+    {% elseif value is iterable %}
+        {% for v in value %}
+            {{ v }}<br>
         {% endfor %}
     {% else %}
-        {{ value[:200]|default('<em>(empty)</em>')|raw }}
+        {{ value[:200] }}
     {% endif %}
-{% endmacro %}
+{% endblock %}
 
-{% macro printrow(key, value) %}
-    {% import _self as macros %}
-    {% set obfuscated = ['cookie', '_csrf/bolt', '_csrf/form', 'bolt_authtoke', 'bolt_session_', 'authenticatio', 'HTTP_COOKIE'] %}
-
+{% block data_row %}
     <tr>
         <th>{{ key }}</th>
         <td>
-            {% if key[:13] in obfuscated %}<span class='obfuscated' data-value="{% endif %}
-            {{- macros.printvalue(value) -}}
-            {%- if key[:13] in obfuscated -%}">(Click to reveal sensitive data)</span>{% endif %}
+            {% spaceless %}
+                {% if key[:13] in obfuscated %}
+                    <span class='obfuscated' data-value="{{ block('data_value') }}">(Click to reveal sensitive data)</span>
+                {% else %}
+                    {{ block('data_value') }}
+                {% endif %}
+            {% endspaceless %}
         </td>
     </tr>
-{% endmacro %}
+{% endblock %}
 
-{% import _self as macros %}
+{% block request_data %}
+    {% set bags = ['attributes', 'query', 'files', 'cookies', 'headers', 'server', 'session'] %}
+    {% set values = ['content', 'languages', 'charsets', 'encodings' , 'acceptableContentTypes', 'pathInfo', 'requestUri', 'baseUrl', 'basePath', 'method'] %}
+    {% set obfuscated = ['cookie', '_csrf/bolt', '_csrf/form', 'bolt_authtoke', 'bolt_session_', 'authenticatio', 'HTTP_COOKIE'] %}
 
-<h1>Request data</h1>
-
-{% set bags = ['attributes', 'query', 'files', 'cookies', 'headers', 'server', 'session'] %}
-{% set values = ['content', 'languages', 'charsets', 'encodings' , 'acceptableContentTypes', 'pathInfo', 'requestUri', 'baseUrl', 'basePath', 'method'] %}
-
-<table class="table table-striped table-hover table-condensed">
-{% for key in values %}
-    {% set value = attribute(request, key)|default() %}
-    {{ macros.printrow(key, value) }}
-{% endfor %}
-</table>
-
-
-{% for bag in bags if (attribute(request, bag)|default()) and (attribute(request, bag).all is not empty)%}
-
-    {% set values = attribute(request, bag).all %}
-
-    <h2>{{ bag|capitalize }}</h2>
+    <h1>Request data</h1>
 
     <table class="table table-striped table-hover table-condensed">
-        {% for key, value in values %}
-            {{ macros.printrow(key, value) }}
+        {% for key in values %}
+            {% set value = attribute(request, key)|default %}
+            {{ block('data_row') }}
         {% endfor %}
     </table>
 
-{% endfor %}
+    {% for bag in bags %}
+        <h2>{{ bag|capitalize }}</h2>
+
+        <table class="table table-striped table-hover table-condensed">
+            {% for key, value in attribute(request_data, bag) %}
+                {{ block('data_row') }}
+            {% endfor %}
+        </table>
+
+    {% endfor %}
+{% endblock %}

--- a/app/view/twig/exception/_trace.twig
+++ b/app/view/twig/exception/_trace.twig
@@ -3,7 +3,7 @@
 <table class="table table-striped table-hover table-condensed">
     {% for t in exception.trace|default() %}
         <tr>
-            <th># {{ loop.index }} </th>
+            <th class="narrow"># {{ loop.index }} </th>
             <td>
                 {% if t.class is defined %}
                     {{ t.class|default()|split("\\")[0:-1]|join("\\") -}}\<strong>{{- t.class|default()|split("\\")|last|trimtext(32) -}}</strong>::

--- a/app/view/twig/exception/exception.twig
+++ b/app/view/twig/exception/exception.twig
@@ -44,9 +44,9 @@
 
                             {% if debug %}
                                 <p class='exception'>
-                                    <tt><abbr title="{{ exception.class_fqn|default('unknown') }}">{{ exception.class_name|default('unknown') }}</abbr></tt> in <tt><abbr title="{{ exception.file_path|default('unknown') }}">
-                                    {{- exception.file_name|default('unknown') }}</abbr></tt> line <tt>
-                                    {{- exception.object.line|default('unknown') }}</tt>: <br>
+                                    <code><abbr title="{{ exception.class_fqn|default('unknown') }}">{{ exception.class_name|default('unknown') }}</abbr></code> in <code><abbr title="{{ exception.file_path|default('unknown') }}">
+                                    {{- exception.file_name|default('unknown') }}</abbr></code> line <code>
+                                    {{- exception.object.line|default('unknown') }}</code>: <br>
                                     <em><strong>{{ exception.object.message|default('unknown')|nl2br }}</strong></em>
                                 </p>
 
@@ -74,7 +74,7 @@
                             {% block request %}
                                 {% if debug and request is defined %}
                                     <hr>
-                                    {{ include('@bolt/exception/_request.twig') }}
+                                    {{ block('request_data', '@bolt/exception/_request.twig') }}
                                 {% endif %}
                             {% endblock request %}
 
@@ -83,10 +83,10 @@
                                     Exception, do one of the following: </p>
 
                                 <ul>
-                                    <li>Set <tt>debug: true</tt> in <tt>config.yml</tt>, and make sure you're logged in
+                                    <li>Set <code>debug: true</code> in <code>config.yml</code>, and make sure you're logged in
                                         to the Bolt Backend.</li>
-                                    <li>Set both <tt>debug: true</tt> and <tt>debug_show_loggedoff: true</tt> in
-                                        <tt>config.yml</tt>.
+                                    <li>Set both <code>debug: true</code> and <code>debug_show_loggedoff: true</code> in
+                                        <code>config.yml</code>.
                                 </ul>
                             {% endif %}
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -15,6 +15,7 @@ use Bolt\Exception\Database\DatabaseExceptionInterface;
 use Bolt\Filesystem\Exception\IOException;
 use Bolt\Filesystem\Handler\DirectoryInterface;
 use Bolt\Helpers\Html;
+use Bolt\Helpers\RequestSanitiser;
 use Bolt\Request\ProfilerAwareTrait;
 use Bolt\Users;
 use Carbon\Carbon;
@@ -248,9 +249,10 @@ class ExceptionListener implements EventSubscriberInterface
         $request = $this->requestStack->getCurrentRequest() ?: Request::createFromGlobals();
 
         return [
-            'debug'     => ($this->debug && ($loggedOnUser || $showLoggedOff)),
-            'request'   => $request,
-            'exception' => [
+            'debug'        => ($this->debug && ($loggedOnUser || $showLoggedOff)),
+            'request'      => $request,
+            'request_data' => RequestSanitiser::filter($request),
+            'exception'    => [
                 'object'      => $exception,
                 'class_name'  => $exception ? (new \ReflectionClass($exception))->getShortName() : null,
                 'class_fqn'   => $exception ? get_class($exception) : null,

--- a/src/Helpers/RequestSanitiser.php
+++ b/src/Helpers/RequestSanitiser.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Bolt\Helpers;
+
+use Bolt\Collection\Bag;
+use Bolt\Collection\MutableBag;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Exception request sanitiser.
+ *
+ * @internal Only to be used to sanitise Request objects for Twig exception renders.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class RequestSanitiser
+{
+    /**
+     * Filter a request object to be safe to pass to Twig.
+     *
+     * @param Request $request
+     *
+     * @return Bag
+     */
+    public static function filter(Request $request)
+    {
+        $bags = MutableBag::from(array_fill_keys(['attributes', 'query', 'files', 'cookies', 'headers', 'server'], null));
+        foreach ($bags->keys() as $key) {
+            $bags[$key] = static::getValues($request->$key->all());
+        }
+        if ($request->hasSession()) {
+            $bags['session'] = static::getValues($request->getSession()->all());
+        }
+
+        return $bags->immutable();
+    }
+
+    /**
+     * @param array $values
+     *
+     * @return Bag
+     */
+    private static function getValues(array $values)
+    {
+        $bag = MutableBag::from($values);
+        foreach ($bag as $k => $v) {
+            /** @var Bag $v */
+            if (is_array($v) && !is_callable($v)) {
+                $bag[$k] = Bag::from($v)->join(' ');
+            } elseif (is_string($v) || (is_object($v) && method_exists($v, '__toString'))) {
+                $bag[$k] = (string) $v;
+            } else {
+                $bag->remove($k);
+            }
+        }
+
+        return $bag->immutable();
+    }
+}

--- a/tests/phpunit/unit/Helper/RequestSanitiserTest.php
+++ b/tests/phpunit/unit/Helper/RequestSanitiserTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bolt\Tests\Helper;
+
+use Bolt\Collection\Bag;
+use Bolt\Helpers\RequestSanitiser;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * @covers \Bolt\Helpers\RequestSanitiser
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class RequestSanitiserTest extends TestCase
+{
+    public function testFilter()
+    {
+        $request = Request::createFromGlobals();
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $result = RequestSanitiser::filter($request);
+
+        $this->assertInstanceOf(Bag::class, $result);
+        $this->assertSame(
+            ['attributes', 'query', 'files', 'cookies', 'headers', 'server', 'session'],
+            $result->keys()->toArray()
+        );
+    }
+}


### PR DESCRIPTION
Sometimes the Exception pages would throw an exception, because we tried to output objects as if they were strings:

```
Catchable Fatal Error: Object of class Bolt\Extension\Bobdenotter\Chmodinator\ChmodinatorExtension could not be converted to string"
```

This would give an obscure, hard to read error, instead of pointing to the correct place where it should be fixed. 

This PR handles that slightly better, as well as makes sure that the output stays within bounds of the screen.

Before: 

![screen shot 2017-08-23 at 17 23 33](https://user-images.githubusercontent.com/1833361/29623905-13e00c2a-8828-11e7-88a2-76d05175d719.png)

After:

![screen shot 2017-08-23 at 17 28 35](https://user-images.githubusercontent.com/1833361/29624167-b08b0750-8828-11e7-96b4-d725c3e6f44c.png)

Also before: 

![screen shot 2017-08-23 at 17 26 26](https://user-images.githubusercontent.com/1833361/29624029-68c0d724-8828-11e7-85db-c23ba04a37d2.png)


Also after: 

![screen shot 2017-08-23 at 17 29 47](https://user-images.githubusercontent.com/1833361/29624174-b51a2684-8828-11e7-8b45-183394209111.png)
