### PR TITLE
Fixed: Don't break the exception page on early exceptions

### DIFF
--- a/app/view/twig/exception/_request.twig
+++ b/app/view/twig/exception/_request.twig
@@ -39,7 +39,7 @@
         {% endfor %}
     </table>
 
-    {% for bag in bags %}
+    {% for bag in bags if attribute(request_data, bag)|default(false) %}
         <h2>{{ bag|capitalize }}</h2>
 
         <table class="table table-striped table-hover table-condensed">


### PR DESCRIPTION
When an exception occurs before there's a session, the exception page could break. This PR checks if there's data, before trying to output it. 

Screenshot: 

![screen shot 2017-11-04 at 10 41 30](https://user-images.githubusercontent.com/1833361/32404250-be7b64a6-c14c-11e7-90ce-ab12001b45d1.png)

After: 

![screen shot 2017-11-04 at 10 42 09](https://user-images.githubusercontent.com/1833361/32404254-d5194d2c-c14c-11e7-9962-239887eb8ab6.png)
