### PR TITLE
[3.4] Add 'contentlink' to routes with disabled XSS protection

### DIFF
--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -30,6 +30,7 @@ class EventListenerServiceProvider implements ServiceProviderInterface
         $app['disable_xss_protection_routes'] = [
             'preview',
             'fileedit',
+            'contentlink',
         ];
         $app['listener.disable_xss_protection'] = $app->share(
             function ($app) {


### PR DESCRIPTION
Add the `contentlink` route to the list of routes for which XSS protection, a Google Chrome feature, is disabled. It fixes the preview screen for records with iframe codes or embedded tweets.

Fixes: #7442

Details
-------

Chrome has a feature that detects HTML code in POST and blocks displaying the response to protect from XSS. It can be disabled however by the server by sending a header `X-XSS-Protection` set to `0`. Bolt needs to do it when displaying for example a record preview, however it doesn't do it anymore because the route used for preview was changed to `contentlink`. This pull request adds that route to the list of routes for which XSS protection is disabled.
   