### PR TITLE
Fixed: "Show" / "Hide" password toggle on log in screen works again.

### DIFF
--- a/app/src/js/init.js
+++ b/app/src/js/init.js
@@ -369,11 +369,11 @@ var init = {
 
         $(".togglepass").on('click', function () {
             if ($(this).hasClass('show-password')) {
-                $('input[name="password"]').attr('type', 'text');
+                $('input[name="user_login[password]"]').attr('type', 'text');
                 $('.togglepass.show-password').hide();
                 $('.togglepass.hide-password').show();
             } else {
-                $('input[name="password"]').attr('type', 'password');
+                $('input[name="user_login[password]"]').attr('type', 'password');
                 $('.togglepass.show-password').show();
                 $('.togglepass.hide-password').hide();
             }


### PR DESCRIPTION
The log in form now uses Symfony Forms. This changed the `name` of the password input. 