### PR TITLE
[3.5] Optionally add undo, redo, cut, copy, paste buttons to toolbar in WYSIWYG

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -307,6 +307,8 @@ wysiwyg:
     blockquote: false        # Allows the user to insert blockquotes using the `<blockquote>`-tag.
     codesnippet: false       # Allows the user to insert code snippets using `<pre><code>`-tags.
     specialchar: false       # Adds a button to insert special chars like '€' or '™'.
+    clipboard: false         # Adds buttons to 'undo' and 'redo'.
+    copypaste: false         # Adds buttons to 'cut', 'copy' and 'paste'.
     ck:
         autoParagraph: true  # If set to 'true', any pasted content is wrapped in `<p>`-tags for multiple line-breaks
         disableNativeSpellChecker: true # If set to 'true' it will stop browsers from underlining spelling mistakes

--- a/app/src/js/modules/ckeditor.js
+++ b/app/src/js/modules/ckeditor.js
@@ -126,6 +126,13 @@
             config.baseFloatZIndex = 100015;
 
             config.toolbar = list(
+                [                 {name: 'clipboard',   items: list( [set.clipboard,   'Undo'          ],
+                                                                     [set.clipboard,   'Redo'          ],
+                                                                     [set.copypaste,   'Cut'           ],
+                                                                     [set.copypaste,   'Copy'          ],
+                                                                     [set.copypaste,   'Paste'         ],
+                                                                     [set.copypaste,   'PasteFromWord' ],
+                                                                     [set.copypaste,   'PasteText'     ] )}],
                 [                 {name: 'styles',      items: list( [                 'Format'        ],
                                                                      [set.styles,      'Styles'        ] )}],
 

--- a/app/src/sass/modules/custom/_ckeditor.scss
+++ b/app/src/sass/modules/custom/_ckeditor.scss
@@ -28,7 +28,7 @@
     margin-bottom: 0px !important;
 }
 
-.cke_toolgroup, .cke_combo_button {
+.cke_toolgroup {
     border-color: #E7E7E7 !important;
     margin: 3px !important;
 }

--- a/app/view/twig/_base/_page.twig
+++ b/app/view/twig/_base/_page.twig
@@ -110,6 +110,8 @@
         underline:   0 + config.get('general/wysiwyg/underline'),
         codesnippet: 0 + config.get('general/wysiwyg/codesnippet'),
         specialchar: 0 + config.get('general/wysiwyg/specialchar'),
+        clipboard:   0 + config.get('general/wysiwyg/clipboard'),
+        copypaste:   0 + config.get('general/wysiwyg/copypaste'),
         ck:          ckConfig,
         filebrowser: {
             browseUrl: path('recordbrowser'),


### PR DESCRIPTION
We have this in CKeditor anyways, might as well make it available to users. 