### PR TITLE
[3.4] Taxonomy template tweak

### DIFF
--- a/app/theme_defaults/_sub_taxonomylinks.twig
+++ b/app/theme_defaults/_sub_taxonomylinks.twig
@@ -1,17 +1,15 @@
-{% if record.taxonomy is defined %}
-    {% for type, values in record|taxonomy %}
-        <em>
+{% for type, values in record|taxonomy %}
+    <em>
         {% if values|length < 2 %}
             {{ config.get('taxonomy')[type].singular_name }}:
         {% else %}
             {{ config.get('taxonomy')[type].name }}:
         {% endif %}
-        </em>
-        {% for link, value in values %}
-            <a href="{{ link }}">{{ value }}</a>{% if not loop.last %}, {% endif %}
-        {% else %}
-            {{ __('general.phrase.none') }}
-        {% endfor %}
-        {% if not loop.last %} - {% endif %}
+    </em>
+    {% for link, value in values %}
+        <a href="{{ link }}">{{ value }}</a>{% if not loop.last %}, {% endif %}
+    {% else %}
+        {{ __('general.phrase.none') }}
     {% endfor %}
-{% endif %}
+    {% if not loop.last %} - {% endif %}
+{% endfor %}


### PR DESCRIPTION
The `|taxonomy` filter will always return an interable