### PR TITLE
Fix the dreaded "Permission 'everyone' is not granted to any roles. You should add a role for this permission".

### DIFF
--- a/app/config/permissions.yml.dist
+++ b/app/config/permissions.yml.dist
@@ -62,6 +62,7 @@ roles-hierarchy:
 # inside the code, so they don't appear here.
 global:
     about: [ everyone ] # view the 'About Bolt' page
+    checks: [ admin, developer ]
     clearcache: [ admin, developer ]
     contentaction: [ editor, admin, developer ]
     dashboard: [ everyone ]

--- a/src/Menu/Resolver/RecentlyEdited.php
+++ b/src/Menu/Resolver/RecentlyEdited.php
@@ -108,6 +108,7 @@ final class RecentlyEdited
                     ->setRoute('editcontent', ['contenttypeslug' => $contentTypeKey, 'id' => $entity->getId()])
                     ->setLabel($label)
                     ->setIcon($contentType->get('icon_one', 'fa:file-text-o'))
+                    ->setPermission('contenttype:' . $contentTypeKey . ':edit')
             );
         }
     }


### PR DESCRIPTION
Fixes this annoyance that appears on any site where a "non admin" is administrating content: 

![40242784-d5e549ca-5abe-11e8-9388-1a57862fa5d2](https://user-images.githubusercontent.com/1833361/40246089-cc54328c-5ac7-11e8-9a44-a43ff21c929f.png)

Oh, and it also fixes: #7487

![screen shot 2018-05-18 at 18 15 52](https://user-images.githubusercontent.com/1833361/40246005-8686823c-5ac7-11e8-85cb-e1b45b626d38.png)

Note how _only_ pages has 'sub items', exactly like i configured it to! 