### PR TITLE
Singletons in submenus need to skip "overview" too.

### DIFF
--- a/app/view/twig/_nav/_secondary-content.twig
+++ b/app/view/twig/_nav/_secondary-content.twig
@@ -31,6 +31,9 @@
     {% set sub = [] %}
 
     {% for sub_menu in menu.children %}
+        {% if sub_menu.has('singleton') %}
+            {% set sub_menu = sub_menu.children|first %}
+        {% endif %}
         {% set sub = sub|merge([sub_menu]) %}
     {% endfor %}
 

--- a/app/view/twig/_nav/_secondary-content.twig
+++ b/app/view/twig/_nav/_secondary-content.twig
@@ -25,17 +25,18 @@
 {% endif %}
 
 {# "Other" ContentType menu and sub-menu #}
-{% if content_menus.other is defined %}
-    {% set menu = content_menus.other %}
-    {% set key = menu.label %}
-    {% set sub = [] %}
+{% if content_menus.grouped is defined %}
+    {% for name, menu in content_menus.grouped.children %}
+        {% set key = menu.label %}
+        {% set sub = [] %}
 
-    {% for sub_menu in menu.children %}
-        {% if sub_menu.has('singleton') %}
-            {% set sub_menu = sub_menu.children|first %}
-        {% endif %}
-        {% set sub = sub|merge([sub_menu]) %}
+        {% for sub_menu in menu.children %}
+            {% if sub_menu.has('singleton') %}
+                {% set sub_menu = sub_menu.children|first %}
+            {% endif %}
+            {% set sub = sub|merge([sub_menu]) %}
+        {% endfor %}
+
+        {{ nav.submenu(menu.icon, menu.label, sub, false, false, null, true) }}
     {% endfor %}
-
-    {{ nav.submenu(menu.icon, menu.label, sub, false, false, null, true) }}
 {% endif %}

--- a/src/Menu/Builder/AdminContent.php
+++ b/src/Menu/Builder/AdminContent.php
@@ -58,7 +58,7 @@ final class AdminContent
         }
 
         // ContentTypes, where show_in_menu is set to a custom value or false
-        $this->addOtherContentTypes($contentRoot);
+        $this->addGroupedMenus($contentRoot);
 
         return $root;
     }
@@ -99,28 +99,58 @@ final class AdminContent
     }
 
     /**
-     * Add the "Other content" menu.
+     * Add the "Other content" & similar menu/sub menus.
      *
      * @param MenuEntry $contentRoot
      */
-    private function addOtherContentTypes(MenuEntry $contentRoot)
+    private function addGroupedMenus(MenuEntry $contentRoot)
     {
-        $contentTypes = $this->contentTypes->filter(function ($k, $v) {
-            return $v['show_in_menu'] !== true;
+        $groups = $this->contentTypes->call(function ($a) {
+            $arr = [];
+            foreach ($a as $v) {
+                if ($v['show_in_menu'] === true) {
+                    continue;
+                }
+                $key = $v['show_in_menu'] ?: 'other';
+                $arr[$key][] = $v;
+            }
+
+            return $arr;
         });
-        if ($contentTypes->isEmpty()) {
+        if ($groups->isEmpty()) {
             return;
         }
 
-        // Other content root
-        $otherEntry = $contentRoot->add(
-            MenuEntry::create('other')
-                ->setLabel(Trans::__('general.phrase.other-content'))
-                ->setIcon('fa:th-list')
+        // Create a master node for these groups
+        $groupedMenusRoot = $contentRoot->add(
+            MenuEntry::create('grouped')
                 ->setPermission('dashboard')
         );
 
-        // Other content children
+        foreach ($groups as $key => $contentTypes) {
+            $label = $key === 'other' ? Trans::__('general.phrase.other-content') : ucwords($key);
+
+            // Other content root
+            $otherEntry = $groupedMenusRoot->add(
+                MenuEntry::create(strtolower($key))
+                    ->setLabel($label)
+                    ->setIcon('fa:th-list')
+                    ->setPermission('dashboard')
+            );
+            $groupedMenusRoot->add($otherEntry);
+
+            $this->addGroupedContentTypes($otherEntry, $contentTypes);
+        }
+    }
+
+    /**
+     * Add a group's children.
+     *
+     * @param MenuEntry $otherEntry
+     * @param array     $contentTypes
+     */
+    private function addGroupedContentTypes(MenuEntry $otherEntry, array $contentTypes)
+    {
         foreach ($contentTypes as $contentTypeKey => $contentType) {
             /** @var Bag $contentType */
             $otherEntry->add(

--- a/src/Menu/Resolver/RecentlyEdited.php
+++ b/src/Menu/Resolver/RecentlyEdited.php
@@ -47,12 +47,24 @@ final class RecentlyEdited
         if (!$contentRoot->has('main')) {
             return;
         }
-
         foreach ($contentRoot->get('main')->children() as $name => $contentMenu) {
+            if ($contentTypes->getPath($name . '/singleton')) {
+                $this->addSingleton($contentMenu, $name);
+                continue;
+            }
             try {
                 $this->addRecentlyEdited($contentMenu, $name, $contentTypes);
             } catch (TableNotFoundException $e) {
                 $contentRoot->get('main')->remove($name);
+            }
+        }
+
+        if (!$contentRoot->has('other')) {
+            return;
+        }
+        foreach ($contentRoot->get('other')->children() as $name => $contentMenu) {
+            if ($contentTypes->getPath($name . '/singleton')) {
+                $this->addSingleton($contentMenu, $name);
             }
         }
     }
@@ -64,12 +76,6 @@ final class RecentlyEdited
      */
     private function addRecentlyEdited(MenuEntry $contentMenu, $contentTypeKey, Bag $contentTypes)
     {
-        $isSingleton = $contentTypes->getPath($contentTypeKey . '/singleton');
-        if ($isSingleton) {
-            $this->addSingleton($contentMenu, $contentTypeKey);
-
-            return;
-        }
         $entities = $this->getRecords($contentTypeKey, 4);
         if (!$entities) {
             return;


### PR DESCRIPTION
This is the last bit to make Singletons fully functional in a grouped menu. They were basically working, except the linked to the "overview" page, instead of the first/new record. See Screenshot:

![screen_shot_2017-09-27_at_16_17_07](https://user-images.githubusercontent.com/1833361/30918882-2278e250-a3a0-11e7-8dba-85ce0a388c62.png)
