### PR TITLE
Enable new group sorting on the equivalent ajax action

### DIFF
--- a/src/Controller/Async/Records.php
+++ b/src/Controller/Async/Records.php
@@ -87,6 +87,7 @@ class Records extends AsyncBase
             ->setPage($referer->query->get('page_' . $contentType))
             ->setFilter($referer->query->get('filter'))
             ->setTaxonomies($taxonomy)
+            ->setGroupSort(true)
         ;
 
         $context = [


### PR DESCRIPTION
Fixes #7151

Add the new group sorting flag on the ajax action so it behaves the same as the normal overview action.