### PR TITLE
Require bolt/package-wrapper ^4.0 || ^5.0 to handle doctrine/common split

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "bolt/common": "^1.0",
         "bolt/filesystem": "^2.3.1",
         "bolt/pathogen": "~0.6",
+        "bolt/package-wrapper": "^4.0 || ^5.0",
         "bolt/requirements": "^1.0.2",
         "bolt/session": "^1.0",
         "bolt/themes": "^2.0",

--- a/tests/phpunit/unit/Storage/Repository/LogChangeRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/LogChangeRepositoryTest.php
@@ -23,59 +23,202 @@ class LogChangeRepositoryTest extends BoltUnitTest
         $this->assertEquals(7, $params['date']);
     }
 
-    public function testActivityQuery()
+    public function providerActivityQueryDefault()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_change log_change ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_change log_change ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryDefault
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryDefault($expected)
     {
         $repo = $this->getRepository();
         $query = $repo->getActivityQuery(1, 10, []);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_change log_change ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql());
 
+        $this->assertEquals($expected, $query->getSql());
+    }
+
+    public function providerActivityQueryContentType()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_change log_change WHERE contenttype = :contenttype ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_change log_change WHERE contenttype = :contenttype ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryContentType
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryContentType($expected)
+    {
+        $repo = $this->getRepository();
         $query = $repo->getActivityQuery(1, 10, ['contenttype' => 'pages']);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_change log_change WHERE contenttype = :contenttype ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql());
         $params = $query->getParameters();
-        $this->assertEquals('pages', $params['contenttype']);
 
+        $this->assertEquals($expected, $query->getSql());
+        $this->assertEquals('pages', $params['contenttype']);
+    }
+
+    public function providerActivityQueryTwoContentTypes()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype_0) OR (contenttype = :contenttype_1) ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype_0) OR (contenttype = :contenttype_1) ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryTwoContentTypes
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryTwoContentTypes($expected)
+    {
+        $repo = $this->getRepository();
         $query = $repo->getActivityQuery(1, 10, ['contenttype' => ['pages', 'entries']]);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype_0) OR (contenttype = :contenttype_1) ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql());
         $params = $query->getParameters();
+
+        $this->assertEquals($expected, $query->getSql());
         $this->assertEquals('pages', $params['contenttype_0']);
         $this->assertEquals('entries', $params['contenttype_1']);
+    }
 
+    public function providerActivityQueryContentTypeContentId()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype) AND (contentid = :contentid) ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype) AND (contentid = :contentid) ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryContentTypeContentId
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryContentTypeContentId($expected)
+    {
+        $repo = $this->getRepository();
         $query = $repo->getActivityQuery(1, 10, ['contenttype' => 'pages', 'contentid' => 123]);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype) AND (contentid = :contentid) ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql());
         $params = $query->getParameters();
+
+        $this->assertEquals($expected, $query->getSql());
         $this->assertEquals('pages', $params['contenttype']);
         $this->assertEquals(123, $params['contentid']);
+    }
 
+    public function providerActivityQueryTwoContentTypesContentId()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_change log_change WHERE ((contenttype = :contenttype_0) OR (contenttype = :contenttype_1)) AND ((contentid = :contentid_0) OR (contentid = :contentid_1)) ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_change log_change WHERE ((contenttype = :contenttype_0) OR (contenttype = :contenttype_1)) AND ((contentid = :contentid_0) OR (contentid = :contentid_1)) ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryTwoContentTypesContentId
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryTwoContentTypesContentId($expected)
+    {
+        $repo = $this->getRepository();
         $query = $repo->getActivityQuery(1, 10, ['contenttype' => ['pages', 'entries'], 'contentid' => [2, 4]]);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_change log_change WHERE ((contenttype = :contenttype_0) OR (contenttype = :contenttype_1)) AND ((contentid = :contentid_0) OR (contentid = :contentid_1)) ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql());
         $params = $query->getParameters();
+
+        $this->assertEquals($expected, $query->getSql());
         $this->assertEquals('pages', $params['contenttype_0']);
         $this->assertEquals('entries', $params['contenttype_1']);
         $this->assertEquals(2, $params['contentid_0']);
         $this->assertEquals(4, $params['contentid_1']);
+    }
 
+    public function providerActivityQueryOwnerId()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_change log_change WHERE ownerid = :ownerid ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_change log_change WHERE ownerid = :ownerid ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryOwnerId
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryOwnerId($expected)
+    {
+        $repo = $this->getRepository();
         $query = $repo->getActivityQuery(1, 10, ['ownerid' => 1]);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_change log_change WHERE ownerid = :ownerid ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql());
         $params = $query->getParameters();
