### PR TITLE
[3.6] Don't display actual Bolt version as Extension's requirement when it is not set

### DIFF
--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -267,7 +267,8 @@ class PackageManager
             // Handle non-Bolt packages
             if ($extension instanceof ResolvedExtension) {
                 $title = $extension->getDisplayName();
-                $constraint = $extension->getDescriptor() ? $extension->getDescriptor()->getConstraint() : null;
+                $descriptor = $extension->getDescriptor();
+                $constraint = $descriptor ? $descriptor->getConstraint() : null;
                 $readme = $this->linkReadMe($extension);
                 $config = $this->linkConfig($extension);
                 $valid = $extension->isValid();

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -267,7 +267,11 @@ class PackageManager
             // Handle non-Bolt packages
             if ($extension) {
                 $title = $extension->getDisplayName();
-                $constraint = $extension->getDescriptor()->getConstraint() ?: Bolt\Version::VERSION;
+                if ($extension->isManaged()) {
+                    $constraint = $extension->getDescriptor()->getConstraint() ?: Bolt\Version::VERSION;
+                } else {
+                    $constraint = Bolt\Version::VERSION;
+                }
                 $readme = $this->linkReadMe($extension);
                 $config = $this->linkConfig($extension);
                 $valid = $extension->isValid();

--- a/src/Composer/PackageManager.php
+++ b/src/Composer/PackageManager.php
@@ -265,20 +265,16 @@ class PackageManager
             $extension = $this->app['extensions']->getResolved($name);
 
             // Handle non-Bolt packages
-            if ($extension) {
+            if ($extension instanceof ResolvedExtension) {
                 $title = $extension->getDisplayName();
-                if ($extension->isManaged()) {
-                    $constraint = $extension->getDescriptor()->getConstraint() ?: Bolt\Version::VERSION;
-                } else {
-                    $constraint = Bolt\Version::VERSION;
-                }
+                $constraint = $extension->getDescriptor() ? $extension->getDescriptor()->getConstraint() : null;
                 $readme = $this->linkReadMe($extension);
                 $config = $this->linkConfig($extension);
                 $valid = $extension->isValid();
                 $enabled = $extension->isEnabled();
             } else {
                 $title = $name;
-                $constraint = Bolt\Version::VERSION;
+                $constraint = null;
                 $readme = null;
                 $config = null;
                 $valid = true;


### PR DESCRIPTION
Continuation of #7486.