### PR TITLE
Make aliased thumbnail generation consistent

### DIFF
--- a/src/Twig/Runtime/ImageRuntime.php
+++ b/src/Twig/Runtime/ImageRuntime.php
@@ -73,9 +73,7 @@ class ImageRuntime
         }
 
         // After v1.5.1 we store image data as an array
-        if (is_array($fileName)) {
-            $fileName = isset($fileName['filename']) ? $fileName['filename'] : (isset($fileName['file']) ? $fileName['file'] : '');
-        }
+        $fileName = $this->normalizeFileName($fileName);
 
         // If _no_ filename is given, return nothing.
         if (!$fileName) {
@@ -312,9 +310,7 @@ class ImageRuntime
         }
 
         // If we're passing in an image as array, instead of a single filename.
-        if (is_array($fileName) && isset($fileName['file'])) {
-            $fileName = $fileName['file'];
-        }
+        $fileName = $this->normalizeFileName($fileName);
 
         return $this->urlGenerator->generate(
             'thumb_alias',
@@ -333,5 +329,25 @@ class ImageRuntime
     private function isAlias($alias)
     {
         return (bool) $this->config->get('theme/thumbnails/aliases/' . $alias, false);
+    }
+
+
+    /**
+     * If $fileName is an array with 'filename' or 'file' return that property,
+     * otherwise return passed value.
+     *
+     * @param array|string $fileName
+     *
+     * @return string
+     */
+    private function normalizeFileName($fileName)
+    {
+        if (!is_array($fileName)) {
+            return $fileName;
+        }
+
+        return isset($fileName['filename']) ? $fileName['filename']
+            : isset($fileName['file']) ? $fileName['file'] : ''
+        ;
     }
 }


### PR DESCRIPTION
Fixes #7427
---

Added function, which converts filename from array to string. That will give a little consistency.

To be honestly, first inclusion will only not work as before if filename is not a string or array. Previously, if filename was neither string or array - code just didn't transform $fileName. Now it converts that to ''. 
But i really doubt, that there's any case with integer or boolean filename without extenstions, which could be processed with this code.
Only if: you have a file like 'files/123` without extension, which will be given by server with correct mime type. And it has dimensions less than processing parameters, which satisfy "don't enlarge smaller images" option. And by the way, that option should be set.
So.. i suppose that replacement is safe in 100% of cases. with 99.99999% probability ;)