### PR TITLE
New storage layer fixed pagination handling

### DIFF
--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -243,7 +243,7 @@ class StorageServiceProvider implements ServiceProviderInterface
 
         $app['storage.request.listing'] = $app->share(
             function ($app) {
-                $cr = new ContentRequest\Listing($app['storage'], $app['query'], $app['config']);
+                $cr = new ContentRequest\Listing($app['storage'], $app['query'], $app['config'], $app['pager']);
 
                 return $cr;
             }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -129,7 +129,7 @@ class Listing
                 ->setTotalpages(ceil($totalResults / $query->getMaxResults()))
                 ->setCurrent($currentPage)
                 ->setShowingFrom(($start * $query->getMaxResults()) + 1)
-                ->setShowingTo((($start - 1) * $query->getMaxResults()) + count($results));
+                ->setShowingTo((($start - 1) * $query->getMaxResults()) + $results->count());
         }
     }
 }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -33,7 +33,7 @@ class Listing
      * @param Config $config
      * @param PagerManager $pager
      */
-    public function __construct(EntityManager $em, Query $query, Config $config, PagerManager $pager)
+    public function __construct(EntityManager $em, Query $query, Config $config, PagerManager $pager = null)
     {
         $this->em = $em;
         $this->query = $query;

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -101,6 +101,7 @@ class Listing
         if ($records === false && $options->getPage() !== null) {
             $contentParameters['page'] = $options->getPreviousPage();
             $records = $this->query->getContent($contentTypeSlug, $contentParameters);
+            $this->runPagerQueries($records);
         }
 
         return $records;
@@ -109,10 +110,12 @@ class Listing
     /**
      * @param QueryResultset $results
      */
-    protected function runPagerQueries(QueryResultset $results)
+    protected function runPagerQueries($results)
     {
+        if (!$results instanceof QueryResultset) {
+            return;
+        }
         foreach ($results->getOriginalQueries() as $pagerName => $query) {
-
             $queryCopy = clone $query;
             $queryCopy->setMaxResults(null);
             $queryCopy->setFirstResult(null);
@@ -121,14 +124,12 @@ class Listing
             $start = $query->getFirstResult() ? $query->getFirstResult() : 0;
             $currentPage = ($start + $query->getMaxResults()) / $query->getMaxResults();
 
-            $pager = $this->pager->createPager($pagerName)
+            $this->pager->createPager($pagerName)
                 ->setCount($totalResults)
                 ->setTotalpages(ceil($totalResults / $query->getMaxResults()))
                 ->setCurrent($currentPage)
                 ->setShowingFrom(($start * $query->getMaxResults()) + 1)
                 ->setShowingTo((($start - 1) * $query->getMaxResults()) + count($results));
         }
-
-
     }
 }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -117,10 +117,11 @@ class Listing
         }
         foreach ($results->getOriginalQueries() as $pagerName => $query) {
             $queryCopy = clone $query;
+            $queryCopy->select('count(*)');
             $queryCopy->setMaxResults(null);
             $queryCopy->setFirstResult(null);
 
-            $totalResults = (int)$queryCopy->execute()->fetchColumn();
+            $totalResults = (int)$queryCopy->execute()->rowCount();
             $start = $query->getFirstResult() ? $query->getFirstResult() : 0;
             $currentPage = ($start + $query->getMaxResults()) / $query->getMaxResults();
 
@@ -129,7 +130,7 @@ class Listing
                 ->setTotalpages(ceil($totalResults / $query->getMaxResults()))
                 ->setCurrent($currentPage)
                 ->setShowingFrom(($start * $query->getMaxResults()) + 1)
-                ->setShowingTo((($start - 1) * $query->getMaxResults()) + $results->count());
+                ->setShowingTo(($start * $query->getMaxResults()) + $results->count());
         }
     }
 }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -129,8 +129,8 @@ class Listing
                 ->setCount($totalResults)
                 ->setTotalpages(ceil($totalResults / $query->getMaxResults()))
                 ->setCurrent($currentPage)
-                ->setShowingFrom(($start * $query->getMaxResults()) + 1)
-                ->setShowingTo(($start * $query->getMaxResults()) + $results->count());
+                ->setShowingFrom($start + 1)
+                ->setShowingTo($start + $results->count());
         }
     }
 }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -121,7 +121,7 @@ class Listing
             $queryCopy->setMaxResults(null);
             $queryCopy->setFirstResult(null);
 
