### PR TITLE
Fix for 7241: Check for CKE changes on repeater duplication

### DIFF
--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -91,8 +91,15 @@
 
                 // Copy values from source to new set.
                 $(setToDuplicate).find(":input").each(function (index) {
-                    var val = $(this).val();
-                    if (val) {
+                    var $input = $(this),
+                        inputId = $input.attr('id'),
+                        val = $input.val(),
+                        isCke = $input.hasClass('ckeditor');
+
+                    // Check for a loaded ckeditor first, as data may have changed since the input loaded
+                    if (isCke && typeof CKEDITOR.instances[inputId] !== 'undefined') {
+                        $(newSet).find(':input').eq(index).val(CKEDITOR.instances[inputId].getData());
+                    } else if (val) {
                         $(newSet).find(':input').eq(index).val(val);
                     }
                 });


### PR DESCRIPTION
Check for CKE changes on repeater duplication.

Fixes: #7241 


Details
-------

CKEditor is "fun" in that it doesn't update the value of the textarea that spawns it, however in some cases may load instances later, where the data in the textarea can be expected to be up to date. This switches from simply grabbing the input value, to first checking if it's a CKE field and if so looking for an instance with the potentially updated data. If there's no instance yet or if it's simply not a CKE field, it then can safely just use the value.