### PR TITLE
Fixes: Taxonomies get saved as 'slugs'

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -349,11 +349,9 @@ class Config
             // Make sure the options are $key => $value pairs, and not have implied integers for keys.
             if (!empty($taxonomy['options']) && is_array($taxonomy['options'])) {
                 $options = [];
-                foreach ($taxonomy['options'] as $optionkey => $optionvalue) {
-                    if (is_numeric($optionkey)) {
-                        $optionkey = Slugify::create()->slugify($optionvalue);
-                    }
-                    $options[$optionkey] = $optionvalue;
+                foreach ($taxonomy['options'] as $optionKey => $optionValue) {
+                    $optionKey = Slugify::create()->slugify($optionKey);
+                    $options[$optionKey] = $optionValue;
                 }
                 $taxonomy['options'] = $options;
             }

--- a/src/Storage/Collection/Taxonomy.php
+++ b/src/Storage/Collection/Taxonomy.php
@@ -147,8 +147,8 @@ class Taxonomy extends ArrayCollection
         foreach ($this as $k => $existing) {
             if (
                 $existing->getContent_id() == $entity->getContent_id() &&
-                $existing->getTaxonomytype() == $entity->getTaxonomytype() &&
-                $existing->getSlug() == $entity->getSlug()
+                $existing->getTaxonomytype() === $entity->getTaxonomytype() &&
+                $existing->getSlug() === $entity->getSlug()
             ) {
                 return $existing;
             }
@@ -167,7 +167,7 @@ class Taxonomy extends ArrayCollection
     public function getField($fieldname)
     {
         return $this->filter(function ($el) use ($fieldname) {
-            return $el->getTaxonomytype() == $fieldname;
+            return $el->getTaxonomytype() === $fieldname;
         });
     }
 
@@ -196,7 +196,7 @@ class Taxonomy extends ArrayCollection
     public function containsKeyValue($field, $value)
     {
         foreach ($this->getField($field) as $element) {
-            if ($element->getSlug() == $value) {
+            if ($element->getSlug() === $value) {
                 return true;
             }
         }
@@ -207,7 +207,7 @@ class Taxonomy extends ArrayCollection
     public function getSortorder($field, $slug)
     {
         foreach ($this->getField($field) as $element) {
-            if ($element->getSlug() == $slug) {
+            if ($element->getSlug() === $slug) {
                 return $element->getSortorder();
             }
         }


### PR DESCRIPTION
Fixes #6973

Fixes: Taxonomies get saved as 'slugs', should also be checked as such in the editor when determining the 'selected' one(s).