### PR TITLE
[3.4] Skip test on Travis

### DIFF
--- a/tests/phpunit/unit/Nut/ExtensionsTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsTest.php
@@ -17,6 +17,10 @@ class ExtensionsTest extends BoltUnitTest
 {
     public function testRun()
     {
+        if (true == getenv('TRAVIS')) {
+            $this->markTestSkipped('Travis uses ancient GnuTLS on Ubuntu.');
+        }
+
         $app = $this->getApp();
 
         $testPackage = new CompletePackage('test', '1.0.1', '1.0');


### PR DESCRIPTION
Travis uses a version of GnuTLS that doesn't properly handle TLS 1.2+ and have been promising for two years to update the images to 16.04 … now 18.04 is out, and we've only just made 14.04.

Ubuntu … :zipper_mouth_face: 

P.S. I am going to follow up with a better way of handling all this today in 3.5, but it would be feature territory, so not aiming it at 3.4