### PR TITLE
Don't Run a group sort if user has ordered via the UI

### DIFF
--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -107,7 +107,7 @@ class Listing
             $records = $this->query->getContent($contentTypeSlug, $contentParameters);
         }
         $this->runPagerQueries($records);
-        if ($options->getGroupSort()) {
+        if ($options->getGroupSort() && !$options->getOrder()) {
             $records = $this->runGroupSort($records);
         }
 


### PR DESCRIPTION
Fixes #7383

Only passes the content result to the groupsort method if we don't have one provided by the user.