### PR TITLE
[3.6] Add new function and filter to get fieldtype in twig

### DIFF
--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -41,7 +41,7 @@ class TwigServiceProvider implements ServiceProviderInterface
             return new Twig\Runtime\AdminRuntime($app['config'], $app['stack'], $app['url_generator'], $app);
         };
         $app['twig.runtime.bolt'] = function ($app) {
-            return new Twig\Runtime\BoltRuntime($app['query']);
+            return new Twig\Runtime\BoltRuntime($app['query'], $app['storage.metadata']);
         };
         $app['twig.runtime.bolt_html'] = function ($app) {
             return new Twig\Runtime\HtmlRuntime(

--- a/src/Twig/Extension/BoltExtension.php
+++ b/src/Twig/Extension/BoltExtension.php
@@ -6,6 +6,7 @@ use Bolt;
 use Bolt\Config;
 use Bolt\Configuration\PathsProxy;
 use Bolt\Storage\EntityManagerInterface;
+use Bolt\Twig\Runtime\BoltRuntime;
 use Bolt\Twig\SetcontentTokenParser;
 use Bolt\Twig\SwitchTokenParser;
 use Twig\Extension\AbstractExtension;
@@ -67,8 +68,9 @@ class BoltExtension extends AbstractExtension implements GlobalsInterface
 
         return [
             // @codingStandardsIgnoreStart
-            new TwigFunction('first', 'twig_first', $env + $deprecated),
-            new TwigFunction('last',  'twig_last', $env + $deprecated),
+            new TwigFunction('first',       'twig_first', $env + $deprecated),
+            new TwigFunction('last',        'twig_last', $env + $deprecated),
+            new TwigFunction('fieldtype',   [BoltRuntime::class, 'fieldType']),
             // @codingStandardsIgnoreEnd
         ];
     }
@@ -82,7 +84,8 @@ class BoltExtension extends AbstractExtension implements GlobalsInterface
         $deprecated = ['deprecated' => true];
 
         return [
-            new TwigFilter('ucfirst', 'twig_capitalize_string_filter', $env + $deprecated + ['alternative' => 'capitalize']),
+            new TwigFilter('ucfirst',   'twig_capitalize_string_filter', $env + $deprecated + ['alternative' => 'capitalize']),
+            new TwigFilter('fieldtype', [BoltRuntime::class, 'fieldType']),
         ];
     }
 

--- a/src/Twig/Runtime/BoltRuntime.php
+++ b/src/Twig/Runtime/BoltRuntime.php
@@ -2,7 +2,11 @@
 
 namespace Bolt\Twig\Runtime;
 
+use Bolt\Legacy\Content as LegacyContent;
+use Bolt\Storage\Entity\Content;
+use Bolt\Storage\Mapping\MetadataDriver;
 use Bolt\Storage\Query\Query;
+use Doctrine\DBAL\Schema\Column;
 
 /**
  * Bolt extension runtime for Twig.
@@ -15,15 +19,18 @@ class BoltRuntime
 {
     /** @var Query */
     private $queryEngine;
+    private $metadataDriver;
 
     /**
      * Constructor.
      *
-     * @param Query $queryEngine
+     * @param Query          $queryEngine
+     * @param MetadataDriver $metadataDriver
      */
-    public function __construct(Query $queryEngine)
+    public function __construct(Query $queryEngine, MetadataDriver $metadataDriver)
     {
         $this->queryEngine = $queryEngine;
+        $this->metadataDriver = $metadataDriver;
     }
 
     /**
@@ -32,5 +39,27 @@ class BoltRuntime
     public function getQueryEngine()
     {
         return $this->queryEngine;
+    }
+
+    /**
+     * @param Content|LegacyContent|string $content
+     * @param Column|string                $column
+     * @param string                       $subField
+     *
+     * @return string
+     */
+    public function fieldType($content, $column, $subField = null)
+    {
+        if ($content instanceof Content) {
+            $name = (string) $content->getContenttype();
+        } elseif ($content instanceof LegacyContent) {
+            $name = $content->contenttype['slug'];
+        } elseif (is_string($content)) {
+            $name = $content;
+        } else {
+            throw new \BadMethodCallException(sprintf('The first parameter passed to fieldtype() but be a Content object or string, %s given', gettype($content)));
+        }
+
+        return $this->metadataDriver->getFieldTypeFor($name, $column, $subField);
     }
 }


### PR DESCRIPTION
This is a simple enhancement that adds both a `fieldtype(record, 'fieldname', 'subfieldname')` function and a `record|fieldtype('fieldname')` filter to Twig. 

It looks up the type of the field from the metadata and is designed as a more maintainable replacement to the current `record.fieldtype()` method which is limited in its ability to lookup more complex new fields and also extension added ones.

From: #7291