### PR TITLE
[3.5 Hotfix] Fix for Select values inside repeaters inside templatefields

### DIFF
--- a/app/view/twig/editcontent/_templatefields.twig
+++ b/app/view/twig/editcontent/_templatefields.twig
@@ -20,7 +20,7 @@
                 {% set templatelabelkey = templatefield.label ?: templatekey|capitalize %}
 
                 {# Ugly hack to be removed with Forms cutover … kittens are crying #}
-                {% if templatefield.type == 'select' %}
+                {% if templatefield.type in ['select', 'repeater', 'block'] %}
                     {% set values = context.values.select_choices.templatefields[templatekey] %}
                 {% endif %}
 

--- a/app/view/twig/editcontent/_templatefields.twig
+++ b/app/view/twig/editcontent/_templatefields.twig
@@ -29,7 +29,7 @@
                     key: 'templatefields-' ~ templatekey,
                     contentkey: templatekey,
                     values: values|default(),
-                    context: context|merge({ content: context.content.get('templatefields') }),
+                    context: context|merge({ content: context.content.get('templatefields'), selectvalues: values|default([]) }),
                     name: 'templatefields[' ~ templatekey ~ ']',
                     labelkey:  templatelabelkey
                 } %}

--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -35,7 +35,7 @@
         {% for rkey, rfield in field.fields %}
             {# Ugly hack to be removed with Forms cutover … kittens are crying #}
             {% if rfield.type == 'select' %}
-                {% set values = context.values.select_choices[name][rkey] %}
+                {% set values = (context.selectvalues is defined) ? context.selectvalues[rkey] : context.values.select_choices[name][rkey] %}
             {% endif %}
             {% set rfield = defaults|merge(rfield) %}
             {% set rcontext = {

--- a/src/Form/Resolver/Choice.php
+++ b/src/Form/Resolver/Choice.php
@@ -41,7 +41,7 @@ final class Choice
         $select = new ArrayObject();
 
         $this->build($select, $contentType->getFields());
-        $this->build($select, $templateFields, true);
+        $this->build($select, $templateFields, 'templatefields');
 
         return iterator_to_array($select) ?: null;
     }
@@ -53,28 +53,37 @@ final class Choice
      * @param array       $fields
      * @param bool        $isTemplateFields
      */
-    private function build(ArrayObject $select, array $fields, $isTemplateFields = false)
+    private function build(ArrayObject $select, array $fields, $prefix = null)
     {
         foreach ($fields as $name => $field) {
             if ($field['type'] === 'repeater') {
                 $subField = new ArrayObject();
                 $this->build($subField, $field['fields']);
-                $select[$name] = iterator_to_array($subField);
+                if ($prefix) {
+                    $select[$prefix][$name] = iterator_to_array($subField);
+                } else {
+                    $select[$name] = iterator_to_array($subField);
+                }
+
             }
             if ($field['type'] === 'block') {
                 foreach ($field['fields'] as $blockName => $block) {
                     $subField = new ArrayObject();
                     $this->build($subField, $block['fields']);
-                    $select[$name][$blockName] = iterator_to_array($subField);
+                    if ($prefix) {
+                        $select[$prefix][$name][$blockName] = iterator_to_array($subField);
+                    } else {
+                        $select[$name][$blockName] = iterator_to_array($subField);
+                    }
                 }
             }
             $values = $this->getValues($field);
             if ($values !== null) {
-                if ($isTemplateFields) {
-                    $select['templatefields'][$name] = $values;
-                    continue;
+                if ($prefix) {
+                    $select[$prefix][$name] = $values;
+                } else {
+                    $select[$name] = $values;
                 }
-                $select[$name] = $values;
             }
         }
     }


### PR DESCRIPTION
Fixes #7547 

The values lookup needed to be adjusted to handle repeaters in a templatefields field. Also the repeater-group template here is adjusted so that it can receive a pre-built set of values rather than looking them up.

This will need to be looked at to simplify because we've essentially got two separate code paths to handle normal vs templatefields repeaters but we can do that as a follow-up.