### PR TITLE
[3.6] Fix that allows default sorting to work when using singular slug

### DIFF
--- a/src/Storage/Query/FrontendQueryScope.php
+++ b/src/Storage/Query/FrontendQueryScope.php
@@ -72,6 +72,9 @@ class FrontendQueryScope implements QueryScopeInterface
         foreach ($contentTypes as $type => $values) {
             if (isset($values['sort'])) {
                 $this->orderBys[$type] = $values['sort'];
+                if (isset($values['singular_slug'])) {
+                    $this->orderBys[$values['singular_slug']] = $values['sort'];
+                }
             }
         }
     }
@@ -85,7 +88,7 @@ class FrontendQueryScope implements QueryScopeInterface
 
         // Setup default ordering of queries on a per-contenttype basis
         $existing = $query->getParameter('order');
-        if (!$existing && $this->orderBys[$ct]) {
+        if (!$existing && isset($this->orderBys[$ct])) {
             $handler = new OrderDirective();
             $handler($query, $this->orderBys[$ct]);
         }


### PR DESCRIPTION
Bug in new storage only, if you do a `getContent('page')` rather than `getContent('pages')` then the default sort order configured via contenttypes.yml wasn't being applied.