### PR TITLE
[3.5] Better handling of Marketplace connections

### DIFF
--- a/app/view/twig/extend/extend.twig
+++ b/app/view/twig/extend/extend.twig
@@ -16,7 +16,7 @@
 {% block page_main %}
     {{ include('@bolt/extend/_package.twig') }}
 
-    {% if context.messages %}
+    {% if context.messages is not empty %}
         <div class="row">
             <div class="col-xs-12">
                 <div class="alert alert-info alert-dismissible">
@@ -134,9 +134,10 @@
             <div class="panel panel-default">
                 <div class="panel-heading"><i class="fa fa-cog fa-fw"></i>{{ __('page.extend.options') }}</div>
                 <div class="panel-body">
+                        {% set disabled = (not context.writeable or not context.online) %}
                         <p><strong>{{ __('page.extend.message.check-for-updates') }}</strong></p>
                         <div class="btn-group">
-                            <a class="btn btn-tertiary{% if not context.writeable or not context.online %} disabled{% endif %} clickspinner" data-request="update-check">
+                            <a class="btn btn-tertiary{% if disabled %} disabled{% endif %} clickspinner" data-request="update-check">
                                 <i class="fa fa-refresh fa-fw"></i> {{ __('page.extend.button.update-check') }}
                             </a>
                         </div>
@@ -144,21 +145,21 @@
                         <hr>
                         <p><strong>{{ __('page.extend.message.maintenance') }}</strong></p>
                         <div class="btn-group">
-                            <a class="btn btn-tertiary{% if not context.writeable or not context.online %} disabled{% endif %} clickspinner" data-request="update-run">
+                            <a class="btn btn-tertiary{% if disabled %} disabled{% endif %} clickspinner" data-request="update-run">
                                 <i class="fa fa-refresh fa-fw"></i> {{ __('page.extend.button.update-all') }}
                             </a>
-                            <button type="button" class="btn btn-tertiary dropdown-toggle" data-toggle="dropdown">
+                            <button type="button" class="btn btn-tertiary dropdown-toggle {% if disabled %} disabled{% endif %}" data-toggle="dropdown">
                                 <span class="caret"></span>
                                 <span class="sr-only">Toggle Dropdown</span>
                             </button>
                             <ul class="dropdown-menu pull-right" role="menu">
                                 <li>
-                                    <a href="#" class="{% if not context.writeable or not context.online %} disabled{% endif %} clickspinner" data-request="install-run">
+                                    <a href="#" class="{% if disabled %} disabled{% endif %} clickspinner" data-request="install-run">
                                         <i class="fa fa-download fa-fw"></i> {{ __('page.extend.button.install-all') }}
                                     </a>
                                 </li>
                                 <li>
-                                    <a href="#" class="{% if not context.writeable or not context.online %} disabled{% endif %} clickspinner" data-request="autoload-dump">
+                                    <a href="#" class="{% if disabled %} disabled{% endif %} clickspinner" data-request="autoload-dump">
                                         <i class="fa fa-refresh fa-fw"></i> {{ __('page.extend.button.autoload-dump') }}
                                     </a>
                                 </li>

--- a/src/Composer/Satis/PingService.php
+++ b/src/Composer/Satis/PingService.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Bolt\Composer\Satis;
+
+use Bolt\Collection\Bag;
+use Bolt\Collection\MutableBag;
+use Bolt\Translation\Translator as Trans;
+use Bolt\Version;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\RequestOptions;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class to provide pinging of the Bolt Marketplace as a service.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+final class PingService
+{
+    /** @var Client */
+    private $client;
+    /** @var RequestStack */
+    private $requestStack;
+    /** @var string */
+    private $uri;
+    /** @var MutableBag */
+    private $messages;
+
+    /**
+     * Constructor.
+     *
+     * @param Client       $client
+     * @param RequestStack $requestStack
+     * @param string       $uri
+     */
+    public function __construct(Client $client, RequestStack $requestStack, $uri)
+    {
+        $this->client = $client;
+        $this->requestStack = $requestStack;
+        $this->uri = $uri;
+        $this->messages = MutableBag::of();
+    }
+
+    /**
+     * Ping site to see if we have a valid connection and it is responding correctly.
+     *
+     * @param bool $addQuery
+     */
+    public function ping($addQuery = false, $debugClient = false)
+    {
+        try {
+            $this->doPing($addQuery, $debugClient);
+
+            return true;
+        } catch (ClientException $e) {
+            // Thrown for 400 level errors
+            $this->messages[] = Trans::__(
+                'page.extend.error-message-client',
+                ['%errormessage%' => $e->getMessage()]
+            );
+        } catch (ServerException $e) {
+            // Thrown for 500 level errors
+            $this->messages[] = Trans::__(
+                'page.extend.error-message-server',
+                ['%errormessage%' => $e->getMessage()]
+            );
+        } catch (RequestException $e) {
+            // Thrown for connection timeout, DNS errors, etc
+            $this->messages[] = Trans::__(
+                'page.extend.error-message-connection',
+                ['%errormessage%' => $e->getMessage()]
+            );
+        } catch (\Exception $e) {
+            // Catch all
+            $this->messages[] = Trans::__(
+                'page.extend.error-message-generic',
+                ['%errormessage%' => $e->getMessage()]
+            );
+        }
+
+        return false;
+    }
+
+    /**
+     * @return Bag
+     */
+    public function getMessages()
+    {
+        return $this->messages->immutable();
+    }
+
+    /**
+     * @param bool $addQuery
+     * @param bool $debugClient
+     *
+     * @throws ClientException
+     * @throws ServerException
+     * @throws RequestException
+     */
+    private function doPing($addQuery, $debugClient)
+    {
+        if ($this->requestStack->getCurrentRequest() !== null) {
+            $www = $this->requestStack->getCurrentRequest()->server->get('SERVER_SOFTWARE', 'unknown');
+        } else {
+            $www = 'unknown';
+        }
+        $query = !$addQuery ? [] : [
+            'bolt_ver'  => Version::VERSION,
+            'php'       => PHP_VERSION,
+            'www'       => $www,
+        ];
+
+        $options = [
+            RequestOptions::QUERY           => $query,
+            RequestOptions::CONNECT_TIMEOUT => 10,
+            RequestOptions::TIMEOUT         => 30,
+        ];
+        if ($debugClient) {
+            $options[RequestOptions::DEBUG] = true;
+        }
+
+        $this->client->head($this->uri, $options);
+    }
+}

