### PR TITLE
Stop stack being queried in _macro.twig when stack is disabled

### DIFF
--- a/app/view/twig/_macro/_macro.twig
+++ b/app/view/twig/_macro/_macro.twig
@@ -200,10 +200,13 @@
         } %}
         <button{{ hattr(attr) }}><i class="fa fa-download"></i> {{ __('field.general.select-from-server') }}</button>
 
-        {% set stack = stack(type) %}
 
         {# Button: Select from Stack #}
-        {% if not config.get('general/backend/stack/disable', false) and stack %}
+        {% if not config.get('general/backend/stack/disable', false) %}
+        	{% set stack = stack(type) %}
+
+		{% if stack %}
+
             <div class="btn-group">
                 <button type="button" class="btn btn-tertiary btn-sm dropdown-toggle" data-toggle="dropdown">
                     <i class="fa fa-paperclip"></i>
@@ -217,6 +220,7 @@
                     {% endfor %}
                 </ul>
             </div>
+		{% endif %}
         {% endif %}
 
     </div>


### PR DESCRIPTION
If assets are stored in an external repository (e.g. S3) then file accesses are slow and disabling the stack can greatly speed up the backend.  This fix removes a stack query that is run when the stack is disabled and causes a major slowdown.  (PS I'm new to pull requests and Bolt, sorry if I've done something wrong).