### PR TITLE
increasing input width in _panel-actions_files

### DIFF
--- a/app/view/twig/files/_panel-actions_files.twig
+++ b/app/view/twig/files/_panel-actions_files.twig
@@ -37,7 +37,7 @@
     <form class="form-inline">
 
       <div class="form-group">
-        <input id="file-manager-search" type="text" class="form-control"  name="filter" style="width: 110px;" placeholder="{{ __('general.phrase.keyword-ellipsis') }}">
+        <input id="file-manager-search" type="text" class="form-control"  name="filter" style="width: 130px;" placeholder="{{ __('general.phrase.keyword-ellipsis') }}">
       </div>
 
     </form>


### PR DESCRIPTION
In some languages "keyword ..." is longer. So i increased width of that field for 20px to avoid placeholder clipping.