### PR TITLE
Make `getListingOrder()` behave correctly on new Storage Layer.

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -9,6 +9,7 @@ use Bolt\Asset\Target;
 use Bolt\Helpers\Input;
 use Bolt\Response\TemplateResponse;
 use Bolt\Storage\Entity\Taxonomy;
+use Bolt\Storage\Mapping\ContentType;
 use Bolt\Storage\Repository\TaxonomyRepository;
 use Bolt\Translation\Translator as Trans;
 use Silex\ControllerCollection;
@@ -523,14 +524,18 @@ class Frontend extends ConfigurableBase
      *  - we let `getContent()` sort by itself
      *  - we explicitly set it to sort on the general/listing_sort setting
      *
-     * @param array $contentType
+     * @param ContentType|array $contentType
      *
      * @return null|string
      */
-    private function getListingOrder(array $contentType)
+    private function getListingOrder($contentType)
     {
+        /** @deprecated since 3.6 to be removed in 4.0 */
         // An empty default isn't set in config yet, arrays got to hate them.
-        $contentType += ['taxonomy' => []];
+        if (is_array($contentType)) {
+            $contentType += ['taxonomy' => []];
+        }
+
         $taxonomies = $this->getOption('taxonomy');
         foreach ($contentType['taxonomy'] as $taxonomyName) {
             if ($taxonomies[$taxonomyName]['has_sortorder']) {


### PR DESCRIPTION
Since `$contentType` that's being passed in is now an object of `ContentType`, we need to handle it correctly. 

Fixes this: 

<img width="1068" alt="screen shot 2018-08-04 at 11 51 23" src="https://user-images.githubusercontent.com/1833361/43675092-9e8ca7fe-97de-11e8-85ba-60b33504ef65.png">
