### PR TITLE
Prevent "Notice: Undefined index" when doing database:import

### DIFF
--- a/src/Storage/Entity/MagicAttributeTrait.php
+++ b/src/Storage/Entity/MagicAttributeTrait.php
@@ -106,13 +106,15 @@ trait MagicAttributeTrait
         $fields = [];
 
         foreach ($this as $k => $v) {
-            if (strpos($k, '_') !== 0) {
+            if (is_string($k) && strpos($k, '_') !== 0) {
                 $fields[] = $k;
             }
         }
 
         foreach ($this->_fields as $k => $v) {
-            $fields[] = $k;
+            if (is_string($k)) {
+                $fields[] = $k;
+            }
         }
 
         return $fields;


### PR DESCRIPTION
Assuming you have a field in content type that has underscore in name eg. `image_origin`, when you have this field exported and trying to import it, this is what happens:
1. `src/Storage/Field/Type/FieldTypeBase.php:95` calls `serializeImageOrigin` through `\Bolt\Storage\Entity\MagicAttributeTrait` but it looks for field imageOrigin there, which is missing in content definition.
2. Check if field exists is done by `MagicAttributeTrait::has($field)` with `in_array($field, $this->getFields())` and it this case it gives false positive.
3. However `MagicAttributeTrait::getFields()` also returns numerics like 0,1,2 etc. even if it should return `string[]`
4. `in_array('something', [0])` returns true (damn php :/)
4. Checking in `getFields()` if field is string fixed my issue and should not break anything :)
