### PR TITLE
ksort the repeater hydrate to ensure grouping order is maintained

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -132,6 +132,7 @@ class RepeaterType extends FieldTypeBase
         }
 
         if (isset($values[$key]) && count($values[$key])) {
+            ksort($values[$key]);
             foreach ($values[$key] as $group => $refs) {
                 $collection->addFromReferences($refs, $group);
             }


### PR DESCRIPTION
Hopefully fixes #7248

Some mysql versions seem not to pull these out in the correct order (and I think it might be the case in SQLite too) so just to make sure we sort the fetched values by the grouping number to make sure they are rendered in the correct order.