--- a/src/Controller/Backend/Extend.php
+++ b/src/Controller/Backend/Extend.php
@@ -3,6 +3,7 @@
 namespace Bolt\Controller\Backend;
 
 use Bolt;
+use Bolt\Composer\Satis\PingService;
 use Bolt\Exception\PackageManagerException;
 use Bolt\Extension\ResolvedExtension;
 use Bolt\Filesystem\Exception\FileNotFoundException;
@@ -328,6 +329,11 @@ class Extend extends BackendBase
      */
     public function overview()
     {
+        /** @var PingService $pinger */
+        $pinger = $this->app['extend.ping'];
+        // Ping the extensions server to confirm connection
+        $this->app['extend.online'] = $pinger->ping(true);
+
         try {
             return $this->render('@bolt/extend/extend.twig', $this->getRenderContext());
         } catch (\Exception $e) {
@@ -461,7 +467,7 @@ class Extend extends BackendBase
         );
 
         return [
-            'messages'       => $this->app['extend.manager']->getMessages(),
+            'messages'       => $this->app['extend.ping']->getMessages(),
             'enabled'        => $this->app['extend.enabled'],
             'writeable'      => $this->app['extend.writeable'],
             'online'         => $this->app['extend.online'],

--- a/src/Nut/ExtensionsInstall.php
+++ b/src/Nut/ExtensionsInstall.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Nut;
 
+use Bolt\Composer\Satis\PingService;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,6 +15,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ExtensionsInstall extends BaseCommand
 {
+    /** @var PingService */
+    private $pinger;
+
     /**
      * {@inheritdoc}
      */
@@ -28,11 +32,23 @@ class ExtensionsInstall extends BaseCommand
         ;
     }
 
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+        $this->pinger = $this->app['extend.ping'];
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!$this->pinger->ping(true, $output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG)) {
+            $this->io->error($this->pinger->getMessages()->toArray());
+
+            return 1;
+        }
+
         $name = $input->getArgument('name');
         $version = $input->getArgument('version');
 

--- a/src/Nut/ExtensionsUpdate.php
+++ b/src/Nut/ExtensionsUpdate.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Nut;
 
+use Bolt\Composer\Satis\PingService;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,6 +14,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ExtensionsUpdate extends BaseCommand
 {
+    /** @var PingService */
+    private $pinger;
+
     /**
      * {@inheritdoc}
      */
@@ -25,13 +29,24 @@ class ExtensionsUpdate extends BaseCommand
         ;
     }
 
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+        $this->pinger = $this->app['extend.ping'];
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $name = $input->getArgument('name');
+        if (!$this->pinger->ping(true, $output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG)) {
+            $this->io->error($this->pinger->getMessages()->toArray());
 
+            return 1;
+        }
+
+        $name = $input->getArgument('name');
         if ($name) {
             $this->io->title('Updating $name');
             $packages = [$name];

--- a/src/Provider/ExtensionServiceProvider.php
+++ b/src/Provider/ExtensionServiceProvider.php
@@ -100,6 +100,12 @@ class ExtensionServiceProvider implements ServiceProviderInterface
             }
         );
 
