### PR TITLE
Fixed: Restrict resizing of `<textarea>` to vertical only.

### DIFF
--- a/app/src/sass/editcontent/_legacy.scss
+++ b/app/src/sass/editcontent/_legacy.scss
@@ -13,6 +13,7 @@
         border-radius: 2px;
         border-color: #CCC;
         font-size: $font-size-base + 1px;
+        resize: vertical;
     }
 
     .error {


### PR DESCRIPTION
Fixes this annoying behaviour, by restricting resizing to vertical only: 

http://g.recordit.co/9n4MsAWTHx.gif