### PR TITLE
New Storage Layer - Add Compatibility features to allow both systems to work concurrently

### DIFF
--- a/app/theme_defaults/_sub_taxonomylinks.twig
+++ b/app/theme_defaults/_sub_taxonomylinks.twig
@@ -1,5 +1,5 @@
 {% if record.taxonomy is defined %}
-    {% for type, values in record.taxonomy %}
+    {% for type, values in record|taxonomy %}
         <em>
         {% if values|length < 2 %}
             {{ config.get('taxonomy')[type].singular_name }}:

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -88,6 +88,8 @@ abstract class Base implements ControllerProviderInterface
         }
         $context += $globals;
 
+        $this->addResolvedRoute($context, $template->getTemplateName());
+
         if ($this->getOption('general/compatibility/template_view', false)) {
             return new TemplateView($template->getTemplateName(), $context);
         }
@@ -102,6 +104,37 @@ abstract class Base implements ControllerProviderInterface
         $response = new TemplateResponse($template->getTemplateName(), $context, $content);
 
         return $response;
+    }
+
+    /**
+     * Update the route attributes to change the canonical URL generated.
+     *
+     * @param array  $context
+     * @param string $template
+     */
+    private function addResolvedRoute(array $context, $template)
+    {
+        if (!isset($context['record'])) {
+            return;
+        }
+
+        $content = $context['record'];
+        $request = $this->app['request_stack']->getCurrentRequest();
+
+        $homepage = $this->getOption('theme/homepage') ?: $this->getOption('general/homepage');
+        $uriID = $content->contenttype['singular_slug'] . '/' . $content->get('id');
+        $uriSlug = $content->contenttype['singular_slug'] . '/' . $content->get('slug');
+
+        if (($uriID === $homepage || $uriSlug === $homepage) && ($template === $this->getOption('general/homepage_template'))) {
+            $request->attributes->add(['_route' => 'homepage', '_route_params' => []]);
+
+            return;
+        }
+
+        list($routeName, $routeParams) = $content->getRouteNameAndParams();
+        if ($routeName) {
+            $request->attributes->add(['_route' => $routeName, '_route_params' => $routeParams]);
+        }
     }
 
     /**

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -150,7 +150,7 @@ class Frontend extends ConfigurableBase
         // First, try to get it by slug.
         $content = $this->getContent($contenttype['slug'], ['slug' => $slug, 'returnsingle' => true, 'log_not_found' => !is_numeric($slug)]);
 
-        if (!$content && is_numeric($slug)) {
+        if (is_numeric($slug) && (!$content || count($content) === 0)) {
             // And otherwise try getting it by ID
             $content = $this->getContent($contenttype['slug'], ['id' => $slug, 'returnsingle' => true]);
         }
@@ -164,16 +164,6 @@ class Frontend extends ConfigurableBase
 
         // Then, select which template to use, based on our 'cascading templates rules'
         $template = $this->templateChooser()->record($content);
-
-        // Update the route attributes to change the canonical URL generated.
-        if ($content->isHome() && ($template === $this->getOption('general/homepage_template'))) {
-            $request->attributes->add(['_route' => 'homepage', '_route_params' => []]);
-        } else {
-            list($routeName, $routeParams) = $content->getRouteNameAndParams();
-            if ($routeName) {
-                $request->attributes->add(['_route' => $routeName, '_route_params' => $routeParams]);
-            }
-        }
 
         // Setting the editlink
         $this->app['editlink'] = $this->generateUrl('editcontent', ['contenttypeslug' => $contenttype['slug'], 'id' => $content->id]);

--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -14,6 +14,7 @@ use Twig\Markup;
  */
 class Content implements \ArrayAccess
 {
+    use Entity\ContentTypeTrait;
     use Entity\ContentRelationTrait;
     use Entity\ContentRouteTrait;
     use Entity\ContentSearchTrait;
@@ -143,8 +144,8 @@ class Content implements \ArrayAccess
         $value = null;
 
         if (isset($this->values[$name])) {
-            $fieldtype = $this->fieldtype($name);
-            $fieldinfo = $this->fieldinfo($name);
+            $fieldtype = $this->fieldType($name);
+            $fieldinfo = $this->fieldInfo($name);
             $allowtwig = !empty($fieldinfo['allowtwig']);
 
             switch ($fieldtype) {
@@ -323,37 +324,6 @@ class Content implements \ArrayAccess
         $next = $this->app['storage']->getContent($this->contenttype['singular_slug'], $params, $pager, $where);
 
         return $next;
-    }
-
-    /**
-     * Get field information for the given field.
-     *
-     * @param string $key
-     *
-     * @return array An associative array containing at least the key 'type',
-     *               and, depending on the type, other keys.
-     */
-    public function fieldinfo($key)
-    {
-        if (isset($this->contenttype['fields'][$key])) {
-            return $this->contenttype['fields'][$key];
-        } else {
-            return ['type' => ''];
-        }
-    }
-
-    /**
-     * Get the fieldtype for a given fieldname.
-     *
-     * @param string $key
-     *
-     * @return string
-     */
-    public function fieldtype($key)
-    {
-        $field = $this->fieldinfo($key);
-
-        return $field['type'];
     }
 
     /**

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -14,6 +14,7 @@ use Carbon\Carbon;
 class Content extends Entity
 {
     use ContentRouteTrait;
+    use ContentTypeTrait;
     use ContentTypeTitleTrait;
 
     /** @var string|Mapping\ContentType */

--- a/src/Storage/Entity/ContentTypeTrait.php
+++ b/src/Storage/Entity/ContentTypeTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bolt\Storage\Entity;
+
+/**
+ * Trait class for ContentType definitions.
+ *
+ * These traits should be considered transitional, the functionality in the
+ * process of refactor, and not representative of a valid approach.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+trait ContentTypeTrait
+{
+    /**
+     * Get field information for the given field.
+     *
+     * @param string $key
+     *
+     * @return array An associative array containing at least the key 'type',
+     *               and, depending on the type, other keys.
+     */
+    public function fieldInfo($key)
+    {
+        if (isset($this->contenttype['fields'][$key])) {
+            return $this->contenttype['fields'][$key];
+        } else {
+            return ['type' => ''];
+        }
+    }
+
+    /**
+     * Get the field type for a given field name.
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function fieldType($key)
+    {
+        $field = $this->fieldInfo($key);
+
+        return $field['type'];
+    }
+}

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -376,7 +376,7 @@ trait ContentValuesTrait
         ];
         // Check if the values need to be unserialized, and pre-processed.
         foreach ($this->values as $key => $value) {
-            if ((in_array($this->fieldtype($key), $serializedFieldTypes)) || ($key === 'templatefields')) {
+            if ((in_array($this->fieldType($key), $serializedFieldTypes)) || ($key === 'templatefields')) {
                 if (!empty($value) && is_string($value) && (substr($value, 0, 2) === 'a:' || $value[0] === '[' || $value[0] === '{')) {
                     try {
                         $unserdata = Lib::smartUnserialize($value);
@@ -390,7 +390,7 @@ trait ContentValuesTrait
                 }
             }
 
-            if ($this->fieldtype($key) === 'video' && is_array($this->values[$key]) && !empty($this->values[$key]['url'])) {
+            if ($this->fieldType($key) === 'video' && is_array($this->values[$key]) && !empty($this->values[$key]['url'])) {
                 $defaultValues = [
                     'html'       => '',
                     'responsive' => '',
@@ -427,7 +427,7 @@ trait ContentValuesTrait
                 $this->values[$key] = $video;
             }
 
-            if ($this->fieldtype($key) === 'repeater' && is_array($this->values[$key]) && !$this->isRootType) {
+            if ($this->fieldType($key) === 'repeater' && is_array($this->values[$key]) && !$this->isRootType) {
                 $originalMapping = null;
                 $originalMapping[$key]['fields'] = $this->contenttype['fields'][$key]['fields'];
                 $originalMapping[$key]['type'] = 'repeater';
@@ -443,7 +443,7 @@ trait ContentValuesTrait
                 $this->values[$key] = $repeater;
             }
 
-            if ($this->fieldtype($key) === 'date' || $this->fieldtype($key) === 'datetime') {
+            if ($this->fieldType($key) === 'date' || $this->fieldType($key) === 'datetime') {
                 if ($this->values[$key] === '') {
                     $this->values[$key] = null;
                 }

--- a/src/Twig/Extension/RecordExtension.php
+++ b/src/Twig/Extension/RecordExtension.php
@@ -33,6 +33,7 @@ class RecordExtension extends AbstractExtension
             new TwigFunction('listtemplates', [Runtime\RecordRuntime::class, 'listTemplates']),
             new TwigFunction('pager',         [Runtime\RecordRuntime::class, 'pager'], $env + $safe),
             new TwigFunction('trimtext',      [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
+            new TwigFunction('taxonomy',      [Runtime\RecordRuntime::class, 'taxonomy']),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -51,6 +52,7 @@ class RecordExtension extends AbstractExtension
             new TwigFilter('excerpt',     [Runtime\RecordRuntime::class, 'excerpt'], $safe),
             new TwigFilter('selectfield', [Runtime\RecordRuntime::class, 'selectField']),
             new TwigFilter('trimtext',    [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
+            new TwigFilter('taxonomy',    [Runtime\RecordRuntime::class, 'taxonomy']),
             // @codingStandardsIgnoreEnd
         ];
     }


### PR DESCRIPTION
This is another set of changes that allow themes to render correctly in TWIG no matter which storage layer provides the objects.

Main additions are moving the field type information into a Trait that can be shared by both objects, adding a Twig filter to post process new-style Taxonomy objects and adding some extra checks to the Frontend controller to handle potential differences between the two object types.