### PR TITLE
[3.4] Remove recursive Bag use from BundleConfigurator

### DIFF
--- a/src/Composer/Script/BundleConfigurator.php
+++ b/src/Composer/Script/BundleConfigurator.php
@@ -80,7 +80,7 @@ final class BundleConfigurator
     private function load()
     {
         if (file_exists(static::FILENAME)) {
-            return MutableBag::fromRecursive(Yaml::parse(file_get_contents(static::FILENAME)) ?: []);
+            return MutableBag::from(Yaml::parse(file_get_contents(static::FILENAME)) ?: []);
         }
 
         return MutableBag::of();
@@ -94,7 +94,7 @@ final class BundleConfigurator
     private function save(MutableBag $contents)
     {
         try {
-            $this->filesystem->dumpFile(static::FILENAME, Yaml::dump($contents->toArrayRecursive()));
+            $this->filesystem->dumpFile(static::FILENAME, Yaml::dump($contents->toArray()));
             $this->io->success('Added the site bundle to .bolt.yml');
         } catch (IOException $e) {
             $this->io->error('Unable to add the site bundle to .bolt.yml');


### PR DESCRIPTION
Fixes #7178
Fixes https://github.com/bolt/collection/issues/32

Using Composer from a PHAR doesn't currently load the "files" section, meaning that calls to is_iterable() are not being handled by the polyfill on installs prior to PHP 7.1.
