### PR TITLE
[3.2] Fix caching of schema tables and prevent multiple builds per-request

### DIFF
--- a/src/Storage/Database/Schema/Manager.php
+++ b/src/Storage/Database/Schema/Manager.php
@@ -200,19 +200,20 @@ class Manager implements SchemaManagerInterface
         if ($this->schemaTables !== null) {
             return $this->schemaTables;
         }
+        $builder = $this->app['schema.builder'];
 
         /** @deprecated Deprecated since 3.0, to be removed in 4.0. */
-        $this->app['schema.builder']['extensions']->addPrefix($this->app['schema.prefix']);
+        $builder['extensions']->addPrefix($this->app['schema.prefix']);
 
         $schema = new Schema();
         $tables = array_merge(
-            $this->app['schema.builder']['base']->getSchemaTables($schema),
-            $this->app['schema.builder']['content']->getSchemaTables($schema, $this->config),
-            $this->app['schema.builder']['extensions']->getSchemaTables($schema)
+            $builder['base']->getSchemaTables($schema),
+            $builder['content']->getSchemaTables($schema, $this->config),
+            $builder['extensions']->getSchemaTables($schema)
         );
         $this->schema = $schema;
 
-        return $tables;
+        return $this->schemaTables = $tables;
     }
 
     /**


### PR DESCRIPTION
That one thing that gets missed  :disappointed: … adding `$this->schemaTables =`  to the `return` statement saves about 15-20 ms per request.

:koala: :koala: :koala: :koala: :koala: :koala: :koala: :koala: :koala: 