### PR TITLE
Added "create new" button in contentedit

### DIFF
--- a/app/view/twig/_sub/_record_list.twig
+++ b/app/view/twig/_sub/_record_list.twig
@@ -57,7 +57,17 @@
                     {% set lastgroup = content.group.name %}
                 {% endif %}
             {% else %}
-                {{ __('contenttypes.generic.none-available', {'%contenttypes%': contenttype.name}) }}
+                <p>
+                    {{ __('contenttypes.generic.none-available', {'%contenttypes%': contenttype.name}) }}
+                </p>
+
+                {% if isallowed('contenttype:' ~ contenttype.slug ~ ':create') %}
+                    <p class="btn-group">
+                        <a class="btn btn-primary" href="{{ path('editcontent', {'contenttypeslug': contenttype.slug}) }}">
+                            <i class="fa fa-plus"></i> {{ __('contenttypes.generic.new', {'%contenttype%': contenttype.singular_name}) }}
+                        </a>
+                    </p>
+                {% endif %}
             {% endfor %}
         </table>
 


### PR DESCRIPTION
When list of records is empty, it's very **friendly** to show a button "create new" button.  That really helps for some of users.

![image](https://user-images.githubusercontent.com/2145313/33222730-dd59cf6c-d18b-11e7-8efd-2ee2619051cd.png)
(sorry for colors, i use themes for my clients)