### PR TITLE
[3.6 Fix] Fix logic error in search expression compile

### DIFF
--- a/src/Storage/Query/SearchQuery.php
+++ b/src/Storage/Query/SearchQuery.php
@@ -132,12 +132,21 @@ class SearchQuery extends SelectQuery
             return null;
         }
 
-        $expr = $this->qb->expr()->orX();
+        $wrapExpr = $this->qb->expr()->andX();
+        $config = $this->config->getConfig($this->contentType);
+        $searchExpr = $this->qb->expr()->orX();
+        $searchKeys = array_keys($config);
+
         /** @var Filter $filter */
         foreach ($this->filters as $filter) {
-            $expr = $expr->add($filter->getExpression());
+            if (in_array($filter->getKey(), $searchKeys)) {
+                $searchExpr->add($filter->getExpression());
+            } else {
+                $wrapExpr->add($filter->getExpression());
+            }
         }
+        $wrapExpr->add($searchExpr);
 
-        return $expr;
+        return $wrapExpr;
     }
 }


### PR DESCRIPTION
This addresses an incorrect behaviour in compiling a search query. Current behaviour uses an or query appended to the previous arguments but the correct behaviour is to AND the result of all search queries where all the search queries are OR.

In sql terms the current behaviour does `WHERE field='val' OR title LIKE '%query%' OR body LIKE '%query%'` whereas the correct query is `WHERE field='val AND (title LIKE '%query%' OR body LIKE '%query%')'`

From: #7291