### PR TITLE
add extra check to test block exists and matches

### DIFF
--- a/src/Storage/Field/Collection/RepeatingFieldCollection.php
+++ b/src/Storage/Field/Collection/RepeatingFieldCollection.php
@@ -122,7 +122,8 @@ class RepeatingFieldCollection extends ArrayCollection
             if (
                 $existing->getName() == $entity->getName() &&
                 $existing->getGrouping() == $entity->getGrouping() &&
-                $existing->getFieldname() == $entity->getFieldname()
+                $existing->getFieldname() == $entity->getFieldname() &&
+                (!$existing->getBlock() || $existing->getBlock() == $entity->getBlock())
             ) {
                 return $existing;
             }


### PR DESCRIPTION
Fixes #7232 

As described in the issue, block types where the fields had the same names as other blocks were being cross written to. This was a bug in the code that selected the correct entity to update.

This fix checks to see if the block exists and if so ensures that the new value matches the old one.