### PR TITLE
Update exception handling in NotFoundListener

### DIFF
--- a/src/EventListener/NotFoundListener.php
+++ b/src/EventListener/NotFoundListener.php
@@ -11,6 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Twig\Environment;
 use Twig\Error\LoaderError;
@@ -79,6 +80,9 @@ class NotFoundListener implements EventSubscriberInterface
 
         $content = $this->storage->getContent($this->notFoundPage, ['returnsingle' => true]);
         if (!$content instanceof Content || empty($content->id)) {
+            $msg = sprintf('No page could be shown, because the "notfound" setting "%s" in config.yml or theme.yml is not valid.', $this->notFoundPage);
+            $event->setException(new NotFoundHttpException($msg, $e));
+
             return;
         }
 


### PR DESCRIPTION
fixes #7345

Now it catches the error in `->resolveTemplate()` and any in `->render()`

I can use `use` statement for that. Also i suppose that we can check if template exists and throw more explanatory exception, before rendering it in chain. 
```php
$template = $this->twig->resolveTemplate($template);

# checking if template is resolved here

$html = $template->render($context);
```
