### PR TITLE
Fix to support multiple contenttypes

### DIFF
--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -141,10 +141,14 @@ final class Choice
         }
 
         $values = [];
+        $ctCount = count($entities->getOriginalQueries());
         foreach ($entities as $entity) {
-            /** @var Content $entity */
             $id = $entity->get($field->get('keys', 'id'));
-            $values[$id] = $entity->get($queryFields[0]);
+            if ($ctCount > 1) {
+                $values[(string)$entity->getContenttype() . '/' . $id] = $entity->get($queryFields[0]);
+            } else {
+                $values[$id] = $entity->get($queryFields[0]);
+            }
             if (isset($queryFields[1])) {
                 $values[$id] .= ' / ' . $entity->get($queryFields[1]);
             }

--- a/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
+++ b/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
@@ -6,6 +6,7 @@ use Bolt\Form\Resolver\Choice;
 use Bolt\Storage\Entity\Content;
 use Bolt\Storage\Mapping\ContentType;
 use Bolt\Storage\Query\Query;
+use Bolt\Storage\Query\QueryResultset;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
@@ -334,12 +335,17 @@ class ChoiceTest extends TestCase
      */
     private function getEntities()
     {
-        return [
+        $set = new QueryResultset();
+
+        $results = [
             new Content(['id' => 10, 'field_1' => 'Foo Magoo', 'field_2' => 'Magoo Foo']),
             new Content(['id' => 22, 'field_1' => 'Iron Bar', 'field_2' => 'Bar Iron']),
             new Content(['id' => 33, 'field_1' => 'Kenny Koala', 'field_2' => 'Koala Kenny']),
             new Content(['id' => 42, 'field_1' => 'Drop Bear', 'field_2' => 'Danger Danger']),
         ];
+        $set->add($results, 'pages');
+
+        return $set;
     }
 
     /**

--- a/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
+++ b/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
@@ -331,7 +331,7 @@ class ChoiceTest extends TestCase
     }
 
     /**
-     * @return Content[]
+     * @return QueryResultset
      */
     private function getEntities()
     {


### PR DESCRIPTION
as discussed in #7303 adjusts the choice builder to store multiple contenttype queries as contenttype/id

Fixes: #7303 
Fixes: #7339 