### PR TITLE
Add `is_numerical` check - See #6995

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -332,13 +332,13 @@ class Config
 
         foreach ($taxonomies as $key => $taxonomy) {
             if (!isset($taxonomy['name'])) {
-                $taxonomy['name'] = ucwords($taxonomy['slug']);
+                $taxonomy['name'] = ucwords(str_replace('-', ' ', Common\Str::humanize($taxonomy['slug'])));
             }
             if (!isset($taxonomy['singular_name'])) {
                 if (isset($taxonomy['singular_slug'])) {
-                    $taxonomy['singular_name'] = ucwords($taxonomy['singular_slug']);
+                    $taxonomy['singular_name'] = ucwords(str_replace('-', ' ', Common\Str::humanize($taxonomy['singular_slug'])));
                 } else {
-                    $taxonomy['singular_name'] = ucwords($taxonomy['slug']);
+                    $taxonomy['singular_name'] = ucwords(str_replace('-', ' ', Common\Str::humanize($taxonomy['slug'])));
                 }
             }
             if (!isset($taxonomy['slug'])) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -322,11 +322,13 @@ class Config
     /**
      * Read and parse the taxonomy.yml configuration file.
      *
+     * @param array|null $taxonomies
+     *
      * @return array
      */
-    protected function parseTaxonomy()
+    protected function parseTaxonomy(array $taxonomies = null)
     {
-        $taxonomies = $this->parseConfigYaml('taxonomy.yml');
+        $taxonomies = $taxonomies ?: $this->parseConfigYaml('taxonomy.yml');
 
         foreach ($taxonomies as $key => $taxonomy) {
             if (!isset($taxonomy['name'])) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -356,6 +356,9 @@ class Config
             if (!empty($taxonomy['options']) && is_array($taxonomy['options'])) {
                 $options = [];
                 foreach ($taxonomy['options'] as $optionKey => $optionValue) {
+                    if (is_numeric($optionKey)) {
+                        $optionKey = $optionValue;
+                    }
                     $optionKey = Slugify::create()->slugify($optionKey);
                     $options[$optionKey] = $optionValue;
                 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -329,6 +329,7 @@ class Config
     protected function parseTaxonomy(array $taxonomies = null)
     {
         $taxonomies = $taxonomies ?: $this->parseConfigYaml('taxonomy.yml');
+        $slugify = Slugify::create();
 
         foreach ($taxonomies as $key => $taxonomy) {
             if (!isset($taxonomy['name'])) {
@@ -342,10 +343,10 @@ class Config
                 }
             }
             if (!isset($taxonomy['slug'])) {
-                $taxonomy['slug'] = strtolower(Str::makeSafe($taxonomy['name']));
+                $taxonomy['slug'] = $slugify->slugify($taxonomy['name']);
             }
             if (!isset($taxonomy['singular_slug'])) {
-                $taxonomy['singular_slug'] = strtolower(Str::makeSafe($taxonomy['singular_name']));
+                $taxonomy['singular_slug'] = $slugify->slugify($taxonomy['singular_name']);
             }
             if (!isset($taxonomy['has_sortorder'])) {
                 $taxonomy['has_sortorder'] = false;
@@ -361,7 +362,7 @@ class Config
                     if (is_numeric($optionKey)) {
                         $optionKey = $optionValue;
                     }
-                    $optionKey = Slugify::create()->slugify($optionKey);
+                    $optionKey = $slugify->slugify($optionKey);
                     $options[$optionKey] = $optionValue;
                 }
                 $taxonomy['options'] = $options;

--- a/src/Config.php
+++ b/src/Config.php
@@ -374,6 +374,8 @@ class Config
             // If taxonomy is like tags, set 'tagcloud' to true by default.
             if (($taxonomy['behaves_like'] === 'tags') && (!isset($taxonomy['tagcloud']))) {
                 $taxonomy['tagcloud'] = true;
+            } else {
+                $taxonomy += ['tagcloud' => false];
             }
 
             $taxonomies[$key] = $taxonomy;

--- a/tests/phpunit/unit/Configuration/ConfigTest.php
+++ b/tests/phpunit/unit/Configuration/ConfigTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Bolt\Tests\Configuration;
+
+use Bolt\Config;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Silex\Application;
+
+/**
+ * @covers \Bolt\Config
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ConfigTest extends TestCase
+{
+    public function providerParseTaxonomyName()
+    {
+        return [
+            'Valid name' => [
+                'Kenny Koala', 'name', ['test' => ['slug' => null, 'name' => 'Kenny Koala']],
+            ],
+            'Missing name' => [
+                'Kenny K Koala', 'name', ['test' => ['slug' => 'kenny-k_koala']],
+            ],
+            'Valid singular name' => [
+                'Bruce Koala', 'singular_name', ['test' => ['slug' => null, 'singular_name' => 'Bruce Koala']],
+            ],
+            'Missing singular_name from slug' => [
+                'Kenny K Koala', 'singular_name', ['test' => ['slug' => 'kenny-k_koala']],
+            ],
+            'Missing singular_name from singular_slug' => [
+                'Bruce M Koala', 'singular_name', ['test' => ['slug' => null, 'singular_slug' => 'bruce-m_koala']],
+            ],
+            'Valid slug' => [
+                'kenny-koala', 'slug', ['test' => ['slug' => 'kenny-koala', 'name' => 'Drop Bears', 'singular_name' => 'Drop Bear']],
+            ],
+            'Missing slug from name' => [ // Should be key in v4
+                'drop-bears', 'slug', ['test' => ['name' => 'Drop Bears', 'singular_name' => 'Drop Bear']],
+            ],
+            'Set true has_sortorder' => [
+                true, 'has_sortorder', ['test' => ['slug' => null, 'has_sortorder' => true]],
+            ],
+            'Set false has_sortorder' => [
+                false, 'has_sortorder', ['test' => ['slug' => null, 'has_sortorder' => false]],
+            ],
+            'Missing has_sortorder' => [
+                false, 'has_sortorder', ['test' => ['slug' => null]],
+            ],
+            'Set true allow_spaces' => [
+                true, 'allow_spaces', ['test' => ['slug' => null, 'allow_spaces' => true]],
+            ],
+            'Set false allow_spaces' => [
+                false, 'allow_spaces', ['test' => ['slug' => null, 'allow_spaces' => false]],
+            ],
+            'Missing allow_spaces' => [
+                false, 'allow_spaces', ['test' => ['slug' => null]],
+            ],
+            'Valid behaves_like' => [
+                'gum-leaves', 'behaves_like', ['test' => ['slug' => null, 'behaves_like' => 'gum-leaves']],
+            ],
+            'Missing behaves_like' => [
+                'tags', 'behaves_like', ['test' => ['slug' => null]],
+            ],
+            'Set true tagcloud' => [
+                true, 'tagcloud', ['test' => ['slug' => null, 'tagcloud' => true]],
+            ],
+            'Set false tagcloud' => [
+                false, 'tagcloud', ['test' => ['slug' => null, 'tagcloud' => false]],
+            ],
+            'Set tagcloud implicitly upon behaves_like === tags' => [
+                true, 'tagcloud', ['test' => ['slug' => null, 'behaves_like' => 'tags']],
+            ],
+            'Do not set tagcloud implicitly upon behaves_like !== tags' => [
+                false, 'tagcloud', ['test' => ['slug' => null, 'behaves_like' => 'gum-leaves']],
+            ],
+            'Indexed options' => [
+                ['a-a-a' => 'a a a', 'b-b-b' => 'b b b', 'c-c-c' => 'c c c'],
+                'options',
+                ['test' => ['slug' => null, 'options' => ['a a a', 'b b b', 'c c c']]],
+            ],
+            'Associative options' => [
+                ['a' => 'aaa', 'bbb' => 'bbb', 'c-c-c' => 'c c c'],
+                'options',
+                ['test' => ['slug' => null, 'options' => ['a' => 'aaa', 'bbb', 'c c c']]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerParseTaxonomyName
+     *
+     * @param mixed  $expected
+     * @param string $key
+     * @param array  $data
+     */
+    public function testParseTaxonomyName($expected, $key, array $data)
+    {
+        $app = new Application();
+        $config = new Config($app);
+        $rm = new ReflectionMethod(Config::class, 'parseTaxonomy');
+        $rm->setAccessible(true);
+
+        $result = $rm->invokeArgs($config, [$data]);
+
+        $this->assertSame($expected, $result['test'][$key]);
+    }
+}


### PR DESCRIPTION
See #6995 .

The numerical check is still required because you can define taxonomies as:
```
- foo
- bar
- baz
```
and
```
foo: Foo
bar: Bar
baz: Baz
```

The code before this pull, would actually save it as:
```
0: foo
1: bar
2: baz
```