### PR TITLE
[FIX] In route generation, lookup parameters from the route defaults

### DIFF
--- a/src/Storage/Entity/ContentRouteTrait.php
+++ b/src/Storage/Entity/ContentRouteTrait.php
@@ -178,6 +178,8 @@ trait ContentRouteTrait
                     $params[$fieldName] = array_pop($tempValues);
                 } elseif ($this->get($fieldName)) {
                     $params[$fieldName] = $this->get($fieldName);
+                } elseif (isset($route['defaults'][$fieldName])) {
+                    $params[$fieldName] = $route['defaults'][$fieldName];
                 } else {
                     // unknown
                     $params[$fieldName] = null;


### PR DESCRIPTION
Fixes a small bug where calls to `content.link()` were not falling back to defaults if the value was not set.