### PR TITLE
[3.3] Handle extension asset packages using paths based on web root

### DIFF
--- a/src/Extension/AssetTrait.php
+++ b/src/Extension/AssetTrait.php
@@ -192,8 +192,16 @@ trait AssetTrait
         }
 
         $app = $this->getContainer();
+        $filesystem = $app['filesystem'];
 
-        $themeFile = $app['filesystem']->getFile(sprintf('theme://%s', $path));
+        $publicFile = $filesystem->getFile("web://$path");
+        if ($publicFile->exists()) {
+            $asset->setPackageName('web');
+
+            return;
+        }
+
+        $themeFile = $filesystem->getFile("theme://$path");
         if ($themeFile->exists()) {
             $asset->setPackageName('theme');
 
@@ -201,10 +209,12 @@ trait AssetTrait
         }
 
         $message = sprintf(
-            "Couldn't add file asset '%s': File does not exist in either %s or %s directories. Make sure the file exists in either of these locations, by " .
-            'placing the file there manually (for Bundled Extensions) or by uninstalling / installing the extension again (for Managed Extensions).',
-            $path,
-            $this->getWebDirectory()->getFullPath(),
+            "Couldn't add file asset '%s': File does not exist in %s, %s or %s directories. Make sure the file " .
+            'exists in one of these locations, by placing the file there manually (for Bundled Extensions) or by ' .
+            'uninstalling and reinstalling the extension again (for Managed Extensions).',
+            $asset->getPath(),
+            $file->getFullPath(),
+            $publicFile->getFullPath(),
             $themeFile->getFullPath()
         );
         $app['logger.system']->error($message, ['event' => 'extensions']);

--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -33,6 +33,7 @@ class AssetServiceProvider implements ServiceProviderInterface
                 $packages->addPackage('files', $app['asset.package_factory']('files'));
                 $packages->addPackage('theme', $app['asset.package_factory']('theme'));
                 $packages->addPackage('themes', $app['asset.package_factory']('themes'));
+                $packages->addPackage('web', $app['asset.package_factory']('web'));
 
                 return $packages;
             }


### PR DESCRIPTION
Fixes #7077

The controversial part here is the addition of the web root as an asset package. We've avoided it up until now for several reasons, but I personally think it valid. 

If we're behind this enough to merge, then I'll follow up with some changes in the docs around this.