### PR TITLE
[3.3] Correct logic for MIME type detection

### DIFF
--- a/src/Embed/GuzzleDispatcher.php
+++ b/src/Embed/GuzzleDispatcher.php
@@ -100,7 +100,7 @@ class GuzzleDispatcher implements DispatcherInterface
 
             /** @var Psr7\Response $response */
             $response = $result['value'];
-            $body = $response->getBody();
+            $body = (string) $response->getBody();
             $baseUrl = (array) $response->getHeader('X-Embed-Request-Uri');
             $redirectUriHistory = $response->getHeader('X-Guzzle-Redirect-History');
             $redirectUri = $redirectUriHistory ? array_pop($redirectUriHistory) : reset($baseUrl);
@@ -178,14 +178,14 @@ class GuzzleDispatcher implements DispatcherInterface
     private function getMimeType(Psr7\Response $response)
     {
         $header = $response->getHeader('Content-Type');
-        if ($header === null) {
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            $mime = finfo_buffer($finfo, $response->getBody());
-            finfo_close($finfo);
-
-            return $mime;
+        if ($header !== []) {
+            return reset($header);
         }
 
-        return reset($header);
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $mime = finfo_buffer($finfo, $response->getBody()->getContents());
+        finfo_close($finfo);
+
+        return $mime;
     }
 }


### PR DESCRIPTION
Look ma', a :koala:!

* PSR-7 getHeader() always returns an array
* Call getContents() on the body object to return the stream contents

… found in one of those _"you don't want to know"_ moments.