### PR TITLE
[3.6] Fix for default ordering (plus code quality updates)

### DIFF
--- a/src/Storage/Query/ContentQueryInterface.php
+++ b/src/Storage/Query/ContentQueryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Bolt\Storage\Query;
+
+interface ContentQueryInterface extends QueryInterface
+{
+    /**
+     * Returns the content type this query is executing on.
+     *
+     * @return string
+     */
+    public function getContentType();
+
+    /**
+     * Returns the value of a parameter by key name.
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function getParameter($key);
+
+    /**
+     * Sets the value of a parameter by key name.
+     *
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return mixed
+     */
+    public function setParameter($key, $value);
+}

--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -137,7 +137,7 @@ class ContentQueryParser
     }
 
     /**
-     * Parses the content area of the querystring.
+     * Parses the content area of the query string.
      */
     protected function parseContent()
     {
@@ -176,7 +176,7 @@ class ContentQueryParser
             return;
         }
 
-        if (in_array($queryParts[0], $this->operations)) {
+        if (in_array($queryParts[0], $this->operations, true)) {
             $operation = array_shift($queryParts);
             if (count($queryParts) && is_numeric($queryParts[0])) {
                 $this->params['limit'] = array_shift($queryParts);
@@ -225,7 +225,7 @@ class ContentQueryParser
     public function runDirectives(QueryInterface $query, array $skipDirective = [])
     {
         foreach ($this->directives as $key => $value) {
-            if (in_array($key, $skipDirective)) {
+            if (in_array($key, $skipDirective, true)) {
                 continue;
             }
             if (!$this->hasDirectiveHandler($key)) {
@@ -242,7 +242,7 @@ class ContentQueryParser
         $this->scope = $scope;
     }
 
-    public function runScopes(QueryInterface $query)
+    public function runScopes(ContentQueryInterface $query)
     {
         if ($this->scope !== null) {
             $this->scope->onQueryExecute($query);
@@ -469,7 +469,7 @@ class ContentQueryParser
      */
     public function addOperation($operation)
     {
-        if (!in_array($operation, $this->operations)) {
+        if (!in_array($operation, $this->operations, true)) {
             $this->operations[] = $operation;
         }
     }
@@ -481,8 +481,8 @@ class ContentQueryParser
      */
     public function removeOperation($operation)
     {
-        if (in_array($operation, $this->operations)) {
-            $key = array_search($operation, $this->operations);
+        if (in_array($operation, $this->operations, true)) {
+            $key = array_search($operation, $this->operations, true);
             unset($this->operations[$key]);
         }
     }

--- a/src/Storage/Query/FrontendQueryScope.php
+++ b/src/Storage/Query/FrontendQueryScope.php
@@ -30,23 +30,7 @@ class FrontendQueryScope implements QueryScopeInterface
     }
 
     /**
-     * Get the config of all fields for a given content type.
-     *
-     * @param string $contentType
-     *
-     * @return array|false
-     */
-    public function getConfig($contentType)
-    {
-        if (array_key_exists($contentType, $this->searchableTypes)) {
-            return $this->searchableTypes[$contentType];
-        }
-
-        return false;
-    }
-
-    /**
-     * Get the config of one given field for a given content type.
+     * Get the default order setting for a given content type.
      *
      * @param string $contentType
      *
@@ -62,27 +46,24 @@ class FrontendQueryScope implements QueryScopeInterface
     }
 
     /**
-     * Iterates over the main config and delegates weighting to both
-     * searchable columns and searchable taxonomies.
+     * Iterates over the main config and sets up what the default ordering should be
      */
     protected function parseContenttypes()
     {
         $contentTypes = $this->config->get('contenttypes');
-
         foreach ($contentTypes as $type => $values) {
-            if (isset($values['sort'])) {
-                $this->orderBys[$type] = $values['sort'];
-                if (isset($values['singular_slug'])) {
-                    $this->orderBys[$values['singular_slug']] = $values['sort'];
-                }
+            $sort = $values['sort'] ?: '-datepublish';
+            $this->orderBys[$type] = $sort;
+            if (isset($values['singular_slug'])) {
+                $this->orderBys[$values['singular_slug']] = $sort;
             }
         }
     }
 
     /**
-     * @param QueryInterface $query
+     * @param ContentQueryInterface $query
      */
-    public function onQueryExecute(QueryInterface $query)
+    public function onQueryExecute(ContentQueryInterface $query)
     {
         $ct = $query->getContentType();
 

--- a/src/Storage/Query/Query.php
+++ b/src/Storage/Query/Query.php
@@ -18,6 +18,7 @@ class Query
      * Constructor.
      *
      * @param ContentQueryParser $parser
+     * @param TwigRecordsView    $recordsView
      */
     public function __construct(ContentQueryParser $parser, TwigRecordsView $recordsView)
     {
@@ -69,15 +70,15 @@ class Query
 
     /**
      * @param string $scopeName
-     * @param string $textquery
+     * @param string $textQuery
      * @param array  $parameters
      *
      * @return QueryResultset|null
      */
-    public function getContentByScope($scopeName, $textquery, $parameters = [])
+    public function getContentByScope($scopeName, $textQuery, array $parameters = [])
     {
         if ($scope = $this->getScope($scopeName)) {
-            $this->parser->setQuery($textquery);
+            $this->parser->setQuery($textQuery);
             $this->parser->setParameters($parameters);
             $this->parser->setScope($scope);
 
@@ -90,15 +91,15 @@ class Query
     /**
      * Helper to be called from Twig that is passed via a TwigRecordsView rather than the raw records.
      *
-     * @param $textquery
+     * @param $textQuery
      * @param array $parameters
      *
      * @return QueryResultset|null
      */
-    public function getContentForTwig($textquery, $parameters = [])
+    public function getContentForTwig($textQuery, array $parameters = [])
     {
         return $this->recordsView->createView(
-            $this->getContentByScope('frontend', $textquery, $parameters)
+            $this->getContentByScope('frontend', $textQuery, $parameters)
         );
     }
 }

--- a/src/Storage/Query/QueryParameterParser.php
+++ b/src/Storage/Query/QueryParameterParser.php
@@ -129,6 +129,8 @@ class QueryParameterParser
      * @param string            $value
      * @param ExpressionBuilder $expr
      *
+     * @throws QueryParseException
+     *
      * @return Filter|null
      */
     public function multipleKeyAndValueHandler($key, $value, $expr)
@@ -150,7 +152,7 @@ class QueryParameterParser
             $multipleValue = $this->multipleValueHandler($key, $val, $this->expr);
             if ($multipleValue) {
                 $filter = $multipleValue->getExpression();
-                $filterParams = $filterParams + $multipleValue->getParameters();
+                $filterParams += $multipleValue->getParameters();
             } else {
                 $val = $this->parseValue($val);
                 $placeholder = $key . '_' . $count;
@@ -182,6 +184,8 @@ class QueryParameterParser
      * @param string            $key
      * @param string            $value
      * @param ExpressionBuilder $expr
+     *
+     * @throws QueryParseException
      *
      * @return Filter|null
      */
@@ -233,6 +237,8 @@ class QueryParameterParser
      * @param string|array      $value
      * @param ExpressionBuilder $expr
      *
+     * @throws QueryParseException
+     *
      * @return Filter
      */
     public function defaultFilterHandler($key, $value, $expr)
@@ -257,16 +263,16 @@ class QueryParameterParser
             $filter->setExpression($composite);
 
             return $filter;
-        } else {
-            $val = $this->parseValue($value);
-            $placeholder = $key . '_1';
-            $exprMethod = $val['operator'];
-
-            $filter->setExpression($expr->andX($expr->$exprMethod($this->alias . $key, ':' . $placeholder)));
-            $filter->setParameters([$placeholder => $val['value']]);
-
-            return $filter;
         }
+
+        $val = $this->parseValue($value);
+        $placeholder = $key . '_1';
+        $exprMethod = $val['operator'];
+
+        $filter->setExpression($expr->andX($expr->$exprMethod($this->alias . $key, ':' . $placeholder)));
+        $filter->setParameters([$placeholder => $val['value']]);
+
+        return $filter;
     }
 
     /**
@@ -330,7 +336,7 @@ class QueryParameterParser
      * @param array  $params   Options to provide to the matched param
      * @param bool   $priority If set item will be prepended to start of list
      */
-    public function addValueMatcher($token, $params = [], $priority = null)
+    public function addValueMatcher($token, array $params = [], $priority = null)
     {
         if ($priority) {
             array_unshift($this->valueMatchers, ['token' => $token, 'params' => $params]);

--- a/src/Storage/Query/QueryScopeInterface.php
+++ b/src/Storage/Query/QueryScopeInterface.php
@@ -4,11 +4,11 @@ namespace Bolt\Storage\Query;
 
 /**
  * Interface QueryScopeInterface
- * Interface defines a class that provides additional scoping for a Query.
+ * Interface defines a class that provides additional scoping for a Content Query.
  *
  * @author Ross Riley <riley.ross@gmail.com>
  */
 interface QueryScopeInterface
 {
-    public function onQueryExecute(QueryInterface $query);
+    public function onQueryExecute(ContentQueryInterface $query);
 }

--- a/src/Storage/Query/SearchConfig.php
+++ b/src/Storage/Query/SearchConfig.php
@@ -144,7 +144,7 @@ class SearchConfig
                 (isset($options['searchable']) && $options['searchable'] === true)) {
                 if (isset($options['searchweight'])) {
                     $weight = (int) $options['searchweight'];
-                } elseif (isset($fields['slug']['uses']) && in_array($field, (array) $fields['slug']['uses'])) {
+                } elseif (isset($fields['slug']['uses']) && in_array($field, (array)$fields['slug']['uses'], true)) {
                     $weight = 100;
                 } else {
                     $weight = 50;

--- a/src/Storage/Query/SearchQuery.php
+++ b/src/Storage/Query/SearchQuery.php
@@ -42,6 +42,8 @@ class SearchQuery extends SelectQuery
      * This method sets the search filter which then triggers the process method.
      *
      * @param string $search full search query
+     *
+     * @throws QueryParseException
      */
     public function setSearch($search)
     {
@@ -92,6 +94,8 @@ class SearchQuery extends SelectQuery
      * This overrides the SelectQuery default to do some extra preparation for a search query.
      * Firstly it builds separate filters for the search query and then it removes the filter
      * from the params and the others will then get processed normally by the parent.
+     *
+     * @throws QueryParseException
      */
     protected function processFilters()
     {
@@ -139,7 +143,7 @@ class SearchQuery extends SelectQuery
 
         /** @var Filter $filter */
         foreach ($this->filters as $filter) {
-            if (in_array($filter->getKey(), $searchKeys)) {
+            if (in_array($filter->getKey(), $searchKeys, true)) {
                 $searchExpr->add($filter->getExpression());
             } else {
                 $wrapExpr->add($filter->getExpression());

--- a/src/Storage/Query/SelectQuery.php
+++ b/src/Storage/Query/SelectQuery.php
@@ -17,7 +17,7 @@ use Doctrine\DBAL\Query\QueryBuilder;
  *
  *  @author Ross Riley <riley.ross@gmail.com>
  */
-class SelectQuery implements QueryInterface
+class SelectQuery implements ContentQueryInterface
 {
     /** @var QueryBuilder */
     protected $qb;
@@ -202,7 +202,7 @@ class SelectQuery implements QueryInterface
             $query->where($this->getWhereExpression());
         }
         foreach ($this->getWhereParameters() as $key => $param) {
-            $query->setParameter($key, $param, (is_array($param)) ? Connection::PARAM_STR_ARRAY : null);
+            $query->setParameter($key, $param, is_array($param) ? Connection::PARAM_STR_ARRAY : null);
         }
 
         return $query;
@@ -262,6 +262,8 @@ class SelectQuery implements QueryInterface
      * Internal method that runs the individual key/value input through
      * the QueryParameterParser. This allows complicated expressions to
      * be turned into simple sql expressions.
+     *
+     * @throws \Bolt\Exception\QueryParseException
      */
     protected function processFilters()
     {


### PR DESCRIPTION
This adds default ordering by reverse datepublish order to content queries, to match the original Bolt behaviour.

Also a few minor code quality changes to the `Storage\Query` module.