### PR TITLE
[3.6] Add new Twig helpers for getting next and previous records

### DIFF
--- a/src/Provider/TwigServiceProvider.php
+++ b/src/Provider/TwigServiceProvider.php
@@ -65,7 +65,8 @@ class TwigServiceProvider implements ServiceProviderInterface
                 $app['pager'],
                 $app['filesystem']->getDir('theme://' . $app['config']->get('theme/template_directory')),
                 $app['config']->get('theme/templateselect/templates', []),
-                $app['config']->get('general/compatibility/twig_globals', true)
+                $app['config']->get('general/compatibility/twig_globals', true),
+                $app['query']
             );
         };
         $app['twig.runtime.bolt_routing'] = function ($app) {

--- a/src/Storage/Entity/ContentTypeTrait.php
+++ b/src/Storage/Entity/ContentTypeTrait.php
@@ -42,4 +42,14 @@ trait ContentTypeTrait
 
         return $field['type'];
     }
+
+    public function next($field, $where)
+    {
+        return $this->app['twig.runtime.bolt_record']->next($this, $field, $where);
+    }
+
+    public function previous($field, $where)
+    {
+        return $this->app['twig.runtime.bolt_record']->previous($this, $field, $where);
+    }
 }

--- a/src/Twig/Extension/RecordExtension.php
+++ b/src/Twig/Extension/RecordExtension.php
@@ -31,7 +31,9 @@ class RecordExtension extends AbstractExtension
             new TwigFunction('excerpt',       [Runtime\RecordRuntime::class, 'excerpt'], $safe),
             new TwigFunction('fields',        [Runtime\RecordRuntime::class, 'fields'], $env + $safe + $deprecated + ['alternative' => 'block(\'sub_fields\')']),
             new TwigFunction('listtemplates', [Runtime\RecordRuntime::class, 'listTemplates']),
+            new TwigFilter('next',            [Runtime\RecordRuntime::class, 'next']),
             new TwigFunction('pager',         [Runtime\RecordRuntime::class, 'pager'], $env + $safe),
+            new TwigFilter('previous',        [Runtime\RecordRuntime::class, 'previous']),
             new TwigFunction('trimtext',      [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
             new TwigFunction('taxonomy',      [Runtime\RecordRuntime::class, 'taxonomy']),
             // @codingStandardsIgnoreEnd
@@ -50,6 +52,8 @@ class RecordExtension extends AbstractExtension
             // @codingStandardsIgnoreStart
             new TwigFilter('current',     [Runtime\RecordRuntime::class, 'current']),
             new TwigFilter('excerpt',     [Runtime\RecordRuntime::class, 'excerpt'], $safe),
+            new TwigFilter('next',        [Runtime\RecordRuntime::class, 'next']),
+            new TwigFilter('previous',    [Runtime\RecordRuntime::class, 'previous']),
             new TwigFilter('selectfield', [Runtime\RecordRuntime::class, 'selectField']),
             new TwigFilter('trimtext',    [Runtime\RecordRuntime::class, 'excerpt'], $safe + $deprecated + ['alternative' => 'excerpt']),
             new TwigFilter('taxonomy',    [Runtime\RecordRuntime::class, 'taxonomy']),


### PR DESCRIPTION
This adds a new way to lookup next and previous records in a way that allows us to decouple this query from the content entity itself.

The current functionality is `record.next()` and `record.previous()` this PR adds the functionality both as a function and a filter so templates can use either `{{ next(record) }} {{ previous(record) }}` or the filter version `{{ record|next }} {{ record|previous }}` 

In all cases both an ordering field and additional where parameters can be passed in optionally as arguments.

Note this has no effect at all on Legacy Storage which can continue to use `record.next()` untouched.

From: #7291