### PR TITLE
Fix taxonomy grouping queries with commas

### DIFF
--- a/src/Storage/Field/Type/JoinTypeBase.php
+++ b/src/Storage/Field/Type/JoinTypeBase.php
@@ -27,11 +27,12 @@ abstract class JoinTypeBase extends FieldTypeBase
      * For example, `_from_id => "4,4,4"` gets normalized to `['fromid'=>4]`
      *
      * @param Traversable $data
-     * @param string      $field
+     * @param string $field
+     * @param string $separator
      *
      * @return array
      */
-    protected function normalizeData($data, $field)
+    protected function normalizeData($data, $field, $separator = ',')
     {
         $normalized = [];
 
@@ -48,7 +49,7 @@ abstract class JoinTypeBase extends FieldTypeBase
             if ($value === null) {
                 continue;
             }
-            foreach (explode(',', $value) as $i => $val) {
+            foreach (explode($separator, $value) as $i => $val) {
                 $compiled[$i][$key] = $val;
             }
         }

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -103,7 +103,7 @@ class TaxonomyType extends JoinTypeBase
     {
         $taxName = $this->mapping['fieldname'];
 
-        $data = $this->normalizeData($data, $taxName);
+        $data = $this->normalizeData($data, $taxName, '|');
         /** @var Entity\Content $entity */
         if (!count($entity->getTaxonomy())) {
             $entity->setTaxonomy($this->em->createCollection(Entity\Taxonomy::class));

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -185,11 +185,11 @@ class TaxonomyType extends JoinTypeBase
 
         switch ($platform) {
             case 'mysql':
-                return "GROUP_CONCAT($column ORDER BY $order ASC) as $alias";
+                return "GROUP_CONCAT($column ORDER BY $order ASC SEPARATOR '|') as $alias";
             case 'sqlite':
-                return "GROUP_CONCAT($column) as $alias";
+                return "GROUP_CONCAT($column, '|') as $alias";
             case 'postgresql':
-                return "string_agg($column" . "::character varying, ',' ORDER BY $order) as $alias";
+                return "string_agg($column" . "::character varying, '|' ORDER BY $order) as $alias";
         }
 
         throw new StorageException(sprintf('Unsupported platform: %s', $platform));


### PR DESCRIPTION
Fixes #7107

This PR introduces the ability to vary the separator used on grouping queries. It means for taxonomies which may contain a comma as part of the results then we can switch to avoid breakages.