### PR TITLE
[WIP][3.5] PackageManager error when Descriptor is null

### DIFF
--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -267,7 +267,11 @@ class PackageManager
             // Handle non-Bolt packages
             if ($extension) {
                 $title = $extension->getDisplayName();
-                $constraint = $extension->getDescriptor()->getConstraint() ?: Bolt\Version::VERSION;
+                if ($extension->isManaged()) {
+                    $constraint = $extension->getDescriptor()->getConstraint() ?: Bolt\Version::VERSION;
+                } else {
+                    $constraint = Bolt\Version::VERSION;
+                }
                 $readme = $this->linkReadMe($extension);
                 $config = $this->linkConfig($extension);
                 $valid = $extension->isValid();


### PR DESCRIPTION
On management/extensions page I was getting error:
```
Call to a member function getConstraint() on null
File: vendor/bolt/bolt/src/Composer/PackageManager.php::270
```
So this PR fixes it.