### PR TITLE
[3.5] Use `path` instead of `url` for the oembed endpoint.

### DIFF
--- a/app/view/twig/editcontent/fielddata/_oembed.twig
+++ b/app/view/twig/editcontent/fielddata/_oembed.twig
@@ -1,2 +1,2 @@
 
-{{ data('endpoint.embed', url('embedRequestEndpoint')) }}
+{{ data('endpoint.embed', path('embedRequestEndpoint')) }}


### PR DESCRIPTION
Same as #7299, only for the generic OEmbed field, instead of Video.