+        $app['extend.ping'] = $app->share(
+            function ($app) {
+                return new Satis\PingService($app['guzzle.client'], $app['request_stack'], $uri = $app['extend.site'] . 'ping');
+            }
+        );
+
         $app['extend.info'] = $app->share(
             function ($app) {
                 return new Satis\QueryService($app['guzzle.client'], $app['extend.site'], $app['extend.urls']);

--- a/tests/phpunit/unit/Composer/Satis/PingServiceTest.php
+++ b/tests/phpunit/unit/Composer/Satis/PingServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Bolt\Tests\Composer\Satis;
+
+use Bolt\Composer\Satis\PingService;
+use Exception;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @covers \Bolt\Composer\Satis\PingService
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class PingServiceTest extends TestCase
+{
+    public function testPing()
+    {
+        $response = new Psr7\Response();
+        $response->withStatus(200);
+        $mock = new MockHandler([$response]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $requestStack = $this->createMock(RequestStack::class);
+
+        $pingService = new PingService($client, $requestStack, 'http://example.com/');
+        $pingService->ping();
+        $messages = $pingService->getMessages();
+
+        $this->assertEmpty($messages);
+    }
+
+    public function providerSetupPingExceptions()
+    {
+        $request = new Psr7\Request('GET', 'https://example.com');
+
+        return [
+            [new MockHandler([new ClientException('There was a 400', $request)]), '/^Client error: There was a 400/'],
+            [new MockHandler([new ServerException('There was a 500', $request)]), '/^Extension server returned an error: There was a 500/'],
+            [new MockHandler([new RequestException('DNS down', $request)]), '/^Testing connection to extension server failed: DNS down/'],
+            [new MockHandler([new Exception('Drop bear')]), '/^Generic failure while testing connection to extension server: Drop bear/'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerSetupPingExceptions
+     *
+     * @param MockHandler $mock
+     * @param string      $regex
+     */
+    public function testSetupPingExceptions($mock, $regex)
+    {
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+        $requestStack = $this->createMock(RequestStack::class);
+
+        $pingService = new PingService($client, $requestStack, 'http://example.com/');
+        $pingService->ping();
+        $messages = $pingService->getMessages();
+
+        $this->assertRegExp($regex, $messages[0]);
+    }
+
+    /**
+     * @deprecated remove in v4 as PHPUnit 5 includes this
+     */
+    protected function createMock($originalClassName)
+    {
+        return $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock()
+        ;
+    }
+}

--- a/tests/phpunit/unit/Nut/ExtensionsInstallTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsInstallTest.php
@@ -3,9 +3,17 @@
 namespace Bolt\Tests\Nut;
 
 use Bolt\Composer\PackageManager;
+use Bolt\Composer\Satis\PingService;
 use Bolt\Nut\ExtensionsInstall;
 use Bolt\Tests\BoltUnitTest;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Class to test src/Nut/ExtensionsEnable.
@@ -29,6 +37,7 @@ class ExtensionsInstallTest extends BoltUnitTest
             ->will($this->returnValue(0));
 
         $this->setService('extend.manager', $runner);
+        $this->setService('extend.ping', $this->getPingServiceMock(new Response(200, ['X-Foo' => 'Bar'])));
 
         $command = new ExtensionsInstall($app);
         $tester = new CommandTester($command);
@@ -52,12 +61,30 @@ class ExtensionsInstallTest extends BoltUnitTest
             ->will($this->returnValue(1));
 
         $this->setService('extend.manager', $runner);
+        $this->setService('extend.ping', $this->getPingServiceMock(new RequestException('Mock testing failure', new Request('GET', 'http://localhost/ping'))));
 
         $command = new ExtensionsInstall($app);
         $tester = new CommandTester($command);
 
         $tester->execute(['name' => 'test', 'version' => '1.0']);
         $result = $tester->getDisplay();
-        $this->assertRegExp('/Installation failed/', $result);
+
+        $this->assertRegExp('/Testing connection to extension server failed: Mock testing failure/', $result);
+    }
+
+    private function getPingServiceMock($response)
+    {
+        $mock = new MockHandler([$response]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack
+            ->expects($this->atLeastOnce())
+            ->method('getCurrentRequest')
+        ;
+
+        return new PingService($client, $requestStack, 'http://localhost/ping');
     }
 }

--- a/tests/phpunit/unit/Nut/ExtensionsTest.php
+++ b/tests/phpunit/unit/Nut/ExtensionsTest.php
@@ -17,10 +17,6 @@ class ExtensionsTest extends BoltUnitTest
 {
     public function testRun()
     {
-        if (true == getenv('TRAVIS')) {
-            $this->markTestSkipped('Travis uses ancient GnuTLS on Ubuntu.');
-        }
-
         $app = $this->getApp();
 
         $testPackage = new CompletePackage('test', '1.0.1', '1.0');


### PR DESCRIPTION
* Re-enable Nut's extension view test
* Move pinging of the Marketplace connection to a service
* Enable Guzzle to output cURL debug data in Nut `extensions:install` & `extensions:update` commands when `-vvv` is used

![nut - fail](https://user-images.githubusercontent.com/1427081/37650708-fdc54ce0-2c35-11e8-9935-23cc66cc98ea.png)

![nut - pass](https://user-images.githubusercontent.com/1427081/37650709-fde3b568-2c35-11e8-8d3d-8b0b74061419.png)
