### PR TITLE
chore: add PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "lstrojny/phpunit-function-mocker": "^0.3 || ^0.4",
         "phpunit/dbunit": "^1.3 || ^3.0",
         "phpunit/php-code-coverage": "^2.0 || ^4.0",
-        "phpunit/phpunit": "^4.8 || ^5.7",
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.4",
         "psr/cache": "^1.0",
         "psr/simple-cache": "^1.0",
         "roave/security-advisories": "dev-master@dev",


### PR DESCRIPTION
Allow PHPUnit 6 for CI and testing.


Details
-------

Currently the CI jobs use PHPUnit 5.7 but should use 6.4 as this is set in the env variable `SYMFONY_PHPUNIT_VERSION=6.4`.


<!--
Choosing a target branch
------------------------

Bolt has a branching strategy that follow these rules: 

 * `release/3.X` — "stable" branch (Note: `X` will be a number)
 * `release/3.Y` — "beta" branch (Note: `Y` will be a number, one greater than `X`)
 * `3.x` — "alpha" branch, major features should be sent here (Note: `x` is literal, it really is an "x")
 * `master` — 4.x development. Things will break, and if they do you get to keep both pieces!
-->
