### PR TITLE
[3.6] Fix loading of taxonomy listing pages where legacy storage is disabled

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -10,6 +10,7 @@ use Bolt\Helpers\Input;
 use Bolt\Response\TemplateResponse;
 use Bolt\Storage\Entity\Taxonomy;
 use Bolt\Storage\Mapping\ContentType;
+use Bolt\Storage\Query\QueryResultset;
 use Bolt\Storage\Repository\TaxonomyRepository;
 use Bolt\Translation\Translator as Trans;
 use Silex\ControllerCollection;
@@ -280,7 +281,7 @@ class Frontend extends ConfigurableBase
      */
     public function taxonomy(Request $request, $taxonomytype, $slug)
     {
-        $taxonomy = $this->storage()->getTaxonomyType($taxonomytype);
+        $taxonomy = $this->app['config']->get('taxonomy/' . $taxonomytype);
         // No taxonomytype, no possible content.
         if (empty($taxonomy)) {
             return false;
@@ -313,7 +314,11 @@ class Frontend extends ConfigurableBase
             ;
 
             $results = $repo->getContentByTaxonomy($query);
-            $content = $results->getCollection();
+            $set = new QueryResultset();
+            foreach ($results->getCollection() as $record) {
+                $set->add([$record]);
+            }
+            $content = $this->app['twig.records.view']->createView($set);
         }
 
         if (!$this->isTaxonomyValid($content, $slug, $taxonomy)) {

--- a/src/Events/QueryEvent.php
+++ b/src/Events/QueryEvent.php
@@ -16,7 +16,7 @@ class QueryEvent extends Event
     protected $query;
     protected $result;
 
-    public function __construct(ContentQueryParser $query, $result = null)
+    public function __construct($query, $result = null)
     {
         $this->query = $query;
         $this->result = $result;

--- a/src/Storage/Repository/TaxonomyRepository.php
+++ b/src/Storage/Repository/TaxonomyRepository.php
@@ -38,6 +38,7 @@ class TaxonomyRepository extends Repository
         $results = $query->execute()->fetchAll();
         $set = new TaxonomyQueryResultset();
         $set->setEntityManager($this->getEntityManager());
+        $set->setEntityManager($this->getEntityManager());
         $set->add($results);
         $executeEvent = new QueryEvent($query, $set);
         $this->getEntityManager()->getEventManager()->dispatch(QueryEvents::EXECUTE, $executeEvent);

--- a/src/Storage/Repository/TaxonomyRepository.php
+++ b/src/Storage/Repository/TaxonomyRepository.php
@@ -38,7 +38,6 @@ class TaxonomyRepository extends Repository
         $results = $query->execute()->fetchAll();
         $set = new TaxonomyQueryResultset();
         $set->setEntityManager($this->getEntityManager());
-        $set->setEntityManager($this->getEntityManager());
         $set->add($results);
         $executeEvent = new QueryEvent($query, $set);
         $this->getEntityManager()->getEventManager()->dispatch(QueryEvents::EXECUTE, $executeEvent);

--- a/tests/phpunit/unit/Controller/FrontendTest.php
+++ b/tests/phpunit/unit/Controller/FrontendTest.php
@@ -378,12 +378,6 @@ class FrontendTest extends ControllerUnitTest
     {
         $this->setRequest(Request::create('/faketaxonomy/main'));
 
-        $storage = $this->getMockStorage();
-        $storage->expects($this->once())
-            ->method('getTaxonomyType')
-            ->will($this->returnValue(false));
-        $this->setService('storage', $storage);
-
         $response = $this->controller()->taxonomy($this->getRequest(), 'faketaxonomy', 'main');
         $this->assertFalse($response);
     }


### PR DESCRIPTION
Fixes #7646

Couple of minor adjustments needed to the taxonomy listing controller code. Also needed to be passed through the Twig Records View creator so the formatting is correct.