### PR TITLE
Add submenu items to custom menu items in backend

### DIFF
--- a/app/view/twig/_nav/_secondary.twig
+++ b/app/view/twig/_nav/_secondary.twig
@@ -37,7 +37,13 @@
         {% if menus.has('files') %}{{ include('@bolt/_nav/_secondary-filemanagement.twig') }}{% endif %}
         {% if menus.has('extensions') %}{{ include('@bolt/_nav/_secondary-extensions.twig') }}{% endif %}
         {% if menus.has('custom') %}
-            {% for menu in menus.get('custom').children %}{{ nav.submenu(null, null, [menu]) }}{% endfor %}
+            {% for menu in menus.get('custom').children %}
+                {% if menu.children != null %}
+                    {{ nav.submenu(menu.icon, menu.label, menu.children) }}
+                {% else %}
+                    {{ nav.submenu(null, null, [menu]) }}
+                {% endif %}
+            {% endfor %}
         {% endif %}
 
         {# Collapse/expand sidebar #}


### PR DESCRIPTION
If a custom backend menu item has children menu items this adds a submenu with those children items.

Example usage in a extension:
```php
protected function registerMenuEntries()
    {
        $menu = new MenuEntry('koala-menu', 'koala');
        $menu->setLabel('Koala Catcher')
            ->setIcon('fa:leaf')
            ->setPermission('settings')
        ;
        
        $submenuItemOne = new MenuEntry('koala-submenu-one', 'koala-tree');
        $submenuItemOne->setLabel('Koala One')
            ->setIcon('fa:leaf')
            ->setPermission('settings');

        $submenuItemTwo = new MenuEntry('koala-submenu-two', 'koala-food');
        $submenuItemTwo->setLabel('Koala Two')
            ->setIcon('fa:leaf')
            ->setPermission('settings');
        $menu->add($submenuItemOne);
        $menu->add($submenuItemTwo);

        return [
            $menu,
        ];
    }
```
