### PR TITLE
[3.6] Add QueryEvent class and new events to listen in

### DIFF
--- a/src/Events/QueryEvent.php
+++ b/src/Events/QueryEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Bolt\Events;
+
+use Bolt\Storage\Query\ContentQueryParser;
+use Bolt\Storage\Query\QueryResultset;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Query event allow access to content queries.
+ *
+ * @author Ross Riley <riley.ross@gmail.com>
+ */
+class QueryEvent extends Event
+{
+    protected $query;
+    protected $result;
+
+    public function __construct(ContentQueryParser $query, $result = null)
+    {
+        $this->query = $query;
+        $this->result = $result;
+    }
+
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    public function hasResult()
+    {
+        return $this->result instanceof QueryResultset;
+    }
+}

--- a/src/Events/QueryEvents.php
+++ b/src/Events/QueryEvents.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bolt\Events;
+
+/**
+ * Definitions for all possible QueryEvents.
+ *
+ *  * @codeCoverageIgnore
+ */
+final class QueryEvents
+{
+
+    const PARSE = 'query.parse';
+    const EXECUTE = 'query.execute';
+
+
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
Simple addition that adds two new events to allow listening in on Bolt query events. The initial two specified are `QueryEvents::PARSE` and `QueryEvents::EXECUTE` 

The goal is to allow different services and extensions to be able to do pre and post modification of Bolt's default db query behaviour.

From: #7291