### PR TITLE
[3.3][Tests] Fix breakage due to upstream 

### DIFF
--- a/tests/phpunit/unit/Embed/GuzzleDispatcherTest.php
+++ b/tests/phpunit/unit/Embed/GuzzleDispatcherTest.php
@@ -65,7 +65,6 @@ class GuzzleDispatcherTest extends TestCase
         /** @var \Bolt\Filesystem\Handler\Image $mockFile */
         $mockFile = $filesystem->getFile('generic-logo.png');
         $fileData = $mockFile->readStream();
-        $dataUrl = 'data:image/png;base64,' . base64_encode($fileData);
 
         $mockHandler = new MockHandler([
             new Psr7\Response(200, ['Content-Type' => 'image/png'], $fileData),
@@ -79,7 +78,6 @@ class GuzzleDispatcherTest extends TestCase
         $urls = [
             Url::create($imageUrl),
             Url::create($thumbnailUrl),
-            Url::create($dataUrl),
         ];
 
         $responses = $dispatcher->dispatchImages($urls);
@@ -89,14 +87,10 @@ class GuzzleDispatcherTest extends TestCase
 
         /** @var ImageResponse $response */
         $response = $responses[0];
-        $this->assertSame($dataUrl, (string) $response->getUrl());
-        $this->assertSame($dataUrl, (string) $response->getStartingUrl());
-
-        $response = $responses[1];
         $this->assertSame($imageUrl, (string) $response->getUrl());
         $this->assertSame($imageUrl, (string) $response->getStartingUrl());
 
-        $response = $responses[2];
+        $response = $responses[1];
         $this->assertSame($thumbnailUrl, (string) $response->getUrl());
         $this->assertSame($thumbnailUrl, (string) $response->getStartingUrl());
     }


### PR DESCRIPTION
This appeared overnight in `embed/embed` **v3.2.1** — https://github.com/oscarotero/Embed/commit/0641d4a9ee8ff2bb4e60a45e42b9c9f46f8a26f4

To my knowledge we don't use the data URIs, but we can't now :wink: 

4am … pre-:coffee: … Something … something … SemVer.