### PR TITLE
Make UploadContainer agnostic of invalid file content type

### DIFF
--- a/src/Filesystem/UploadContainer.php
+++ b/src/Filesystem/UploadContainer.php
@@ -41,7 +41,7 @@ class UploadContainer implements ContainerInterface
      */
     public function save($file, $content)
     {
-        $this->filesystem->put($file, $content);
+        $this->filesystem->put($file, (string) $content);
     }
 
     /**


### PR DESCRIPTION
More info: https://github.com/siriusphp/upload/pull/28

This could be a temporary fix.