### PR TITLE
Fix display in overview when 'has_sortorder: false'

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -25,13 +25,21 @@
 
 {% set modifiable = permissions.create or permissions.edit or permissions.delete or permissions.publish or permissions.depublish %}
 
+{% if content.taxonomy.grouped|default() %}
+    {% set orderbycontenttype = content.taxonomy.grouped|keys|first %}
+    {% set showorder = app.config.get('taxonomy')[orderbycontenttype].has_sortorder %}
+{% else %}
+    {% set showorder = false %}
+{% endif %}
+
 {% set prop = {
 extended:       not compact,
 has_groupname:  content.group.name is defined,
 nextgroup:      new_group|default(false),
 unordered:      global.request.get('order') == '',
 first:          loop.first,
-last:           loop.last
+last:           loop.last,
+showorder:      showorder
 }%}
 
 {% set local = {
@@ -199,7 +207,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                 {% else %}
                     <i class="fa fa-circle status-{{ content.status }} fa-fw"></i> {{ content.datepublish|localedatetime('%x') }}<br>
                 {% endif %}
-                {% if content.sortorder|default() is not empty %}
+                {% if prop.showorder %}
                     <i class="fa fa-align-left fa-fw"></i>
                     <a href="{{ path('editcontent', {'contenttypeslug': content.contenttype.slug, 'id': content.id}) }}#taxonomy" >
                         {{ __('general.phrase.order-colon-sort',{'%sort%': content.sortorder}) }}

--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -208,7 +208,7 @@ class TaxonomyType extends JoinTypeBase
         $group = null;
         $taxData = $this->mapping['data'];
         foreach ($taxonomy as $tax) {
-            if ($taxData['has_sortorder']) {
+            if ($taxData['behaves_like'] === 'grouping') {
                 // Previously we only cared about the last one… so yeah
                 $needle = $tax->getSlug();
                 $index = array_search($needle, array_keys($taxData['options']));


### PR DESCRIPTION
This PR fixes two quirks that show when you have a taxonomy with `behaves_like: grouping` and also `has_sortorder: false`. 

Before: 
![screen_shot_2018-03-12_at_18_05_57](https://user-images.githubusercontent.com/1833361/37298586-fba4cf3c-2620-11e8-84a5-87c85da6bfc9.png)

After:

![screen_shot_2018-03-12_at_18_04_51](https://user-images.githubusercontent.com/1833361/37298590-ff18812c-2620-11e8-8b5e-7fc958969cf7.png)

