### PR TITLE
Remove v1 version-lock on paragonie/random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "ircmaxell/random-lib": "^1.1",
         "jdorn/sql-formatter": "^1.2",
         "monolog/monolog": "^1.12",
-        "paragonie/random_compat": "^1.4",
         "passwordlib/passwordlib": "^1.0@beta",
         "php": "^5.5.9 || ^7.0",
         "silex/silex": "^1.3",


### PR DESCRIPTION
Fixes #7358.

🐵  Tested and found to be working on PHP 5.5.38, 5.6.31, 7.0.22 and 7.1.6 and 7.21. 