### PR TITLE
Fix named repeaters during CLI import and export

### DIFF
--- a/src/Storage/Field/Collection/RepeatingFieldCollection.php
+++ b/src/Storage/Field/Collection/RepeatingFieldCollection.php
@@ -288,7 +288,11 @@ class RepeatingFieldCollection extends ArrayCollection
     {
         $output = [];
         foreach ($this as $collection => $vals) {
-            $output[$collection] = $vals->serialize();
+            if ($vals->getBlock() !== null) {
+                $output[$collection][$vals->getBlock()] = $vals->serialize();
+            } else {
+                $output[$collection] = $vals->serialize();
+            }
         }
 
         return $output;

--- a/src/Storage/Migration/Import.php
+++ b/src/Storage/Migration/Import.php
@@ -135,6 +135,9 @@ final class Import
         $taxonomies = $this->em->createCollection(Entity\Taxonomy::class);
         $taxonomy = [];
         foreach ($taxonomyFields as $taxonomyField) {
+            if ($importDatum->get($taxonomyField) === null) {
+                continue;
+            }
             foreach ($importDatum->get($taxonomyField) as $value) {
                 $taxonomy[$taxonomyField][] = $value->toArray();
                 $entity->set($taxonomyField, null);


### PR DESCRIPTION
Couple of minor adjustments to add serialize support for new named repeaters.

This ensures that both ways of database:import and database:export work correctly.