### PR TITLE
Don't break if UserId is `null`

### DIFF
--- a/src/Users.php
+++ b/src/Users.php
@@ -231,7 +231,7 @@ class Users
         $this->getUsers();
 
         // In most cases by far, we'll request an ID, and we can return it here.
-        if (array_key_exists($userId, $this->users)) {
+        if ($userId && array_key_exists($userId, $this->users)) {
             return $this->users[$userId];
         }
 


### PR DESCRIPTION
If - say - you have content that gets inserted into the DB by another script, and the UserId (`ownerid` column) isn't set, Bolt would break. 