### PR TITLE
PT language Code needs to match the language folder name

### DIFF
--- a/app/resources/translations/pt/validators.pt.xlf
+++ b/app/resources/translations/pt/validators.pt.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="1" approved="yes">
         <source>Passwords must match.</source>
-        <target xml:lang="pt-PT">As senhas têm de ser iguais.</target>
+        <target xml:lang="pt">As senhas têm de ser iguais.</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Language code needs to match folder corresponding language name

Details
-------
 - Else it fails when you pick the language in main config
  
