### PR TITLE
[3.4] Update handling of user form data

### DIFF
--- a/src/Form/FieldType/UserRoleType.php
+++ b/src/Form/FieldType/UserRoleType.php
@@ -4,6 +4,7 @@ namespace Bolt\Form\FieldType;
 
 use Bolt\AccessControl\Permissions;
 use Bolt\AccessControl\Token\Token;
+use Bolt\Common\Deprecated;
 use Bolt\Translation\Translator as Trans;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -12,6 +13,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * User permission/role type.
+ *
+ * @deprecated Since 3.4. Do not use
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
@@ -47,6 +50,8 @@ class UserRoleType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        Deprecated::cls(3.4);
+
         $roles = array_flip(array_map(
             function ($role) {
                 return $role['label'];

--- a/src/Form/FormType/UserData.php
+++ b/src/Form/FormType/UserData.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Bolt\Form\FormType;
+
+use Bolt\Helpers\ListMutator;
+use Bolt\Storage\Entity;
+
+/**
+ * User form DTO.
+ *
+ * @internal
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class UserData
+{
+    /** @var int */
+    private $id;
+    /** @var string */
+    private $userName;
+    /** @var string */
+    private $password;
+    /** @var string */
+    private $email;
+    /** @var string */
+    private $displayName;
+    /** @var \DateTime */
+    protected $lastSeen;
+    /** @var string */
+    protected $lastIp;
+    /** @var array */
+    private $stack = [];
+    /** @var bool */
+    private $enabled;
+    /** @var array */
+    private $roles = [];
+
+    /**
+     * Constructor.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param Entity\Users $entity
+     *
+     * @return UserData
+     */
+    public static function createFromEntity(Entity\Users $entity)
+    {
+        $user = new self();
+        $user->id = $entity->getId();
+        $user->userName = $entity->getUserName();
+        $user->password = $entity->getPassword();
+        $user->email = $entity->getEmail();
+        $user->displayName = $entity->getDisplayname();
+        $user->lastSeen = $entity->getLastSeen();
+        $user->lastIp = $entity->getLastIp();
+        $user->stack = $entity->getStack();
+        $user->enabled = $entity->getEnabled();
+        $user->roles = $entity->getRoles();
+
+        return $user;
+    }
+
+    public function applyToEntity(Entity\Users $entity, ListMutator $mutator = null)
+    {
+        $entity->setUserName($this->userName);
+        $entity->setPassword($this->password);
+        $entity->setEmail($this->email);
+        $entity->setDisplayName($this->displayName);
+        $entity->setLastSeen($this->lastSeen);
+        $entity->setLastIp($this->lastIp);
+        $entity->setStack($this->stack);
+        $entity->setEnabled($this->enabled);
+        if ($mutator) {
+            $entity->setRoles($mutator($entity->getRoles(), $this->roles));
+        }
+    }
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUserName()
+    {
+        return $this->userName;
+    }
+
+    /**
+     * @param string $userName
+     *
+     * @return UserData
+     */
+    public function setUserName($userName)
+    {
+        $this->userName = $userName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * @param string $password
+     *
+     * @return UserData
+     */
+    public function setPassword($password)
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param string $email
+     *
+     * @return UserData
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayName()
+    {
+        return $this->displayName;
+    }
+
+    /**
+     * @param string $displayName
+     *
+     * @return UserData
+     */
+    public function setDisplayName($displayName)
+    {
+        $this->displayName = $displayName;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getLastSeen()
+    {
+        return $this->lastSeen;
+    }
+
+    /**
+     * @param \DateTime $lastSeen
+     *
+     * @return UserData
+     */
+    public function setLastSeen($lastSeen)
+    {
+        $this->lastSeen = $lastSeen;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastIp()
+    {
+        return $this->lastIp;
+    }
+
+    /**
+     * @param string $lastIp
+     *
+     * @return UserData
+     */
+    public function setLastIp($lastIp)
+    {
+        $this->lastIp = $lastIp;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getStack()
+    {
+        return $this->stack;
+    }
+
+    /**
+     * @param array $stack
+     *
+     * @return UserData
+     */
+    public function setStack($stack)
+    {
+        $this->stack = $stack;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool $enabled
+     *
+     * @return UserData
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+
+    /**
+     * @param array $roles
+     *
+     * @return UserData
+     */
+    public function setRoles($roles)
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+}

--- a/src/Form/FormType/UserEditType.php
+++ b/src/Form/FormType/UserEditType.php
@@ -18,13 +18,15 @@ class UserEditType extends AbstractUserType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        parent::buildForm($builder, $options);
+
         $this
             ->addUserName($builder)
-            ->addPassword($builder, ['required' => $options['require_password']])
+            ->addPassword($builder, $options['password'])
             ->addEmail($builder)
             ->addDisplayName($builder)
             ->addEnabled($builder)
-            ->addRoles($builder)
+            ->addRoles($builder, $options['roles'])
             ->addLastSeen($builder)
             ->addLastIp($builder)
             ->addSave($builder, ['label' => Trans::__('page.edit-users.button.save')])
@@ -36,8 +38,10 @@ class UserEditType extends AbstractUserType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        parent::configureOptions($resolver);
+
         $resolver->setDefaults([
-            'require_password' => false,
+            'password' => ['required' => false],
         ]);
     }
 }

--- a/src/Form/FormType/UserNewType.php
+++ b/src/Form/FormType/UserNewType.php
@@ -17,6 +17,8 @@ class UserNewType extends AbstractUserType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        parent::buildForm($builder, $options);
+
         $this
             ->addUserName($builder)
             ->addPassword($builder, ['required' => true])

--- a/src/Form/FormType/UserProfileType.php
+++ b/src/Form/FormType/UserProfileType.php
@@ -17,6 +17,8 @@ class UserProfileType extends AbstractUserType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        parent::buildForm($builder, $options);
+
         $this
             ->addPassword($builder, ['required' => false])
             ->addEmail($builder)

--- a/src/Helpers/ListMutator.php
+++ b/src/Helpers/ListMutator.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Bolt\Helpers;
+
+use Bolt\Collection\MutableBag;
+
+/**
+ * @internal
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class ListMutator
+{
+    /** @var MutableBag */
+    private $available;
+    /** @var MutableBag */
+    private $mutable;
+
+    /**
+     * Constructor.
+     *
+     * @param array $available
+     * @param array $mutable
+     */
+    public function __construct(array $available, array $mutable)
+    {
+        $this->available = MutableBag::from($available);
+        $this->mutable = MutableBag::from($mutable);
+    }
+
+    public function __invoke(array $original, array $proposed)
+    {
+        $isAvailable = function ($k, $v) {
+            return $this->available->hasItem($v);
+        };
+        $isMutable = function ($k, $v) {
+            return $this->mutable->hasItem($v);
+        };
+        $original = MutableBag::from($original)->filter($isAvailable);
+        $proposed = MutableBag::from($proposed)->filter($isAvailable)->filter($isMutable);
+
+        $removedFromOriginal = $original->diff($proposed);
+        $addedInProposed = $proposed->diff($original);
+
+        // If after post-filtering both arrays match, we're done
+        if ($removedFromOriginal->isEmpty() && $addedInProposed->isEmpty()) {
+            return $proposed->toArray();
+        }
+
+        // Start with values in origin that are also in the proposed array
+        $result = $original->intersect($proposed);
+
+        // Re-add selections that are not in the proposed result, but are not mutable
+        foreach ($removedFromOriginal as $item) {
+            if (!$this->mutable->hasItem($item)) {
+                $result->add($item);
+            }
+        }
+        // Add selections from the proposed result that are mutable
+        foreach ($addedInProposed as $item) {
+            if ($this->mutable->hasItem($item)) {
+                $result->add($item);
+            }
+        }
+
+        return $result->values()->toArray();
+    }
+}

--- a/tests/phpunit/unit/Form/FormType/UserDataTest.php
+++ b/tests/phpunit/unit/Form/FormType/UserDataTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Bolt\Tests\Form\FormType;
+
+use Bolt\Form\FormType\UserData;
+use Bolt\Storage\Entity\Users;
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Bolt\Form\FormType\UserData
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class UserDataTest extends TestCase
+{
+    public function testApplyToEntity()
+    {
+        $entity = $this->createEntity();
+        $dto = UserData::createFromEntity($entity)
+            ->setEnabled(false)
+            ->setStack([])
+            ->setLastIp('::1/128')
+            ->setDisplayName('Julian L. Dropbear')
+            ->setLastSeen(Carbon::createFromTimestamp(1234))
+            ->setEmail('julian@dropbear.com.au')
+            ->setUserName('julian')
+            ->setPassword('top$ecret')
+            ->setRoles(['sushi', 'egg'])
+            ->setEnabled(false)
+        ;
+        $dto->applyToEntity($entity);
+
+        self::assertSame(42, $dto->getId());
+        self::assertSame('julian', $dto->getUserName());
+        self::assertSame('top$ecret', $dto->getPassword());
+        self::assertSame('julian@dropbear.com.au', $dto->getEmail());
+        self::assertSame('Julian L. Dropbear', $dto->getDisplayName());
+        self::assertSame((string) Carbon::createFromTimestamp(1234), (string) $dto->getLastSeen());
+        self::assertSame('::1/128', $dto->getLastIp());
+        self::assertSame([], $dto->getStack());
+        self::assertSame(false, $dto->isEnabled());
+        self::assertSame(['sushi', 'egg'], $dto->getRoles());
+    }
+
+    public function providerDto()
+    {
+        yield [UserData::createFromEntity($this->createEntity())];
+    }
+    /**
+     * @dataProvider providerDto
+     */
+    public function testGetId(UserData $dto)
+    {
+        self::assertSame(42, $dto->getId());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testUserName(UserData $dto)
+    {
+        self::assertSame('kenny', $dto->getUserName());
+        self::assertSame('bruce', $dto->setUserName('bruce')->getUserName());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testPassword(UserData $dto)
+    {
+        self::assertSame('Dr0pß3@r', $dto->getPassword());
+        self::assertSame('hunter42', $dto->setPassword('hunter42')->getPassword());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testEmail(UserData $dto)
+    {
+        self::assertSame('kenny@koala.com.au', $dto->getEmail());
+        self::assertSame('bruce@koala.com.au', $dto->setEmail('bruce@koala.com.au')->getEmail());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testDisplayName(UserData $dto)
+    {
+        self::assertSame('Kenny J. Koala', $dto->getDisplayName());
+        self::assertSame('Bruce M. Koala', $dto->setDisplayName('Bruce M. Koala')->getDisplayName());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testLastSeen(UserData $dto)
+    {
+        self::assertSame((string) Carbon::createFromTimestamp(0), (string) $dto->getLastSeen());
+        self::assertSame((string) Carbon::createFromTimestamp(42), (string) $dto->setLastSeen(Carbon::createFromTimestamp(42))->getLastSeen());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testLastIp(UserData $dto)
+    {
+        self::assertSame('127.0.0.1', $dto->getLastIp());
+        self::assertSame('::1/128', $dto->setLastIp('::1/128')->getLastIp());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testStack(UserData $dto)
+    {
+        self::assertSame(['rosie.jpg'], $dto->getStack());
+        self::assertSame([], $dto->setStack([])->getStack());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testEnabled(UserData $dto)
+    {
+        self::assertSame(true, $dto->isEnabled());
+        self::assertSame(false, $dto->setEnabled(false)->isEnabled());
+    }
+
+    /**
+     * @dataProvider providerDto
+     */
+    public function testRoles(UserData $dto)
+    {
+        self::assertSame(['salad', 'ham'], $dto->getRoles());
+        self::assertSame(['turkey', 'potato'], $dto->setRoles(['turkey', 'potato'])->getRoles());
+    }
+
+    private function createEntity()
+    {
+        return new Users([
+            'id'          => 42,
+            'username'    => 'kenny',
+            'password'    => 'Dr0pß3@r',
+            'email'       => 'kenny@koala.com.au',
+            'lastseen'    => Carbon::createFromTimestamp(0),
+            'lastip'      => '127.0.0.1',
+            'displayname' => 'Kenny J. Koala',
+            'stack'       => ['rosie.jpg'],
+            'enabled'     => true,
+            'roles'       => ['salad', 'ham'],
+        ]);
+    }
+}

--- a/tests/phpunit/unit/Helper/ListMutatorTest.php
+++ b/tests/phpunit/unit/Helper/ListMutatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bolt\Tests\Helper;
+
+use Bolt\Helpers\ListMutator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Bolt\Helpers\ListMutator
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ListMutatorTest extends TestCase
+{
+    public static $available = [
+        'Salad'  => 'salad',
+        'Sushi'  => 'sushi',
+        'Ham'    => 'ham',
+        'Egg'    => 'egg',
+        'Bread'  => 'bread',
+        'Spring' => 'spring',
+        'Pizza'  => 'pizza',
+    ];
+
+    public function provider()
+    {
+        yield 'All values mutatable, original & proposed are the same' => [
+            self::$available, ['ham', 'egg'], ['ham', 'egg'], ['ham', 'egg'],
+        ];
+        yield 'All values mutatable, and an invalid value in original' => [
+            self::$available, ['ham', 'egg', 'koala'], ['ham', 'salad'], ['ham', 'salad'],
+        ];
+        yield 'Immutable value can not be removed from the original' => [
+            [], ['ham', 'egg'], ['egg'], ['ham', 'egg'],
+        ];
+        yield 'Immutable value can not be added' => [
+            [], ['ham'], ['egg'], ['ham'],
+        ];
+        yield 'Nothing is mutatable, and not values are proposed' => [
+            [], self::$available, [], array_values(self::$available),
+        ];
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testMutationResults(array $mutable, array $original, array $proposed, array $expected)
+    {
+        $mutator = new ListMutator(self::$available, $mutable);
+
+        self::assertSame($expected, $mutator($original, $proposed));
+    }
+}


### PR DESCRIPTION
Fixes #7309

There are two key things here, that I really wanted to tackle ages ago, but thought we could work around in the meantime … Namely, add a list mutator, and use a DTO on the user forms

This mutator is constructed with a list of available possible items, and a second sub-list of items that can be mutated.

The object can then be invoked with two parameters, first is the original list contents, the second being proposed changes.

The returned list will:
- contain only items that are in the 'available' list
- contain any items that appear in both original and proposed lists
- gain only available items that are also mutatable
- lose only items that are mutatable

