### PR TITLE
On Dashboard listings, use 'key' instead of 'slug'

### DIFF
--- a/app/view/twig/dashboard/_recently_edited.twig
+++ b/app/view/twig/dashboard/_recently_edited.twig
@@ -17,7 +17,7 @@
                 'compact':       true,
                 'content':       content,
                 'excerptlength': 280,
-                'permissions':   context.permissions[contenttype.slug],
+                'permissions':   context.permissions[contenttype_key],
                 'thumbsize':     54,
             } %}
             {{ include(['@bolt/custom/listing/' ~ content.contenttype.slug ~ '.twig', '@bolt/_sub/_listing.twig'],  listing_vars) }}

--- a/app/view/twig/dashboard/dashboard.twig
+++ b/app/view/twig/dashboard/dashboard.twig
@@ -30,9 +30,9 @@
                 {% endif %}
             </div>
 
-            {% for contenttype, multiplecontent in context.latest %}
+            {% for contenttype_key, multiplecontent in context.latest %}
                 {% if multiplecontent %}
-                    {% set contenttype = config.get('contenttypes/' ~ contenttype) %}
+                    {% set contenttype = config.get('contenttypes/' ~ contenttype_key) %}
                     {{ include('@bolt/dashboard/_recently_edited.twig') }}
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
Additional fix for #7124, using 'key' instead of 'slug'. Using the CT from #7124, you'd get this on the dashboard: 

![screen shot 2017-11-03 at 11 26 56](https://user-images.githubusercontent.com/1833361/32370419-39dac5a8-c08d-11e7-9856-6d0ecae02db8.png)

In the listings, we pass in the permissions, using `context.permissions[contenttype.slug]`, but this should use the 'key' instead. 