### PR TITLE
Set preserve_keys in array_slice to keep numeric array key association

### DIFF
--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -4,7 +4,6 @@ namespace Bolt\Form\Resolver;
 
 use ArrayObject;
 use Bolt\Collection\Bag;
-use Bolt\Storage\Entity\Content;
 use Bolt\Storage\Mapping\ContentType;
 use Bolt\Storage\Query\Query;
 use Bolt\Storage\Query\QueryResultset;
@@ -105,7 +104,7 @@ final class Choice
      */
     private function getYamlValues(Bag $field)
     {
-        $values = array_slice($field->get('values', []), 0, $field->get('limit'));
+        $values = array_slice($field->get('values', []), 0, $field->get('limit'), true);
         if ($field->get('sortable')) {
             asort($values, SORT_REGULAR);
         }

--- a/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
+++ b/tests/phpunit/unit/Form/Resolver/ChoiceTest.php
@@ -61,6 +61,16 @@ class ChoiceTest extends TestCase
                     ],
                 ],
             ],
+            'Field un-sorted indexed array' => [
+                ['select_array' => [1 => 'bar', 3 => 'drop bear', 0 => 'foo', 2 => 'koala']],
+                [
+                    'select_array' => [
+                        'type'     => 'select',
+                        'sortable' => false,
+                        'values'   => [1 => 'bar', 3 => 'drop bear', 0 => 'foo', 2 => 'koala'],
+                    ],
+                ],
+            ],
             'Field with limited count indexed array' => [
                 ['select_array' => ['foo', 'bar']],
                 [


### PR DESCRIPTION
#### Fixes #7411 
In `Form\Resolve\Choice.php` `array_slice` clears indices of original associative array.
