### PR TITLE
Correct redirect after saving "new" record.

### DIFF
--- a/src/Storage/ContentRequest/Save.php
+++ b/src/Storage/ContentRequest/Save.php
@@ -273,6 +273,12 @@ class Save
         if ($new) {
             $this->loggerFlash->success(Trans::__('contenttypes.generic.saved-new', ['%contenttype%' => $contentType['singular_name']]));
             $this->loggerSystem->info('Created: ' . $content->getTitle(), ['event' => 'content']);
+        } else {
+            $this->loggerFlash->success(Trans::__('contenttypes.generic.saved-changes', ['%contenttype%' => $contentType['singular_name']]));
+            $this->loggerSystem->info('Saved: ' . $content->getTitle(), ['event' => 'content']);
+        }
+
+        if ($new && ($returnTo === 'save')) {
             $redirectUri = $this->generateUrl(
                 'editcontent',
                 [
@@ -282,35 +288,35 @@ class Save
             );
 
             return new RedirectResponse($redirectUri);
-        } else {
-            $this->loggerFlash->success(Trans::__('contenttypes.generic.saved-changes', ['%contenttype%' => $contentType['singular_name']]));
-            $this->loggerSystem->info('Saved: ' . $content->getTitle(), ['event' => 'content']);
-        }
+        } elseif ($returnTo === 'ajax') {
+            return $this->createJsonUpdate($content, true);
+        } elseif ($returnTo === 'save_create') {
+            $redirectUri = $this->generateUrl(
+                'editcontent',
+                [
+                    'contenttypeslug' => $contentType['slug'],
+                    '_fragment'       => $returnTo,
+                ]
+            );
 
-        if ($returnTo) {
-            if ($returnTo === 'ajax') {
-                return $this->createJsonUpdate($content, true);
-            } elseif ($returnTo === 'save_create') {
-                return new RedirectResponse(
-                    $this->generateUrl(
-                        'editcontent',
-                        [
-                            'contenttypeslug' => $contentType['slug'],
-                            '_fragment'       => $returnTo,
-                        ]
-                    )
-                );
-            } elseif ($returnTo === 'save_return') {
-                // No returnto, so we go back to the 'overview' for this contenttype.
-                // check if a pager was set in the referrer - if yes go back there
-                if ($editReferrer) {
-                    return new RedirectResponse($editReferrer);
-                }
-
-                return new RedirectResponse($this->generateUrl('overview', ['contenttypeslug' => $contentType['slug']]));
-            } elseif ($returnTo === 'test') {
-                return $this->createJsonUpdate($content, false);
+            return new RedirectResponse($redirectUri);
+        } elseif ($returnTo === 'save_return') {
+            // No returnto, so we go back to the 'overview' for this contenttype.
+            // check if a pager was set in the referrer - if yes go back there
+            if ($editReferrer) {
+                return new RedirectResponse($editReferrer);
             }
+
+            $redirectUri = $this->generateUrl(
+                'overview',
+                [
+                    'contenttypeslug' => $contentType['slug']
+                ]
+            );
+
+            return new RedirectResponse($redirectUri);
+        } elseif ($returnTo === 'test') {
+            return $this->createJsonUpdate($content, false);
         }
 
         return null;

--- a/tests/phpunit/unit/Controller/Backend/RecordsTest.php
+++ b/tests/phpunit/unit/Controller/Backend/RecordsTest.php
@@ -5,7 +5,6 @@ namespace Bolt\Tests\Controller\Backend;
 use Bolt\Common\Json;
 use Bolt\Storage\Entity;
 use Bolt\Tests\Controller\ControllerUnitTest;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -172,10 +171,6 @@ class RecordsTest extends ControllerUnitTest
         // Save a test record
         $response = $this->controller()->edit($this->getRequest(), 'showcases', null);
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $parts = explode('/', $response->getTargetUrl());
-        $newId = array_pop($parts);
-
-        $response = $this->controller()->edit($this->getRequest(), 'showcases', $newId);
         $this->assertEquals('/bolt/overview/showcases', $response->getTargetUrl());
     }
 
@@ -203,12 +198,6 @@ class RecordsTest extends ControllerUnitTest
 
         // Save a test record
         $response = $this->controller()->edit($request, 'pages', null);
-        $this->assertInstanceOf(RedirectResponse::class, $response);
-        $parts = explode('/', $response->getTargetUrl());
-        $newId = array_pop($parts);
-
-        $response = $this->controller()->edit($request, 'pages', $newId);
-        $this->assertInstanceOf(JsonResponse::class, $response);
 
         $returned = Json::parse($response->getContent());
         $this->assertEquals('Koala Country', $returned['title']);


### PR DESCRIPTION
Fixes #7344 

If we have a "new" item, don't immediately redirect, but take `save and return` and `save and add new` into account. 

(ps: the changelog looks wonky. I changed a lot less lines)