### PR TITLE
Allocate the other results to an ungrouped array

### DIFF
--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -154,6 +154,8 @@ class Listing
             }
             if ($taxGroup !== null) {
                 $grouped[$taxGroup][] = $result;
+            } else {
+                $grouped['ungrouped'][] = $result;
             }
         }
 


### PR DESCRIPTION
Fixes #7150

In instances where no taxonomy is set on a record some were slipping through the net, this ensures that they get passed on to the results array.