### PR TITLE
Ensure firefox updates the CSRF value, even on a "soft refresh"

### DIFF
--- a/app/view/twig/editcontent/editcontent.twig
+++ b/app/view/twig/editcontent/editcontent.twig
@@ -84,7 +84,7 @@
             {% endif %}
 
             {{ form_start(context.form, {'attr': attr_form}) }}
-                {{ form_widget(context.form._token) }}
+                {{ form_widget(context.form._token, { 'attr': { 'autocomplete': 'off' } }) }}
 
                 <input{{ macro.attr(attributes.hid_editreferrer) }}>
                 <input{{ macro.attr(attributes.hid_contenttype) }}>


### PR DESCRIPTION
Because Firefox likes to be "helpful" and remember form inputs, when you refresh. This might cause CSRF tokens to not get updated on a refresh. Setting `autocomplete` off prevents this behaviour.