### PR TITLE
Fixes for `title_format`

### DIFF
--- a/app/view/twig/_macro/_macro.twig
+++ b/app/view/twig/_macro/_macro.twig
@@ -28,7 +28,7 @@
  #}
 {% macro contentlink(contenttype, content) %}
     {% import _self as crosslinks %}
-    {% set title = content.getTitle(true) %}
+    {% set title = content.getTitle() %}
     {{ crosslinks.contentlink_by_id(contenttype, title, content.id) }}
 {% endmacro %}
 

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -334,13 +334,21 @@ class Content extends Entity
      */
     public function getTitle()
     {
-        if (array_key_exists('title', $this->_fields)) {
-            return $this->_fields['title'];
+        $fields = $this->_fields;
+
+        if (array_key_exists('title', $fields)) {
+            return $fields['title'];
         }
 
-        $fieldName = $this->getTitleColumnName($this->contenttype);
+        $fieldNames = $this->getTitleColumnNames($this->contenttype);
 
-        return $this->$fieldName;
+        $title = [];
+        foreach ($fieldNames as $fieldName) {
+            // Make sure we add strings only, as some fields may be an array or DateTime.
+            $title[] = is_array($fields[$fieldName]) ? implode(' ', $fields[$fieldName]) : (string) $fields[$fieldName];
+        }
+
+        return implode(' ', $title);
     }
 
     /**

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -592,8 +592,10 @@ trait ContentValuesTrait
         }
 
         foreach ($this->getTitleColumnName() as $fieldName) {
-            if (strip_tags($this->values[$fieldName], $allowedTags) !== '') {
-                $titleParts[] = strip_tags($this->values[$fieldName], $allowedTags);
+            // Make sure we add strings only, as some fields may be an array or DateTime.
+            $value = is_array($this->values[$fieldName]) ? implode(' ', $this->values[$fieldName]) : (string) $this->values[$fieldName];
+            if (strip_tags($value, $allowedTags) !== '') {
+                $titleParts[] = strip_tags($value, $allowedTags);
             }
         }
 
@@ -616,11 +618,7 @@ trait ContentValuesTrait
     {
         // If we specified a specific fieldname or array of fieldnames as 'title'.
         if (!empty($this->contenttype['title_format'])) {
-            if (!is_array($this->contenttype['title_format'])) {
-                $this->contenttype['title_format'] = [$this->contenttype['title_format']];
-            }
-
-            return $this->contenttype['title_format'];
+            return (array) $this->contenttype['title_format'];
         }
 
         // Sets the names of some 'common' names for the 'title' column.

--- a/src/Storage/Mapping/ContentTypeTitleTrait.php
+++ b/src/Storage/Mapping/ContentTypeTitleTrait.php
@@ -18,39 +18,57 @@ trait ContentTypeTitleTrait
      *
      * @param ContentType|array $contentType
      *
-     * @return array
+     * @return string
      */
     protected function getTitleColumnName($contentType)
     {
         Deprecated::method();
 
-        $fields = $contentType['fields'];
+        $names = $this->getTitleColumnNames($contentType);
+
+        return reset($names);
+    }
+
+    /**
+     * Get an array of the columnname(s) of the title.
+     *
+     * @param ContentType|array $contentType
+     *
+     * @return array
+     */
+    protected function getTitleColumnNames($contentType)
+    {
+        Deprecated::method();
+
+        // If we specified a specific fieldname or array of fieldnames as 'title'.
+        if (!empty($contentType['title_format'])) {
+            return (array) $contentType['title_format'];
+        }
+
         $names = [
-            // EN
-            'title', 'name', 'caption', 'subject',
-            // NL
-            'titel', 'naam', 'onderwerp',
-            // FR
-            'nom', 'sujet',
-            // ES
-            'nombre', 'sujeto',
-            // PT
-            'titulo', 'nome', 'subtitulo', 'assunto',
+            'title', 'name', 'caption', 'subject', //EN
+            'titel', 'naam', 'onderwerp', // NL
+            'nom', 'sujet', // FR
+            'nombre', 'sujeto', // ES
+            'titulo', 'nome', 'subtitulo', 'assunto', // PT
         ];
 
-        foreach ($fields as $name => $values) {
-            if (in_array($name, $names)) {
-                return $name;
+        foreach ($names as $name) {
+            if (isset($contentType['fields'][$name])) {
+                return [$name];
             }
         }
 
-        foreach ($fields as $name => $values) {
-            if ($values['type'] === 'text') {
-                return $name;
+        // Otherwise, grab the first field of type 'text', and assume that's the title.
+        if (!empty($contentType['fields'])) {
+            foreach ($contentType['fields'] as $key => $field) {
+                if ($field['type'] === 'text') {
+                    return [$key];
+                }
             }
         }
 
-        // If this is a contenttype without any textfields
+        // If this is a ContentType without any textfields
         $keys = array_keys($fields);
 
         return reset($keys);


### PR DESCRIPTION
Fixes #6870. Fixes #7064.

This PR makes `title_format` work for the new storage layer, as it did for the old one. The code in `ContentTypeTitleTrait::getTitleColumnNames` is mostly adapted from `ContentValuesTrait::getTitleColumnName`.

I also modified the old implementation in `ContentValuesTrait`, to fix #6870 for places where the old storage layer is used. (like in the "Last modified" block in the right aside. 