### PR TITLE
[BUGFIX] PermissionParser is not handling UTF-8 properly

### DIFF
--- a/src/Storage/ContentRequest/Modify.php
+++ b/src/Storage/ContentRequest/Modify.php
@@ -6,6 +6,7 @@ use Bolt\Helpers\Input;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Storage\Entity\Content;
 use Bolt\Storage\EntityManager;
+use Bolt\Storage\Mapping;
 use Bolt\Storage\Repository;
 use Bolt\Translation\Translator as Trans;
 use Bolt\Users;
@@ -103,8 +104,9 @@ class Modify
     protected function deleteRecord(Repository $repo, Content $entity)
     {
         $recordId = $entity->getId();
+        /** @var Mapping\ContentType $contentType */
         $contentType = $entity->getContenttype();
-        $contentTypeName = $contentType['singular_name'];
+        $contentTypeName = (string) $contentType;
         if (!$this->users->isAllowed("contenttype:$contentTypeName:delete:$recordId")) {
             $this->loggerFlash->error(Trans::__('general.access-denied.content-not-modified', ['%title%' => $entity->getTitle()]));
 
@@ -112,7 +114,7 @@ class Modify
         }
         $result = $repo->delete($entity);
         if ($result) {
-            $this->loggerSystem->info(sprintf('Deleted %s: %s', $contentTypeName, $entity->getTitle()), ['event' => 'content']);
+            $this->loggerSystem->info(sprintf('Deleted %s: %s', $contentType['singular_name'], $entity->getTitle()), ['event' => 'content']);
         }
 
         return $result;


### PR DESCRIPTION
Affected version: 3.3.3

Probably BC Break.

Using UTF-8 characters in Content Type's singular name breaks PermissionParser.

```
PermissionLexerException in PermissionParser.php line 226:
Unexpected character '�' while parsing query contenttype:Wiadomość:delete:1
in PermissionParser.php line 226
at PermissionParser::lex('ść:delete:1') in PermissionParser.php line 151
at PermissionParser::run('contenttype:Wiadomość:delete:1') in Permissions.php line 557
at Permissions->isAllowed('contenttype:Wiadomość:delete:1', array('id' => '1', 'username' => 'admin', 'password' => null, 'email' => 'marcin.piela@tsh.io', 'lastseen' => object(Carbon), 'lastip' => '109.196.57.163', 'displayname' => 'admin', 'stack' => array('files://2017-09/wodospad-siklawica-850x450.jpg'), 'enabled' => true, 'shadowpassword' => null, 'shadowtoken' => null, 'shadowvalidity' => null, 'failedlogins' => '0', 'throttleduntil' => null, 'roles' => array('root', 'everyone')), null, null) in Users.php line 495
at Users->isAllowed('contenttype:Wiadomość:delete:1') in Modify.php line 107
at Modify->deleteRecord(object(MessageRepository), object(Message)) in Modify.php line 84
```
