### PR TITLE
[3.5] Fix setting listing order on frontend

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -467,7 +467,7 @@ class Frontend extends ConfigurableBase
 
         // Build the pager
         $page = $this->app['pager']->getCurrentPage($contentType['slug']);
-        $order = $contentType['sort'] ?: $this->getListingOrder($contentType);
+        $order = $contentType['listing_sort'] ?: $this->getListingOrder($contentType);
 
         // CT value takes precedence over theme & config.yml
         if (!empty($contentType['listing_records'])) {

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -467,7 +467,7 @@ class Frontend extends ConfigurableBase
 
         // Build the pager
         $page = $this->app['pager']->getCurrentPage($contentType['slug']);
-        $order = $contentType['listing_sort'] ?: $this->getListingOrder($contentType);
+        $order = isset($contentType['listing_sort']) ? $contentType['listing_sort'] : $this->getListingOrder($contentType);
 
         // CT value takes precedence over theme & config.yml
         if (!empty($contentType['listing_records'])) {


### PR DESCRIPTION
This pull request fixes setting different sorting order of records on frontend and backend.

Details
-------
The [documentation says](https://docs.bolt.cm/3.5/contenttypes/intro#defining-contenttypes) that the `sort` parameter in content types definition should set the listing order on backend and the `listing_sort` should do the same but on frontend. However in the base frontend controller there was a bug and the `sort` parameter was used also on frontend side. 

Because of that the user couldn't set a different sorting order for giver content type on frontend. Also when they set the `sort` parameter for backend the proper value was also not inherited from them or general config.

Example config for testing:
```
entries:
    ...
    sort: id
    listing_sort: title
```