### PR TITLE
Fixed: On log in page, prevents 'An invalid form control is not focusable' on hidden form field

### DIFF
--- a/app/src/js/init.js
+++ b/app/src/js/init.js
@@ -381,11 +381,13 @@ var init = {
 
         $('.login-forgot').bind('click', function () {
             $('.login-group, .password-group').hide();
+            $('#user_login_password').attr('required', false);
             $('.reset-group').show();
         });
 
         $('.login-remembered').bind('click', function () {
             $('.login-group, .password-group').show();
+            $('#user_login_password').attr('required', true);
             $('.reset-group').hide();
         });
     },


### PR DESCRIPTION
Fixes #7237.