### PR TITLE
[WIP] Implement StorageTrait into SimpleExtension.

### DIFF
--- a/src/Extension/SimpleExtension.php
+++ b/src/Extension/SimpleExtension.php
@@ -3,6 +3,7 @@
 namespace Bolt\Extension;
 
 use Bolt\Events\ControllerEvents;
+use Bolt\Extension\StorageTrait;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -23,6 +24,7 @@ abstract class SimpleExtension extends AbstractExtension implements ServiceProvi
     use NutTrait;
     use TwigTrait;
     use TranslationTrait;
+    use StorageTrait;
 
     /**
      * {@inheritdoc}
@@ -35,6 +37,7 @@ abstract class SimpleExtension extends AbstractExtension implements ServiceProvi
         $this->extendAssetServices();
         $this->extendNutService();
         $this->extendTranslatorService();
+        $this->extendRepositoryMapping();
 
         $this->registerServices($app);
     }

--- a/tests/phpunit/unit/Extension/SimpleExtensionTest.php
+++ b/tests/phpunit/unit/Extension/SimpleExtensionTest.php
@@ -71,7 +71,7 @@ class SimpleExtensionTest extends BoltUnitTest
         $this->assertSame($expected, $events);
     }
 
-    public function testRegisterRepositoryMappings()
+    public function testStorageTraitHasBeenImported()
     {
         $ext = new NormalExtension();
         $storageTraitHasBeenImported = method_exists($ext, 'extendRepositoryMapping');

--- a/tests/phpunit/unit/Extension/SimpleExtensionTest.php
+++ b/tests/phpunit/unit/Extension/SimpleExtensionTest.php
@@ -70,4 +70,12 @@ class SimpleExtensionTest extends BoltUnitTest
 
         $this->assertSame($expected, $events);
     }
+
+    public function testRegisterRepositoryMappings()
+    {
+        $ext = new NormalExtension();
+        $storageTraitHasBeenImported = method_exists( $ext, 'extendRepositoryMapping');
+
+        $this->assertTrue( $storageTraitHasBeenImported );
+    }
 }

--- a/tests/phpunit/unit/Extension/SimpleExtensionTest.php
+++ b/tests/phpunit/unit/Extension/SimpleExtensionTest.php
@@ -74,8 +74,8 @@ class SimpleExtensionTest extends BoltUnitTest
     public function testRegisterRepositoryMappings()
     {
         $ext = new NormalExtension();
-        $storageTraitHasBeenImported = method_exists( $ext, 'extendRepositoryMapping');
+        $storageTraitHasBeenImported = method_exists($ext, 'extendRepositoryMapping');
 
-        $this->assertTrue( $storageTraitHasBeenImported );
+        $this->assertTrue($storageTraitHasBeenImported);
     }
 }


### PR DESCRIPTION
## Details
Based on the documentation linked below, to extend the storage repositories it is necessary to import `StorageTrait` and implement his function into your custom extension first.

This PR would implement `StorageTrait` directly into the `SimpleExtension` so that we can skip this step.

[https://docs.bolt.cm/3.5/extensions/advanced/storage-repositories](https://docs.bolt.cm/3.5/extensions/advanced/storage-repositories)