### PR TITLE
[3.4] Use "first_image" to return the first image, for display in overview listings.

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -166,7 +166,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
 
         {# COLUMN: Thumbnail #}
         <td class="listthumb">
-            {% set listimage = content.getImage %}
+            {% set listimage = content|first_image %}
             {% if listimage is not empty %}
                 {% if listimage is iterable and listimage['file'] is not defined %}
                     {% set listimage = listimage|first %}

--- a/src/Twig/Extension/RecordExtension.php
+++ b/src/Twig/Extension/RecordExtension.php
@@ -53,6 +53,7 @@ class RecordExtension extends AbstractExtension
             new TwigFilter('selectfield', [Runtime\RecordRuntime::class, 'selectField']),
             new TwigFilter('trimtext',    [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
             new TwigFilter('taxonomy',    [Runtime\RecordRuntime::class, 'taxonomy']),
+            new TwigFilter('first_image', [Runtime\RecordRuntime::class, 'getFirstImage'], $safe + $deprecated),
             // @codingStandardsIgnoreEnd
         ];
     }

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -135,6 +135,35 @@ class RecordRuntime
     }
 
     /**
+     * Gets the first image from the given content record.
+     *
+     * This method is deprecated. In Bolt 3.5 it'll be replaced / removed to
+     * fall in line with the work done for #6985
+     *
+     * @param \Bolt\Storage\Entity\Content $content
+     *
+     * @return array|null image
+     */
+    public function getFirstImage($content)
+    {
+        Deprecated::method('3.4');
+
+        if (!is_array($content->contenttype['fields'])) {
+            return null;
+        }
+
+        // Grab the first field of type 'image', and return that.
+        foreach ($content->contenttype['fields'] as $key => $field) {
+            if ($field['type'] === 'image' && is_array($content->get($key))) {
+                return $content->get($key);
+            }
+        }
+
+        // otherwise, no image.
+        return null;
+    }
+
+    /**
      * Output all (relevant) fields to the browser. Convenient for dumping the
      * content in order in, say, a `record.twig` template, without having to
      * iterate over them in the browser.
@@ -149,7 +178,7 @@ class RecordRuntime
      * @param string|array         $exclude
      * @param bool                 $skip_uses
      *
-     * @return string
+     * @return string|null
      */
     public function fields(
         Environment $env,


### PR DESCRIPTION
Fixes #7194

Note: Once Ross' work for #6985 lands, this will be integrated into that, and this specific implementation will be replaced / removed.