### PR TITLE
[3.6 Feature] add a Taxonomy repo and allow query content by taxonomy types

### DIFF
--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -173,6 +173,7 @@ class StorageServiceProvider implements ServiceProviderInterface
             Entity\FieldValue::class => Repository\FieldValueRepository::class,
             Entity\LogChange::class  => Repository\LogChangeRepository::class,
             Entity\LogSystem::class  => Repository\LogSystemRepository::class,
+            Entity\Taxonomy::class   => Repository\TaxonomyRepository::class,
             Entity\Users::class      => Repository\UsersRepository::class,
         ];
 

--- a/src/Storage/Query/TaxonomyQueryResultset.php
+++ b/src/Storage/Query/TaxonomyQueryResultset.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Bolt\Storage\Query;
+
+use Bolt\Storage\Collection\LazyCollection;
+use Bolt\Storage\EntityManager;
+use Bolt\Storage\EntityProxy;
+
+/**
+ * This class builds on the default QueryResultset to add
+ * the ability to merge sets based on weighted scores.
+ */
+class TaxonomyQueryResultset extends QueryResultset
+{
+    protected $em;
+
+    public function getCollection()
+    {
+        $collection = new LazyCollection();
+
+        foreach ($this->results as $proxy) {
+            $collection->add(new EntityProxy($proxy['contenttype'], $proxy['id'], $this->getEntityManager()));
+        }
+
+        return $collection;
+    }
+
+    public function setEntityManager(EntityManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * @return EntityManager
+     */
+    public function getEntityManager()
+    {
+        return $this->em;
+    }
+}

--- a/src/Storage/Repository/TaxonomyRepository.php
+++ b/src/Storage/Repository/TaxonomyRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Bolt\Storage\Repository;
+
+use Bolt\Events\QueryEvent;
+use Bolt\Events\QueryEvents;
+use Bolt\Exception\InvalidRepositoryException;
+use Bolt\Storage\Query\TaxonomyQueryResultset;
+use Bolt\Storage\Repository;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class TaxonomyRepository extends Repository
+{
+    /**
+     * @param array $contentTypes
+     * @param array $taxonomyTypes
+     *
+     * @throws InvalidRepositoryException
+     *
+     * @return QueryBuilder
+     */
+    public function queryContentByTaxonomy($contentTypes, $taxonomyTypes)
+    {
+        $query = $this->createQueryBuilder();
+        $this->buildJoin($query, $contentTypes);
+        $this->buildWhere($query, $taxonomyTypes);
+
+        return $query;
+    }
+
+    /**
+     * @param QueryBuilder $query
+     *
+     * @return TaxonomyQueryResultset
+     */
+    public function getContentByTaxonomy(QueryBuilder $query)
+    {
+        $results = $query->execute()->fetchAll();
+        $set = new TaxonomyQueryResultset();
+        $set->setEntityManager($this->getEntityManager());
+        $set->add($results);
+        $executeEvent = new QueryEvent($query, $set);
+        $this->getEntityManager()->getEventManager()->dispatch(QueryEvents::EXECUTE, $executeEvent);
+
+        return $set;
+    }
+
+    /**
+     * @param QueryBuilder $query
+     * @param array        $contentTypes
+     *
+     * @throws InvalidRepositoryException
+     */
+    protected function buildJoin(QueryBuilder $query, $contentTypes)
+    {
+        $subQuery = '(SELECT ';
+        $fragments = [];
+        foreach ($contentTypes as $content) {
+            $repo = $this->getEntityManager()->getRepository($content);
+            $table = $repo->getTableName();
+            $fragments[] = "id,status, '$content' AS tablename FROM " . $table;
+        }
+        $subQuery .= join(' UNION SELECT ', $fragments);
+        $subQuery .= ')';
+
+        $query->from($subQuery, 'content');
+        $query->addSelect('content.*');
+    }
+
+    /**
+     * @param QueryBuilder $query
+     * @param array        $taxonomyTypes
+     */
+    protected function buildWhere(QueryBuilder $query, $taxonomyTypes)
+    {
+        $params = [];
+        $i = 0;
+        $where = $query->expr()->andX();
+        foreach ($taxonomyTypes as $name => $slug) {
+            $where->add($query->expr()->eq('taxonomy.taxonomytype', ':taxonomytype_' . $i));
+            $where->add($query->expr()->eq('taxonomy.slug', ':slug_' . $i));
+            $params['taxonomytype_' . $i] = $name;
+            $params['slug_' . $i] = $slug;
+            $i++;
+        }
+        $query->where($where)->setParameters($params);
+        $query->andWhere("content.status='published'");
+        $query->andWhere('taxonomy.contenttype=content.tablename');
+        $query->andWhere('taxonomy.content_id=content.id');
+    }
+}


### PR DESCRIPTION
This adds some missing functionality into the new storage layer, it mirrors the legacy `getContentByTaxonomy` and allows us to do generate a similar query by using the repo.

Example:

```
$repo = $this->app['storage']->getRepository(Taxonomy::class);
$query = $repo->queryContentByTaxonomy(['pages', 'entries'], ['categories' => 'news']);
```

This will initially only be used internally but the plan is to expose it via the normal `setcontent` searches in a future PR. 