### PR TITLE
Allow backend filtering of unsearchable contenttypes

### DIFF
--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -62,12 +62,12 @@ class Listing
             'order'   => $options->getOrder() ?: $contentType['sort'],
             'page'    => $options->getPage(),
             'filter'  => $options->getFilter(),
-            'invisible' => true,
         ];
 
         // If we have a text filter we switch the query into search mode
         if ($options->getFilter()) {
             $textQuery = $contentTypeSlug . '/search';
+            $contentParameters['invisible'] = true;
         } else {
             $textQuery = $contentTypeSlug;
         }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -62,6 +62,7 @@ class Listing
             'order'   => $options->getOrder() ?: $contentType['sort'],
             'page'    => $options->getPage(),
             'filter'  => $options->getFilter(),
+            'invisible' => true,
         ];
 
         // If we have a text filter we switch the query into search mode

--- a/src/Storage/Query/SearchConfig.php
+++ b/src/Storage/Query/SearchConfig.php
@@ -24,6 +24,8 @@ class SearchConfig
     /** @var array */
     protected $joins = [];
 
+    protected $searchInvisible = false;
+
     public function __construct(Config $config)
     {
         $this->config = $config;
@@ -43,29 +45,13 @@ class SearchConfig
             return $this->searchableTypes[$contentType];
         }
 
-        return false;
-    }
-
-    /**
-     * Get the config of all fields for a given content type including those markes
-     * as invisible..
-     *
-     * @param string $contentType
-     *
-     * @return array|false
-     */
-    public function getConfigForAll($contentType)
-    {
-        if (array_key_exists($contentType, $this->searchableTypes)) {
-            return $this->searchableTypes[$contentType];
-        }
-
-        if (array_key_exists($contentType, $this->invisibleTypes)) {
+        if ($this->canSearchInvisible() && array_key_exists($contentType, $this->invisibleTypes)) {
             return $this->invisibleTypes[$contentType];
         }
 
         return false;
     }
+
 
     /**
      * Get the config of one given field for a given content type.
@@ -79,6 +65,10 @@ class SearchConfig
     {
         if (isset($this->searchableTypes[$contentType][$field])) {
             return $this->searchableTypes[$contentType][$field];
+        }
+
+        if ($this->canSearchInvisible() && isset($this->invisibleTypes[$contentType][$field])) {
+            return $this->invisibleTypes[$contentType][$field];
         }
 
         return false;
@@ -190,5 +180,21 @@ class SearchConfig
         }
 
         return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canSearchInvisible()
+    {
+        return $this->searchInvisible;
+    }
+
+    /**
+     * @param bool $searchInvisible
+     */
+    public function enableSearchInvisible($searchInvisible)
+    {
+        $this->searchInvisible = $searchInvisible;
     }
 }

--- a/src/Storage/Query/SearchQuery.php
+++ b/src/Storage/Query/SearchQuery.php
@@ -102,12 +102,11 @@ class SearchQuery extends SelectQuery
         }
 
         if (isset($params['invisible']) && $params['invisible'] === true) {
-            dump("lalalalalalalal");
-            $config = $this->config->getConfigForAll($this->contentType);
-        } else {
-            if (!$config = $this->config->getConfig($this->contentType)) {
-                throw new QueryParseException('You have attempted to run a search query on an unknown ContentType or one that is not searchable', 1);
-            }
+            $this->config->enableSearchInvisible(true);
+        }
+
+        if (!$config = $this->config->getConfig($this->contentType)) {
+            throw new QueryParseException('You have attempted to run a search query on an unknown ContentType or one that is not searchable', 1);
         }
 
         unset($params['filter'], $params['invisible']);

--- a/src/Storage/Query/SearchQuery.php
+++ b/src/Storage/Query/SearchQuery.php
@@ -95,15 +95,21 @@ class SearchQuery extends SelectQuery
      */
     protected function processFilters()
     {
+        $params = $this->params;
+
         if (!$this->contentType) {
             throw new QueryParseException('You have attempted to run a search query without specifying a ContentType', 1);
         }
 
-        if (!$config = $this->config->getConfig($this->contentType)) {
-            throw new QueryParseException('You have attempted to run a search query on an unknown ContentType or one that is not searchable', 1);
+        if (isset($params['invisible']) && $params['invisible'] === true) {
+            dump("lalalalalalalal");
+            $config = $this->config->getConfigForAll($this->contentType);
+        } else {
+            if (!$config = $this->config->getConfig($this->contentType)) {
+                throw new QueryParseException('You have attempted to run a search query on an unknown ContentType or one that is not searchable', 1);
+            }
         }
 
-        $params = $this->params;
         unset($params['filter']);
 
         foreach ($config as $field => $options) {

--- a/src/Storage/Query/SearchQuery.php
+++ b/src/Storage/Query/SearchQuery.php
@@ -110,7 +110,7 @@ class SearchQuery extends SelectQuery
             }
         }
 
-        unset($params['filter']);
+        unset($params['filter'], $params['invisible']);
 
         foreach ($config as $field => $options) {
             $params[$field] = $this->getSearchParameter();


### PR DESCRIPTION
Fixes #7214 

This adds a toggle to the search config class to allow searching on those contenttypes that would ordinarily be invisible.