### PR TITLE
[3.4] Compensate for upstream BC break in TwigDataCollector constructor

### DIFF
--- a/src/Provider/WebProfilerServiceProvider.php
+++ b/src/Provider/WebProfilerServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Bolt\Provider;
 
 use Pimple\Container;
+use Symfony\Bridge\Twig\DataCollector\TwigDataCollector;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 
 /**
@@ -37,6 +38,17 @@ class WebProfilerServiceProvider extends \Silex\Provider\WebProfilerServiceProvi
             }
 
             return $profiler;
+        });
+
+        // Provided for Symfony 3.4+ support, and can be removed if/when
+        // https://github.com/silexphp/Silex-WebProfiler/pull/126 or similar
+        // fix is implemented for Silex's WebProfilerServiceProvider
+        $app['data_collectors'] = $app->extend('data_collectors', function ($collectors, $app) {
+            $collectors['twig'] = function ($app) {
+                return new TwigDataCollector($app['twig.profiler.profile'], $app['twig']);
+            };
+
+            return $collectors;
         });
     }
 }


### PR DESCRIPTION
Handles break introduced in https://github.com/symfony/symfony/pull/24236