### PR TITLE
Change imagelist upload location from abolute to relative

### DIFF
--- a/app/view/twig/editcontent/fields/_imagelist.twig
+++ b/app/view/twig/editcontent/fields/_imagelist.twig
@@ -12,7 +12,7 @@
 {% set attributes = {
     fileupload: {
         accept:       option.extensions ? '.' ~ option.extensions|join(',.') : '',
-        data_url:     url('upload', {' handler': option.upload }, true),
+        data_url:     path('upload', {' handler': option.upload }),
         id:           'fileupload-' ~ key,
         multiple:     true,
         name:         'files[]',


### PR DESCRIPTION
> Fixes #7396 

I suppose that this fix should affect any existing configuration, because uploading to remote server instead of the one, that you're testing/using - is unexpected.