### PR TITLE
Fix links to 'first page' in pager, keep filtering

### DIFF
--- a/app/theme_defaults/pager/_base.twig
+++ b/app/theme_defaults/pager/_base.twig
@@ -50,7 +50,7 @@
 {% block render_item %}
     {% with {
         page: i,
-        link: (i == 1 and pager.for != 'search') ? canonical() : pager.makelink() ~ i,
+        link: pager.makelink() ~ i,
         active: i == pager.current,
         first: i == 1,
         last: i == pager.totalpages,

--- a/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
@@ -6,7 +6,6 @@ use Bolt\Asset\Snippet\Snippet;
 use Bolt\Legacy\Content;
 use Bolt\Pager\Pager;
 use Bolt\Pager\PagerManager;
-use Bolt\Routing\Canonical;
 use Bolt\Storage\Repository;
 use Bolt\Tests\BoltUnitTest;
 use Bolt\Twig\Runtime\RecordRuntime;
@@ -466,18 +465,6 @@ GRINGALET;
         ;
         $pager->for = $pagerName = 'Clippy';
         $pager->totalpages = $surr = 2;
-
-        $canonical = $this->getMockBuilder(Canonical::class)
-            ->setMethods(['getUrl'])
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $canonical
-            ->expects($this->atLeastOnce())
-            ->method('getUrl')
-            ->will($this->returnValue('1'))
-        ;
-        $app['canonical'] = $canonical;
 
         $manager = $this->getMockBuilder(PagerManager::class)
             ->setMethods(['isEmptyPager', 'getPager'])


### PR DESCRIPTION
This should be in the theme-specific twig template, not in the generic / default one. 

Fixes #7534