### PR TITLE
[GitHub] Re-prioritise the issue template slightly

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,27 +1,36 @@
-Prefix your issue title with either [BUG] or [RFC]. If you open an [RFC] it is
-expected that you are willing to help out in the implementation of said feature
-request.
-
+<!-- 
 This issue tracker is NOT for support questions. If you have a question, please
-join us in the community, on one of our social platforms like Slack, IRC or the
-forum: http://bolt.cm/community.
+join us in the community, on one of our social platforms like Slack, IRC or the 
+forum: http://bolt.cm/community. 
 
------------
+If you open a "request for comment" (or "RFC" for short) please prefix your 
+title with [RFC]. It is expected that you are willing to help out in the 
+implementation of said feature request. Other appropiate labels will be applied 
+by the Bolt team, when assessing issues. 
 
-A brief description of the issue goes here. If you haven't yet done so, please
-read the 'contributing guidelines' thoroughly. 
+-->
+
+A brief description of the issue goes here.
+
+<!--
+
+If you haven't yet done so, please read the "contributing guidelines" 
+thoroughly. Then, proceed by filling out the rest of the details in the issue 
+template below. The more details you can give us, the easier it will be for us 
+to determine the cause of a problem. 
 
 See: https://github.com/bolt/bolt/blob/master/.github/CONTRIBUTING.md
+
+--> 
 
 Details
 -------
 
- - Relevant Bolt Version: [ 3.2 | 3.3 | master ]
- - Install type: [ GitHub checkout | Zip/tarball install | Composer install ]
- - PHP version: [ 5.5 | 5.6 | 7.0 ]
+ - Relevant Bolt Version: [ 3.2 | 3.3 | 3.4 | 3.5 | master ]
+ - Install type: [ Zip/tarball install | Composer install | GitHub checkout ]
+ - PHP version: [ 5.5 | 5.6 | 7.0 | 7.1 | 7.2 ]
  - Used web server: [ Apache | Nginx ] version [ version ]
  - For UX/UI issues: [ browser name and version ]
-
 
 Reproduction
 ------------
@@ -29,25 +38,44 @@ Reproduction
 If you're filing a bug, please describe how to reproduce it. Include as much
 relevant information as possible, such as:
 
- 1. **Bug summary**: 
+### Bug summary
+
+<!-- 
     * Write a short summary of the bug
     * Try to pinpoint it as much as possible
     * Try to state the _actual problem_, and not just what you _think_ the 
       solution might be.
- 2. **Specifics**:
+-->
+
+### Specifics
+
+<!-- 
     * Mention the URL where this bug occurs, if applicable
     * What version of Bolt are you using (down to the very last digit!)
     * What method did you use to install Bolt
     * What browser and version you are using
     * Please mention if you've checked it in other browsers as well 
     * Please include *full error messages* and *screenshots* if possible
- 3. **Steps to reproduce**:
+-->
+
+### Steps to reproduce
+
+<!-- 
     * Clearly mention the steps to reproduce the bug
- 4. **Expected result**: 
+-->
+
+### Expected result
+
+<!-- 
     * What did you _expect_ that would happen on your Bolt site?
     * Describe the intended outcome after you did the steps mentioned before
- 5. **Actual result**: 
+-->
+
+### Actual result
+
+<!-- 
     * What is the actual result of the above steps? 
     * Describe the behaviour of the bug 
     * Please, please include **error messages** and screenshots. They might mean 
       nothing to you, but they are _very_ helpful to us.
+-->


### PR DESCRIPTION
- Prioritise _"This issue tracker is NOT for support questions"_
- Remove suggestion of adding `[BUG]` prefix as that is a triage task, and also better handled with tags
- Added some more PHP versions
- Illegal white space removed :see_no_evil: :hear_no_evil: :speak_no_evil:  `</humour>`

## Next … 

Something that has been irking me since day 1, is these templates are written with the assumption that the are going to be rendered, not displayed as raw text (see below).

Volunteers please feel free to :hand: 

Also, it might be good to have the "contribution guidelines" ~~be based on~~ located at https://bolt.cm/community and mirrored in the `.CONTRIBUTING.md` file :thinking: 

![image](https://user-images.githubusercontent.com/1427081/30001673-dfb7276a-9094-11e7-8800-48147e48a91e.png)

