### PR TITLE
Handle deletion of field content after a content record is deleted

### DIFF
--- a/src/Storage/ContentRequest/Modify.php
+++ b/src/Storage/ContentRequest/Modify.php
@@ -5,6 +5,7 @@ namespace Bolt\Storage\ContentRequest;
 use Bolt\Helpers\Input;
 use Bolt\Logger\FlashLoggerInterface;
 use Bolt\Storage\Entity\Content;
+use Bolt\Storage\Entity\FieldValue;
 use Bolt\Storage\EntityManager;
 use Bolt\Storage\Mapping;
 use Bolt\Storage\Repository;
@@ -115,6 +116,14 @@ class Modify
         $result = $repo->delete($entity);
         if ($result) {
             $this->loggerSystem->info(sprintf('Deleted %s: %s', $contentType['singular_name'], $entity->getTitle()), ['event' => 'content']);
+            $fieldRepo = $this->em->getRepository(FieldValue::class);
+            $deleteFieldQuery = $fieldRepo->createQueryBuilder()
+                ->delete($fieldRepo->getTableName())
+                ->where('content_id = :content_id')
+                ->andWhere('contenttype= :contenttype')
+                ->setParameter('content_id', $recordId)
+                ->setParameter('contenttype', $contentTypeName);
+            $deleteFieldQuery->execute();
         }
 
         return $result;


### PR DESCRIPTION
Fixes #7088

Runs a delete query on relevant field content when a main content item is deleted.