### PR TITLE
Filtered choice

### DIFF
--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -169,7 +169,7 @@ final class Choice
             $entities = $repo->findBy([], $orderBy, $limit);
         } else {
             /** @var QueryResultset $entities */
-            $entities = $this->query->getContent('pages', $filter);
+            $entities = $this->query->getContent($contentType, $filter);
         }
         if (!$entities) {
             return $values;

--- a/src/Nut/DatabaseExport.php
+++ b/src/Nut/DatabaseExport.php
@@ -21,7 +21,7 @@ class DatabaseExport extends BaseCommand
             ->setName('database:export')
             ->setDescription('[EXPERIMENTAL] Export the database records to a YAML or JSON file.')
             ->addOption('no-interaction', 'n', InputOption::VALUE_NONE, 'Do not ask for confirmation')
-            ->addOption('contenttypes',   'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'One or more contenttypes to export records for.')
+            ->addOption('contenttypes',   'c', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'One or more ContentTypes to export records for.')
             ->addOption('file',           'f', InputOption::VALUE_REQUIRED, 'A YAML or JSON file to use for export data. Must end with .yml, .yaml or .json')
         ;
     }


### PR DESCRIPTION
As raised by @xiaohutai last night, and the :koala: found by @rossriley minutes later!

That aside, I think we've introduced another regression, @rossriley, with the changes in #6878 … The [`sortable`](https://docs.bolt.cm/3.3/fields/select#making-the-selected-values-sortable) option now does nothing for ContentType selects.

I think this is the legacy of trying to jam too much into Twig at the time, so we need to decide what to do here, update the PHP, or drop the above section from the docs? 

ping @SahAssar ^