### PR TITLE
[3.5] Fix for undefined property in FieldCollection::$collection

### DIFF
--- a/src/Storage/Field/Collection/FieldCollection.php
+++ b/src/Storage/Field/Collection/FieldCollection.php
@@ -145,7 +145,7 @@ class FieldCollection extends ArrayCollection implements FieldCollectionInterfac
     {
         $output = [];
 
-        foreach ($this->collection as $field) {
+        foreach ($this->getIterator() as $field) {
             $output[$field->getFieldName()] = $field->getValue();
         }
 


### PR DESCRIPTION
Fix serialization for field collection - remove reference to non-existing property.

When I want to serialize RepaterCollection with FieldCollection objects, I cannot do this because of reference to non-existing property and serialization cannot be done.

Fixes: #7558