### PR TITLE
[3.4] Fix select values in new named repeater blocks

### DIFF
--- a/app/view/twig/editcontent/fields/_block-group.twig
+++ b/app/view/twig/editcontent/fields/_block-group.twig
@@ -28,16 +28,21 @@
         } %}
         {% for rkey, rfield in field.fields[block].fields %}
             {% set rfield = defaults|merge(rfield) %}
+            {% if rfield.type == 'select' %}
+                {% set values = context.values.select_choices[rkey] %}
+            {% endif %}
             {% set rcontext = {
-            'key':        name ~ '_' ~ index ~ '_' ~ block ~ '_' ~ rkey,
-            'name':       name ~ '[' ~ index ~ '][' ~ block ~ '][' ~ rkey ~ ']',
-            'contentkey': rkey,
-            'field':      rfield,
-            'labelkey':   rfield.label|default(rkey|ucfirst),
-            'context': {
-            'content':  content,
-            'can':      context.can,
-            }
+                'key':        name ~ '_' ~ index ~ '_' ~ block ~ '_' ~ rkey,
+                'name':       name ~ '[' ~ index ~ '][' ~ block ~ '][' ~ rkey ~ ']',
+                'contentkey': rkey,
+                'values':     values|default(),
+                'field':      rfield,
+                'labelkey':   rfield.label|default(rkey|ucfirst),
+                'context': {
+                    'content':  content,
+                    'can':      context.can,
+                    'file_matcher': context.file_matcher,
+                }
             } %}
             <div class="block-field" data-bolt-fieldset="{{ rfield.type }}">
                 {# Prefix #}

--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -60,6 +60,11 @@ final class Choice
             if ($field['type'] === 'repeater') {
                 $this->build($select, $field['fields']);
             }
+            if ($field['type'] === 'block') {
+                foreach ($field['fields'] as $blockName => $block) {
+                    $this->build($select, $block['fields']);
+                }
+            }
             $values = $this->getValues($field);
             if ($values !== null) {
                 if ($isTemplateFields) {


### PR DESCRIPTION
This fixes #7062 

In the choice resolver we do an extra loop for repeater fields, just need to do the same to the block fields and loop each of the sub-fields.

Couple of minor adjustments to the template file to reflect changes in the equivalent repeater block.