### PR TITLE
Don't show empty "Latest changes panel" if the changelog is not enabled.

### DIFF
--- a/app/view/twig/components/panel-activity.twig
+++ b/app/view/twig/components/panel-activity.twig
@@ -2,5 +2,7 @@
  # Sidebar-Panel: Displays the latest activity
  # (Usage Example: Dashboards sidebar)
  #}
-{{ include('@bolt/components/panel-activity-change.twig', context) }}
+{% if context.change %}
+    {{ include('@bolt/components/panel-activity-change.twig', context) }}
+{% endif %}
 {{ include('@bolt/components/panel-activity-system.twig', context) }}

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -178,7 +178,11 @@ class General extends AsyncBase
         // Test/get page number
         $page = $this->app['pager']->getCurrentPage('activity');
 
-        $change = $this->app['logger.manager']->getActivity('change', $page, 8);
+        if ($this->app['config']->get('general/changelog/enabled')) {
+            $change = $this->app['logger.manager']->getActivity('change', $page, 8);
+        } else {
+            $change = null;
+        }
         $system = $this->app['logger.manager']->getActivity('system', $page, 8, ['context' => ['authentication', 'security']]);
 
         $response = $this->render(


### PR DESCRIPTION
This one: 

![screen shot 2017-10-18 at 11 39 49](https://user-images.githubusercontent.com/1833361/31711937-f815f6e6-b3f9-11e7-9481-674b4f525774.png)

