### PR TITLE
Handle Empty Search Parameter Error

### DIFF
--- a/src/Storage/Query/Handler/SearchQueryHandler.php
+++ b/src/Storage/Query/Handler/SearchQueryHandler.php
@@ -32,6 +32,11 @@ class SearchQueryHandler
             $query->setContentType($contentType);
 
             $searchParam = $contentQuery->getParameter('filter');
+            /** If we have an empty search filter then we need to return early */
+            if (empty($searchParam)) {
+                return $set;
+            }
+
             $query->setParameters($contentQuery->getParameters());
             $query->setSearch($searchParam);
 


### PR DESCRIPTION
Fixes #7711

Credit to @ntomka for spotting this one. Since the content search depends on having a value to search against we need to make sure we don't send empty strings to the search handler.

If we get one, we just return an empty resultset, site owners can then handle the error in frontend rather than throwing an exception.