### PR TITLE
Update select2sortable plugin to sort on the full text value of element

### DIFF
--- a/app/src/lib/select2-ext/select2.sortable.js
+++ b/app/src/lib/select2-ext/select2.sortable.js
@@ -15,7 +15,7 @@
                 stop: function() {
                     $($(ul).find('.select2-selection__choice').get().reverse()).each(function() {
                         var id = $(this).attr('title');
-                        var option = select.find('option[value="' + id + '"]')[0];
+                        var option = select.find('option:contains("'+id+'")')[0];
                         $(select).prepend(option);
                     });
                 }


### PR DESCRIPTION
Another bug from the changes to underlying select2 library.

When we use the `contenttype/id,title` layout on a field then the value of the original and duplicated titles are not the same so instead this adjusts it to select on the full text content so they sort correctly.