### PR TITLE
Add missing part of select field values in repeaters

### DIFF
--- a/app/view/twig/editcontent/fields/_repeater-group.twig
+++ b/app/view/twig/editcontent/fields/_repeater-group.twig
@@ -57,7 +57,7 @@
         {% for rkey, rfield in field.fields %}
             {# Ugly hack to be removed with Forms cutover … kittens are crying #}
             {% if rfield.type == 'select' %}
-                {% set values = context.values.select_choices[name][rkey] %}
+                {% set values = (context.selectvalues is defined) ? context.selectvalues[rkey] : context.values.select_choices[name][rkey] %}
             {% endif %}
             {% set rfield = defaults|merge(rfield) %}
             {% set rcontext = {


### PR DESCRIPTION
As noted by @tiito78 in #7697, this part of the original PR #7636 got lost when merging into 3.6. This PR rectifies that. Thanks, @tiito78 