### PR TITLE
[Hotfix 3.5] Ensure select choices are built and accessed via multi-level field names

### DIFF
--- a/app/view/twig/editcontent/fields/_block-group.twig
+++ b/app/view/twig/editcontent/fields/_block-group.twig
@@ -48,7 +48,7 @@
         {% for rkey, rfield in field.fields[block].fields %}
             {% set rfield = defaults|merge(rfield) %}
             {% if rfield.type == 'select' %}
-                {% set values = context.values.select_choices[rkey] %}
+                {% set values = context.values.select_choices[name][block][rkey] %}
             {% endif %}
             {% set rcontext = {
                 'key':        name ~ '_' ~ index ~ '_' ~ block ~ '_' ~ rkey,

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -35,7 +35,7 @@
         {% for rkey, rfield in field.fields %}
             {# Ugly hack to be removed with Forms cutover … kittens are crying #}
             {% if rfield.type == 'select' %}
-                {% set values = context.values.select_choices[rkey] %}
+                {% set values = context.values.select_choices[name][rkey] %}
             {% endif %}
             {% set rfield = defaults|merge(rfield) %}
             {% set rcontext = {

--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -58,11 +58,15 @@ final class Choice
     {
         foreach ($fields as $name => $field) {
             if ($field['type'] === 'repeater') {
-                $this->build($select, $field['fields']);
+                $subField = new ArrayObject();
+                $this->build($subField, $field['fields']);
+                $select[$name] = iterator_to_array($subField);
             }
             if ($field['type'] === 'block') {
                 foreach ($field['fields'] as $blockName => $block) {
-                    $this->build($select, $block['fields']);
+                    $subField = new ArrayObject();
+                    $this->build($subField, $block['fields']);
+                    $select[$name][$blockName] = iterator_to_array($subField);
                 }
             }
             $values = $this->getValues($field);

--- a/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
+++ b/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
@@ -34,7 +34,11 @@ class ChoiceTest extends TestCase
                 ],
             ],
             'Repeater field with indexed array' => [
-                ['select_array' => ['foo', 'bar', 'koala', 'drop bear']],
+                [
+                    'repeater' => [
+                        'select_array' => ['foo', 'bar', 'koala', 'drop bear']
+                    ],
+                ],
                 [
                     'repeater' => [
                         'type'   => 'repeater',


### PR DESCRIPTION
Fixes #7496 

This one actually affected all repeaters and block fields. The current version builds a flat array of field names to select values which means that any values in base fields are overwritten by any other fieldname with the same key.

This PR adjusts the repeater and block builds to add to a multi-dimensional array so that the only constraint is unique field name per repeater or block set.