### PR TITLE
[3.5] Make `notfound` setting more fault-tolerant

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -82,17 +82,11 @@ cron_hour: 3
 homepage: homepage/1
 homepage_template: index.twig
 
-# The default content for the 404 page. Uses the 'record_template' template by
-# default.
+# The default content for the 404 page. Can be an (array of) template names or
+# identifiers for records, which will be tried until a match is found.
 #
-# Make sure this is set to an existing record, otherwise visitors will get an
-# error-page when the request a non-existing page.
-#
-# Note 1: The record specified in this parameter must be set to 'published'
-# Note 2: If you are logged on, and debug is set to 'true', you will NOT see the
-#         404 page!
-# Note 3: This may also point to a template without a record, eg 'error404.twig'
-notfound: block/404-not-found
+# Note: The record specified in this parameter must be set to 'published'.
+notfound: [ not-found.twig, block/404-not-found ]
 
 # The default template and amount of records to use for listing-pages on the
 # site.


### PR DESCRIPTION
This PR builds on #7346 as well as something that has popped up before: the `notfound: ` setting can have _either_ the name of a template _or_ an identifier for a single record. 

Well…

![porque-no-las-dos-o](https://user-images.githubusercontent.com/1833361/37412557-6c8eb23c-27a5-11e8-8e74-db458dc6de15.gif)

This PR allows a setting like this: 

```
notfound: [ not-found.twig, block/404-not-found ]
```

Each will be attempted in turn, until a match is found. If none is found, it gives the same exception as  #7346 does. 

Additional benefit: The long, outdated and wrong description in `config.yml.dist` can be made significantly shorter.