-        $this->assertEquals(1, $params['ownerid']);
 
+        $this->assertEquals($expected, $query->getSql());
+        $this->assertEquals(1, $params['ownerid']);
+    }
+
+    public function providerActivityQueryContentTypeContentIdOwnerId()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype) AND (contentid = :contentid) AND (ownerid = :ownerid) ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype) AND (contentid = :contentid) AND (ownerid = :ownerid) ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryContentTypeContentIdOwnerId
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryContentTypeContentIdOwnerId($expected)
+    {
+        $repo = $this->getRepository();
         $query = $repo->getActivityQuery(1, 10, ['contenttype' => 'pages', 'contentid' => 1, 'ownerid' => 42]);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_change log_change WHERE (contenttype = :contenttype) AND (contentid = :contentid) AND (ownerid = :ownerid) ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql());
         $params = $query->getParameters();
+
+        $this->assertEquals($expected, $query->getSql());
         $this->assertEquals('pages', $params['contenttype']);
         $this->assertEquals(1, $params['contentid']);
         $this->assertEquals(42, $params['ownerid']);

--- a/tests/phpunit/unit/Storage/Repository/LogSystemRepositoryTest.php
+++ b/tests/phpunit/unit/Storage/Repository/LogSystemRepositoryTest.php
@@ -13,7 +13,7 @@ use Psr\Log\LogLevel;
  */
 class LogSystemRepositoryTest extends BoltUnitTest
 {
-    public function testActivityQuery()
+    public function testActivityQueryTrim()
     {
         $repo = $this->getRepository();
 
@@ -22,21 +22,61 @@ class LogSystemRepositoryTest extends BoltUnitTest
             'DELETE FROM bolt_log_system WHERE date < :date',
             $queryTrimLog->getSql()
         );
+    }
+
+    public function providerActivityQueryCritical()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_system log_system WHERE (level = :level) AND (context = :context) ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_system log_system WHERE (level = :level) AND (context = :context) ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryCritical
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryCritical($expected)
+    {
+        $repo = $this->getRepository();
 
         $query = $repo->getActivityQuery(1, 10, ['level' => LogLevel::CRITICAL, 'context' => 'system']);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_system log_system WHERE (level = :level) AND (context = :context) ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql()
-        );
+        $this->assertEquals($expected, $query->getSql());
         $params = $query->getParameters();
         $this->assertEquals('critical', $params['level']);
         $this->assertEquals('system', $params['context']);
+    }
+
+    public function providerActivityQueryNotice()
+    {
+        if (PHP_VERSION_ID < 70100) {
+            return [
+                ['SELECT * FROM bolt_log_system log_system WHERE (level = :level) AND ((context = :context_0) OR (context = :context_1)) ORDER BY id DESC LIMIT 10 OFFSET 0'],
+            ];
+        }
+
+        return [
+            ['SELECT * FROM bolt_log_system log_system WHERE (level = :level) AND ((context = :context_0) OR (context = :context_1)) ORDER BY id DESC LIMIT 10'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerActivityQueryNotice
+     *
+     * @param string $expected
+     */
+    public function testActivityQueryNotice($expected)
+    {
+        $repo = $this->getRepository();
 
         $query = $repo->getActivityQuery(1, 10, ['level' => LogLevel::NOTICE, 'context' => ['system', 'twig']]);
-        $this->assertEquals(
-            'SELECT * FROM bolt_log_system log_system WHERE (level = :level) AND ((context = :context_0) OR (context = :context_1)) ORDER BY id DESC LIMIT 10 OFFSET 0',
-            $query->getSql()
-        );
+        $this->assertEquals($expected, $query->getSql());
         $params = $query->getParameters();
         $this->assertEquals('notice', $params['level']);
         $this->assertEquals('system', $params['context_0']);


### PR DESCRIPTION
This PR adds an updated set of requirements for the old `bolt/package-wrapper` meta-package.

With the [release of DBAL 2.8](https://www.doctrine-project.org/2018/07/12/common-2-9-and-dbal-2-8-and-orm-2-6-2.html), `doctrine/common` has been split into `doctrine/persistence`, `doctrine/event-manager`, and `doctrine/reflection`. 

Bolt requires classes from `doctrine/persistence`, but this itself requires PHP 7.1+. So the meta-package enables PHP <7.1 to run a working version of DBAL, and PHP 7.1+ to run 2.8+ with `doctrine/persistence`