### PR TITLE
Allow custom slug field label

### DIFF
--- a/app/view/twig/editcontent/fields/_slug.twig
+++ b/app/view/twig/editcontent/fields/_slug.twig
@@ -58,7 +58,7 @@
 {% block fieldset_type 'slug' %}
 {% block fieldset_widget 'fieldSlug' %}
 
-{% block fieldset_label_text option.viewless ? trans.label_alias : trans.label_permalink %}
+{% block fieldset_label_text field.label|default(option.viewless ? trans.label_alias : trans.label_permalink) %}
 {% block fieldset_label_class 'col-sm-12' %}
 
 {% block fieldset_controls %}


### PR DESCRIPTION
Fixes #7424 . Now it looks up for `field.label` , then to previous options.