### PR TITLE
Adding font sizes to headings in ckeditor

### DIFF
--- a/app/view/css/ckeditor-contents.css
+++ b/app/view/css/ckeditor-contents.css
@@ -61,10 +61,45 @@ ol,ul,dl
 	padding: 0 40px;
 }
 
+p, li
+{
+	font-size: 14px;
+}
+
 h1,h2,h3,h4,h5,h6
 {
 	font-weight: normal;
 	line-height: 1.2;
+}
+
+h1
+{
+	font-size: 26px;
+}
+
+h2
+{
+	font-size: 24px;
+}
+
+h3
+{
+	font-size: 22px;
+}
+
+h4
+{
+	font-size: 20px;
+}
+
+h5
+{
+	font-size: 18px;
+}
+
+h6
+{
+	font-size: 16px;
 }
 
 hr


### PR DESCRIPTION
Ckeditor gives no styling to headings in the WYSIWYG editor and leaves that to the users' browser. This causes headings in some browsers to be displayed smaller than paragraph text. 
I added font sizes for h1, h2, h3, h4, h5, h6 tags. This improves readability and visual hierarchy in WYSIWYG fields.
