### PR TITLE
Ensure hyphens in urls are replaced with underscores before going into the Query Engine

### DIFF
--- a/src/Storage/Mapping/MetadataDriver.php
+++ b/src/Storage/Mapping/MetadataDriver.php
@@ -113,8 +113,8 @@ class MetadataDriver implements MappingDriver
             if ($tableName = $table->getName()) {
                 $mainAlias = $this->getContentTypeFromAlias($table->getOption('alias'));
                 $this->aliases[$mainAlias] = $tableName;
-                $slugAlias = $this->getContentTypeFromAlias($table->getOption('alias'), true);
-                $singularAlias = $this->getContentTypeFromAlias($table->getOption('alias'), 'singular');
+                $slugAlias = $this->normalizeClassName($this->getContentTypeFromAlias($table->getOption('alias'), true));
+                $singularAlias = $this->normalizeClassName($this->getContentTypeFromAlias($table->getOption('alias'), 'singular'));
 
                 if ($mainAlias !== $slugAlias) {
                     $this->aliases[$slugAlias] = $tableName;

--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -25,6 +25,7 @@ class SelectQueryHandler
         $query = $contentQuery->getService('select');
 
         foreach ($contentQuery->getContentTypes() as $contentType) {
+            $contentType = str_replace('-', '_', $contentType);
             $repo = $contentQuery->getEntityManager()->getRepository($contentType);
             $query->setQueryBuilder($repo->createQueryBuilder('_' . $contentType));
             $query->setContentType($contentType);


### PR DESCRIPTION
Fixes #7124

Fixes a couple more places where hyphens were leaking into the query engine.