### PR TITLE
[3.6] Add class support to new storage and where applicable disable all legacy polyfills

### DIFF
--- a/src/AccessControl/Permissions.php
+++ b/src/AccessControl/Permissions.php
@@ -364,12 +364,14 @@ class Permissions
      * @param string $permissionName
      * @param string $contenttype
      *
+     * @throws \Bolt\Exception\StorageException
+     *
      * @return bool
      */
     private function checkRoleContentTypePermission($roleName, $permissionName, $contenttype)
     {
         // Actions on non-existing contenttypes are not allowed.
-        if (!$this->app['storage']->getContentType($contenttype)) {
+        if (!$this->app['storage.metadata']->createContentType($contenttype)) {
             return false;
         }
 
@@ -688,7 +690,7 @@ class Permissions
                 // If content was not passed but our rule contains the content
                 // we need, lets fetch the Content object @see #3909
                 if (is_string($content) || ($contenttype && $contentId)) {
-                    $content = $this->app['storage']->getContent("$contenttype/$contentId", ['hydrate' => false]);
+                    $content = $this->app['query']->getContent("$contenttype/$contentId", ['hydrate' => false]);
                 }
 
                 if ((int) ($content['ownerid']) && ((int) ($content['ownerid']) === (int) ($user['id']))) {

--- a/src/Controller/Base.php
+++ b/src/Controller/Base.php
@@ -426,9 +426,7 @@ abstract class Base implements ControllerProviderInterface
         $params = array_merge($parameters, $whereParameters);
         unset($params['log_not_found']); // New storage system removes this functionality from the query engine
 
-        return $this->app['twig.records.view']->createView(
-            $this->app['query']->getContentByScope('frontend', $textQuery, $params)
-        );
+        return $this->app['query']->getContentForTwig($textQuery, $params);
     }
 
     /**

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -13,12 +13,17 @@ class MenuBuilder
     /** @var Application */
     private $app;
 
+    /**@var string @internal */
+    private $storageAccessor;
+
     /**
      * @param Application $app
+     * @param string      $storageAccessor
      */
-    public function __construct(Application $app)
+    public function __construct(Application $app, $storageAccessor = 'storage')
     {
         $this->app = $app;
+        $this->storageAccessor = $storageAccessor;
     }
 
     public function menu($identifier = null, $resolved = true)
@@ -203,8 +208,9 @@ class MenuBuilder
      */
     private function populateItemFromRecord(array $item, $path)
     {
-        /** @var \Bolt\Legacy\Content $content */
-        $content = $this->app['storage']->getContent($path, ['hydrate' => false]);
+        /** @var \Bolt\Legacy\Storage $engine */
+        $engine = $this->app[$this->storageAccessor];
+        $content = $engine->getContent($path, ['hydrate' => false]);
 
         if ($content) {
             if (empty($item['label'])) {

--- a/src/Provider/MenuServiceProvider.php
+++ b/src/Provider/MenuServiceProvider.php
@@ -21,9 +21,12 @@ class MenuServiceProvider implements ServiceProviderInterface
     {
         $app['menu'] = $app->share(
             function ($app) {
-                $builder = new MenuBuilder($app);
+                $accessor = 'storage';
+                if ($app['config']->get('general/compatibility/setcontent_legacy') === false) {
+                    $accessor = 'query';
+                }
 
-                return $builder;
+                return new MenuBuilder($app, $accessor);
             }
         );
 

--- a/src/Provider/StorageServiceProvider.php
+++ b/src/Provider/StorageServiceProvider.php
@@ -55,8 +55,11 @@ class StorageServiceProvider implements ServiceProviderInterface
                     $app['storage.metadata'],
                     $app['logger.system']
                 );
-                $storage->setLegacyService($app['storage.legacy_service']);
-                $storage->setLegacyStorage($app['storage.legacy']);
+                if ($app['config']->get('general/compatibility/setcontent_legacy', true)) {
+                    $storage->setLegacyService($app['storage.legacy_service']);
+                    $storage->setLegacyStorage($app['storage.legacy']);
+                }
+
                 $storage->setEntityBuilder($app['storage.entity_builder']);
                 $storage->setFieldManager($app['storage.field_manager']);
                 $storage->setCollectionManager($app['storage.collection_manager']);
@@ -74,10 +77,8 @@ class StorageServiceProvider implements ServiceProviderInterface
         $app['storage.content_repository'] = $app->protect(
             function ($classMetadata) use ($app) {
                 $repoClass = $app['storage.repository.default'];
-                /** @var Repository\ContentRepository $repo */
-                $repo = new $repoClass($app['storage'], $classMetadata);
 
-                return $repo;
+                return new $repoClass($app['storage'], $classMetadata);
             }
         );
 
@@ -85,9 +86,9 @@ class StorageServiceProvider implements ServiceProviderInterface
             function ($app) {
                 $allowedTags = $app['config']->get('general/htmlcleaner/allowed_tags', []);
                 $allowedAttributes = $app['config']->get('general/htmlcleaner/allowed_attributes', []);
-                $allowedWyswig = $app['config']->get('general/wysiwyg', []);
+                $allowedWysiwyg = $app['config']->get('general/wysiwyg', []);
 
-                return new Field\Sanitiser\Sanitiser($allowedTags, $allowedAttributes, $allowedWyswig);
+                return new Field\Sanitiser\Sanitiser($allowedTags, $allowedAttributes, $allowedWysiwyg);
             }
         );
 

--- a/src/Storage/EntityManager.php
+++ b/src/Storage/EntityManager.php
@@ -8,6 +8,7 @@ use Bolt\Legacy\Storage;
 use Bolt\Storage\Collection\CollectionManager;
 use Bolt\Storage\Mapping\ClassMetadata;
 use Bolt\Storage\Mapping\MetadataDriver;
+use Bolt\Storage\Query\Query;
 use Bolt\Storage\Repository\ContentRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata as ClassMetadataInterface;
@@ -24,7 +25,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * Legacy methods:
  *
- * @method array getContentType($contenttypeslug)
  * @method void  publishTimedRecords($contenttype)
  * @method void  depublishExpiredRecords($contenttype)
  */
@@ -54,6 +54,8 @@ class EntityManager implements EntityManagerInterface
     protected $defaultRepositoryFactory;
     /** @var  ContentLegacyService */
     protected $legacyService;
+    /** @var Query */
+    private $queryService;
 
     /**
      * Creates a new EntityManager that operates on the given database connection
@@ -94,6 +96,8 @@ class EntityManager implements EntityManagerInterface
      * @param string                 $className The type of entity to create
      * @param array                  $data      The data to use to hydrate the new entity
      * @param ClassMetadataInterface $metadata
+     *
+     * @throws InvalidRepositoryException
      *
      * @return Entity\Entity
      */
@@ -200,6 +204,8 @@ class EntityManager implements EntityManagerInterface
      * @param string     $className class name of the object to find
      * @param int|string $id        identity of the object to find
      *
+     * @throws InvalidRepositoryException
+     *
      * @return object the found object
      */
     public function find($className, $id)
@@ -213,6 +219,8 @@ class EntityManager implements EntityManagerInterface
      * The object will be entered into the database as a result of this operation.
      *
      * @param object $object the instance to persist to storage
+     *
+     * @throws InvalidRepositoryException
      *
      * @return bool
      */
@@ -234,6 +242,8 @@ class EntityManager implements EntityManagerInterface
      * Passed in object will be removed from the database as a result of this operation.
      *
      * @param object $object the object instance to remove
+     *
+     * @throws InvalidRepositoryException
      *
      * @return bool
      */
@@ -308,7 +318,7 @@ class EntityManager implements EntityManagerInterface
             $repo = new Repository($this, $classMetadata);
         }
 
-        if ($repo instanceof Repository\ContentRepository) {
+        if ($repo instanceof Repository\ContentRepository && $this->legacyService !== null) {
             /** @var ContentRepository $repo */
             $repo->setLegacyService($this->legacyService);
         }
@@ -440,6 +450,11 @@ class EntityManager implements EntityManagerInterface
         return $this->logger;
     }
 
+    public function setQueryService($queryService)
+    {
+        $this->queryService = $queryService;
+    }
+
     /******* Deprecated functions ******/
 
     /**
@@ -452,7 +467,9 @@ class EntityManager implements EntityManagerInterface
      */
     public function __call($method, array $args)
     {
-        return call_user_func_array([$this->legacy(), $method], $args);
+        if ($this->legacyStorage !== null) {
+            return call_user_func_array([$this->legacy(), $method], $args);
+        }
     }
 
     /**
@@ -464,10 +481,28 @@ class EntityManager implements EntityManagerInterface
      * @param array  $pager
      * @param array  $whereparameters
      *
-     * @return \Bolt\Legacy\Content|\Bolt\Legacy\Content[]
+     * @deprecated
+     *
+     * @return mixed
      */
     public function getContent($textquery, $parameters = [], &$pager = [], $whereparameters = [])
     {
         return $this->legacy()->getContent($textquery, $parameters, $pager, $whereparameters);
+    }
+
+    /**
+     * Drop in replacement for the legacy storage getContentType method.
+     *
+     * @param string $alias
+     *
+     * @return Mapping\ContentType|array
+     */
+    public function getContentType($alias)
+    {
+        if ($this->legacyStorage !== null) {
+            return $this->legacy()->getContentType($alias);
+        }
+
+        return $this->mapping->createContentType($alias);
     }
 }

--- a/src/Storage/Mapping/ClassMetadata.php
+++ b/src/Storage/Mapping/ClassMetadata.php
@@ -51,6 +51,16 @@ class ClassMetadata implements ClassMetadataInterface
     }
 
     /**
+     * Allows overriding the Entity Name for this mapping
+     *
+     * @param $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
      * Gets the fully-qualified class name of this persistent class.
      *
      * @return string

--- a/tests/phpunit/unit/Menu/MenuBuilderTest.php
+++ b/tests/phpunit/unit/Menu/MenuBuilderTest.php
@@ -191,8 +191,10 @@ class MenuBuilderTest extends BoltUnitTest
      * @param array|null $content
      * @param array      $item
      * @param string     $link
+     *
+     * @throws \ReflectionException
      */
-    public function testpopulateItemFromRecord($expected, $content, $item, $link)
+    public function testPopulateItemFromRecord($expected, $content, $item, $link)
     {
         $app = $this->getApp();
         $app['request'] = Request::createFromGlobals();
@@ -225,6 +227,7 @@ class MenuBuilderTest extends BoltUnitTest
         $this->setService('storage', $storage);
 
         $mb = new MenuBuilder($app);
+
         $method = new \ReflectionMethod(
             get_class($mb),
             'populateItemFromRecord'


### PR DESCRIPTION
OK, I think this is the last PR that makes 3.6 feature complete when using new storage instead of the old one.

This is all assuming you have:

```yml
compatibility:
    setcontent_legacy: false
```

in your config and you can now add something like this to your contenttype definition:

```yml
pages:
    name: Pages
    singular_name: Page
    fields:
        title:
            type: text
            class: large
            group: content
        slug:
            type: slug
            uses: title
        image:
            type: image
        teaser:
            type: html
            height: 150px
        body:
            type: html
            height: 300px
        template:
            type: templateselect
            label: Choose the template
    class: Bundle\Site\RossEntity
```

The only proviso here is that your entity needs to extend the base Content entity although this will hopefully change in the future when config and contenttypes have more precise classes with interfaces.

There's a few other minor clean ups in here, mainly code quality and when the flag is on this now allows us to disable all the legacy service injection into content entities.
