### PR TITLE
Pass taxonomy field through a platform id quote

### DIFF
--- a/src/Storage/Field/Type/TaxonomyType.php
+++ b/src/Storage/Field/Type/TaxonomyType.php
@@ -82,14 +82,16 @@ class TaxonomyType extends JoinTypeBase
             $alias = $from[0]['table'];
         }
 
+        $quotedField = $query->getConnection()->quoteIdentifier($field);
+
         $query
             ->addSelect($this->getPlatformGroupConcat("$field.id", $order, '_' . $field . '_id', $query))
             ->addSelect($this->getPlatformGroupConcat("$field.slug", $order, '_' . $field . '_slug', $query))
             ->addSelect($this->getPlatformGroupConcat("$field.name", $order, '_' . $field . '_name', $query))
             ->addSelect($this->getPlatformGroupConcat("$field.taxonomytype", $order, '_' . $field . '_taxonomytype',
                 $query))
-            ->leftJoin($alias, $target, $field,
-                "$alias.id = $field.content_id AND $field.contenttype='$boltname' AND $field.taxonomytype='$field'")
+            ->leftJoin($alias, $target, $quotedField,
+                "$alias.id = $quotedField.content_id AND $quotedField.contenttype='$boltname' AND $quotedField.taxonomytype='$field'")
             ->addGroupBy("$alias.id")
         ;
 


### PR DESCRIPTION
Fixes #7482 

Properly quotes the taxonomy field identifier before sending it to the db connection