### PR TITLE
[3.6] Add upload autoconfirm option

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -223,10 +223,15 @@ htmlcleaner:
 #
 # You can change the pattern match and replacement on uploaded files and if the
 # resulting filename should be transformed to lower case.
+#
+# Setting 'autoconfirm: true' prevents the creation of temporary lock files
+# while uploading.
+#
 # upload:
 #     pattern: '[^A-Za-z0-9\.]+'
 #     replacement: '-'
 #     lowercase: true
+#     autoconfirm: false
 
 # Define the file types (extensions to be exact) that are acceptable for upload
 # in either 'file' fields or through the 'files' screen.

--- a/src/Controller/Backend/Upload.php
+++ b/src/Controller/Backend/Upload.php
@@ -104,8 +104,10 @@ class Upload extends BackendBase
         $result = $this->app['upload']->process($filesToProcess);
 
         if ($result->isValid()) {
-            // Remove the .lock file attached to the file
-            $result->confirm();
+            if (!$this->app['config']->get('general/upload/autoconfirm')) {
+                // Remove the .lock file attached to the file
+                $result->confirm();
+            }
 
             $successfulFiles = [];
             foreach ($result as $resultFile) {
@@ -114,13 +116,14 @@ class Upload extends BackendBase
 
             return $successfulFiles;
         }
-            // The file that was saved during process() has a .lock file attached
-            // and can now be cleared, in the case where form processing fails
-            try {
-                $result->clear();
-            } catch (\Exception $e) {
-                // It's an error state anyway
-            }
+
+        // The file that was saved during process() has a .lock file attached
+        // and can now be cleared, in the case where form processing fails
+        try {
+            $result->clear();
+        } catch (\Exception $e) {
+            // It's an error state anyway
+        }
 
         $errorFiles = [];
         foreach ($result as $resultFile) {

--- a/src/Provider/UploadServiceProvider.php
+++ b/src/Provider/UploadServiceProvider.php
@@ -33,6 +33,7 @@ class UploadServiceProvider implements ServiceProviderInterface
                 $uploadHandler = new UploadHandler($app['upload.container']);
                 $uploadHandler->setPrefix($app['upload.prefix']);
                 $uploadHandler->setOverwrite($app['upload.overwrite']);
+                $uploadHandler->setAutoconfirm($app['config']->get('general/upload/autoconfirm'));
                 $uploadHandler->addRule('extension', ['allowed' => $allowedExtensions]);
 
                 $uploadHandler->setSanitizerCallback(function ($filename) use ($app) {


### PR DESCRIPTION
**This is a feature but it can be used to avoid bug in one of vendors.**

Adds `autoconfirm` option to upload config. Setting this to true will stop filesystem from making .lock files while uploading.

Setting this option to true also fixes #7510 and #6754.

Bugfix: no
New feature: yes
Relevant Bolt version: 3.5
Docs: updated
Tests: will add if needed