### PR TITLE
Performance improvements: No joins in query for pagers

### DIFF
--- a/src/Storage/ContentRequest/Listing.php
+++ b/src/Storage/ContentRequest/Listing.php
@@ -129,6 +129,7 @@ class Listing
             $queryCopy->setMaxResults(null);
             $queryCopy->setFirstResult(null);
             $queryCopy->resetQueryPart('orderBy');
+            $queryCopy->resetQueryPart('join');
 
             $totalResults = (int) count($queryCopy->execute()->fetchAll());
             $start = $query->getFirstResult() ? $query->getFirstResult() : 0;


### PR DESCRIPTION
As discovered by Czeslaw on Slack: 

> @bob previously i was too optimistic :slightly_smiling_face: turned out that te server was holding up some kind of temporary cache for the query and it returned the results from this cache :slightly_smiling_face: but - i found a proper solution, i've added `$queryCopy->resetQueryPart('join');` to line 131 of `Listing.php`
because that is basically the place where the [paging] occurs
this way i preserved all the paging behavior, but unbind the unnecessary relations
this works fine, and gives 1.5ms reaction