### PR TITLE
If there's no route for 'contentlink', don't show the "save on site" button

### DIFF
--- a/app/view/twig/editcontent/_aside-preview.twig
+++ b/app/view/twig/editcontent/_aside-preview.twig
@@ -10,7 +10,7 @@
         </button>
     {% endif %}
 
-    {% if context.content.status == "published" and context.content.link is defined %}
+    {% if context.content.status == "published" and context.content.link is defined and 'contentlink' in config.get('routing')|keys %}
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
             <span class="caret"></span>
             <span class="sr-only">Toggle Dropdown</span>

--- a/app/view/twig/editcontent/_buttons.twig
+++ b/app/view/twig/editcontent/_buttons.twig
@@ -50,7 +50,7 @@
                 {% endif %}
 
                 {# Dropdown #}
-                {% if context.content.status == "published" and context.content.link is defined %}
+                {% if context.content.status == "published" and context.content.link is defined and 'contentlink' in config.get('routing')|keys %}
                     <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                         <span class="caret"></span>
                         <span class="sr-only">Toggle Dropdown</span>


### PR DESCRIPTION
Fixes these issues, when the developer removed the 'contentlink' route: 

 - Don't show the "show saved on site" button, because it can not link to a sensible page
 - Don't throw an exception after saving (regression found in #7340)