### PR TITLE
[3.5] Ensure a content editing form CSRF token exists at logon

### DIFF
--- a/src/AccessControl/Login.php
+++ b/src/AccessControl/Login.php
@@ -129,7 +129,7 @@ class Login extends AccessChecker
             }
         }
 
-        $this->dispatcher->dispatch(AccessControlEvents::LOGIN_SUCCESS, $event->setDispatched());
+        $this->dispatcher->dispatch(AccessControlEvents::LOGIN_SUCCESS, $event);
 
         return $this->loginFinish($userEntity);
     }
@@ -164,7 +164,7 @@ class Login extends AccessChecker
             $userTokenEntity->setLastseen(Carbon::now());
             $this->getRepositoryAuthtoken()->save($userTokenEntity);
             $this->flashLogger->success(Trans::__('general.phrase.session-resumed-colon'));
-            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_SUCCESS, $event->setDispatched());
+            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_SUCCESS, $event);
 
             return $this->loginFinish($userEntity);
         }

--- a/src/Provider/EventListenerServiceProvider.php
+++ b/src/Provider/EventListenerServiceProvider.php
@@ -16,7 +16,8 @@ class EventListenerServiceProvider implements ServiceProviderInterface
                 return new Listener\AccessControlListener(
                     $app['filesystem'],
                     $app['session.storage'],
-                    $app['storage.lazy']
+                    $app['storage.lazy'],
+                    $app['csrf']
                 );
             }
         );
@@ -160,6 +161,7 @@ class EventListenerServiceProvider implements ServiceProviderInterface
             'template_view',
             'zone_guesser',
             'pager',
+            'access_control',
         ];
 
         foreach ($listeners as $name) {


### PR DESCRIPTION
Workaround the `content_edit` CSRF token race by creating the token at login. :disappointed: 

Closes #7512