### PR TITLE
[3.3][SEC] Use a prepared statement for group_concat_max_len query

### DIFF
--- a/src/EventListener/DoctrineListener.php
+++ b/src/EventListener/DoctrineListener.php
@@ -8,6 +8,7 @@ use Bolt\Exception\Database\DatabaseConnectionException;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Event\ConnectionEventArgs;
 use Doctrine\DBAL\Events;
+use PDO;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 
@@ -83,7 +84,7 @@ class DoctrineListener implements EventSubscriber
             // the outcome of a GROUP_CONCAT() query will be more than 1024 bytes.
             // See also: http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_group_concat_max_len
             $groupConcatMaxLen = $this->config->get('general/database/group_concat_max_len', 100000);
-            $db->executeQuery('SET SESSION group_concat_max_len = ' . $groupConcatMaxLen);
+            $db->executeQuery('SET SESSION group_concat_max_len = ?', [$groupConcatMaxLen], [PDO::PARAM_INT]);
         } elseif ($platformName === 'postgresql') {
             /** @see https://github.com/doctrine/dbal/pull/828 */
             $db->executeQuery("SET NAMES 'utf8'");

--- a/src/EventListener/DoctrineListener.php
+++ b/src/EventListener/DoctrineListener.php
@@ -76,7 +76,7 @@ class DoctrineListener implements EventSubscriber
             // Set database character set & collation as configured
             $charset   = $this->config->get('general/database/charset');
             $collation = $this->config->get('general/database/collate');
-            $db->executeQuery(sprintf('SET NAMES %s COLLATE %s', $charset, $collation));
+            $db->executeQuery('SET NAMES ? COLLATE ?', [$charset, $collation], [PDO::PARAM_STR]);
 
             // Increase group_concat_max_len to 100000. By default, MySQL
             // sets this to a low value – 1024 – which causes issues with

--- a/tests/phpunit/database/Entity/AbstractEntityTest.php
+++ b/tests/phpunit/database/Entity/AbstractEntityTest.php
@@ -115,7 +115,7 @@ abstract class AbstractEntityTest extends BoltUnitTest
         try {
             $app['schema']->update();
         } catch (\Exception $e) {
-            $this->fail(sprintf('[FAIL %s] Unable to update schema: %s%s%s', $e->getMessage(), PHP_EOL, $e->getTraceAsString()));
+            $this->fail(sprintf('[FAIL %s] Unable to update schema: %s%s%s', $this->getBrand(), $e->getMessage(), PHP_EOL, $e->getTraceAsString()));
         }
     }
 


### PR DESCRIPTION
Small potential security hole, introduced in #6978, and not in a tagged release.