### PR TITLE
Get news through a proxy w/o authentication

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -434,9 +434,9 @@ hash_strength: 10
 
 # If you want Bolt installation get news through a proxy
 # httpProxy:
-#     host: my.proxy.server
-#     user: usr
-#     password: pwd
+#     host: scheme://my.proxy.server:port
+#     user: [usr]
+#     password: [pwd]
 
 # Options for backend user interface
 # backend:

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -457,12 +457,17 @@ class General extends AsyncBase
         ];
 
         if ($this->getOption('general/httpProxy')) {
-            $options['proxy'] = sprintf(
-                '%s:%s@%s',
-                $this->getOption('general/httpProxy/user'),
-                $this->getOption('general/httpProxy/password'),
-                $this->getOption('general/httpProxy/host')
-            );
+            if ($this->getOption('general/httpProxy/user') != '') {
+                $options['proxy'] = sprintf(
+                    '%s:%s@%s',
+                    $this->getOption('general/httpProxy/user'),
+                    $this->getOption('general/httpProxy/password'),
+                    $this->getOption('general/httpProxy/host')
+                );
+            }
+            else {
+                $options['proxy'] = $this->getOption('general/httpProxy/host');
+            }
         }
 
         return $options;

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -457,7 +457,7 @@ class General extends AsyncBase
         ];
 
         if ($this->getOption('general/httpProxy')) {
-            if ($this->getOption('general/httpProxy/user') != '') {
+            if ($this->getOption('general/httpProxy/user')) {
                 $options['proxy'] = sprintf(
                     '%s:%s@%s',
                     $this->getOption('general/httpProxy/user'),

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -464,8 +464,7 @@ class General extends AsyncBase
                     $this->getOption('general/httpProxy/password'),
                     $this->getOption('general/httpProxy/host')
                 );
-            }
-            else {
+            } else {
                 $options['proxy'] = $this->getOption('general/httpProxy/host');
             }
         }


### PR DESCRIPTION
This patch allows bolt to look for news using a proxy without user/password fields, if general/httpProxy/user is empty

Details
-------

This PR may be tested using a simple squid proxy

Choosing a target branch
------------------------

Change made on branch 3.5