### PR TITLE
Add check for existing `grouping` taxonomies

### DIFF
--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -176,7 +176,10 @@ class Listing
         if (isset($taxGroup) && $taxGroup !== null) {
             foreach ($grouped as &$group) {
                 usort($group, function ($a, $b) use ($resultTaxOrders) {
-                    return $resultTaxOrders[$a->getId()] - $resultTaxOrders[$b->getId()];
+                    $aOrder = isset($resultTaxOrders[$a->getId()]) ? $resultTaxOrders[$a->getId()] : 0;
+                    $bOrder = isset($resultTaxOrders[$b->getId()]) ? $resultTaxOrders[$b->getId()] : 0;
+
+                    return $aOrder - $bOrder;
                 });
             }
         }


### PR DESCRIPTION
Prevents #7362

1. Have a contenttype, add some records.
2. Later, you add a `grouping` taxonomy.
3. Create a new record and assign a `grouping` taxonomy.
4. The listing in Bolt breaks because the old records in (1) do _not_ have a grouping via the `bolt_taxonomy` table