### PR TITLE
[3.6] More improvements to New Storage Layer Compatibility

### DIFF
--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -424,8 +424,11 @@ abstract class Base implements ControllerProviderInterface
             return $this->storage()->getContent($textQuery, $parameters, $pager, $whereParameters);
         }
         $params = array_merge($parameters, $whereParameters);
+        unset($params['log_not_found']); // New storage system removes this functionality from the query engine
 
-        return  $this->app['query']->getContent($textQuery, $params);
+        return $this->app['twig.records.view']->createView(
+            $this->app['query']->getContentByScope('frontend', $textQuery, $params)
+        );
     }
 
     /**

--- a/src/Provider/QueryServiceProvider.php
+++ b/src/Provider/QueryServiceProvider.php
@@ -20,7 +20,7 @@ class QueryServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['query'] = function ($app) {
-            $runner = new Query($app['query.parser']);
+            $runner = new Query($app['query.parser'], $app['twig.records.view']);
             $runner->addScope('frontend', $app['query.scope.frontend']);
 
             return $runner;

--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -299,6 +299,14 @@ class TwigServiceProvider implements ServiceProviderInterface
             return $options;
         };
 
+        $app['twig.records.view'] = $app->share(
+            function ($app) {
+                $wrapper = new Twig\TwigRecordsView($app['storage.metadata']);
+
+                return $wrapper;
+            }
+        );
+
         $app['safe_twig'] = $app->share(
             function ($app) {
                 Deprecated::service('safe_twig', 3.3, 'Use "twig" service with sandbox enabled instead.');

--- a/src/Storage/ContentLegacyService.php
+++ b/src/Storage/ContentLegacyService.php
@@ -38,6 +38,7 @@ class ContentLegacyService
     public function initialize(Entity\Entity $entity)
     {
         $this->setupContenttype($entity);
+        $this->setupContainer($entity);
     }
 
     /**
@@ -51,5 +52,10 @@ class ContentLegacyService
         if (is_string($contentType)) {
             $entity->contenttype = new ContentType($contentType, $this->app['storage']->getContenttype($contentType));
         }
+    }
+
+    public function setupContainer($entity)
+    {
+        $entity->app = $this->app;
     }
 }

--- a/src/Storage/Entity/ContentValuesTrait.php
+++ b/src/Storage/Entity/ContentValuesTrait.php
@@ -3,7 +3,6 @@
 namespace Bolt\Storage\Entity;
 
 use Bolt\Common\Json;
-use Bolt\Helpers\Excerpt;
 use Bolt\Helpers\Input;
 use Bolt\Legacy;
 use Bolt\Library as Lib;
@@ -54,56 +53,6 @@ trait ContentValuesTrait
         }
 
         return false;
-    }
-
-    /**
-     * Alias for getExcerpt().
-     *
-     * @param int          $length
-     * @param bool         $includeTitle
-     * @param string|array $focus
-     *
-     * @return Markup
-     */
-    public function excerpt($length = 200, $includeTitle = false, $focus = null)
-    {
-        return $this->getExcerpt($length, $includeTitle, $focus);
-    }
-
-    /**
-     * Create an excerpt for the content.
-     *
-     * @param int          $length
-     * @param bool         $includeTitle
-     * @param string|array $focus
-     *
-     * @return Markup
-     */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null)
-    {
-        $excerptParts = [];
-
-        if (!empty($this->contenttype['fields'])) {
-            foreach ($this->contenttype['fields'] as $key => $field) {
-                // Skip empty fields, and fields used as 'title'.
-                if (!isset($this->values[$key]) || in_array($key, $this->getTitleColumnName())) {
-                    continue;
-                }
-                // add 'text', 'html' and 'textarea' fields.
-                if (in_array($field['type'], ['text', 'html', 'textarea'])) {
-                    $excerptParts[] = $this->values[$key];
-                }
-                // add 'markdown' field
-                if ($field['type'] === 'markdown') {
-                    $excerptParts[] = $this->app['markdown']->text($this->values[$key]);
-                }
-            }
-        }
-
-        $excerpter = new Excerpt(implode(' ', $excerptParts), $this->getTitle());
-        $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus);
-
-        return new Markup($excerpt, 'UTF-8');
     }
 
     /**

--- a/src/Storage/Query/Query.php
+++ b/src/Storage/Query/Query.php
@@ -3,6 +3,7 @@
 namespace Bolt\Storage\Query;
 
 use Bolt\Storage\Entity\Content;
+use Bolt\Twig\TwigRecordsView;
 
 class Query
 {
@@ -10,15 +11,18 @@ class Query
     protected $parser;
     /** @var array */
     protected $scopes;
