### PR TITLE
Fixes regex warnings on Windows when a directory name starts with a 'p'

### DIFF
--- a/app/web.php
+++ b/app/web.php
@@ -21,7 +21,7 @@ if (PHP_SAPI === 'cli-server') {
     // Absolute path to entry file
     $_SERVER['SCRIPT_FILENAME'] = $frame['file'];
     // Relative path to entry file from document root (dir the server is point to)
-    $_SERVER['SCRIPT_NAME'] = preg_replace("#^{$_SERVER['DOCUMENT_ROOT']}#", '', $_SERVER['SCRIPT_FILENAME']);
+    $_SERVER['SCRIPT_NAME'] = preg_replace('#^' . preg_quote($_SERVER['DOCUMENT_ROOT'], '\\') . "#", '', $_SERVER['SCRIPT_FILENAME']);
 }
 
 return require __DIR__ . '/bootstrap.php';


### PR DESCRIPTION
Details
-------

character `#` somehow managed to came into `$_SERVER['DOCUMENT_ROOT']` when runing local server on windows via command `php vendor\bolt\bolt\app\nut server:run` (see the [source code in diff](https://github.com/bolt/bolt/pull/6950/commits/94b40caba02f4875a432c63e6f84bc75f414608f))

Choosing a target branch
------------------------

* current
