### PR TITLE
[3.5] fix for incompatibility with latest passwordlib (origin and bolt fork)

### DIFF
--- a/src/Legacy/PasswordLib/PasswordLibFactory.php
+++ b/src/Legacy/PasswordLib/PasswordLibFactory.php
@@ -22,7 +22,7 @@ final class PasswordLibFactory extends Factory
     /**
      * {@inheritdoc}
      */
-    public function createHash($password, $prefix = '$2a$')
+    public function createHash($password, $prefix = '$2a$', array $options = array())
     {
         if ($prefix === false) {
             throw new \DomainException('Unsupported Prefix Supplied');
@@ -30,7 +30,7 @@ final class PasswordLibFactory extends Factory
         foreach ($this->implementations as $impl) {
             if ($impl::getPrefix() == $prefix) {
                 /** @var AbstractPassword $instance */
-                $instance = new $impl();
+                $instance = new $impl($options);
                 $instance->setGenerator($this->getGenerator());
 
                 return $instance->create($password);


### PR DESCRIPTION
There has been a change in the latest PasswordLib package, both the original package and the bolt fork. Du a change i method signature, the extending legacy code in bolt now throws a warning.

```
ContextErrorException in PasswordLibFactory.php line 15:
Warning: Declaration of Bolt\Legacy\PasswordLib\PasswordLibFactory::createHash($password, $prefix = '$2a$') should be compatible with PasswordLib\Password\Factory::createHash($password, $prefix = '$2a$', array $options = Array)
```

This fix is actually only a backport for a change that is already in Bolt 3.6