### PR TITLE
Fixed: ContextErrorException in RelationType.php, on sites with "missing" relationships.

### DIFF
--- a/src/Storage/Field/Type/IncomingRelationType.php
+++ b/src/Storage/Field/Type/IncomingRelationType.php
@@ -63,14 +63,16 @@ class IncomingRelationType extends RelationType
         }
 
         foreach ($data as $relData) {
-            $rel = [];
-            $rel['id'] = $relData['id'];
-            $rel['from_id'] = $relData['fromid'];
-            $rel['from_contenttype'] = $relData['fromcontenttype'];
-            $rel['to_contenttype'] = (string) $entity->getContenttype();
-            $rel['to_id'] = $entity->getId();
-            $relEntity = new Entity\Relations($rel);
-            $entity->getRelation()->add($relEntity);
+            if (isset($relData['fromcontenttype'])) {
+                $rel = [];
+                $rel['id'] = $relData['id'];
+                $rel['from_id'] = $relData['fromid'];
+                $rel['from_contenttype'] = $relData['fromcontenttype'];
+                $rel['to_contenttype'] = (string) $entity->getContenttype();
+                $rel['to_id'] = $entity->getId();
+                $relEntity = new Entity\Relations($rel);
+                $entity->getRelation()->add($relEntity);
+            }
         }
     }
 

--- a/src/Storage/Field/Type/RelationType.php
+++ b/src/Storage/Field/Type/RelationType.php
@@ -101,15 +101,17 @@ class RelationType extends JoinTypeBase
 
         $fieldRels = $this->em->createCollection(Entity\Relations::class);
         foreach ($data as $relData) {
-            $rel = [];
-            $rel['id'] = $relData['id'];
-            $rel['from_id'] = $entity->getId();
-            $rel['from_contenttype'] = (string) $entity->getContenttype();
-            $rel['to_contenttype'] = $field;
-            $rel['to_id'] = $relData['toid'];
-            $relEntity = new Entity\Relations($rel);
-            $entity->getRelation()->add($relEntity);
-            $fieldRels->add($relEntity);
+            if (isset($relData['id'])) {
+                $rel = [];
+                $rel['id'] = $relData['id'];
+                $rel['from_id'] = $entity->getId();
+                $rel['from_contenttype'] = (string) $entity->getContenttype();
+                $rel['to_contenttype'] = $field;
+                $rel['to_id'] = $relData['toid'];
+                $relEntity = new Entity\Relations($rel);
+                $entity->getRelation()->add($relEntity);
+                $fieldRels->add($relEntity);
+            }
         }
         $this->set($entity, $fieldRels[$field]);
     }


### PR DESCRIPTION
Bumped into this when updating an older site to 3.4. Missing relationships would throw an exception, rendering the backend useless. 

![screen shot 2017-11-28 at 14 00 30](https://user-images.githubusercontent.com/1833361/33322860-eca625a8-d44a-11e7-9765-4b055df02291.png)
