### PR TITLE
Slugifying folder names, created from file manager [tests update required]

### DIFF
--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -105,7 +105,20 @@ class FilesystemManager extends AsyncBase
         $folderName = $request->request->get('foldername');
 
         try {
-            $dir = $this->filesystem()->getDir("$namespace://$parentPath/$folderName");
+            // Trimming spaces and cleaning folder name
+            $folderName = trim($folderName);
+            $slugifiedFolderName = $this->app['slugify']->slugify($folderName);
+
+            // If slugified folder name differs, we show warning
+            if ($slugifiedFolderName !== $folderName) {
+                $warningText = Trans::__(
+                    'Directory <strong>"%DIR%"</strong> was created with another name: <strong>"%SLUGDIR%"</strong>.',
+                    ['%DIR%' => $folderName, '%SLUGDIR%' => $slugifiedFolderName,]
+                );
+                $this->app['logger.flash']->warning($warningText);
+            }
+
+            $dir = $this->filesystem()->getDir("$namespace://$parentPath/$slugifiedFolderName");
             $dir->create();
 
             return $this->json($dir->getPath(), Response::HTTP_OK);


### PR DESCRIPTION
**tests update required (!)**

### closes #7425 

When user creates a folder, if the folder name contains non-latin symbols, name is slugified. And if it's changed, we a show warning:
`Directory "%DIR%" was created with another name: "%SLUGDIR%".`