### PR TITLE
Only set a group when the taxonomy is relevant

### DIFF
--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -120,7 +120,10 @@ class TaxonomyType extends JoinTypeBase
             $fieldTaxonomy->add($taxEntity);
         }
         $this->set($entity, $fieldTaxonomy);
-        $entity->setGroup($this->getGroup($fieldTaxonomy));
+        $grouping = $this->getGroup($fieldTaxonomy);
+        if ($grouping) {
+            $entity->setGroup($this->getGroup($fieldTaxonomy));
+        }
         $entity->setSortorder($this->getSortorder($fieldTaxonomy));
     }
 


### PR DESCRIPTION
Fixes #7149

This was a slight logic error, we only want to set the group if the taxonomy concerned is a grouping one, otherwise we just skip over it.