### PR TITLE
Fix grouping support in backend overview

### DIFF
--- a/src/Controller/Backend/Records.php
+++ b/src/Controller/Backend/Records.php
@@ -183,6 +183,7 @@ class Records extends BackendBase
             ->setPage($request->query->get('page_' . $contenttypeslug))
             ->setFilter($request->query->get('filter'))
             ->setTaxonomies($taxonomy)
+            ->setGroupSort(true)
         ;
 
         $context = [

--- a/src/Storage/Collection/Taxonomy.php
+++ b/src/Storage/Collection/Taxonomy.php
@@ -251,4 +251,19 @@ class Taxonomy extends ArrayCollection
         return $output;
     }
 
+
+    /**
+     * @return null|string
+     */
+    public function getGroupingTaxonomy()
+    {
+        foreach ($this->config->getData() as $taxKey => $taxonomy) {
+            if ($taxonomy['behaves_like'] === 'grouping') {
+                return $taxKey;
+            }
+        }
+
+        return null;
+    }
+
 }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -153,6 +153,10 @@ class Listing
             $grouped[$taxGroup][] = $result;
         }
 
+        if (!count($grouped)) {
+            return $results;
+        }
+
         return call_user_func_array('array_merge', $grouped);
     }
 }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -99,6 +99,9 @@ class Listing
             $records = $this->query->getContent($contentTypeSlug, $contentParameters);
         }
         $this->runPagerQueries($records);
+        if ($options->getGroupSort()) {
+            $records = $this->runGroupSort();
+        }
 
         return $records;
     }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -100,7 +100,7 @@ class Listing
         }
         $this->runPagerQueries($records);
         if ($options->getGroupSort()) {
-            $records = $this->runGroupSort();
+            $records = $this->runGroupSort($records);
         }
 
         return $records;

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -145,12 +145,15 @@ class Listing
         }
         $grouped = [];
         foreach ($results as $result) {
+            $taxGroup = null;
             foreach ($result->getTaxonomy() as $taxonomy) {
                 if ($taxonomy->getTaxonomytype() == $result->getTaxonomy()->getGroupingTaxonomy()) {
                     $taxGroup = $taxonomy->getSlug();
                 }
             }
-            $grouped[$taxGroup][] = $result;
+            if ($taxGroup !== null) {
+                $grouped[$taxGroup][] = $result;
+            }
         }
 
         if (!count($grouped)) {

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -130,4 +130,26 @@ class Listing
                 ->setShowingTo($start + $results->count());
         }
     }
+
+    /**
+     * @param $results
+     * @return array
+     */
+    protected function runGroupSort($results)
+    {
+        if (!$results instanceof QueryResultset) {
+            return $results;
+        }
+        $grouped = [];
+        foreach ($results as $result) {
+            foreach ($result->getTaxonomy() as $taxonomy) {
+                if ($taxonomy->getTaxonomytype() == $result->getTaxonomy()->getGroupingTaxonomy()) {
+                    $taxGroup = $taxonomy->getSlug();
+                }
+            }
+            $grouped[$taxGroup][] = $result;
+        }
+
+        return call_user_func_array('array_merge', $grouped);
+    }
 }

--- a/src/Storage/ContentRequest/ListingOptions.php
+++ b/src/Storage/ContentRequest/ListingOptions.php
@@ -17,6 +17,8 @@ class ListingOptions
     protected $taxonomies;
     /** @var string */
     protected $filter;
+    /** @var bool */
+    protected $groupSort;
 
     /**
      * Set the order.
@@ -124,5 +126,25 @@ class ListingOptions
     public function getFilter()
     {
         return $this->filter;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getGroupSort()
+    {
+        return $this->groupSort;
+    }
+
+    /**
+     * @param mixed $groupSort
+     *
+     * @return ListingOptions
+     */
+    public function setGroupSort($groupSort)
+    {
+        $this->groupSort = $groupSort;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Fixes #7096

Adds support in the new storage layer for reordering a resultset based on a grouping taxonomy.
