### PR TITLE
[Tests] Use @legacy annotation to mark tests as "legacy group"

### DIFF
--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -51,6 +51,9 @@ class FrontendTest extends ControllerUnitTest
         $this->assertSame('index.twig', $response->getTemplate());
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyDefaultHomepage()
     {
         $this->setRequest(Request::create('/'));
@@ -119,6 +122,9 @@ class FrontendTest extends ControllerUnitTest
         $this->assertSame('page.twig', $response->getTemplate());
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyRecord()
     {
         $this->getService('config')->set('general/compatibility/template_view', false);
@@ -335,6 +341,9 @@ class FrontendTest extends ControllerUnitTest
         $this->assertTrue($response instanceof TemplateView);
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyListing()
     {
         $this->getService('config')->set('general/compatibility/template_view', false);
@@ -401,6 +410,9 @@ class FrontendTest extends ControllerUnitTest
         $this->assertSame('listing.twig', $response->getTemplate());
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyTaxonomyListing()
     {
         $this->getService('config')->set('general/compatibility/template_view', false);
@@ -423,6 +435,9 @@ class FrontendTest extends ControllerUnitTest
         $this->assertSame('index.twig', $response->getTemplate());
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyTemplate()
     {
         $this->getService('config')->set('general/compatibility/template_view', false);
@@ -453,6 +468,9 @@ class FrontendTest extends ControllerUnitTest
         $this->assertSame('search.twig', $response->getTemplate());
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacySearch()
     {
         $this->getService('config')->set('general/compatibility/template_view', false);

--- a/tests/phpunit/unit/Extension/MenuTraitTest.php
+++ b/tests/phpunit/unit/Extension/MenuTraitTest.php
@@ -35,6 +35,9 @@ class MenuTraitTest extends BoltUnitTest
         $this->assertSame([], $extendMenu->children());
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyMenuAdds()
     {
         $app = $this->getApp();

--- a/tests/phpunit/unit/Extensions/SnippetLocationTest.php
+++ b/tests/phpunit/unit/Extensions/SnippetLocationTest.php
@@ -12,9 +12,11 @@ use Bolt\Tests\BoltUnitTest;
  */
 class SnippetLocationTest extends BoltUnitTest
 {
-    public function testLegacyListAll()
+    /**
+     * @group legacy
+     */
+    public function testListAll()
     {
-        $app = $this->getApp();
         $location = new Location();
         $this->assertGreaterThan(1, $location->listAll());
     }

--- a/tests/phpunit/unit/Field/ManagerTest.php
+++ b/tests/phpunit/unit/Field/ManagerTest.php
@@ -13,6 +13,9 @@ use Bolt\Tests\BoltUnitTest;
  */
 class ManagerTest extends BoltUnitTest
 {
+    /**
+     * @group legacy
+     */
     public function testLegacyManagerDefaultsSetup()
     {
         $manager = new Manager();
@@ -36,7 +39,10 @@ class ManagerTest extends BoltUnitTest
         $this->assertTrue($manager->has('slug'));
     }
 
-    public function testLegacyAddingFetchingfields()
+    /**
+     * @group legacy
+     */
+    public function testLegacyAddingFetchingFields()
     {
         /** @var Base $field */
         $field = $this->getMockBuilder(Base::class)

--- a/tests/phpunit/unit/Helper/ArrTest.php
+++ b/tests/phpunit/unit/Helper/ArrTest.php
@@ -13,7 +13,10 @@ use Bolt\Tests\BoltUnitTest;
  */
 class ArrTest extends BoltUnitTest
 {
-    public function testLegacyMakeValuePairs()
+    /**
+     * @group legacy
+     */
+    public function testMakeValuePairs()
     {
         $test = [
             ['id' => 1, 'value' => 1],
@@ -23,7 +26,10 @@ class ArrTest extends BoltUnitTest
         $this->assertEquals([0 => 1, 1 => 2], Arr::makeValuePairs($test, '', 'value'));
     }
 
-    public function testLegacyMergeRecursiveDistinct()
+    /**
+     * @group legacy
+     */
+    public function testMergeRecursiveDistinct()
     {
         $arr1 = ['key' => 'orig value'];
         $arr2 = ['key' => 'new value'];

--- a/tests/phpunit/unit/Logger/ChangeLogTest.php
+++ b/tests/phpunit/unit/Logger/ChangeLogTest.php
@@ -36,7 +36,10 @@ class ChangeLogTest extends BoltUnitTest
         $this->assertEquals(1, count($logs2));
     }
 
-    public function testLegacyCountChangeLog()
+    /**
+     * @group legacy
+     */
+    public function testCountChangeLog()
     {
         $count = $this->getLogChangeRepository()->countChangeLog();
         $this->assertGreaterThanOrEqual(1, $count);

--- a/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
+++ b/tests/phpunit/unit/Provider/TwigServiceProviderTest.php
@@ -27,6 +27,9 @@ class TwigServiceProviderTest extends BoltUnitTest
         $this->assertContains('bolt', $app['twig.loader.bolt_filesystem']->getNamespaces(), 'bolt namespace was not added to filesystem loader');
     }
 
+    /**
+     * @group legacy
+     */
     public function testLegacyProvider()
     {
         $app = $this->getApp();


### PR DESCRIPTION
Symfony deprecated this in the PHPUnit bridge in 3.3 