### PR TITLE
[3.5 Hotfix] Add a placeholder form input to always trigger saving of Block Fields

### DIFF
--- a/app/view/twig/editcontent/fields/_block-group.twig
+++ b/app/view/twig/editcontent/fields/_block-group.twig
@@ -34,6 +34,10 @@
             </div>
         </div>
     </div>
+
+    {# This ensures that a form value is always submitted even if all the fields are empty #}
+    <input type="hidden" name="{{ name ~ '[' ~ index ~ '][' ~ block ~ ']' }}[__internal]" value="1">
+
     <div class="panel-body">
         {% set defaults = {
             class:      '',

--- a/src/Storage/Field/Type/BlockType.php
+++ b/src/Storage/Field/Type/BlockType.php
@@ -39,6 +39,7 @@ class BlockType extends RepeaterType
                 foreach ($outerCollection as $group => $block) {
                     foreach ($block as $blockName => $fields) {
                         if (is_array($fields)) {
+                            unset($fields['__internal']);
                             $collection->addFromArray($fields, $group, $entity, $blockName);
                         }
                     }


### PR DESCRIPTION
Fixes #7116

These block fields needed some special handling since we previously added a filter to prevent empty arrays being counted as a form submission. This PR adds an internal form field so that the value doesn't get filtered out before the BlockType can save.