### PR TITLE
Fix issue with html fields

### DIFF
--- a/app/src/js/widgets/fields/fieldRepeater.js
+++ b/app/src/js/widgets/fields/fieldRepeater.js
@@ -113,11 +113,9 @@
             self.element.find('.repeater-slot').sortable({
                 cursor: "move",
                 handle: ".panel-heading",
-                classes: {
-                    "ui-sortable": "highlight"
-                },
-                stop: function () {
+                stop: function (event, ui) {
                     self._renumber();
+                    self._resetEditors(ui.item);
                 }
             });
 


### PR DESCRIPTION
issue: When the repeaters contain a field `type: html`, this field's content will be blank after sorting.