### PR TITLE
Fix taxonomies on database:import CLI script

### DIFF
--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -144,7 +144,6 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
     public function serialize()
     {
         $output = [];
-        $this->initialize();
 
         foreach ($this->collection as $field) {
             $output[$field->getFieldName()] = $field->getValue();

--- a/src/Storage/Field/Collection/LazyFieldCollection.php
+++ b/src/Storage/Field/Collection/LazyFieldCollection.php
@@ -145,4 +145,16 @@ class LazyFieldCollection extends AbstractLazyCollection implements FieldCollect
 
         $this->em = null;
     }
+
+    public function serialize()
+    {
+        $output = [];
+        $this->initialize();
+
+        foreach ($this->collection as $field) {
+            $output[$field->getFieldName()] = $field->getValue();
+        }
+
+        return $output;
+    }
 }

--- a/src/Storage/Migration/Import.php
+++ b/src/Storage/Migration/Import.php
@@ -141,6 +141,7 @@ final class Import
         foreach ($taxonomyFields as $taxonomyField) {
             foreach ($importDatum->get($taxonomyField) as $value) {
                 $taxonomy[$taxonomyField][] = $value['slug'];
+                $entity->set($taxonomyField, null);
             }
         }
 


### PR DESCRIPTION
Fixing the database:import to allow taxonomies to save correctly. There were a couple of issues, primarily a clash between what was set on the `$entity->taxonomy` property versus the `$entity->field` property so before import this clears the field value and uses the outer taxonomy collection.

Fixes #7037