### PR TITLE
[3.2] Drop use of "sortable" as it is only used in Twig

### DIFF
--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -88,21 +88,20 @@ final class Choice
         $field += [
             'values'   => [],
             'limit'    => null,
-            'sortable' => false,
             'filter'   => null,
             'sort'     => null,
         ];
         $values = $field['values'];
         $limit = $field['limit'];
-        $sortable = $field['sortable'];
+        $sort = $field['sort'];
         $filter = $field['filter'];
         $key = isset($field['keys']) ? $field['keys'] : 'id';
         $orderBy = $field['sort'];
 
         // Get the appropriate values
         return is_string($values)
-            ? $this->getEntityValues($values, $limit, $sortable, $filter, $key, $orderBy)
-            : $this->getYamlValues($values, $limit, $sortable)
+            ? $this->getEntityValues($values, $limit, $filter, $key, $orderBy)
+            : $this->getYamlValues($values, $limit, $sort)
         ;
     }
 
@@ -111,16 +110,16 @@ final class Choice
      *
      * @param array $values
      * @param int   $limit
-     * @param bool  $sortable
+     * @param bool  $sort
      *
      * @return array
      */
-    private function getYamlValues(array $values, $limit, $sortable)
+    private function getYamlValues(array $values, $limit, $sort)
     {
         if ($values !== null) {
             $values = array_slice($values, 0, $limit);
         }
-        if ($sortable) {
+        if ($sort) {
             asort($values, SORT_REGULAR);
         }
 
@@ -132,13 +131,12 @@ final class Choice
      *
      * @param string $queryString
      * @param int    $limit
-     * @param bool   $sortable
      * @param array  $filter
      * @param string $key
      *
      * @return array
      */
-    private function getEntityValues($queryString, $limit, $sortable, $filter, $key, $orderBy = null)
+    private function getEntityValues($queryString, $limit, $filter, $key, $orderBy = null)
     {
         $baseParts = explode('/', $queryString);
         if (count($baseParts) < 2) {

--- a/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
+++ b/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
@@ -77,9 +77,9 @@ class ChoiceTest extends TestCase
         $contentType = new ContentType('koala', [
             'fields' => [
                 'select_array' => [
-                    'type'     => 'select',
-                    'sortable' => true,
-                    'values'   => $values,
+                    'type'   => 'select',
+                    'sort'   => true,
+                    'values' => $values,
                 ],
             ],
         ]);
@@ -131,9 +131,9 @@ class ChoiceTest extends TestCase
         $contentType = new ContentType('koala', [
             'fields' => [
                 'select_array' => [
-                    'type'     => 'select',
-                    'sortable' => true,
-                    'values'   => $values,
+                    'type'   => 'select',
+                    'sort'   => true,
+                    'values' => $values,
                 ],
             ],
         ]);


### PR DESCRIPTION
Confirmed today with @SahAssar and tested as such:

> `sortable` is drag and drop sorting of selected entries. `sort` is the field to automatically sort entries after a field. 
> So I'd use `sortable` to say "display these three blocks on the front page in an order that the editor can decide" and i'd use `sort` to say "display these five related articles alphabetically by title"

Related #6841 #6845 #6865 #6878