### PR TITLE
[koala] Pass in `user` in `flashbag()` macro. :koala:

### DIFF
--- a/app/view/twig/_sub/_messages.twig
+++ b/app/view/twig/_sub/_messages.twig
@@ -29,11 +29,11 @@
 {% if wrapper is defined and wrapper and app['logger.flash'].keys() is not empty %}
     <div class="row">
         <div class="col-md-8">
-            {{ self.flashbag() }}
+            {{ self.flashbag(user) }}
         </div>
     </div>
 {% else %}
-    {{ self.flashbag() }}
+    {{ self.flashbag(user) }}
 {% endif %}
 
 {# No Javascript #}


### PR DESCRIPTION
Fixes "missing" flashbags of type 'danger' and 'warning'.

![tumblr_oo67ufqsla1rtlnwxo1_500](https://user-images.githubusercontent.com/1833361/33838610-4a023f4e-de90-11e7-8001-30caf8db1460.gif)
