### PR TITLE
Only pass user's ID into Users::addRole()

### DIFF
--- a/src/Users.php
+++ b/src/Users.php
@@ -454,7 +454,9 @@ class Users
         $this->app['logger.flash']->info(Trans::__('general.phrase.missing-root-jackpot'));
 
         // If we reach this point, there is no user 'root'. We promote the current user.
-        return $this->addRole($this->getCurrentUser(), 'root');
+        $user = $this->getCurrentUser();
+
+        return $this->addRole($user['id'], 'root');
     }
 
     /**


### PR DESCRIPTION
Resolved small bug that occurs when first user is created via app/nut command without Root permissions.
At line 458, `addRole()` is aimed to accept a user id (int or string), the whole user object as array was passed instead causing a crash at line 234 when userId is used in `array_key_exists`.
Sorry for IDE autoindent
