### PR TITLE
[3.6] Minor Query Handler tweaks

### DIFF
--- a/src/Storage/Query/Handler/SearchQueryHandler.php
+++ b/src/Storage/Query/Handler/SearchQueryHandler.php
@@ -36,6 +36,7 @@ class SearchQueryHandler
             $query->setSearch($searchParam);
 
             $contentQuery->runDirectives($query);
+            $contentQuery->runScopes($query);
 
             $result = $repo->queryWith($query);
             if ($result) {
@@ -47,8 +48,10 @@ class SearchQueryHandler
                     $weighter->setSearchWords($query->getSearchWords());
 
                     $scores = $weighter->weight();
+                    $set->setOriginalQuery($contentType, $query->getQueryBuilder());
                     $set->add($result, $contentType, $scores);
                 } else {
+                    $set->setOriginalQuery($contentType, $query->getQueryBuilder());
                     $set->add($result, $contentType);
                 }
             }

--- a/src/Storage/Query/Handler/SelectQueryHandler.php
+++ b/src/Storage/Query/Handler/SelectQueryHandler.php
@@ -23,6 +23,7 @@ class SelectQueryHandler
         $set = new QueryResultset();
         /** @var SelectQuery $query */
         $query = $contentQuery->getService('select');
+        $query->setSingleFetchMode(false);
 
         foreach ($contentQuery->getContentTypes() as $contentType) {
             $contentType = str_replace('-', '_', $contentType);


### PR DESCRIPTION
Keeps a copy of original search query objects in case we need to refer to them in events.

On normal selects, reset the fetch mode before starting a new query.