### PR TITLE
Small update to repeater headers

### DIFF
--- a/app/resources/translations/en_GB/messages.en_GB.yml
+++ b/app/resources/translations/en_GB/messages.en_GB.yml
@@ -133,7 +133,6 @@ field.image.label.alt: "Alt"
 field.markdown.label.markedview: "Markdown"
 field.markdown.label.preview: "Preview"
 
-field.repeater.caption: "Repeater set"
 field.repeater.collapse: "Collapse this set"
 field.repeater.collapse-all: "Collapse all"
 field.repeater.delete-set: "Delete Set"

--- a/app/resources/translations/nl_NL/messages.nl_NL.yml
+++ b/app/resources/translations/nl_NL/messages.nl_NL.yml
@@ -128,7 +128,6 @@ field.image.label.alt: "Alt."
 field.markdown.label.markedview: "Markdown"
 field.markdown.label.preview: "Voorvertoning"
 
-field.repeater.caption: "Repeater set"
 field.repeater.collapse: "Klap deze set in"
 field.repeater.collapse-all: "Klap alles in"
 field.repeater.delete-set: "Verwijder Set"

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -8,7 +8,7 @@
                         {% set grouptitle = content.get(fieldname) %}
                     {% endfor %}
                     <span class="text-muted"><i class="fa fa-ellipsis-v"></i></span> &nbsp;
-                    <span class="repeater-heading" data-default="{{ defaultcaption }}">
+                    <span class="repeater-heading" data-default="{{ field.label }}">
                         {{ grouptitle|default(field.label) }}
                     </span>
                 </label>

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -7,7 +7,7 @@
                     {% for fieldname, f in field.fields if f['type'] == 'text' and grouptitle == false %}
                         {% set grouptitle = content.get(fieldname) %}
                     {% endfor %}
-                    {% set defaultcaption = __('field.repeater.caption') %}
+                    {% set defaultcaption = field.label %}
                     <span class="text-muted"><i class="fa fa-ellipsis-v"></i></span> &nbsp;
                     <span class="repeater-heading" data-default="{{ defaultcaption }}">
                         {{ grouptitle|default(defaultcaption) }}

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -7,10 +7,9 @@
                     {% for fieldname, f in field.fields if f['type'] == 'text' and grouptitle == false %}
                         {% set grouptitle = content.get(fieldname) %}
                     {% endfor %}
-                    {% set defaultcaption = field.label %}
                     <span class="text-muted"><i class="fa fa-ellipsis-v"></i></span> &nbsp;
                     <span class="repeater-heading" data-default="{{ defaultcaption }}">
-                        {{ grouptitle|default(defaultcaption) }}
+                        {{ grouptitle|default(field.label) }}
                     </span>
                 </label>
             </div>


### PR DESCRIPTION
Removed the `caption` option as we'll default to the repeater's label for the individual headers if there is no type: text field contained in the repeater.
