### PR TITLE
[3.3] Fix linking for files in CKEditor

### DIFF
--- a/app/view/twig/components/stack/list-item.twig
+++ b/app/view/twig/components/stack/list-item.twig
@@ -1,7 +1,7 @@
 {# file \Bolt\Filesystem\Handler\FileInterface #}
 
 <li data-file="{{ file.toJs|json_encode }}">
-    <a href="#" class="filebrowserCallbackLink">
+    <a href="{{ file.url }}" class="filebrowserCallbackLink">
         {{- file.filename }}
         <small>
             (


### PR DESCRIPTION
Fixes #6873
Introduced in #5836

I think this was a derp in #5836 as the following template files behave this way:
- `app/view/twig/files_ck/_files.twig`
- `app/view/twig/recordbrowser/_content.twig`
- `app/view/twig/components/stack/ck-item.twig`
