### PR TITLE
Added method to login as specific user without password

### DIFF
--- a/src/AccessControl/Login.php
+++ b/src/AccessControl/Login.php
@@ -146,21 +146,23 @@ class Login extends AccessChecker
         }
 
         // Passwords can be ignored if you log in via loginAsUser()
-        $isValid = $ignorePassword ? true : $this->passwordFactory->verifyHash($password, $userAuth->getPassword());
+        if(!$ignorePassword){
+            $isValid = $this->passwordFactory->verifyHash($password, $userAuth->getPassword());
 
-        if (!$isValid) {
-            $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_PASSWORD));
+            if (!$isValid) {
+                $this->dispatcher->dispatch(AccessControlEvents::LOGIN_FAILURE, $event->setReason(AccessControlEvents::FAILURE_PASSWORD));
 
-            return $this->loginFailed($userEntity);
-        }
+                return $this->loginFailed($userEntity);
+            }
 
-        // Rehash password if not using Blowfish algorithm
-        if (!Blowfish::detect($userAuth->getPassword())) {
-            $userEntity->setPassword($this->passwordFactory->createHash($password, '$2y$'));
-            try {
-                $this->getRepositoryUsers()->update($userEntity);
-            } catch (NotNullConstraintViolationException $e) {
-                // Database needs updating
+            // Rehash password if not using Blowfish algorithm
+            if (!Blowfish::detect($userAuth->getPassword())) {
+                $userEntity->setPassword($this->passwordFactory->createHash($password, '$2y$'));
+                try {
+                    $this->getRepositoryUsers()->update($userEntity);
+                } catch (NotNullConstraintViolationException $e) {
+                    // Database needs updating
+                }
             }
         }
 

--- a/src/AccessControl/Login.php
+++ b/src/AccessControl/Login.php
@@ -83,7 +83,7 @@ class Login extends AccessChecker
     }
 
     /**
-     * Attempt to login a user with the given password. Accepts username or
+     * Attempt to login as a user with the given username without checking the password. Accepts username or
      * email.
      *
      * @param string             $userName
@@ -106,7 +106,7 @@ class Login extends AccessChecker
             return $this->loginCheckAuthtoken($authCookie, $event);
         }
 
-        $this->systemLogger->error('Login function called with empty username/password combination, or no authentication token.', ['event' => 'security']);
+        $this->systemLogger->error('LoginAsUser function called with empty username, or no authentication token.', ['event' => 'security']);
         throw new AccessControlException('Invalid login parameters.');
     }
 

--- a/src/AccessControl/Login.php
+++ b/src/AccessControl/Login.php
@@ -114,7 +114,7 @@ class Login extends AccessChecker
      * Check a user login request for username/password combinations.
      *
      * @param string $userName
-     * @param string $password
+     * @param string|null $password
      * @param AccessControlEvent $event
      * @param bool $ignorePassword
      *

--- a/src/AccessControl/Login.php
+++ b/src/AccessControl/Login.php
@@ -146,7 +146,7 @@ class Login extends AccessChecker
         }
 
         // Passwords can be ignored if you log in via loginAsUser()
-        if(!$ignorePassword){
+        if (!$ignorePassword) {
             $isValid = $this->passwordFactory->verifyHash($password, $userAuth->getPassword());
 
             if (!$isValid) {

--- a/src/AccessControl/Login.php
+++ b/src/AccessControl/Login.php
@@ -113,9 +113,10 @@ class Login extends AccessChecker
     /**
      * Check a user login request for username/password combinations.
      *
-     * @param string             $userName
-     * @param string             $password
+     * @param string $userName
+     * @param string $password
      * @param AccessControlEvent $event
+     * @param bool $ignorePassword
      *
      * @return bool
      */


### PR DESCRIPTION
As discussed on Slack, the added `loinAsUser()` method enabled extension creators to override the login mechanics and connect bolt to various kinds of SSO systems. Since the logic for user management and authentication is currently (pre 4.0) not centralized enough, a lot of needed code would have to be duplicated to archive this. (And we certainly dont want to go there ;) )

I also renamed the `loginCheckPassword()` method to `loginCheckUser()` since the name is more fitting it's function, especially when password checks are now optional.

PS: The file is identical to 3.5 and could also be backported?

I can provide guides on how to do this if needed.