### PR TITLE
[3.4] Don't check for changes in dynamically inserted elements

### DIFF
--- a/app/src/js/modules/editcontent.js
+++ b/app/src/js/modules/editcontent.js
@@ -74,14 +74,16 @@
         var changes = 0;
 
         $('form[name="content_edit"]').find('input, textarea, select').each(function () {
-            if (this.type === 'textarea' && $(this).hasClass('ckeditor')) {
-                if (ckeditor.instances[this.id].checkDirty()) {
-                    changes++;
-                }
-            } else {
-                var val = getComparable(this);
-                if (val !== undefined && $(this).data('watch') !== val) {
-                    changes++;
+            if($(this).attr('name') !== 'content_edit[save]') {
+                if (this.type === 'textarea' && $(this).hasClass('ckeditor')) {
+                    if (ckeditor.instances[this.id].checkDirty()) {
+                        changes++;
+                    }
+                } else {
+                    var val = getComparable(this);
+                    if (val !== undefined && $(this).data('watch') !== val) {
+                        changes++;
+                    }
                 }
             }
         });


### PR DESCRIPTION
Fixes #6991

An input element is inserted on save, causing the form to think it's changed, and thus preventing the save. Needs sanity check from @GawainLynch since the editcontent.js is long and hard and takes more brainpower than I got left