### PR TITLE
Drag-sort for repeaters

### DIFF
--- a/app/config/contenttypes.yml.dist
+++ b/app/config/contenttypes.yml.dist
@@ -210,6 +210,7 @@ showcases:
         repeater:
             type: repeater
             group: repeater
+            label: Simple repeater example
             limit: 3
             prefix: "<p>This allows you to create multiple sets of fields. Use the add button at the bottom to create a new empty set.</p>"
             fields:

--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -133,6 +133,7 @@ field.image.label.alt: "Alt"
 field.markdown.label.markedview: "Markdown"
 field.markdown.label.preview: "Preview"
 
+field.repeater.caption: "Repeater set"
 field.repeater.collapse: "Collapse this set"
 field.repeater.collapse-all: "Collapse all"
 field.repeater.delete-set: "Delete Set"

--- a/app/resources/translations/nl_NL/messages.nl_NL.yml
+++ b/app/resources/translations/nl_NL/messages.nl_NL.yml
@@ -128,6 +128,7 @@ field.image.label.alt: "Alt."
 field.markdown.label.markedview: "Markdown"
 field.markdown.label.preview: "Voorvertoning"
 
+field.repeater.caption: "Repeater set"
 field.repeater.collapse: "Klap deze set in"
 field.repeater.collapse-all: "Klap alles in"
 field.repeater.delete-set: "Verwijder Set"

--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -173,8 +173,9 @@
                     var $container = $(this).closest('.repeater-group');
                     var fieldToUse = $container.find('.bolt-field-text input:first');
                     var headingToUpdate = $container.find('.repeater-heading');
+                    var fallback = headingToUpdate.data('default');
 
-                    headingToUpdate.text($(fieldToUse).val());
+                    headingToUpdate.text($(fieldToUse).val().substring(0,60) || fallback);
                 }
             });
 

--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -109,6 +109,18 @@
                 self._renumber();
             });
 
+            // Sortable repeaters
+            self.element.find('.repeater-slot').sortable({
+                cursor: "move",
+                handle: ".panel-heading",
+                classes: {
+                    "ui-sortable": "highlight"
+                },
+                stop: function () {
+                    self._renumber();
+                }
+            });
+
             self.element.on('click', '.delete-button', function () {
                 var setToDelete = $(this).closest('.repeater-group');
 
@@ -154,6 +166,16 @@
                 $container.find('.repeater-collapse').removeClass('collapsed');
 
                 setToShow.slideDown();
+            });
+
+            self.element.on('keyup change', 'input[type=text]', function () {
+                if ($(this).closest('.bolt-field-text').length) {
+                    var $container = $(this).closest('.repeater-group');
+                    var fieldToUse = $container.find('.bolt-field-text input:first');
+                    var headingToUpdate = $container.find('.repeater-heading');
+
+                    headingToUpdate.text($(fieldToUse).val());
+                }
             });
 
             // Add initial groups until minimum number is reached.

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -1,27 +1,35 @@
-<div class="repeater-group row panel panel-default">
-    <div class="panel-heading text-right">
-        <div class="btn-group">
-            <button type="button" class="btn btn-sm btn-default move-up">
-                <i class="fa fa-arrow-up" title="{{ __('general.phrase.move-up') }}"></i>
-            </button>
-            <button type="button" class="btn btn-sm btn-default move-down">
-                <i class="fa fa-arrow-down" title="{{ __('general.phrase.move-down') }}"></i>
-            </button>
-            {% if field.collapsible is not defined or field.collapsible %}
-                <button type="button" class="btn btn-sm btn-default repeater-collapse">
-                    <span class="collapsible" title="{{ __('field.repeater.collapse') }}">
-                        <i class="fa fa-compress"></i>
-                    </span>
-                    <span class="expandible" title="{{ __('field.repeater.expand') }}">
-                        <i class="fa fa-expand"></i>
-                    </span>
-                </button>
-            {% endif %}
-        </div>
-        <div class="btn-group">
-            <button type="button" class="btn btn-sm btn-silent-danger delete-button" title="{{ __('field.repeater.delete-set') }}">
-                <i class="fa fa-trash"></i>
-            </button>
+<div class="repeater-group panel panel-default">
+    <div class="panel-heading">
+        <div class="row">
+            <div class="col-xs-8 col-md-9">
+                <label class="main">
+                    {% set grouptitle = false %}
+                    {% for fieldname, f in field.fields if f['type'] == 'text' and grouptitle == false %}
+                        {% set grouptitle = content.get(fieldname) %}
+                    {% endfor %}
+                    <span class="text-muted"><i class="fa fa-ellipsis-v"></i></span> &nbsp;
+                    <span class="repeater-heading">{{ grouptitle }}</span>
+                </label>
+            </div>
+            <div class="col-xs-4 col-md-3 text-right">
+                <div class="btn-group">
+                    {% if field.collapsible is not defined or field.collapsible %}
+                        <button type="button" class="btn btn-sm btn-default repeater-collapse">
+                            <span class="collapsible" title="{{ __('field.repeater.collapse') }}">
+                                <i class="fa fa-compress"></i>
+                            </span>
+                            <span class="expandible" title="{{ __('field.repeater.expand') }}">
+                                <i class="fa fa-expand"></i>
+                            </span>
+                        </button>
+                    {% endif %}
+                </div>
+                <div class="btn-group">
+                    <button type="button" class="btn btn-sm btn-silent-danger delete-button" title="{{ __('field.repeater.delete-set') }}">
+                        <i class="fa fa-trash"></i>
+                    </button>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -7,8 +7,11 @@
                     {% for fieldname, f in field.fields if f['type'] == 'text' and grouptitle == false %}
                         {% set grouptitle = content.get(fieldname) %}
                     {% endfor %}
+                    {% set defaultcaption = __('field.repeater.caption') %}
                     <span class="text-muted"><i class="fa fa-ellipsis-v"></i></span> &nbsp;
-                    <span class="repeater-heading">{{ grouptitle }}</span>
+                    <span class="repeater-heading" data-default="{{ defaultcaption }}">
+                        {{ grouptitle|default(defaultcaption) }}
+                    </span>
                 </label>
             </div>
             <div class="col-xs-4 col-md-3 text-right">

--- a/app/view/twig/editcontent/fields/_repeater.twig
+++ b/app/view/twig/editcontent/fields/_repeater.twig
@@ -38,7 +38,8 @@
     {% endif %}
 
     <div class="repeater-slot">
-        <script type="text/template">
+        <script type="text/template" class="hidden">
+        {# ^^ Added class="hidden" to prevent jittery behavior when drag-sorting repeaters, if not hidden it becomes a "sortable" element, which causes the jittery behavior #}
             {% set index = '#' %}
             {{ include('@bolt/editcontent/fields/_repeater-group.twig', {'content': repeatfieldvals.getEmptySet, 'index': index}) }}
         </script>


### PR DESCRIPTION
- Removed move up/down buttons
- Added kebab for Repeater headers as the 'sortable' indicator
- Uses the first field type=text for the headers

