### PR TITLE
[3.4] Fix styling for image divs

### DIFF
--- a/app/src/js/init.js
+++ b/app/src/js/init.js
@@ -299,7 +299,7 @@ var init = {
 
         // @todo make it prettier, and distinguish between '.in' and '.hover'.
         $(document).bind('dragover', function (e) {
-            var dropZone = $('.dropzone'),
+            var dropZone = $('.elm-dropzone'),
                 timeout = window.dropZoneTimeout;
             if (!timeout) {
                 dropZone.addClass('in');

--- a/app/src/js/widgets/buic/buicUpload.js
+++ b/app/src/js/widgets/buic/buicUpload.js
@@ -30,7 +30,7 @@
         _create: function () {
             var fieldset = this.element,
                 fileInput = $('input[type=file]', fieldset),
-                dropZone = $('.dropzone', fieldset),
+                dropZone = $('.elm-dropzone', fieldset),
                 //
                 accept = $(fileInput).attr('accept'),
                 extensions = accept ? accept.replace(/^\./, '').split(/,\./) : [],

--- a/app/src/sass/editcontent/_legacy.scss
+++ b/app/src/sass/editcontent/_legacy.scss
@@ -49,9 +49,25 @@ form[name="content_edit"] {
 
     /*** Dropzone ***/
 
-    .dropzone.hover,
-    .dropzone.in {
-        background: #DEF;
+    .elm-dropzone.hover,
+    .elm-dropzone.in {
+        background:rgba($boltblue, .6);
+        position:relative;
+
+        &:before {
+            content:'\f093';
+            font-family: FontAwesome;
+            font-size:25px;
+            font-style: normal;
+            font-weight: normal;
+            text-decoration: inherit;
+            position:absolute;
+            top:50%;
+            left:50%;
+            z-index:999999999;
+            transform:translate3d(-50%,-50%,0);
+            color:#fff;
+        }
 
         & * {
             opacity: 0.7;

--- a/app/view/twig/editcontent/fields/_file.twig
+++ b/app/view/twig/editcontent/fields/_file.twig
@@ -43,7 +43,7 @@
 {% block fieldset_label_class 'col-xs-12' %}
 
 {% block fieldset_controls %}
-    <div class="col-xs-12 dropzone clearfix">
+    <div class="col-xs-12 elm-dropzone clearfix">
         {# Path #}
         <input{{ macro.attr(attributes.filepath) }}>
 

--- a/app/view/twig/editcontent/fields/_filelist.twig
+++ b/app/view/twig/editcontent/fields/_filelist.twig
@@ -60,7 +60,7 @@
     {{ data('field.filelist.template.empty', template_empty) }}
     {{ data('field.filelist.template.item', template_item) }}
 
-    <div class="col-xs-12 dropzone">
+    <div class="col-xs-12 elm-dropzone">
         {# Filelist #}
         <div class="list">
             {% for item in list %}

--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -94,7 +94,7 @@
 {% block fieldset_label_class 'col-xs-12 control-label' %}
 
 {% block fieldset_controls %}
-    <div class="col-xs-12 dropzone">
+    <div class="col-xs-12 elm-dropzone">
         <div class="row">
             <div class="col-xs-8">
                 {# Path #}

--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -62,7 +62,7 @@
     {{ data('field.imagelist.template.empty', template_empty) }}
     {{ data('field.imagelist.template.item', template_item) }}
 
-    <div class="col-xs-12 dropzone">
+    <div class="col-xs-12 elm-dropzone">
         {# Imagelist #}
         <div class="list">
             {% for image in list %}


### PR DESCRIPTION
Closes #6925 

I’ve done the following, i’ve gone with a quick solution to make the styling a bit more consistent between the buic dropzone and the lib, but they are still controlled by their original components. 