### PR TITLE
[3.6][Hotfix] For BC content methods - Add default parameter values

### DIFF
--- a/src/Storage/Entity/ContentTypeTrait.php
+++ b/src/Storage/Entity/ContentTypeTrait.php
@@ -43,12 +43,12 @@ trait ContentTypeTrait
         return $field['type'];
     }
 
-    public function next($field, $where)
+    public function next($field = 'datepublish', $where = [])
     {
         return $this->app['twig.runtime.bolt_record']->next($this, $field, $where);
     }
 
-    public function previous($field, $where)
+    public function previous($field = 'datepublish', $where = [])
     {
         return $this->app['twig.runtime.bolt_record']->previous($this, $field, $where);
     }


### PR DESCRIPTION
For the new BC methods in ContentTypeTrait these methods were missing the default parameters to match the ones in the Twig Runtime.