### PR TITLE
Loose compare order parameter as it can't be empty

### DIFF
--- a/src/Storage/Query/Directive/OrderDirective.php
+++ b/src/Storage/Query/Directive/OrderDirective.php
@@ -17,7 +17,7 @@ class OrderDirective
      */
     public function __invoke(QueryInterface $query, $order)
     {
-        if ($order === false) {
+        if (!$order) {
             return;
         }
 


### PR DESCRIPTION
Fixes #7019
Closes #7020