### PR TITLE
add an empty hidden field to ensure the field is saved

### DIFF
--- a/app/view/twig/editcontent/fields/_block.twig
+++ b/app/view/twig/editcontent/fields/_block.twig
@@ -19,6 +19,9 @@
         </div>
     {% endif %}
 
+    {# This ensures that an empty value is always submitted even if there are no subsequent repeater sets #}
+    <input type="hidden" name="{{ name }}[]">
+
     <div class="block-slot">
         {% set blockfieldvals = context.content.get(contentkey) %}
         {% for blockname,block in field.fields %}


### PR DESCRIPTION
Fixes #7116

Just a port of the same issue with normal repeaters. Adding a hidden empty form value makes sure that the field is saved even if the content is empty.