### PR TITLE
Fix search results (Frontend, Omnisearch, Async)

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -518,7 +518,7 @@ class Frontend extends ConfigurableBase
             $searchResult = $this->getContent($textQuery, $params);
 
             $result = [
-                'results' => $searchResult,
+                'results' => $searchResult->getSortedResults(),
                 'query'   => [
                     'sanitized_q' => strip_tags($q),
                 ],

--- a/src/Storage/Query/SearchQueryResultset.php
+++ b/src/Storage/Query/SearchQueryResultset.php
@@ -49,4 +49,35 @@ class SearchQueryResultset extends QueryResultset
 
         $this->results[$label] = $sorted;
     }
+
+    /**
+     * @return array
+     */
+    public function getSortedResults()
+    {
+        $results = [];
+        foreach ($this->results as $type => $records) {
+            $scores = $this->scores[$type];
+
+            foreach ($records as $i => $record) {
+                $results[] = [
+                    'record' => $record,
+                    'score'  => $scores[$i],
+                ];
+            }
+        }
+
+        usort($results, function ($a, $b) {
+            if ($a['score'] == $b['score']) {
+                return 0;
+            }
+            return ($a['score'] < $b['score']) ? -1 : 1;
+        });
+
+        $results = array_map(function ($item) {
+            return $item['record'];
+        }, $results);
+
+        return $results;
+    }
 }


### PR DESCRIPTION
Fixes: #7667 

- Fixes Omnisearch in Async
- Fixes search results in Frontend search as well: it was always grouped per contenttype (but sorted within a contenttype group):
  - page/1
  - page/2
  - page/3
  - entry/1
  - entry/2
  - entry/3
  - showcase/1
  - showcase/2
  - showcase/3

The results between legacy and non-legacy are different, that may be because of a new/different search weighter.

For the code I looked at `Frontend`'s handling of search results. Not sure about the proper location for `getSortedResults` (see https://github.com/bolt/bolt/commit/d4e58ed815037debad013543c588d26acc6272c8). I'm kinda out of the loop with regards to the architecture.

Feedback more than welcome.