### PR TITLE
Remove import for Bolt\Common\Deprecated

### DIFF
--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -2,7 +2,6 @@
 
 namespace Bolt\Helpers;
 
-use Bolt\Common\Deprecated;
 use Cocur\Slugify\Slugify;
 
 class Str extends \Bolt\Common\Str


### PR DESCRIPTION
Fixes #7090
Related to PHP bug [66773](https://bugs.php.net/bug.php?id=66773), [66862](https://bugs.php.net/bug.php?id=66862) and [71079](https://bugs.php.net/bug.php?id=71079) (commit https://github.com/php/php-src/commit/2a75f5026a47099f585e29c5a9d8a2989dab42af)