### PR TITLE
[3.5][Tests] Set database:repair command call to non-interactive

### DIFF
--- a/tests/phpunit/unit/Nut/DatabaseRepairTest.php
+++ b/tests/phpunit/unit/Nut/DatabaseRepairTest.php
@@ -26,7 +26,7 @@ class DatabaseRepairTest extends BoltUnitTest
         $command = new DatabaseRepair($app);
         $tester = new CommandTester($command);
 
-        $tester->execute([]);
+        $tester->execute([], ['interactive' => false]);
         $result = $tester->getDisplay();
         $this->assertRegExp('/Your database is already up to date/', $result);
     }


### PR DESCRIPTION
This prevents blocking test execution when the test database schema can't be updated.
