### PR TITLE
[Hotfix] directives should always be cleared before re-parsing

### DIFF
--- a/src/Storage/Query/ContentQueryParser.php
+++ b/src/Storage/Query/ContentQueryParser.php
@@ -202,11 +202,11 @@ class ContentQueryParser
      */
     protected function parseDirectives()
     {
+        $this->directives = [];
+
         if (!$this->params) {
             return;
         }
-
-        $this->directives = [];
 
         foreach ($this->params as $key => $value) {
             if ($this->hasDirectiveHandler($key)) {

--- a/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
+++ b/tests/codeception/acceptance/100-BackendAdmin/BackendAdminCest.php
@@ -437,7 +437,7 @@ class BackendAdminCest extends AbstractAcceptanceTest
         $I->submitForm('form[name="content_edit"]', ['content_edit' => ['save' => 1]]);
 
         $I->see('The new Showcase has been saved.');
-        $I->seeLink('A Strange Drop Bear', '/bolt/editcontent/showcases/');
+        $I->seeLink('A Strange Drop Bear', '/bolt/editcontent/showcases/1');
     }
 
     /**

--- a/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
+++ b/tests/phpunit/unit/Storage/Query/ContentQueryParserTest.php
@@ -273,12 +273,14 @@ class ContentQueryParserTest extends BoltUnitTest
 
         $qb = new ContentQueryParser($app['storage'], $app['query.select']);
         $qb->setQuery('pages/5');
-        $qb->setParameter('printquery', true);
         $qb->parse();
         $this->assertEquals(['pages'], $qb->getContentTypes());
         $this->assertEquals('namedselect', $qb->getOperation());
         $this->assertEquals('5', $qb->getIdentifier());
 
+        $qb = new ContentQueryParser($app['storage'], $app['query.select']);
+        $qb->setQuery('pages/5');
+        $qb->setParameter('printquery', true);
         $this->expectOutputString('SELECT _pages.* FROM bolt_pages _pages WHERE _pages.id = :id_1');
         $res = $qb->fetch();
         $this->assertInstanceOf(Entity\Content::class, $res);


### PR DESCRIPTION
Fixes #7679 

When running a new query the flags always need to be reset. Fixes an issue where flags like `returnsingle` were sticking around between queries. Credit @JarJak for spotting this one.