### PR TITLE
Feature: drag-sort for content blocks

### DIFF
--- a/app/src/js/widgets/fields/fieldBlock.js
+++ b/app/src/js/widgets/fields/fieldBlock.js
@@ -65,6 +65,15 @@
                 self._append(el);
             });
 
+            self.element.find('.block-slot').sortable({
+                cursor: "move",
+                handle: ".panel-heading",
+                stop: function (event, ui) {
+                    self._renumber();
+                    self._resetEditors(ui.item);
+                }
+            });
+
             self.element.on('click', '.delete-button', function () {
                 var setToDelete = $(this).closest('.block-group');
 
@@ -110,6 +119,18 @@
 
                 setToShow.slideDown();
             });
+
+            self.element.on('keyup change', 'input[type=text]', function () {
+                if ($(this).closest('.bolt-field-text').length) {
+                    var $container = $(this).closest('.block-group');
+                    var fieldToUse = $container.find('.bolt-field-text input:first');
+                    var headingToUpdate = $container.find('.block-heading');
+                    var fallback = headingToUpdate.data('default');
+
+                    headingToUpdate.text($(fieldToUse).val().substring(0,60) || fallback);
+                }
+            });
+
         },
 
         /**

--- a/app/view/twig/editcontent/fields/_block-group.twig
+++ b/app/view/twig/editcontent/fields/_block-group.twig
@@ -1,7 +1,6 @@
 {% if field.fields[block] is defined %}
 <div class="repeater-group block-group panel panel-default">
-    {% set grouplabel = field.fields[block].label|default('') %}
-    <div class="panel-heading" title="{{ grouplabel }}">
+    <div class="panel-heading">
         <div class="row">
             <div class="col-xs-8 col-md-9">
                 <label class="main">
@@ -9,11 +8,12 @@
                     {% for fieldname, f in field.fields[block].fields if f['type'] == 'text' and grouptitle == false %}
                         {% set grouptitle = content.get(fieldname) %}
                     {% endfor %}
+                    {% set grouplabel = field.fields[block].label|default('') %}
                     <span class="text-muted">
                         <i class="fa fa-ellipsis-v"></i>
                         {% set groupicon = field.fields[block].icon|default('') %}
                         {% if groupicon[:3] == 'fa:' %}
-                            <i class="fa fa-{{ groupicon[3:] }}"></i>
+                            <i class="fa fa-{{ groupicon[3:] }}" title="{{ grouplabel }}"></i>
                         {% endif %}
                     </span> &nbsp;
                     <span class="block-heading">{{ grouptitle|default(grouplabel) }}</span>

--- a/app/view/twig/editcontent/fields/_block-group.twig
+++ b/app/view/twig/editcontent/fields/_block-group.twig
@@ -1,20 +1,26 @@
 {% if field.fields[block] is defined %}
-<div class="repeater-group block-group row panel panel-default">
-    <div class="panel-heading">
+<div class="repeater-group block-group panel panel-default">
+    {% set grouplabel = field.fields[block].label|default('') %}
+    <div class="panel-heading" title="{{ grouplabel }}">
         <div class="row">
-            <div class="col-xs-5">
+            <div class="col-xs-8 col-md-9">
                 <label class="main">
-                    {{ field.fields[block].label }}
+                    {% set grouptitle = false %}
+                    {% for fieldname, f in field.fields[block].fields if f['type'] == 'text' and grouptitle == false %}
+                        {% set grouptitle = content.get(fieldname) %}
+                    {% endfor %}
+                    <span class="text-muted">
+                        <i class="fa fa-ellipsis-v"></i>
+                        {% set groupicon = field.fields[block].icon|default('') %}
+                        {% if groupicon[:3] == 'fa:' %}
+                            <i class="fa fa-{{ groupicon[3:] }}"></i>
+                        {% endif %}
+                    </span> &nbsp;
+                    <span class="block-heading">{{ grouptitle|default(grouplabel) }}</span>
                 </label>
             </div>
-            <div class="col-xs-7 text-right">
+            <div class="col-xs-4 col-md-3 text-right">
                 <div class="btn-group">
-                    <button type="button" class="btn btn-sm btn-default move-up">
-                        <i class="fa fa-arrow-up" title="{{ __('general.phrase.move-up') }}"></i>
-                    </button>
-                    <button type="button" class="btn btn-sm btn-default move-down">
-                        <i class="fa fa-arrow-down" title="{{ __('general.phrase.move-down') }}"></i>
-                    </button>
                     {% if field.collapsible is not defined or field.collapsible %}
                         <button type="button" class="btn btn-sm btn-default repeater-collapse">
                             <span class="collapsible" title="{{ __('field.repeater.collapse') }}">

--- a/app/view/twig/editcontent/fields/_block.twig
+++ b/app/view/twig/editcontent/fields/_block.twig
@@ -39,7 +39,7 @@
     <div class="block-slot">
         {% set blockfieldvals = context.content.get(contentkey) %}
         {% for blockname,block in field.fields %}
-            <script type="text/template" data-block-type="{{ blockname }}">
+            <script type="text/template" data-block-type="{{ blockname }}" class="hidden">
                 {% set index = '#' %}
                 {{ include('@bolt/editcontent/fields/_block-group.twig', {'content': blockfieldvals.getEmptySet, 'index': index, 'block': blockname}) }}
             </script>
@@ -65,7 +65,13 @@
                 {% endif %}
                 <li>
                     <a class="add-button" data-block-type="{{ blockname }}">
-                        <i class="fa fa-plus"></i> {{  __('field.block.label.add-set', {'%label%': block.label}) }}
+                        {% set groupicon = block.icon|default('') %}
+                        {% set grouplabel = block.label|default(blockname) %}
+                        {% if groupicon[:3] == 'fa:' %}
+                            <i class="fa fa-{{ groupicon[3:] }}"></i> {{  __('field.block.label.add-set', {'%label%': grouplabel}) }}
+                        {% else %}
+                            <i class="fa fa-plus"></i> {{  __('field.block.label.add-set', {'%label%': grouplabel}) }}
+                        {% endif %}
                     </a>
                 </li>
             {% endfor %}


### PR DESCRIPTION
* Blocks are now drag-sortable
* Added kebab icon to indicate drag-sortable-ness
* Added `icon` property
* Use first `type: text` field for the block header, if not use the block's `label`
* The new `icon` property also is displayed in the "Add new" button dropdown, falls back to the regular plus sign, if one is not defined
* Removed the move up/down buttons