### PR TITLE
[3.6] Allow fields to be unsearchable

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -533,7 +533,8 @@ class Storage
         // Build fields 'WHERE'
         $fieldsWhere = [];
         foreach ($fields as $field => $fieldconfig) {
-            if (in_array($fieldconfig['type'], $searchableTypes)) {
+            if (in_array($fieldconfig['type'], $searchableTypes)
+                && (!isset($fieldconfig['searchable']) || $fieldconfig['searchable'] !== false)) {
                 foreach ($query['words'] as $word) {
                     // Build the LIKE, lowering the searched field to cover case-sensitive database systems
                     $fieldsWhere[] = sprintf('LOWER(%s.%s) LIKE LOWER(%s)', $table, $field, $this->app['db']->quote('%' . $word . '%'));

--- a/src/Storage/Entity/ContentSearchTrait.php
+++ b/src/Storage/Entity/ContentSearchTrait.php
@@ -98,7 +98,8 @@ trait ContentSearchTrait
 
         // Set the searchweights to the configured value, otherwise default to '50' or '100'
         foreach ($this->contenttype['fields'] as $key => $config) {
-            if (in_array($config['type'], $searchableTypes)) {
+            if (in_array($config['type'], $searchableTypes)
+                && (!isset($fieldconfig['searchable']) || $fieldconfig['searchable'] !== false)) {
                 $defaultValue = in_array($key, $slugFields) ? 100 : 50;
                 $fields[$key] = isset($config['searchweight']) ? $config['searchweight'] : $defaultValue;
             }


### PR DESCRIPTION
This is a new feature in the _legacy_ part of Bolt. The fix was simpler than I thought.

### Use Case

For some clients, we add a `textarea`-type field for _notes_; however, the search still searches this and highlights the keywords in that field. My initial thought was to set the `searchweight` to something low, but a low `searchweight` does not mean it's _filtered_.

### Usage

Add `searchable: false` to your field definition:

```diff
 field_notes: &field_notes
     notes:
         label: Notes
         type: html
         height: 300px
+        searchable: false
```

![search-bois](https://user-images.githubusercontent.com/4630335/37668653-4bd99f38-2c65-11e8-898c-eeddb38c6931.png)

---

Update with related Docs PR: https://github.com/bolt/docs/pull/888