### PR TITLE
[Tests] Fixes for "not found" assertions

### DIFF
--- a/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
+++ b/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
@@ -371,7 +371,7 @@ class BackendAdminCest extends AbstractAcceptanceTest
 
         $body = file_get_contents(CODECEPTION_DATA . '/not-found.body.html');
 
-        $I->fillField('#title', '404');
+        $I->fillField('#title', '404 reasons to cry');
         $I->fillField('#slug',  'not-found');
         $I->fillField('#body',  $body);
 

--- a/tests/codeception/acceptance/200-Frontend/FrontendCest.php
+++ b/tests/codeception/acceptance/200-Frontend/FrontendCest.php
@@ -107,8 +107,8 @@ class FrontendCest
 
         $I->amOnPage('/resources');
 
-        $I->see('404 not found');
-        $I->see('The requested page was not found.');
+        $I->see('404 reasons to cry');
+        $I->see('Well, this is kind of embarrassing!');
     }
 
     /**
@@ -122,8 +122,8 @@ class FrontendCest
 
         $I->amOnPage('/derp-a-derp');
 
-        $I->see('404 not found');
-        $I->see('The requested page was not found.');
+        $I->see('404 reasons to cry');
+        $I->see('Well, this is kind of embarrassing!');
     }
 
     /**

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -66,25 +66,26 @@ class FrontendTest extends ControllerUnitTest
 
     public function testConfiguredConfigHomepageTemplate()
     {
+        $this->getService('filesystem')->put('theme://custom-home.twig', '');
         $this->getService('config')->set('general/homepage_template', 'custom-home.twig');
         $this->setRequest(Request::create('/'));
 
         $response = $this->controller()->homepage($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateView);
-        $this->assertSame('index.twig', $response->getTemplate());
+        $this->assertSame('custom-home.twig', $response->getTemplate());
     }
 
     public function testConfiguredThemeHomepageTemplate()
     {
-        $this->getService('filesystem')->put('theme://custom-home.twig', '');
-        $this->getService('config')->set('theme/homepage_template', 'custom-home.twig');
+        $this->getService('filesystem')->put('theme://custom-theme-home.twig', '');
+        $this->getService('config')->set('theme/homepage_template', 'custom-theme-home.twig');
         $this->setRequest(Request::create('/'));
 
         $response = $this->controller()->homepage($this->getRequest());
 
         $this->assertTrue($response instanceof TemplateView);
-        $this->assertSame('custom-home.twig', $response->getTemplate());
+        $this->assertSame('custom-theme-home.twig', $response->getTemplate());
     }
 
     public function testHomepageContent()


### PR DESCRIPTION
`bolt/themes` 1.0.1 got tagged this morning … that threw up more than one :koala: in our tests :frowning_face: 