### PR TITLE
[3.5] Add feature to fetch placeholder images from remote URLs

### DIFF
--- a/src/Storage/Database/Prefill/ApiClient.php
+++ b/src/Storage/Database/Prefill/ApiClient.php
@@ -3,6 +3,7 @@
 namespace Bolt\Storage\Database\Prefill;
 
 use GuzzleHttp\Client;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Handles fetching prefill text content from an API service.
@@ -35,5 +36,19 @@ class ApiClient
         $uri = $base . ltrim($request, '/');
 
         return $this->client->get($uri, ['timeout' => 10])->getBody();
+    }
+
+    /**
+     * Fetches an image from a remote source.
+     *
+     * @param string $url URL of the remote image to fetch
+     *
+     * @return StreamInterface
+     */
+    public function getImage($url)
+    {
+        $url = str_replace('__random__', rand(100000, 999999), $url);
+
+        return $this->client->get($url, ['timeout' => 10])->getBody();
     }
 }


### PR DESCRIPTION
Tired of the same random placeholder images? Too few kittens? This PR will allow you to add new placeholder images to your contenttypes, when using the "add loripsum content": 

![screen shot 2018-03-08 at 19 27 36](https://user-images.githubusercontent.com/1833361/37169324-e67a57e2-2307-11e8-8495-4727df285b7a.png)


```
    fields:
        title:
            type: text
            class: large
            group: content
        …
        image:
            type: image
            group: media
            placeholder: https://source.unsplash.com/1600x900/?nature,water/__random__
```

or `https://source.unsplash.com/1600x900/?kitten/__random__` for more kittens. 

Should be trivial to make work with other placeholder services, like pexels, visualhunt or placekitten. Or we could even write our own, if we don't want to be reliant on a 3rd party service.