### PR TITLE
[3.5 Hotfix] Add the json_array column to the text search

### DIFF
--- a/src/Storage/Field/Type/RepeaterType.php
+++ b/src/Storage/Field/Type/RepeaterType.php
@@ -98,6 +98,9 @@ class RepeaterType extends FieldTypeBase
                         ->add(
                             $q->expr()->{$parsed['operator']}('f.value_string', ':' . $placeholder)
                         )
+                        ->add(
+                            $q->expr()->{$parsed['operator']}('f.value_json_array', ':' . $placeholder)
+                        )
                 );
             $filter->setParameter($placeholder, $parsed['value']);
             $count++;


### PR DESCRIPTION
Minor fix to include json_array columns in text searches within repeaters.

