### PR TITLE
[3.6] Two minor query parser bugs

### DIFF
--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -206,6 +206,8 @@ class ContentQueryParser
             return;
         }
 
+        $this->directives = [];
+
         foreach ($this->params as $key => $value) {
             if ($this->hasDirectiveHandler($key)) {
                 $this->directives[$key] = $value;

--- a/src/Storage/Query/Directive/OrderDirective.php
+++ b/src/Storage/Query/Directive/OrderDirective.php
@@ -27,6 +27,9 @@ class OrderDirective
             if (strpos($order, '-') === 0) {
                 $direction = 'DESC';
                 $order = substr($order, 1);
+            } elseif (strpos($order, ' DESC') !== false) {
+                $direction = 'DESC';
+                $order = str_replace(' DESC', '', $order);
             } else {
                 $direction = null;
             }


### PR DESCRIPTION
There's a few places in both documentation and code where we use `setcontent records='pages' orderby orderfield DESC` instead of the standard `-orderfield`

This adds support for using `DESC` as well as the negation operator as well.

Secondly there's a bugfix to force clear directives should you do two queries in a row.