### PR TITLE
[3.6] Add editlink method to a twig runtime function

### DIFF
--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -69,7 +69,13 @@ class TwigServiceProvider implements ServiceProviderInterface
             );
         };
         $app['twig.runtime.bolt_routing'] = function ($app) {
-            return new Twig\Runtime\RoutingRuntime($app['canonical'], $app['request_stack'], $app['locale']);
+            return new Twig\Runtime\RoutingRuntime(
+                $app['canonical'],
+                $app['request_stack'],
+                $app['locale'],
+                $app['url_generator'],
+                $app['users']
+            );
         };
         $app['twig.runtime.bolt_text'] = function ($app) {
             return new Twig\Runtime\TextRuntime($app['logger.system'], $app['slugify']);

--- a/src/Storage/Entity/ContentRouteTrait.php
+++ b/src/Storage/Entity/ContentRouteTrait.php
@@ -29,13 +29,7 @@ trait ContentRouteTrait
      */
     public function editlink()
     {
-        $perm = 'contenttype:' . $this->contenttype['slug'] . ':edit:' . $this->id;
-
-        if ($this->app['users']->isAllowed($perm)) {
-            return $this->app['url_generator']->generate('editcontent', ['contenttypeslug' => $this->contenttype['slug'], 'id' => $this->id]);
-        }
-
-        return false;
+        return $this->app['twig.runtime.bolt_routing']->editlink($this);
     }
 
     /**

--- a/src/Twig/Extension/RoutingExtension.php
+++ b/src/Twig/Extension/RoutingExtension.php
@@ -23,6 +23,7 @@ class RoutingExtension extends AbstractExtension
         return [
             // @codingStandardsIgnoreStart
             new TwigFunction('canonical',      [Runtime\RoutingRuntime::class, 'canonical']),
+            new TwigFunction('editlink',       [Runtime\RoutingRuntime::class, 'editlink']),
             new TwigFunction('htmllang',       [Runtime\RoutingRuntime::class, 'htmlLang']),
             new TwigFunction('ismobileclient', [Runtime\RoutingRuntime::class, 'isMobileClient']),
             new TwigFunction('redirect',       [Runtime\RoutingRuntime::class, 'redirect'], ['deprecated' => true]),

--- a/tests/phpunit/unit/Twig/Runtime/RoutingRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/RoutingRuntimeTest.php
@@ -141,7 +141,9 @@ class RoutingRuntimeTest extends BoltUnitTest
         return new RoutingRuntime(
             $app['canonical'],
             $app['request_stack'],
-            $app['locale']
+            $app['locale'],
+            $app['url_generator'],
+            $app['users']
         );
     }
 }


### PR DESCRIPTION
This is intended as the future replacement and current alternative to `record.editlink()` 

It will allow us to decouple knowledge of the router from the content entity. For now everything will work identically `{{ record.editlink() }}` and `editlink(record)` will be functionally identical but with the latter as the supported way in the future.

From: #7291