### PR TITLE
Added: Add support for "Singleton" ContentTypes

### DIFF
--- a/app/view/twig/_nav/_secondary-content.twig
+++ b/app/view/twig/_nav/_secondary-content.twig
@@ -16,6 +16,8 @@
         {# Recently edited records for this ContentType #}
         {% if menu.has('recent') %}
             {% for record_menu in menu.get('recent').children %}{% set sub = sub|merge([record_menu]) %}{% endfor %}
+        {% elseif menu.has('singleton') %}
+            {% set sub = sub|merge([menu.children|first]) %}
         {% endif %}
 
         {{ nav.submenu(menu.icon, menu.label, sub, active, true) }}

--- a/app/view/twig/dashboard/_recently_edited.twig
+++ b/app/view/twig/dashboard/_recently_edited.twig
@@ -1,3 +1,4 @@
+{% if not multiplecontent|first.contenttype.singleton %}
 <div class="contenttype-title">
     <span class="pull-right">
             <a href="{{ path('overview', {'contenttypeslug': contenttype}) }}" class="morelink">
@@ -23,3 +24,4 @@
         {% endfor %}
     </table>
 </div>
+{% endif %}

--- a/src/Config.php
+++ b/src/Config.php
@@ -540,6 +540,9 @@ class Config
         if (!isset($contentType['allow_numeric_slugs'])) {
             $contentType['allow_numeric_slugs'] = false;
         }
+        if (!isset($contentType['singleton'])) {
+            $contentType['singleton'] = false;
+        }
 
         list($fields, $groups) = $this->parseFieldsAndGroups($contentType['fields'], $generalConfig);
         $contentType['fields'] = $fields;

--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -50,6 +50,10 @@ class Records extends BackendBase
         $duplicate = $request->query->getBoolean('duplicate');
         $new = $duplicate ? false : empty($id);
 
+        // Override return redirect for singletons
+        $isSingleton = $this->getOption('contenttypes/' . $contentTypeKey . '/singleton');
+        $deleteRoute = $isSingleton ? 'editcontent' : 'overview';
+
         // Test the access control
         if ($response = $this->checkEditAccess($contentTypeKey, $id)) {
             return $response;
@@ -76,7 +80,7 @@ class Records extends BackendBase
             if ($button->getName() === 'delete') {
                 $this->app['storage.request.modify']->action($contentTypeKey, [$id => ['delete' => true]]);
 
-                return $this->redirectToRoute('overview', ['contenttypeslug' => $contentTypeKey]);
+                return $this->redirectToRoute($deleteRoute, ['contenttypeslug' => $contentTypeKey]);
             } else {
                 $response = $this->recordSave()->action($formValues, $contentType, $id, $new || $duplicate, $returnTo, $editReferrer);
             }

--- a/src/Menu/Resolver/RecentlyEdited.php
+++ b/src/Menu/Resolver/RecentlyEdited.php
@@ -60,7 +60,7 @@ final class RecentlyEdited
      */
     private function addRecentlyEdited(MenuEntry $contentMenu, $contentTypeKey, Bag $contentTypes)
     {
-        $isSingleton = $contentType->getPath($contentTypeKey . '/singleton');
+        $isSingleton = $contentTypes->getPath($contentTypeKey . '/singleton');
         if ($isSingleton) {
             $this->addSingleton($contentMenu, $contentTypeKey);
 

--- a/src/Menu/Resolver/RecentlyEdited.php
+++ b/src/Menu/Resolver/RecentlyEdited.php
@@ -60,6 +60,12 @@ final class RecentlyEdited
      */
     private function addRecentlyEdited(MenuEntry $contentMenu, $contentTypeKey, Bag $contentTypes)
     {
+        $isSingleton = $contentType->getPath($contentTypeKey . '/singleton');
+        if ($isSingleton) {
+            $this->addSingleton($contentMenu, $contentTypeKey);
+
+            return;
+        }
         $entities = $this->getRecords($contentTypeKey, 4);
         if (!$entities) {
             return;
@@ -83,6 +89,39 @@ final class RecentlyEdited
                     ->setIcon($contentType->get('icon_one', 'fa:file-text-o'))
             );
         }
+    }
+
+    /**
+     * @param MenuEntry $contentMenu
+     * @param string    $contentTypeKey
+     */
+    private function addSingleton(MenuEntry $contentMenu, $contentTypeKey)
+    {
+        $singleton = MenuEntry::create('singleton')
+            ->setLabel($contentMenu->getLabel())
+            ->setIcon($contentMenu->getIcon())
+        ;
+
+        // If there is an existing record, remove the ability to create a new one
+        $entities = $this->getRecords($contentTypeKey, 1);
+        if ($entities) {
+            $entity = reset($entities);
+            $singleton
+                ->setRoute('editcontent', ['contenttypeslug' => $contentTypeKey, 'id' => $entity->getId()])
+                ->setPermission('contenttype:' . $contentTypeKey)
+            ;
+        } else {
+            $singleton
+                ->setRoute('editcontent', ['contenttypeslug' => $contentTypeKey])
+                ->setPermission('contenttype:' . $contentTypeKey . ':create')
+            ;
+        }
+
+        $contentMenu->add($singleton);
+
+        // We don't need 'view' or 'new' here
+        $contentMenu->remove('view');
+        $contentMenu->remove('new');
     }
 
     /**


### PR DESCRIPTION
Working off of the proposed solution here https://github.com/bolt/bolt/pull/6309
The twig logic kinda got me off track a bit, but here is what i've come up with so far. Would love some feedback.

Update:
So moved away the logic from the Twig templates, and added some extra features like:
- Don't go back to overview when you delete the singleton, but to create new. You don't need the overview for a singleton
- Still just a PR about aligning the UI with the singleton principle
- Removed the singleton from the recently edited section

Lots of love for koalakiller @GawainLynch for the help
