### PR TITLE
Implement the getBlock method on the LazyFieldCollection

### DIFF
--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -68,6 +68,14 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
     }
 
     /**
+     * @return string
+     */
+    public function getBlock()
+    {
+        return $this->first()->getBlock();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getFieldType($fieldName)


### PR DESCRIPTION
This was an oversight when introducing the separate class for LazyFields in place of the normal FieldCollection, this implements the same method as on the other class.