### PR TITLE
New Storage Layer - Allow use of short alias for singular_slug

### DIFF
--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -114,11 +114,17 @@ class MetadataDriver implements MappingDriver
                 $mainAlias = $this->getContentTypeFromAlias($table->getOption('alias'));
                 $this->aliases[$mainAlias] = $tableName;
                 $slugAlias = $this->getContentTypeFromAlias($table->getOption('alias'), true);
+                $singularAlias = $this->getContentTypeFromAlias($table->getOption('alias'), 'singular');
+
                 if ($mainAlias !== $slugAlias) {
                     $this->aliases[$slugAlias] = $tableName;
                 }
+                if ($mainAlias !== $singularAlias) {
+                    $this->aliases[$singularAlias] = $tableName;
+                }
             }
         }
+
     }
 
     /**
@@ -738,7 +744,11 @@ class MetadataDriver implements MappingDriver
     public function getContentTypeFromAlias($alias, $forceSlug = false)
     {
         foreach ($this->contenttypes->getData() as $key => $contenttype) {
-            if ($forceSlug) {
+            if ($forceSlug && $forceSlug==='singular') {
+                if (isset($contenttype['singular_slug']) && ($contenttype['slug'] == $alias || $contenttype['tablename'] == $alias)) {
+                    return $contenttype['singular_slug'];
+                }
+            } elseif ($forceSlug) {
                 if (isset($contenttype['slug']) && ($contenttype['slug'] == $alias || $contenttype['tablename'] == $alias)) {
                     return $contenttype['slug'];
                 }

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -745,19 +745,19 @@ class MetadataDriver implements MappingDriver
     {
         foreach ($this->contenttypes->getData() as $key => $contenttype) {
             if ($forceSlug && $forceSlug === 'singular') {
-                if (isset($contenttype['singular_slug']) && ($contenttype['slug'] == $alias || $contenttype['tablename'] == $alias)) {
+                if (isset($contenttype['singular_slug']) && ($contenttype['slug'] === $alias || $contenttype['tablename'] === $alias)) {
                     return $contenttype['singular_slug'];
                 }
             } elseif ($forceSlug) {
-                if (isset($contenttype['slug']) && ($contenttype['slug'] == $alias || $contenttype['tablename'] == $alias)) {
+                if (isset($contenttype['slug']) && ($contenttype['slug'] === $alias || $contenttype['tablename'] === $alias)) {
                     return $contenttype['slug'];
                 }
             }
-            if (isset($contenttype['tablename']) && $contenttype['tablename'] == $alias) {
+            if (isset($contenttype['tablename']) && $contenttype['tablename'] === $alias) {
                 return $key;
             }
 
-            if (isset($contenttype['slug']) && $contenttype['slug'] == $alias) {
+            if (isset($contenttype['slug']) && $contenttype['slug'] === $alias) {
                 return $key;
             }
         }

--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -744,7 +744,7 @@ class MetadataDriver implements MappingDriver
     public function getContentTypeFromAlias($alias, $forceSlug = false)
     {
         foreach ($this->contenttypes->getData() as $key => $contenttype) {
-            if ($forceSlug && $forceSlug==='singular') {
+            if ($forceSlug && $forceSlug === 'singular') {
                 if (isset($contenttype['singular_slug']) && ($contenttype['slug'] == $alias || $contenttype['tablename'] == $alias)) {
                     return $contenttype['singular_slug'];
                 }


### PR DESCRIPTION
This will be a series of PRs to fix exceptions when using the new storage layer to run `setcontent` queries.

This allows singular contenttype slugs to work,( eg: `setcontent record='showcase/1'`) the same as the main slug.