### PR TITLE
[3.5 Hotfix] Handle fatal error when Block Groups and Sub-Fields have the same name

### DIFF
--- a/src/Storage/Entity/Builder.php
+++ b/src/Storage/Entity/Builder.php
@@ -212,7 +212,7 @@ class Builder
 
             if ($subField !== null) {
                 $subMapping = isset($mapping['data']['fields'][$subField]) ? $mapping['data']['fields'][$subField] : null;
-                if ($subMapping === null) {
+                if (!isset($subMapping['fieldtype'])) {
                     continue;
                 }
                 $fieldType = $this->fieldManager->get($subMapping['fieldtype'], $subMapping);


### PR DESCRIPTION
Fixes #7461

Handles an incorrect assumption of sub-field type because the mapping exists. This changes to check for an actual fieldtype definition.