### PR TITLE
Allow `group` on named repeater's sets

### DIFF
--- a/app/view/twig/editcontent/fields/_block.twig
+++ b/app/view/twig/editcontent/fields/_block.twig
@@ -36,12 +36,18 @@
     <div class="col-xs-12">
         <div class="block-add">
             <div class="btn-group">
-                <button type="button" class="btn btn-default">{{ __('field.block.label.add-new') }}</button>
                 <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                    {{ __('field.block.label.add-new') }}
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu" role="menu">
                     {% for blockname, block in field.fields %}
+                        {% if block.group is defined %}
+                            {% if not loop.first %}
+                                <li class="divider"></li>
+                            {% endif %}
+                            <li class="dropdown-header">{{ block.group }}</li>
+                        {% endif %}
                         <li>
                             <a class="add-button" data-block-type="{{ blockname }}">
                                 <i class="fa fa-plus"></i> {{  __('field.block.label.add-set', {'%label%': block.label}) }}


### PR DESCRIPTION
Nothing fancy, but this is a nice PoC/snippet.

It's not as advanced as the `group` for fields, because this one goes from top to bottom and doesn't check for existing groups.

The button isn't split with a button and a caret anymore.

From:

![named-repeaters](https://user-images.githubusercontent.com/4630335/31675994-85e3c906-b366-11e7-8f2d-691c59508467.png)

To:

![grouped-named-repeaters](https://user-images.githubusercontent.com/4630335/31675833-0ed41438-b366-11e7-9fbb-e1e449d138f1.png)
