### PR TITLE
Group Concat settings in config.yml

### DIFF
--- a/src/EventListener/DoctrineListener.php
+++ b/src/EventListener/DoctrineListener.php
@@ -82,7 +82,8 @@ class DoctrineListener implements EventSubscriber
             // certain Bolt content types – particularly repeaters – where
             // the outcome of a GROUP_CONCAT() query will be more than 1024 bytes.
             // See also: http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_group_concat_max_len
-            $db->executeQuery('SET SESSION group_concat_max_len = 100000');
+            $groupConcatMaxLen = $this->config->get('general/database/group_concat_max_len', 100000);
+            $db->executeQuery('SET SESSION group_concat_max_len = ' . $groupConcatMaxLen);
         } elseif ($platformName === 'postgresql') {
             /** @see https://github.com/doctrine/dbal/pull/828 */
             $db->executeQuery("SET NAMES 'utf8'");


### PR DESCRIPTION
If you have to work with a lot of relations you can't increase max group_concat_max_len cause DoctrineLister overrides mysql value:
`$db->executeQuery('SET SESSION group_concat_max_len = 100000');`
I came up with that problem so I think is useful to put it in config file if someone wants override it.

With love, Shayla <3