### PR TITLE
Fix data compatibility in preview page

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -195,13 +195,7 @@ class Frontend extends ConfigurableBase
         }
 
         $contenttype = $this->getContentType($contenttypeslug);
-
-        $id = $request->request->get('id');
-        if ($id) {
-            $content = $this->storage()->getContent($contenttype['slug'], ['id' => $id, 'returnsingle' => true, 'status' => '!undefined']);
-        } else {
-            $content = $this->storage()->getContentObject($contenttypeslug);
-        }
+        $content = $this->storage()->getContentObject($contenttypeslug, [], false);
 
         $content->setFromPost($request->request->all(), $contenttype);
 

--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -56,12 +56,13 @@ class Storage
      *
      * @param array|string $contenttype
      * @param array        $values
+     * @param bool         $isRootType
      *
      * @throws \Exception
      *
      * @return \Bolt\Legacy\Content
      */
-    public function getContentObject($contenttype, $values = [])
+    public function getContentObject($contenttype, $values = [], $isRootType = true)
     {
         // Make sure $contenttype is an array, and not just the slug.
         if (!is_array($contenttype)) {
@@ -71,14 +72,14 @@ class Storage
         // If the contenttype has a 'class' specified, and the class exists,
         // Initialize the content as an object of that class.
         if (!empty($contenttype['class']) && class_exists($contenttype['class'])) {
-            $content = new $contenttype['class']($this->app, $contenttype, $values);
+            $content = new $contenttype['class']($this->app, $contenttype, $values, $isRootType);
 
             // Check if the class actually extends \Bolt\Legacy\Content.
             if (!($content instanceof Content)) {
                 throw new \Exception($contenttype['class'] . ' does not extend \\Bolt\\Legacy\\Content.');
             }
         } else {
-            $content = new Content($this->app, $contenttype, $values);
+            $content = new Content($this->app, $contenttype, $values, $isRootType);
         }
 
         return $content;


### PR DESCRIPTION
Fix for data compatibility in preview page by creating empty contentObject and fill post data to it.

Fixes: #7328 

Details
-------

Repeater type field in preview page has wrong type during serialization, because of this field was array instead of RepeatingFieldCollection

