### PR TITLE
[3.6] Fix new setcontent

### DIFF
--- a/src/Storage/Field/Type/DateType.php
+++ b/src/Storage/Field/Type/DateType.php
@@ -45,7 +45,7 @@ class DateType extends FieldTypeBase
         foreach ($dateParams as $key => $val) {
             $time = strtotime($val);
             if (!$time) {
-                throw new QueryParseException('Unable to query $field = $val, not a valid date search', 1);
+                throw new QueryParseException("Unable to query $field = $val, not a valid date search", 1);
             }
             $replacement = date('Y-m-d H:i:s', $time);
             $query->setWhereParameter($key, $replacement);

--- a/src/Storage/Query/Directive/OrderDirective.php
+++ b/src/Storage/Query/Directive/OrderDirective.php
@@ -21,6 +21,9 @@ class OrderDirective
             return;
         }
 
+        // remove default order
+        $query->getQueryBuilder()->resetQueryPart('orderBy');
+
         $separatedOrders = $this->getOrderBys($order);
         foreach ($separatedOrders as $order) {
             $order = trim($order);
@@ -33,7 +36,7 @@ class OrderDirective
             } else {
                 $direction = null;
             }
-            $query->getQueryBuilder()->orderBy($order, $direction);
+            $query->getQueryBuilder()->addOrderBy($order, $direction);
         }
     }
 

--- a/src/Storage/Query/Directive/OrderDirective.php
+++ b/src/Storage/Query/Directive/OrderDirective.php
@@ -33,7 +33,7 @@ class OrderDirective
             } else {
                 $direction = null;
             }
-            $query->getQueryBuilder()->addOrderBy($order, $direction);
+            $query->getQueryBuilder()->orderBy($order, $direction);
         }
     }
 

--- a/src/Storage/Query/FrontendQueryScope.php
+++ b/src/Storage/Query/FrontendQueryScope.php
@@ -68,8 +68,7 @@ class FrontendQueryScope implements QueryScopeInterface
         $ct = $query->getContentType();
 
         // Setup default ordering of queries on a per-contenttype basis
-        $existing = $query->getParameter('order');
-        if (!$existing && isset($this->orderBys[$ct])) {
+        if (empty($query->getQueryBuilder()->getQueryPart('orderBy')) && isset($this->orderBys[$ct])) {
             $handler = new OrderDirective();
             $handler($query, $this->orderBys[$ct]);
         }

--- a/src/Storage/Query/Query.php
+++ b/src/Storage/Query/Query.php
@@ -98,6 +98,13 @@ class Query
      */
     public function getContentForTwig($textQuery, array $parameters = [])
     {
+        // fix BC break
+        if (func_num_args() === 3) {
+            $whereparameters = func_get_arg(2);
+            if (is_array($whereparameters) && !empty($whereparameters)) {
+                $parameters = array_merge($parameters, $whereparameters);
+            }
+        }
         return $this->recordsView->createView(
             $this->getContentByScope('frontend', $textQuery, $parameters)
         );

--- a/src/Storage/Query/SelectQuery.php
+++ b/src/Storage/Query/SelectQuery.php
@@ -150,7 +150,7 @@ class SelectQuery implements ContentQueryInterface
     {
         return array_intersect_key(
             $this->getWhereParameters(),
-            array_flip(preg_grep('/^' . $fieldName . '_/', array_keys($this->getWhereParameters())))
+            array_flip(preg_grep('/^' . $fieldName . '_\d+$/', array_keys($this->getWhereParameters())))
         );
     }
 


### PR DESCRIPTION
What gets fixed:
- `where` parameters are taken into account
- order by (default order happens only if no `orderby` is set in setcontent)