### PR TITLE
[3.6 Fix] Add accessor for enabled searchable contenttypes

### DIFF
--- a/src/Storage/Query/SearchConfig.php
+++ b/src/Storage/Query/SearchConfig.php
@@ -197,4 +197,14 @@ class SearchConfig
     {
         $this->searchInvisible = $searchInvisible;
     }
+
+    /**
+     * Return an array of searchable contenttypes
+     * @return array
+     */
+    public function getSearchableTypes()
+    {
+        return $this->searchableTypes;
+    }
+
 }


### PR DESCRIPTION
Small getter to access outside the class

From: #7291