+    /** @var TwigRecordsView */
+    protected $recordsView;
 
     /**
      * Constructor.
      *
      * @param ContentQueryParser $parser
      */
-    public function __construct(ContentQueryParser $parser)
+    public function __construct(ContentQueryParser $parser, TwigRecordsView $recordsView)
     {
         $this->parser = $parser;
+        $this->recordsView = $recordsView;
     }
 
     /**
@@ -81,5 +85,20 @@ class Query
         }
 
         return null;
+    }
+
+    /**
+     * Helper to be called from Twig that is passed via a TwigRecordsView rather than the raw records.
+     *
+     * @param $textquery
+     * @param array $parameters
+     *
+     * @return QueryResultset|null
+     */
+    public function getContentForTwig($textquery, $parameters = [])
+    {
+        return $this->recordsView->createView(
+            $this->getContentByScope('frontend', $textquery, $parameters)
+        );
     }
 }

--- a/src/Twig/Extension/ArrayExtension.php
+++ b/src/Twig/Extension/ArrayExtension.php
@@ -58,8 +58,12 @@ class ArrayExtension extends AbstractExtension
      *
      * @return array
      */
-    public function order(array $array, $on, $onSecondary = null)
+    public function order($array, $on, $onSecondary = null)
     {
+        // We only want to work with real arrays, anything else is ignored
+        if (!is_array($array)) {
+            return $array;
+        }
         // If we don't get a string, we can't determine a sort order.
         if (!is_string($on)) {
             throw new \InvalidArgumentException(sprintf('Second parameter passed to %s must be a string, %s given', __METHOD__, gettype($on)));

--- a/src/Twig/SetcontentNode.php
+++ b/src/Twig/SetcontentNode.php
@@ -60,7 +60,7 @@ class SetcontentNode extends Node
             ->write("\$context['")
             ->raw($this->getAttribute('name'))
             ->raw("'] = ")
-            ->raw("\$this->env->getRuntime('" . BoltRuntime::class . "')->getQueryEngine()->getContent(")
+            ->raw("\$this->env->getRuntime('" . BoltRuntime::class . "')->getQueryEngine()->getContentForTwig(")
             ->subcompile($this->getAttribute('contenttype'))
             ->raw(', ')
             ->subcompile($arguments)

--- a/src/Twig/TwigRecordsView.php
+++ b/src/Twig/TwigRecordsView.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Bolt\Twig;
+
+use Bolt\Storage\Entity\Content;
+use Bolt\Storage\Field\Collection\FieldCollection;
+use Bolt\Storage\Mapping\MetadataDriver;
+use Bolt\Storage\Query\QueryResultset;
+use ParsedownExtra;
+use Twig\Markup;
+
+/**
+ * Twig Records View, wraps content records before they are passed to Twig
+ * so appropriate transformation can occur.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class TwigRecordsView
+{
+    /** @var MetadataDriver */
+    protected $metadata;
+    /** @var array $transformers */
+    protected $transformers;
+
+    /**
+     * Constructor.
+     *
+     * @param MetadataDriver $metadata
+     */
+    public function __construct(MetadataDriver $metadata)
+    {
+        $this->metadata = $metadata;
+        $this->setupDefaults();
+    }
+
+    /**
+     *  Here we register some transformers that prepare the fields to be passed to
+     *  twig. For repeaters and blocks this is recursive.
+     */
+    protected function setupDefaults()
+    {
+        $this->addTransformer('html', function ($value) {
+            return new Markup($value, 'UTF-8');
+        });
+        $this->addTransformer('text', function ($value) {
+            return new Markup($value, 'UTF-8');
+        });
+        $this->addTransformer('textarea', function ($value) {
+            return new Markup($value, 'UTF-8');
+        });
+        $this->addTransformer('markdown', function ($value) {
+            $markdown = new ParsedownExtra();
+            $value = $markdown->text($value);
+
+            return new Markup($value, 'UTF-8');
+        });
+
+        $this->addTransformer('repeater', function ($value) {
+            /** @var FieldCollection $collection */
+            foreach ($value as $collection) {
+                foreach ($collection as $field) {
+                    $field->setValue($this->transform($field->getValue(), $field->getFieldType()));
+                }
+            }
+
+            return $value;
+        });
+
+        $this->addTransformer('block', function ($value) {
+            return $this->transform($value, 'repeater');
+        });
+    }
+
+    /**
+     * This loads the relevant record or records and activates the class.
+     *
+     * @param Content|QueryResultset $records
+     *
+     * @return Content|QueryResultset
+     */
+    public function createView($records)
+    {
+        if ($records instanceof Content) {
+            $this->processSingleRecord($records);
+        } elseif ($records instanceof QueryResultset) {
+            $this->processRecords($records);
+        }
+
+        return $records;
+    }
+
+    /**
+     * @param $record
+     */
+    protected function processSingleRecord($record)
+    {
+        $values = $record->getValues();
+        if (is_array($values)) {
+            foreach ($values as $field => $value) {
+                $type = $this->metadata->getFieldMetadata((string) $record->getContenttype(), $field);
+                $boltType = $type['data']['type'];
+                $record->set($field, $this->transform($value, $boltType, $type));
+            }
+        }
+    }
+
+    /**
+     * @param $records
+     */
+    protected function processRecords($records)
+    {
+        foreach ($records as $record) {
+            $this->processSingleRecord($record);
+        }
+    }
+
+    /**
+     * Adds a transformer callback to the field type $label
+     *
+     * @param $label
+     * @param callable $callback
+     */
+    public function addTransformer($label, callable $callback)
+    {
+        $this->transformers[$label] = $callback;
+    }
+
+    /**
+     * Checks if a transformer is registered for $label
+     *
+     * @param $label
+     *
+     * @return bool
+     */
+    public function hasTransformer($label)
+    {
+        return array_key_exists($label, $this->transformers);
+    }
+
+    /**
+     * @param $label
+     *
+     * @return array|mixed
+     */
+    public function getTransformer($label)
+    {
+        if ($this->hasTransformer($label)) {
+            return $this->transformers[$label];
+        }
+    }
+
+    /**
+     * @param $value
+     * @param $label
+     * @param array $fieldData
+     *
+     * @return mixed
+     */
+    protected function transform($value, $label, array $fieldData = [])
+    {
+        if ($this->hasTransformer($label)) {
+            return $this->transformers[$label]($value, $fieldData);
+        }
+
+        return $value;
+    }
+}

--- a/tests/phpunit/unit/Storage/Query/Directive/PagingDirectiveTest.php
+++ b/tests/phpunit/unit/Storage/Query/Directive/PagingDirectiveTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bolt\Tests\Storage\Query\Directive;
+
+use Bolt\Storage\Query\ContentQueryParser;
+use Bolt\Tests\BoltUnitTest;
+
+/**
+ * @covers \Bolt\Storage\Query\Directive\PagingDirective
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class PagingDirectiveTest extends BoltUnitTest
+{
+    public function testInputParameters()
+    {
+        $app = $this->getApp();
+
+        $qb = new ContentQueryParser($app['storage']);
+        $qb->setQuery('pages');
+        $qb->setParameters(['page' => '5']);
+        $qb->parse();
+        $this->assertEquals(['pages'], $qb->getContentTypes());
+        $this->assertEquals('select', $qb->getOperation());
+        $this->assertEmpty($qb->getIdentifier());
+    }
+}


### PR DESCRIPTION
This is targeted at installs where legacy `setcontent` is turned off so the Content objects are filled using the new storage layer.

As discussed in #6985 methods on the content object itself are moved to twig functions and filters with a compatibility patch used to avoid things breaking until 4.0.

There's also some ongoing work on performance here, targeted at closing some performance problems with content object hydration.

Existing systems using the legacy setcontent system will continue to work as before.