### PR TITLE
[3.6] Improving relation get set interface

### DIFF
--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -256,6 +256,7 @@ class Content extends Entity
     public function setRelation(Collection\Relations $rel)
     {
         $this->relation = $rel;
+        $rel->setOwner($this);
     }
 
     /**

--- a/tests/phpunit/unit/Storage/Collection/RelationsTest.php
+++ b/tests/phpunit/unit/Storage/Collection/RelationsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Bolt\Tests\Storage\Collection;
+
+use Bolt\Storage\Collection;
+use Bolt\Storage\Entity\Content;
+use Bolt\Tests\BoltUnitTest;
+
+class RelationsTest extends BoltUnitTest
+{
+    public function setUp()
+    {
+        $this->addSomeContent(['pages', 'entries', 'showcases']);
+    }
+
+    public function testGetField()
+    {
+        $app = $this->getApp();
+        /** @var Content $owner */
+        $owner = $app['query']->getContent('showcases/1');
+        $relations = $owner->getRelation();
+
+        $this->assertInstanceOf(Collection\Relations::class, $relations);
+        $field = $relations->getField('empty');
+        $this->assertInstanceOf(Collection\Relations::class, $field);
+        $this->assertCount(0, $field);
+
+        $relations->associate('pages', [1]);
+        $relations->associate('entries', [2]);
+        $this->assertCount(2, $relations);
+        $this->assertCount(1, $relations->getField('pages'));
+        $this->assertCount(1, $relations->getField('entries'));
+    }
+
+    public function testAssociate()
+    {
+        $app = $this->getApp();
+        /** @var Content $owner */
+        $owner = $app['query']->getContent('showcases/1');
+        $relations = $owner->getRelation();
+        $entityToTest = $app['query']->getContent('pages/1');
+
+        $relations->associate($entityToTest);
+        $this->assertCount(1, $relations['pages']);
+    }
+
+    public function testAssociateCollection()
+    {
+        $app = $this->getApp();
+        /** @var Content $owner */
+        $owner = $app['query']->getContent('showcases/1');
+        $relations = $owner->getRelation();
+        $collectionToTest = $app['query']->getContent('pages');
+
+        $relations->associate($collectionToTest);
+        $this->assertCount(count($collectionToTest), $relations['pages']);
+    }
+}


### PR DESCRIPTION
This is based on feedback from #7497 that the interface for interacting with relations has become a bit complicated.

This is a small PR that adds a helper method to make it easier to associate content entities with an owner.

The public-facing API is straightforward, given either an entity, a collection or a string/id combination we can easily associate relations.

```php
$repo = $app['storage']->getRepository('entries');
$entry = $app['query']->getContent('entries/1');
// Or direct from the repo
$entry = $repo->find(1);

// Option 1: Associate relations with this entity by name and ids
$entry->relation->associate('pages', [1,2,3]);

// Option 2: Associate relations via passing a single Entity
$page = $app['query']->getContent('pages/1');
$entry->relation->associate($page);

// Option 3: Associate a set of relations by passing a collection
$pages = $app['query']->getContent('pages', ['id'=> '1 || 2 | |3]']);
$entry->relation->associate($pages);


// Save
$repo->save($entry);
```




```