### PR TITLE
Allow grouping for other taxonomies than only the first one that has `behaves_like: grouping`.

### DIFF
--- a/src/Storage/Collection/Taxonomy.php
+++ b/src/Storage/Collection/Taxonomy.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Storage\Collection;
 
+use Bolt\Common\Deprecated;
 use Bolt\Storage\Entity;
 use Bolt\Storage\Mapping\MetadataDriver;
 use Closure;
@@ -256,6 +257,8 @@ class Taxonomy extends ArrayCollection
      */
     public function getGroupingTaxonomy()
     {
+        Deprecated::method(3.4, 'getGroupingTaxonomies');
+
         foreach ($this->config->getData() as $taxKey => $taxonomy) {
             if ($taxonomy['behaves_like'] === 'grouping') {
                 return $taxKey;
@@ -263,5 +266,21 @@ class Taxonomy extends ArrayCollection
         }
 
         return null;
+    }
+
+    /**
+     * @return array
+     */
+    public function getGroupingTaxonomies()
+    {
+        $result = [];
+
+        foreach ($this->config->getData() as $taxKey => $taxonomy) {
+            if ($taxonomy['behaves_like'] === 'grouping') {
+                $result[] = $taxKey;
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -157,7 +157,7 @@ class Listing
         foreach ($results as $result) {
             $taxGroup = null;
             foreach ($result->getTaxonomy() as $taxonomy) {
-                if ($taxonomy->getTaxonomytype() == $result->getTaxonomy()->getGroupingTaxonomy()) {
+                if (in_array($taxonomy->getTaxonomytype(), $result->getTaxonomy()->getGroupingTaxonomies())) {
                     $taxGroup = $taxonomy->getSlug();
                     $taxOrder = $taxonomy->getSortorder();
                     $resultTaxOrders[$result->getId()] = $taxOrder;


### PR DESCRIPTION
Fixes #7313 