### PR TITLE
[3.5][WIP] Allow for extra locale parameter with `localedatetime` filter.

### DIFF
--- a/src/Twig/Runtime/TextRuntime.php
+++ b/src/Twig/Runtime/TextRuntime.php
@@ -58,7 +58,7 @@ class TextRuntime
      *
      * @return string Formatted date and time
      */
-    public function localeDateTime($dateTime, $format = '%B %e, %Y %H:%M')
+    public function localeDateTime($dateTime, $format = '%B %e, %Y %H:%M', $tempLocale = null)
     {
         if (!$dateTime instanceof \DateTime) {
             $dateTime = new \DateTime($dateTime);
@@ -72,8 +72,8 @@ class TextRuntime
         // According to http://php.net/manual/en/function.setlocale.php manual
         // if the second parameter is "0", the locale setting is not affected,
         // only the current setting is returned.
-        $result = setlocale(LC_ALL, 0);
-        if ($result === false) {
+        $currentLocale = setlocale(LC_ALL, 0);
+        if ($currentLocale === false) {
             // This shouldn't occur, but.. Dude!
             // You ain't even got locale or English on your platform??
             // Various things we could do. We could fail miserably, but a more
@@ -83,9 +83,21 @@ class TextRuntime
 
             return $dateTime->format('Y-m-d H:i:s');
         }
-        $timestamp = $dateTime->getTimestamp();
 
-        return strftime($format, $timestamp);
+        // Temporarily set the locale, if needed
+        if ($tempLocale) {
+            setlocale(LC_ALL, array_merge((array) $tempLocale, (array) $currentLocale));
+        }
+
+        $timestamp = $dateTime->getTimestamp();
+        $result = strftime($format, $timestamp);
+
+        // And reset the locale, if needed
+        if ($tempLocale) {
+            setlocale(LC_ALL, $currentLocale);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/phpunit/unit/Twig/Runtime/TextRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/TextRuntimeTest.php
@@ -57,6 +57,21 @@ class TextRuntimeTest extends BoltUnitTest
         $this->assertSame('2012-06-14 09:07', $result);
     }
 
+    public function testLocaleDateTimeStringWithFormatAndLocale()
+    {
+        $app = $this->getApp();
+        $handler = new TextRuntime($app['logger.system'], $app['slugify']);
+
+        $result = $handler->localeDateTime('2012-06-14 09:07:55', '%A %B %e', 'is_IS');
+        $this->assertSame('fimmtudagur júní 14', $result);
+
+        $result = $handler->localeDateTime('2012-06-14 09:07:55', '%A %B %e', ['foo_BAR', 'fi_FI']);
+        $this->assertSame('Torstai Kesäkuu 14', $result);
+
+        $result = $handler->localeDateTime('2012-06-14 09:07:55', '%A %B %e');
+        $this->assertSame('Thursday June 14', $result);
+    }
+
     /**
      * @runInSeparateProcess
      */


### PR DESCRIPTION
Fixes #7378 

With this, you can add an optional parameter to `localedatetime`, to set the locale to be used. For example: `{{ "now"|localedatetime("%A %B %e", request.get('locale')) }}`.

This: 

```twig
        <ul>
            <li>{{ "now"|localedatetime("%A %B %e") }}</li> {# Default locale #}
            <li>{{ "now"|localedatetime("%A %B %e", 'en_GB') }}</li> {# British english #}
            <li>{{ "now"|localedatetime("%A %B %e", 'nl_NL') }}</li> {# Dutch #}
            <li>{{ "now"|localedatetime("%A %B %e", ['foo_BAR', 'fi_FI']) }}</li>  {# Either foo_Bar or Finnish #}
            <li>{{ "now"|localedatetime("%A %B %e") }}</li> {# And back to Default locale #}
        </ul>
```

Outputs: 

```
  • fimmtudagur mars 29
  • Thursday March 29
  • donderdag maart 29
  • Torstai Maaliskuu 29
  • fimmtudagur mars 29
```

I added tests, but the tests don't want to do `setlocale`. :-/