-            $totalResults = (int)$queryCopy->execute()->rowCount();
+            $totalResults = (int)count($queryCopy->execute()->fetchAll());
             $start = $query->getFirstResult() ? $query->getFirstResult() : 0;
             $currentPage = ($start + $query->getMaxResults()) / $query->getMaxResults();
 

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -112,7 +112,7 @@ class Listing
      */
     protected function runPagerQueries($results)
     {
-        if (!$results instanceof QueryResultset) {
+        if (!$results instanceof QueryResultset || $this->pager === null) {
             return;
         }
         foreach ($results->getOriginalQueries() as $pagerName => $query) {

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -101,8 +101,8 @@ class Listing
         if ($records === false && $options->getPage() !== null) {
             $contentParameters['page'] = $options->getPreviousPage();
             $records = $this->query->getContent($contentTypeSlug, $contentParameters);
-            $this->runPagerQueries($records);
         }
+        $this->runPagerQueries($records);
 
         return $records;
     }

--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -7,6 +7,7 @@ use Bolt\Storage\EntityManager;
 use Bolt\Storage\Query\Directive\GetQueryDirective;
 use Bolt\Storage\Query\Directive\HydrateDirective;
 use Bolt\Storage\Query\Directive\LimitDirective;
+use Bolt\Storage\Query\Directive\OffsetDirective;
 use Bolt\Storage\Query\Directive\OrderDirective;
 use Bolt\Storage\Query\Directive\PagingDirective;
 use Bolt\Storage\Query\Directive\PrintQueryDirective;
@@ -86,6 +87,7 @@ class ContentQueryParser
         $this->addDirectiveHandler('hydrate', new HydrateDirective());
         $this->addDirectiveHandler('limit', new LimitDirective());
         $this->addDirectiveHandler('order', new OrderDirective());
+        $this->addDirectiveHandler('page', new OffsetDirective());
         $this->addDirectiveHandler('paging', new PagingDirective());
         $this->addDirectiveHandler('printquery', new PrintQueryDirective());
         $this->addDirectiveHandler('returnsingle', new ReturnSingleDirective());

--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -226,7 +226,7 @@ class ContentQueryParser
                 continue;
             }
             if (is_callable($this->getDirectiveHandler($key))) {
-                call_user_func($this->getDirectiveHandler($key), $query, $value);
+                call_user_func($this->getDirectiveHandler($key), $query, $value, $this->directives);
             }
         }
     }

--- a/src/Storage/Query/Directive/OffsetDirective.php
+++ b/src/Storage/Query/Directive/OffsetDirective.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bolt\Storage\Query\Directive;
+
+use Bolt\Storage\Query\QueryInterface;
+use Bolt\Storage\Query\SelectQuery;
+
+/**
+ *  Directive to add a limit modifier to the query.
+ */
+class OffsetDirective
+{
+    /**
+     * @param SelectQuery $query
+     * @param $page
+     */
+    public function __invoke(SelectQuery $query, $page)
+    {
+        $limit = $query->getParameter('limit');
+        $query->getQueryBuilder()->setFirstResult(($page - 1) * $limit);
+    }
+}

--- a/src/Storage/Query/Directive/OffsetDirective.php
+++ b/src/Storage/Query/Directive/OffsetDirective.php
@@ -2,7 +2,6 @@
 
 namespace Bolt\Storage\Query\Directive;
 
-use Bolt\Storage\Query\QueryInterface;
 use Bolt\Storage\Query\SelectQuery;
 
 /**
@@ -13,10 +12,11 @@ class OffsetDirective
     /**
      * @param SelectQuery $query
      * @param $page
+     * @param $otherDirectives
      */
-    public function __invoke(SelectQuery $query, $page)
+    public function __invoke(SelectQuery $query, $page, $otherDirectives)
     {
-        $limit = $query->getParameter('limit');
+        $limit = $otherDirectives['limit'] ? $otherDirectives['limit'] : 0;
         $query->getQueryBuilder()->setFirstResult(($page - 1) * $limit);
     }
 }

--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -44,6 +44,7 @@ class SelectQueryHandler
 
             $result = $repo->queryWith($query);
             if ($result) {
+                $set->setOriginalQuery($contentType, $query);
                 $set->add($result, $contentType);
             }
         }

--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -44,7 +44,7 @@ class SelectQueryHandler
 
             $result = $repo->queryWith($query);
             if ($result) {
-                $set->setOriginalQuery($contentType, $query);
+                $set->setOriginalQuery($contentType, $query->getQueryBuilder());
                 $set->add($result, $contentType);
             }
         }

--- a/src/Storage/Query/QueryResultset.php
+++ b/src/Storage/Query/QueryResultset.php
@@ -5,6 +5,7 @@ namespace Bolt\Storage\Query;
 use AppendIterator;
 use ArrayIterator;
 use Countable;
+use Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * This class is a wrapper that handles single or multiple
@@ -16,6 +17,9 @@ class QueryResultset extends AppendIterator implements Countable
 {
     /** @var array */
     protected $results = [];
+
+    /** @var QueryBuilder[] */
+    protected $originalQueries = [];
 
     /**
      * @param array  $results A set of results
@@ -66,5 +70,27 @@ class QueryResultset extends AppendIterator implements Countable
     public function count()
     {
         return count($this->get());
+    }
+
+    /**
+     * @param $type
+     * @param $originalQuery
+     */
+    public function setOriginalQuery($type, $originalQuery)
+    {
+        $this->originalQueries[$type] = $originalQuery;
+    }
+
+    /**
+     * @param null $type
+     * @return QueryBuilder
+     */
+    public function getOriginalQuery($type = null)
+    {
+        if ($type !== null) {
+            return $this->originalQueries[$type];
+        }
+
+        return reset($this->originalQueries);
     }
 }

--- a/src/Storage/Query/QueryResultset.php
+++ b/src/Storage/Query/QueryResultset.php
@@ -93,4 +93,12 @@ class QueryResultset extends AppendIterator implements Countable
 
         return reset($this->originalQueries);
     }
+
+    /**
+     * @return QueryBuilder[]
+     */
+    public function getOriginalQueries()
+    {
+        return $this->originalQueries;
+    }
 }


### PR DESCRIPTION
Fixes #6999 

This finishes off support for pagination, the original query is now exposed via the QueryResultset object and that allows other areas of the codebase to get the query and modify/re-run which will likely be useful in other areas of the code or extensions too.

Also added a dependency injection of the pager manager to the backend content listing action so it can update the pager values accordingly.