### PR TITLE
[3.5] Enabled JSON manifest asset version strategy

### DIFF
--- a/src/Asset/JsonManifestVersionStrategy.php
+++ b/src/Asset/JsonManifestVersionStrategy.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bolt\Asset;
+
+use Bolt\Filesystem\Handler\FileInterface;
+use Bolt\Filesystem\Handler\JsonFile;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
+
+/**
+ * @internal
+ * @deprecated to be replaced with upstream implementation in v4
+ *
+ * The manifest file uses the following format:
+ *     {
+ *         "main.js": "main.abc123.js",
+ *         "css/styles.css": "css/styles.555abc.css"
+ *     }
+ */
+final class JsonManifestVersionStrategy implements VersionStrategyInterface
+{
+    /** @var FileInterface|JsonFile */
+    private $manifestFile;
+    /** @var array|null */
+    private $manifestData;
+
+    public function __construct(FileInterface $manifestFile)
+    {
+        $this->manifestFile = $manifestFile;
+    }
+
+    public function getVersion($path)
+    {
+        return $this->applyVersion($path);
+    }
+
+    public function applyVersion($path)
+    {
+        return $this->getManifestPath($path) ?: $path;
+    }
+
+    private function getManifestPath($path)
+    {
+        if ($this->manifestData === null) {
+            if (!$this->manifestFile->exists()) {
+                throw new \RuntimeException(sprintf('Asset manifest file "%s" does not exist.', $this->manifestFile->getFullPath()));
+            }
+
+            $this->manifestData = $this->manifestFile->parse();
+        }
+
+        return isset($this->manifestData[$path]) ? $this->manifestData[$path] : null;
+    }
+}

--- a/src/Provider/AssetServiceProvider.php
+++ b/src/Provider/AssetServiceProvider.php
@@ -55,10 +55,17 @@ class AssetServiceProvider implements ServiceProviderInterface
 
         $app['asset.version_strategy'] = $app->protect(
             function ($nameOrDir) use ($app) {
-                $dir = $nameOrDir instanceof DirectoryInterface ? $nameOrDir :
-                    $app['filesystem']->getFilesystem($nameOrDir)->getDir('');
+                $dir = $nameOrDir instanceof DirectoryInterface
+                    ? $nameOrDir
+                    : $app['filesystem']->getFilesystem($nameOrDir)->getDir('');
+                $mount = $dir->getMountPoint();
+                $manifest = $app['config']->get("general/assets/$mount/json_manifest_path");
 
-                return new Asset\BoltVersionStrategy($dir, $app['asset.salt']);
+                if ($manifest === null) {
+                    return new Asset\BoltVersionStrategy($dir, $app['asset.salt']);
+                }
+
+                return new Asset\JsonManifestVersionStrategy($dir->getFile($manifest));
             }
         );
 


### PR DESCRIPTION
When using Symfony Encore one can enable `Encore.enableVersioning(Encore.isProduction())` which will output files that include a _"chunk hash"_ in the file name, and a `manifest.json` file that allows the base file name to be mapped to the hashed file name.

For example a `manifest.json` might contain something like:

```json
{
  "build/app.css": "/build/app.8fd8daccd3a40a57bad06ae2d8f4c28d.css",
  "build/app.js": "/build/app.2fec6da74d584bcd9fd2.js"
}
```

With this PR, you can enable a package/mount-point to use the manifest strategy by setting the relative path to the JSON file as a value in `config.yml`, e.g.

```yaml
assets:
    web:
        json_manifest_path: build/manifest.json 
        # This file is at %webroot%/build/manifest.json
        # which in a default install is %site%/public/build/manifest.json
```

Then in your Twig templates:
```twig
<link rel="stylesheet" href="{{ asset('assets/app.css', 'web') }}" />
<script src="{{ asset('assets/app.js', 'web') }}"></script>
```

Would output:
```html
<link rel="stylesheet" href="/build/app.8fd8daccd3a40a57bad06ae2d8f4c28d.css" />
<script src="/build/app.2fec6da74d584bcd9fd2.js"></script>
```

See the [Symfon y blog post](https://symfony.com/blog/new-in-symfony-3-3-manifest-based-asset-versioning) for more details.