### PR TITLE
[3.3][Audit] Add roave/security-advisories to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         "predis/predis": "^1.1",
         "psr/cache": "^1.0",
         "psr/simple-cache": "^1.0",
+        "roave/security-advisories": "dev-master@dev",
         "sebastian/phpcpd": "^2.0",
         "sorien/silex-pimple-dumper": "^1.0",
         "symfony/phpunit-bridge": "^2.8"


### PR DESCRIPTION
I am slowly working my way though CII to get us in compliance (where we might not be currently) for a "pass" level.

While this one does not cover a specific MUST or SHOULD, it does give us some degree of "heads-up" for this:

> <b><i>Publicly known vulnerabilities fixed</i></b>
>
> <ul>
>
> <li><a name="vulnerabilities_fixed_60_days"></a>There MUST be no unpatched vulnerabilities of medium or high severity that have been publicly known for more than 60 days.
> <dl><dt><i>Details</i>:<dt> <dd>The vulnerability must be patched and released by the project itself (patches may be developed elsewhere). A vulnerability becomes publicly known (for this purpose) once it has a CVE with publicly released non-paywalled information (reported, for example, in the <a href="https://nvd.nist.gov/">National Vulnerability Database</a>) or when the project has been informed and the information has been released to the public (possibly by the project). A vulnerability is medium to high severity if its <a href="https://nvd.nist.gov/cvss.cfm">CVSS 2.0</a> base score is 4 or higher. <strong>Note</strong>: this means that users might be left vulnerable to all attackers worldwide for up to 60 days. This criterion is often much easier to meet than what Google recommends in <a href="https://security.googleblog.com/2010/07/rebooting-responsible-disclosure-focus.html">Rebooting responsible disclosure</a>, because Google recommends that the 60-day period start when the project is notified <em>even</em> if the report is not public.</dd></dl></li>

This would mean that Travis, and local `composer update`s that most core developers do on an almost daily basis, will fail if a package version is listed as vulnerable. Giving us a pretty quick indication, and time to meet our 60-day obligation.
