### PR TITLE
Don't change route from 'preview' to 'contentlink', because it breaks disbling of XSS protection

### DIFF
--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -131,9 +131,17 @@ abstract class Base implements ControllerProviderInterface
             return;
         }
 
+        // In case we're previewing a record, this will override the `_route`, but keep the original
+        // one, used to see if we need to disable the XSS protection header.
+        // See PR https://github.com/bolt/bolt/pull/7458
         list($routeName, $routeParams) = $content->getRouteNameAndParams();
         if ($routeName) {
-            $request->attributes->add(['_route' => $routeName, '_route_params' => $routeParams]);
+            /** @deprecated since 3.4 to be removed in 4.0 */
+            $request->attributes->add([
+                '_route'          => $routeName,
+                '_route_params'   => $routeParams,
+                '_internal_route' => $request->attributes->get('_route'),
+            ]);
         }
     }
 

--- a/src/EventListener/DisableXssProtectionListener.php
+++ b/src/EventListener/DisableXssProtectionListener.php
@@ -41,7 +41,11 @@ class DisableXssProtectionListener implements EventSubscriberInterface
             return;
         }
 
-        $route = $request->attributes->get('_route');
+        // In case we're using 'preview', the `_route` has been set to `contentlink`, because we're
+        // viewing a single page, but `_original_route` will be `preview`, which should take
+        // precedence, if set. See PR https://github.com/bolt/bolt/pull/7458
+        /** @deprecated since 3.4 to be removed in 4.0 */
+        $route = $request->attributes->get('_internal_route', $request->attributes->get('_route'));
 
         if (!in_array($route, $this->routes)) {
             return;


### PR DESCRIPTION
Fixes #7442. Replaces #7456. 

~~The only "downside" of this that I could discover, is that now a "preview" page doesn't get a proper canonical anymore:~~

```
    	<link rel="canonical" href="http://bolt-origin.localhost/preview/page">
```

~~While, up until 3.5.0, a _preview_ page got the correct canonical:~~ 

```
    	<link rel="canonical" href="http://bolt-origin.localhost/page/lorem-ipsum">
```

~~In my opinion, a preview page doesn't _need_ a canonical, since it really shouldn't be spidered in the first place (see #7457). So, no big deal.~~ 
