### PR TITLE
[3.4] Use `path` instead of `url` for the Video embed endpoint.

### DIFF
--- a/app/view/twig/editcontent/fielddata/_video.twig
+++ b/app/view/twig/editcontent/fielddata/_video.twig
@@ -1,2 +1,2 @@
 
-{{ data('endpoint.embed', url('embedRequestEndpoint')) }}
+{{ data('endpoint.embed', path('embedRequestEndpoint')) }}


### PR DESCRIPTION
Reason for this patch: 

![screen_shot_2018-01-16_at_17_09_10](https://user-images.githubusercontent.com/1833361/34998730-2a4b705a-fae0-11e7-810b-2510b0f28b49.png)
