### PR TITLE
Fix for #7266, Require password for new users from admin

### DIFF
--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -89,8 +89,12 @@ class Users extends BackendBase
             return $this->redirectToRoute('users');
         }
 
+        $formOptions = [
+            'require_password' => !$userEntity->getId(),
+        ];
+
         // Generate the form
-        $form = $this->createFormBuilder(FormType\UserEditType::class, $userEntity)
+        $form = $this->createFormBuilder(FormType\UserEditType::class, $userEntity, $formOptions)
             ->getForm()
             ->handleRequest($request)
         ;

--- a/src/Form/FormType/UserEditType.php
+++ b/src/Form/FormType/UserEditType.php
@@ -4,6 +4,7 @@ namespace Bolt\Form\FormType;
 
 use Bolt\Translation\Translator as Trans;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Bolt user editing form type.
@@ -19,7 +20,7 @@ class UserEditType extends AbstractUserType
     {
         $this
             ->addUserName($builder)
-            ->addPassword($builder, ['required' => false])
+            ->addPassword($builder, ['required' => $options['require_password']])
             ->addEmail($builder)
             ->addDisplayName($builder)
             ->addEnabled($builder)
@@ -28,5 +29,15 @@ class UserEditType extends AbstractUserType
             ->addLastIp($builder)
             ->addSave($builder, ['label' => Trans::__('page.edit-users.button.save')])
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'require_password' => false,
+        ]);
     }
 }


### PR DESCRIPTION
Require password for new users from admin.

Fixes: #7266 


Details
-------

Adds an option to the user edit type to dynamically require the password depending on if the loaded user entity has an id yet.

I know @GawainLynch is closest to the SF forms stuff, and am curious if there's a better way to do this, perhaps a conditional constraint in the AbstractUserType, though this seemed the simplest solution to me currently.
