### PR TITLE
Get fields from Block, even if Block isn't last.

### DIFF
--- a/src/Storage/ContentRequest/Edit.php
+++ b/src/Storage/ContentRequest/Edit.php
@@ -404,11 +404,11 @@ class Edit
                         $fieldtypes[$rfield['type']] = true;
                     }
                 }
-            }
-            if ($field['type'] === 'block') {
-                foreach ($field['fields'] as $block) {
-                    foreach ($block['fields'] as $rfield) {
-                        $fieldtypes[$rfield['type']] = true;
+                if ($field['type'] === 'block') {
+                    foreach ($field['fields'] as $block) {
+                        foreach ($block['fields'] as $rfield) {
+                            $fieldtypes[$rfield['type']] = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #7275.

See also: #6719.