### PR TITLE
Make sure we sort on something, if no explicit order is given.

### DIFF
--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -128,7 +128,7 @@ final class Choice
         }
 
         $filter = $field->get('filter');
-        $filter['order'] = $field->get('sort');
+        $filter['order'] = $field->get('sort', $queryFields[0]);
         /** @var QueryResultset $entities */
         $entities = $this->query->getContent($contentType, $filter);
         if (!$entities) {


### PR DESCRIPTION
Fixes #7019

A regression in 9896b26f41fc8fe8476f57f5e6a16ba8e7789799 allowed for the situation where no sort was given. This makes sure it falls back to the first part of the `values: `, as it was in 3.3.0. 