### PR TITLE
In single fetch mode return false instead of empty set

### DIFF
--- a/src/Storage/Query/Handler/SearchQueryHandler.php
+++ b/src/Storage/Query/Handler/SearchQueryHandler.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Storage\Query\Handler;
 
+use Bolt\Storage\Entity\Content;
 use Bolt\Storage\Query\ContentQueryParser;
 use Bolt\Storage\Query\SearchQuery;
 use Bolt\Storage\Query\SearchQueryResultset;
@@ -15,7 +16,7 @@ class SearchQueryHandler
     /**
      * @param ContentQueryParser $contentQuery
      *
-     * @return SearchQueryResultset
+     * @return SearchQueryResultset|Content|false
      */
     public function __invoke(ContentQueryParser $contentQuery)
     {
@@ -54,6 +55,10 @@ class SearchQueryHandler
         }
 
         if ($query->getSingleFetchMode()) {
+            if ($set->count() === 0) {
+                return false;
+            }
+
             return $set->current();
         }
 

--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -16,7 +16,7 @@ class SelectQueryHandler
     /**
      * @param ContentQueryParser $contentQuery
      *
-     * @return QueryResultset|Content|null
+     * @return QueryResultset|Content|false
      */
     public function __invoke(ContentQueryParser $contentQuery)
     {
@@ -50,6 +50,10 @@ class SelectQueryHandler
         }
 
         if ($query->getSingleFetchMode()) {
+            if ($set->count() === 0) {
+                return false;
+            }
+
             return $set->current();
         }
 


### PR DESCRIPTION
Fixes #6938

In general the idea was to standardise results as a QueryResultset object which can be added to, counted and iterated etc.

However after the issue above was raised it does seem to make a bit more sense to treat queries with the `returnsingle` flag set to return either a single object or false in the absence of any result.

In Twig both eventualities can be covered by always using the `|length` filter which will return true if 1 result or more and false if no results.

