### PR TITLE
Fix check for numeric slug

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -150,7 +150,7 @@ class Frontend extends ConfigurableBase
         // First, try to get it by slug.
         $content = $this->getContent($contenttype['slug'], ['slug' => $slug, 'returnsingle' => true, 'log_not_found' => !is_numeric($slug)]);
 
-        if (is_numeric($slug) && (!$content || count($content) === 0)) {
+        if (is_numeric($slug) && !$content) {
             // And otherwise try getting it by ID
             $content = $this->getContent($contenttype['slug'], ['id' => $slug, 'returnsingle' => true]);
         }


### PR DESCRIPTION
Fixes an error when `allow_numeric_slugs: true` is set. Thanks to @eduardomart for finding, and @rossriley for pointing out what the issue was. 

![screen shot 2018-04-29 at 13 55 25](https://user-images.githubusercontent.com/1833361/39408425-48da87e4-4bd6-11e8-9da6-3fc844f1e4bf.png)
