### PR TITLE
Improve upon the dreaded `unexpected token <` in Extensions screen.

### DIFF
--- a/app/src/js/modules/extend.js
+++ b/app/src/js/modules/extend.js
@@ -26,6 +26,12 @@
         return $('.extend-bolt-container').find(selector);
     }
 
+    function stripHTML(string) {
+        var tempElement = $(string);
+        var result = tempElement.find('h1, h2, h3, p').text() || tempElement.text();
+        return result.trim().replace(/ +/g, " ").replace(/\s+\n/g, "\n");
+    }
+
     function formatErrorLog(data) {
         var errObj = '',
             html = '',
@@ -34,12 +40,24 @@
         try {
             errObj = $.parseJSON(data.responseText);
         } catch(err) {
-            $('.modal').modal('hide');
-            bootbox.alert('<p>An unknown error occurred. This was the error message:</p>\n\n' +
-                '<pre>' + err.message + '</pre>');
+            // Do nothing, JSON parse error is handled below.
         }
 
-        if (errObj.error.type === 'Bolt\\Exception\\PackageManagerException') {
+        if (typeof errObj.error === 'undefined') {
+            msg = 'This was the received response:\n\n' +
+                '<textarea>' + stripHTML(data.responseText) + '</textarea>\n\n' +
+                'Inspect the console output in the browser\'s Debug Inspector for more details.';
+
+            html = bolt.data(
+                'extend.packages.error',
+                {
+                    '%ERROR_TYPE%': 'Unknown Error',
+                    '%ERROR_MESSAGE%': msg,
+                    '%ERROR_LOCATION%': ''
+                }
+            );
+            console.log(data);
+        } else if (errObj.error.type === 'Bolt\\Exception\\PackageManagerException') {
             // Clean up Composer messages.
             msg = errObj.error.message.replace(/(<http)/g, '<a href="http').replace(/(\w+>)/g, '">this link<\/a>');
 

--- a/app/src/sass/modules/_extend.scss
+++ b/app/src/sass/modules/_extend.scss
@@ -170,5 +170,13 @@
     code {
         display: block;
         white-space: pre-wrap;
+        padding: 1em;
+    }
+    textarea {
+        width: 100%;
+        height: 140px;
+        background-color: transparent;
+        border-width: 1px 0;
+        padding: 1em 0;
     }
 }

--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -54,8 +54,8 @@ class EventListenerServiceProvider implements ServiceProviderInterface
         );
 
         $app['listener.exception_json'] = $app->share(
-            function () {
-                return new Listener\ExceptionToJsonListener();
+            function ($app) {
+                return new Listener\ExceptionToJsonListener($app['path_resolver']);
             }
         );
 


### PR DESCRIPTION
If you've used the Extensions screen, you've undoubtedly seen this: 

![screen shot 2017-12-20 at 12 08 07](https://user-images.githubusercontent.com/1833361/34206353-86197ae0-e586-11e7-8a2c-0debc813ea78.png)

There are two main reasons why this happens: 

 - The result is an exception, and we should return proper JSON
 - The result is an exception / error we couldn't catch or have no control over.

This PR won't fix it for all cases, but it improves on this behaviour for the end user in two distinct ways: 

1) For async requests to our own Bolt code, return a JSON-formatted error. 
(note, i've changed the structure, to match [what's used elsewhere](https://github.com/bolt/bolt/blob/3.4/src/Controller/Backend/Extend.php#L496-L503).)

![screen shot 2017-12-20 at 13 01 24](https://user-images.githubusercontent.com/1833361/34206557-3f5ba1ae-e587-11e7-8538-7fff18777914.png)


2) When the result is _not_ JSON, it displays it as plain text, instead of the JSON parse error.

![screen shot 2017-12-20 at 12 33 42](https://user-images.githubusercontent.com/1833361/34206561-4302d624-e587-11e7-97ec-531daa3802ae.png)
