### PR TITLE
Set right order of grouped menu entries

### DIFF
--- a/app/view/twig/_nav/_secondary-content.twig
+++ b/app/view/twig/_nav/_secondary-content.twig
@@ -5,38 +5,39 @@
 {# Each "main" ContentType menu and sub-menu #}
 {% if content_menus.main is defined %}
     {% for name, menu in content_menus.main.children %}
-        {% set active = (page_nav == 'Content/*' and context.contenttype.slug|default == name) %}
         {% set sub = [] %}
+        {% set active = false %}
 
-        {# View ContentType & New ContentType #}
-        {% if menu.has('view') %}{% set sub = sub|merge([menu.get('view')]) %}{% endif %}
-        {% if menu.has('new') %}{% set sub = sub|merge([menu.get('new')]) %}{% endif %}
-        {% set sub = sub|merge(['-']) %}
+        {% if menu.group %}
+            {% for sub_menu in menu.children %}
+                {% if sub_menu.has('singleton') %}
+                    {% set sub_menu = sub_menu.children|first %}
+                {% endif %}
+                {% set sub = sub|merge([sub_menu]) %}
+            {% endfor %}
+        {% else %}
+            {% set active = (page_nav == 'Content/*' and context.contenttype.slug|default == name) %}
+            {% set is_submenu = false %}
 
-        {# Recently edited records for this ContentType #}
-        {% if menu.has('recent') %}
-            {% for record_menu in menu.get('recent').children %}{% set sub = sub|merge([record_menu]) %}{% endfor %}
-        {% elseif menu.has('singleton') %}
-            {% set sub = sub|merge([menu.children|first]) %}
+            {# View ContentType & New ContentType #}
+            {% if menu.has('view') %}
+                {% set sub = sub|merge([menu.get('view')]) %}
+            {% endif %}
+            {% if menu.has('new') %}
+                {% set sub = sub|merge([menu.get('new')]) %}
+            {% endif %}
+            {% set sub = sub|merge(['-']) %}
+
+            {# Recently edited records for this ContentType #}
+            {% if menu.has('recent') %}
+                {% for record_menu in menu.get('recent').children %}
+                    {% set sub = sub|merge([record_menu]) %}
+                {% endfor %}
+            {% elseif menu.has('singleton') %}
+                {% set sub = sub|merge([menu.children|first]) %}
+            {% endif %}
         {% endif %}
 
-        {{ nav.submenu(menu.icon, menu.label, sub, active, true) }}
-    {% endfor %}
-{% endif %}
-
-{# "Other" ContentType menu and sub-menu #}
-{% if content_menus.grouped is defined %}
-    {% for name, menu in content_menus.grouped.children %}
-        {% set key = menu.label %}
-        {% set sub = [] %}
-
-        {% for sub_menu in menu.children %}
-            {% if sub_menu.has('singleton') %}
-                {% set sub_menu = sub_menu.children|first %}
-            {% endif %}
-            {% set sub = sub|merge([sub_menu]) %}
-        {% endfor %}
-
-        {{ nav.submenu(menu.icon, menu.label, sub, false, false, null, true) }}
+        {{ nav.submenu(menu.icon, menu.label, sub, active, not menu.group, null, menu.group) }}
     {% endfor %}
 {% endif %}

--- a/app/view/twig/_nav/_secondary-content.twig
+++ b/app/view/twig/_nav/_secondary-content.twig
@@ -6,9 +6,9 @@
 {% if content_menus.main is defined %}
     {% for name, menu in content_menus.main.children %}
         {% set sub = [] %}
-        {% set active = false %}
 
         {% if menu.group %}
+            {% set active = false %}
             {% for sub_menu in menu.children %}
                 {% if sub_menu.has('singleton') %}
                     {% set sub_menu = sub_menu.children|first %}

--- a/src/Menu/MenuEntry.php
+++ b/src/Menu/MenuEntry.php
@@ -30,6 +30,8 @@ class MenuEntry implements Serializable
     protected $icon;
     /** @var string */
     protected $permission;
+    /** @var bool */
+    protected $group = false;
 
     /** @var string */
     protected $uri;
@@ -207,6 +209,30 @@ class MenuEntry implements Serializable
     public function setPermission($permission)
     {
         $this->permission = $permission;
+
+        return $this;
+    }
+
+    /**
+     * Check if menu entry is a group.
+     *
+     * @return bool
+     */
+    public function isGroup()
+    {
+        return $this->group;
+    }
+
+    /**
+     * Set if the menu entry is a group.
+     *
+     * @param bool $group
+     *
+     * @return MenuEntry
+     */
+    public function setGroup($group)
+    {
+        $this->group = $group;
 
         return $this;
     }

--- a/src/Menu/Resolver/RecentlyEdited.php
+++ b/src/Menu/Resolver/RecentlyEdited.php
@@ -48,21 +48,27 @@ final class RecentlyEdited
             return;
         }
         foreach ($contentRoot->get('main')->children() as $name => $contentMenu) {
+            if ($contentMenu->isGroup()) {
+                $this->resolveGroupMenu($contentMenu, $contentTypes);
+                continue;
+            }
             if ($contentTypes->getPath($name . '/singleton')) {
                 $this->addSingleton($contentMenu, $name);
                 continue;
             }
             $this->addRecentlyEdited($contentMenu, $name, $contentTypes);
         }
+    }
 
-        if (!$contentRoot->has('grouped')) {
-            return;
-        }
-        foreach ($contentRoot->get('grouped')->children() as $groupName => $groupMenu) {
-            foreach ($groupMenu->children() as $name => $contentMenu) {
-                if ($contentTypes->getPath($name . '/singleton')) {
-                    $this->addSingleton($contentMenu, $name);
-                }
+    /**
+     * @param MenuEntry $groupMenu
+     * @param Bag       $contentTypes
+     */
+    private function resolveGroupMenu(MenuEntry $groupMenu, Bag $contentTypes)
+    {
+        foreach ($groupMenu->children() as $name => $contentMenu) {
+            if ($contentTypes->getPath($name . '/singleton')) {
+                $this->addSingleton($contentMenu, $name);
             }
         }
     }

--- a/tests/phpunit/unit/Menu/Builder/AdminContentTest.php
+++ b/tests/phpunit/unit/Menu/Builder/AdminContentTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Bolt\Tests\Menu\Builder;
+
+use Bolt\Collection\Bag;
+use Bolt\Menu\Builder\AdminContent;
+use Bolt\Menu\MenuEntry;
+use Bolt\Tests\BoltUnitTest;
+
+/**
+ * Class to test src/Menu/Builder/AdminContent.
+ *
+ * @author Jarek Jakubowski <egger1991@gmail.com>
+ */
+class AdminContentTest extends BoltUnitTest
+{
+    public static function buildProvider()
+    {
+        return [
+            [
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1'))->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry'))->parent())
+                    ->parent(),
+                Bag::fromRecursive([
+                    'entry1' => [
+                        'show_in_menu' => true,
+                    ],
+                    'othergroupentry' => [
+                        'show_in_menu' => false,
+                    ],
+                ]),
+            ],
+            [
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1'))->parent()
+                    ->add(MenuEntry::create('entry2'))->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry1'))->parent()
+                        ->add(MenuEntry::create('othergroupentry2'))->parent())
+                    ->parent(),
+                Bag::fromRecursive([
+                    'entry1' => [
+                        'show_in_menu' => true,
+                    ],
+                    'othergroupentry1' => [
+                        'show_in_menu' => false,
+                    ],
+                    'entry2' => [
+                        'show_in_menu' => true,
+                    ],
+                    'othergroupentry2' => [
+                        'show_in_menu' => false,
+                    ],
+                ]),
+            ],
+            [
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1'))->parent()
+                    ->add(MenuEntry::create('group1')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('group1entry1'))->parent()
+                        ->add(MenuEntry::create('group1entry2'))->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('entry2'))->parent()
+                    ->add(MenuEntry::create('entry3'))->parent()
+                    ->add(MenuEntry::create('group2')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('group2entry1'))->parent()
+                        ->add(MenuEntry::create('group2entry2'))->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('entry4'))->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry1'))->parent()
+                        ->add(MenuEntry::create('othergroupentry2'))->parent())
+                    ->parent(),
+                Bag::fromRecursive([
+                    'entry1' => [
+                        'show_in_menu' => true,
+                    ],
+                    'othergroupentry1' => [
+                        'show_in_menu' => false,
+                    ],
+                    'group1entry1' => [
+                        'show_in_menu' => 'group1',
+                    ],
+                    'entry2' => [
+                        'show_in_menu' => true,
+                    ],
+                    'entry3' => [
+                        'show_in_menu' => true,
+                    ],
+                    'group2entry1' => [
+                        'show_in_menu' => 'group2',
+                    ],
+                    'group1entry2' => [
+                        'show_in_menu' => 'group1',
+                    ],
+                    'othergroupentry2' => [
+                        'show_in_menu' => false,
+                    ],
+                    'group2entry2' => [
+                        'show_in_menu' => 'group2',
+                    ],
+                    'entry4' => [
+                        'show_in_menu' => true,
+                    ],
+                ]),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider buildProvider
+     *
+     * @param MenuEntry $expectedMain
+     * @param Bag       $contentTypes
+     */
+    public function testBuild($expectedMain, $contentTypes)
+    {
+        $ac = new AdminContent($contentTypes);
+        $result = $ac->build(MenuEntry::create('root'));
+
+        $expected = MenuEntry::create('root')
+            ->add(
+                MenuEntry::create('content')->add($expectedMain)->parent()
+            )
+            ->parent()
+        ;
+
+        $this->assertEquals($this->extractTestedDataFromMenuEntries($expected), $this->extractTestedDataFromMenuEntries($result));
+    }
+
+    /**
+     * @param MenuEntry $menuEntry
+     *
+     * @return array
+     */
+    private function extractTestedDataFromMenuEntries($menuEntry)
+    {
+        return [
+            'name'     => $menuEntry->getName(),
+            'group'    => $menuEntry->isGroup(),
+            'children' => array_map(function ($child) {
+                return $this->extractTestedDataFromMenuEntries($child);
+            }, array_filter($menuEntry->children(), function ($child) {
+                return $child->getName() !== 'new' && $child->getName() !== 'view';
+            })),
+        ];
+    }
+}

--- a/tests/phpunit/unit/Menu/MenuBuilderTest.php
+++ b/tests/phpunit/unit/Menu/MenuBuilderTest.php
@@ -9,7 +9,7 @@ use Bolt\Tests\BoltUnitTest;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class to test src/Helper/MenuBuilder.
+ * Class to test src/Menu/MenuBuilder.
  *
  * @author Sufijen Bani <bolt@sbani.net>
  */

--- a/tests/phpunit/unit/Menu/MenuEntryTest.php
+++ b/tests/phpunit/unit/Menu/MenuEntryTest.php
@@ -49,6 +49,17 @@ class MenuEntryTest extends BoltUnitTest
         $this->assertSame($extendEntry, $rootEntry->children()['dropbear']);
     }
 
+    public function testCreateGroup()
+    {
+        $rootEntry = $this->createRoot();
+        
+        $this->assertSame(false, $rootEntry->isGroup());
+        
+        $rootEntry->setGroup(true);
+        
+        $this->assertSame(true, $rootEntry->isGroup());
+    }
+
     public function testRoute()
     {
         /** @var UrlGeneratorInterface|MockObject $urlGenerator */

--- a/tests/phpunit/unit/Menu/Resolver/RecentlyEditedTest.php
+++ b/tests/phpunit/unit/Menu/Resolver/RecentlyEditedTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Bolt\Tests\Menu\Builder;
+
+use Bolt\Collection\Bag;
+use Bolt\Menu\MenuEntry;
+use Bolt\Menu\Resolver\RecentlyEdited;
+use Bolt\Storage\Entity\Content;
+use Bolt\Storage\EntityManager;
+use Bolt\Storage\Repository;
+use Bolt\Tests\BoltUnitTest;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Parsedown;
+
+/**
+ * Class to test src/Menu/Resolver/RecentlyEdited.
+ *
+ * @author Jarek Jakubowski <egger1991@gmail.com>
+ */
+class RecentlyEditedTest extends BoltUnitTest
+{
+    public static function resolveProvider()
+    {
+        return [
+            [
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1'))->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry'))->parent())
+                    ->parent(),
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1'))->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry'))->parent())
+                    ->parent(),
+                Bag::fromRecursive([
+                    'entry1' => [
+                        'show_in_menu' => true,
+                    ],
+                    'othergroupentry' => [
+                        'show_in_menu' => false,
+                    ],
+                ]),
+            ],
+            [
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1')
+                        ->add(MenuEntry::create('singleton'))->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('entry2')
+                        ->add(MenuEntry::create('singleton'))->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry1')
+                            ->add(MenuEntry::create('singleton'))->parent())
+                        ->parent()
+                        ->add(MenuEntry::create('othergroupentry2')
+                            ->add(MenuEntry::create('singleton'))->parent())
+                        ->parent())
+                    ->parent(),
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1'))->parent()
+                    ->add(MenuEntry::create('entry2'))->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry1'))->parent()
+                        ->add(MenuEntry::create('othergroupentry2'))->parent())
+                    ->parent(),
+                Bag::fromRecursive([
+                    'entry1' => [
+                        'show_in_menu' => true,
+                        'singleton'    => true,
+                    ],
+                    'othergroupentry1' => [
+                        'show_in_menu' => false,
+                        'singleton'    => true,
+                    ],
+                    'entry2' => [
+                        'show_in_menu' => true,
+                        'singleton'    => true,
+                    ],
+                    'othergroupentry2' => [
+                        'show_in_menu' => false,
+                        'singleton'    => true,
+                    ],
+                ]),
+            ],
+            [
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1'))->parent()
+                    ->add(MenuEntry::create('group1')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('group1entry1'))->parent()
+                        ->add(MenuEntry::create('group1entry2')
+                            ->add(MenuEntry::create('singleton'))->parent())
+                        ->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('entry2')
+                        ->add(MenuEntry::create('singleton'))->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('entry3'))->parent()
+                    ->add(MenuEntry::create('group2')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('group2entry1'))->parent()
+                        ->add(MenuEntry::create('group2entry2'))->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('entry4'))->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry1'))->parent()
+                        ->add(MenuEntry::create('othergroupentry2'))->parent())
+                    ->parent(),
+                MenuEntry::create('main')
+                    ->add(MenuEntry::create('entry1'))->parent()
+                    ->add(MenuEntry::create('group1')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('group1entry1'))->parent()
+                        ->add(MenuEntry::create('group1entry2'))->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('entry2'))->parent()
+                    ->add(MenuEntry::create('entry3'))->parent()
+                    ->add(MenuEntry::create('group2')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('group2entry1'))->parent()
+                        ->add(MenuEntry::create('group2entry2'))->parent())
+                    ->parent()
+                    ->add(MenuEntry::create('entry4'))->parent()
+                    ->add(MenuEntry::create('other')
+                        ->setGroup(true)
+                        ->add(MenuEntry::create('othergroupentry1'))->parent()
+                        ->add(MenuEntry::create('othergroupentry2'))->parent())
+                    ->parent(),
+                Bag::fromRecursive([
+                    'entry1' => [
+                        'show_in_menu' => true,
+                    ],
+                    'othergroupentry1' => [
+                        'show_in_menu' => false,
+                    ],
+                    'group1entry1' => [
+                        'show_in_menu' => 'group1',
+                    ],
+                    'entry2' => [
+                        'show_in_menu' => true,
+                        'singleton'    => true,
+                    ],
+                    'entry3' => [
+                        'show_in_menu' => true,
+                    ],
+                    'group2entry1' => [
+                        'show_in_menu' => 'group2',
+                    ],
+                    'group1entry2' => [
+                        'show_in_menu' => 'group1',
+                        'singleton'    => true,
+                    ],
+                    'othergroupentry2' => [
+                        'show_in_menu' => false,
+                    ],
+                    'group2entry2' => [
+                        'show_in_menu' => 'group2',
+                    ],
+                    'entry4' => [
+                        'show_in_menu' => true,
+                    ],
+                ]),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider resolveProvider
+     *
+     * @param MenuEntry $expectedMain
+     * @param Bag       $contentTypes
+     */
+    public function testResolve($expectedMain, $entryMain, $contentTypes)
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->expects($this->any())
+            ->method('setMaxResults')
+            ->willReturn($qb)
+        ;
+        $qb->expects($this->any())
+            ->method('orderBy')
+            ->willReturn($qb)
+        ;
+
+        $repo = $this->createMock(Repository::class);
+        $repo->expects($this->any())
+            ->method('findWith')
+            ->willReturn([new Content()])
+        ;
+        $repo->expects($this->any())
+            ->method('createQueryBuilder')
+            ->willReturn($qb)
+        ;
+
+        $em = $this->createMock(EntityManager::class);
+        $em->expects($this->any())
+            ->method('getRepository')
+            ->willReturn($repo)
+        ;
+
+        $re = new RecentlyEdited($em, $this->createMock(ParseDown::class));
+
+        $expected = MenuEntry::create('root')
+            ->add(
+                MenuEntry::create('content')->add($expectedMain)->parent()
+            )
+            ->parent()
+        ;
+        $entry = MenuEntry::create('root')
+            ->add(
+                MenuEntry::create('content')->add($entryMain)->parent()
+            )
+            ->parent()
+        ;
+
+        $re->resolve($entry, $contentTypes);
+
+        $this->assertEquals($this->extractTestedDataFromMenuEntries($expected), $this->extractTestedDataFromMenuEntries($entry));
+    }
+
+    /**
+     * @param MenuEntry $menuEntry
+     *
+     * @return array
+     */
+    private function extractTestedDataFromMenuEntries($menuEntry)
+    {
+        return [
+            'name'     => $menuEntry->getName(),
+            'group'    => $menuEntry->isGroup(),
+            'children' => array_map(function ($child) {
+                return $this->extractTestedDataFromMenuEntries($child);
+            }, array_filter($menuEntry->children(), function ($child) {
+                return $child->getName() !== 'recent';
+            })),
+        ];
+    }
+}


### PR DESCRIPTION
Previously, all grouped menu entries were put at the bottom of menu (as "other" menu).

Now they can be mixed with non-grouped entries with proper order as defined in contenttypes.yml.

I will add tests later (or update if some of them would fail).

Discussed on Slack with @bobdenotter 