### PR TITLE
Only allow POST on `/preview`, because there's no need to GET it.

### DIFF
--- a/app/config/routing.yml.dist
+++ b/app/config/routing.yml.dist
@@ -28,6 +28,7 @@ preview:
         _controller: controller.frontend:preview
     requirements:
         contenttypeslug: controller.requirement:anyContentType
+    methods: [POST]
 
 contentlink:
     path: /{contenttypeslug}/{slug}

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -13,6 +13,7 @@ use Silex\ControllerCollection;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 /**
  * Standard Frontend actions.
@@ -189,6 +190,10 @@ class Frontend extends ConfigurableBase
      */
     public function preview(Request $request, $contenttypeslug)
     {
+        if (!$request->isMethod('POST')) {
+            throw new MethodNotAllowedHttpException(['POST'], 'This route only accepts POST requests.');
+        }
+
         $contenttype = $this->getContentType($contenttypeslug);
 
         $id = $request->request->get('id');

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -311,7 +311,7 @@ class FrontendTest extends ControllerUnitTest
 
     public function testPreview()
     {
-        $this->setRequest(Request::create('/pages'));
+        $this->setRequest(Request::create('/pages', 'POST'));
         $this->controller()->listing($this->getRequest(), 'pages/test');
 
         $templates = $this->getMockBuilder(TemplateChooser::class)

--- a/tests/phpunit/unit/Nut/DebugRouterTest.php
+++ b/tests/phpunit/unit/Nut/DebugRouterTest.php
@@ -15,7 +15,7 @@ class DebugRouterTest extends BoltUnitTest
 {
     use TableHelperTrait;
 
-    protected $regexExpectedA = '/(preview).+(ANY).+(ANY).+(ANY).+(\/{contenttypeslug})/';
+    protected $regexExpectedA = '/(preview).+(POST).+(ANY).+(ANY).+(\/{contenttypeslug})/';
     protected $regexExpectedB = '/(contentaction).+(POST).+(ANY).+(ANY).+(\/async\/content\/action)/';
 
     public function testRunNormal()


### PR DESCRIPTION
Part of the fix for #7442 -> We should disable the "XSS protection header" on the "preview" route, but that also means we should _not_ accept GET requests on that route, in order to prevent potential XSS. 