### PR TITLE
Use senderMail in outgoing mail

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -338,6 +338,9 @@ liveeditor: false
 #
 # Protip: If your webhost does not support SMTP, sign up for a (free) Sparkpost
 # account at https://www.sparkpost.com/pricing/ for sending emails reliably.
+#
+# The mail defaults use bolt@yourhostname with the site title as a default.
+# Override this with the senderName and senderMail fields
 
 # mailoptions:
 #     transport: smtp

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -432,8 +432,10 @@ class Users extends BackendBase
         );
 
         $name = $this->getOption('general/mailoptions/senderName', $this->getOption('general/sitename'));
-        $from = ['bolt@' . $request->getHost() => $name];
+        $sendermail = $this->getOption('general/mailoptions/senderMail', 'bolt@' . $request->getHost());
+        $from = [$sendermail => $name];
         $email = $this->getOption('general/mailoptions/senderMail', $email);
+        $this->getOption('general/mailoptions/senderMail');
         try {
             /** @var Message $message */
             $message = $mailer

--- a/src/Controller/Backend/Users.php
+++ b/src/Controller/Backend/Users.php
@@ -435,7 +435,6 @@ class Users extends BackendBase
         $sendermail = $this->getOption('general/mailoptions/senderMail', 'bolt@' . $request->getHost());
         $from = [$sendermail => $name];
         $email = $this->getOption('general/mailoptions/senderMail', $email);
-        $this->getOption('general/mailoptions/senderMail');
         try {
             /** @var Message $message */
             $message = $mailer


### PR DESCRIPTION
This PR makes Bolt use general/mailoptions/senderMail for outgoing account emails.
It also explains the option in the config.yml.dist

This fixes #6398