### PR TITLE
[3.6 / Hotfix] Address bug where limit was overwritten on search operations

### DIFF
--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -176,7 +176,9 @@ class ContentQueryParser
 
         if (in_array($queryParts[0], $this->operations)) {
             $operation = array_shift($queryParts);
-            $this->params['limit'] = array_shift($queryParts);
+            if (count($queryParts) && is_numeric($queryParts[0])) {
+                $this->params['limit'] = array_shift($queryParts);
+            }
             $this->identifier = implode(',', $queryParts);
         } else {
             $this->identifier = implode(',', $queryParts);


### PR DESCRIPTION
Small fix prevents limit from failing on `pages/search` style queries.

From: #7291