### PR TITLE
[3.6] [Feature] Port across relations get from old storage

### DIFF
--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -235,7 +235,7 @@ class Content extends Entity
     /**
      * @param string|null $contentType
      *
-     * @return Collection\Relations
+     * @return Collection\Relations|Collection\LazyCollection
      */
     public function getRelation($contentType = null)
     {
@@ -257,6 +257,22 @@ class Content extends Entity
     {
         $this->relation = $rel;
         $rel->setOwner($this);
+    }
+
+    /**
+     * Gets all related content items
+     *
+     * @param $contentType
+     *
+     * @return Collection\LazyCollection
+     */
+    public function getRelated($contentType = null)
+    {
+        if ($contentType !== null) {
+            return $this->getRelation($contentType);
+        }
+
+        return $this->getRelation()->all();
     }
 
     /**


### PR DESCRIPTION
Another new storage compatibility feature pulled from #7291 

This allows content records to have a related method on them when using the new storage system.

eg: `{% for rel in record.related %}` or `{% for rel in record.related('pages') %}`