### PR TITLE
Add logs to profiler

### DIFF
--- a/src/Provider/ProfilerServiceProvider.php
+++ b/src/Provider/ProfilerServiceProvider.php
@@ -8,6 +8,7 @@ use Bolt\Profiler\DebugToolbarEnabler;
 use Doctrine\DBAL\Logging\DebugStack;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 
 /**
  * @author Carson Full <carsonfull@gmail.com>
@@ -55,6 +56,7 @@ class ProfilerServiceProvider implements ServiceProviderInterface
                     // @codingStandardsIgnoreStart
                     $collectors['bolt'] = $app->share(function ($app) { return new BoltDataCollector($app); });
                     $collectors['db'] = $app->share(function ($app) { return new DatabaseDataCollector($app['db.logger']); });
+                    $collectors['logs'] = $app->share(function ($app) { return new LoggerDataCollector($app['logger']); });
                     // @codingStandardsIgnoreEnd
 
                     return $collectors;


### PR DESCRIPTION
This PR fulfills empty Logs tab in Profiler, using default Symfony LoggerCollector. It should have no impact on performance since logging is disabled by default and then NullLogger is used.