### PR TITLE
Add an 'if' statement for missing Block field

### DIFF
--- a/app/view/twig/editcontent/fields/_block-group.twig
+++ b/app/view/twig/editcontent/fields/_block-group.twig
@@ -1,3 +1,4 @@
+{% if field.fields[block] is defined %}
 <div class="repeater-group block-group row panel panel-default">
     <div class="panel-heading">
         <div class="row">
@@ -69,3 +70,4 @@
         {% endfor %}
     </div>
 </div>
+{% endif %}


### PR DESCRIPTION
If you try to access a page that uses a block field that is no longer used, you get an error, when using strict variables. (Since the field does not exist anymore)

This might happen after a refactor, when the block field is still in the DB, but no longer exists in contenttypes.yml.

Adding a `is defined` fixes this!

Error:
![image](https://user-images.githubusercontent.com/5583671/39237667-6a4901d8-487c-11e8-8a7e-f4774c3f6c87.png)

