### PR TITLE
Fixed asset url generation

### DIFF
--- a/src/Asset/File/Queue.php
+++ b/src/Asset/File/Queue.php
@@ -62,10 +62,12 @@ class Queue implements QueueInterface
             $asset->setPackageName('extensions');
         }
 
+        $key = $asset->getPackageName()."/".$asset->getPath();
+
         if ($asset->getType() === 'javascript') {
-            $this->javascript[$asset->getPath()] = $asset;
+            $this->javascript[$key] = $asset;
         } elseif ($asset->getType() === 'stylesheet') {
-            $this->stylesheet[$asset->getPath()] = $asset;
+            $this->stylesheet[$key] = $asset;
         } else {
             throw new \InvalidArgumentException(sprintf('Requested asset type %s is not valid.', $asset->getType()));
         }
@@ -128,7 +130,9 @@ class Queue implements QueueInterface
 
         if ($asset->getZone() !== Zone::get($request)) {
             return;
-        } elseif ($asset->isLate()) {
+        }
+
+        if ($asset->isLate()) {
             if ($asset->getLocation() === null) {
                 $location = Target::END_OF_BODY;
             } else {

--- a/src/Asset/File/Queue.php
+++ b/src/Asset/File/Queue.php
@@ -62,13 +62,10 @@ class Queue implements QueueInterface
             $asset->setPackageName('extensions');
         }
 
-        $url = $this->packages->getUrl($asset->getPath(), $asset->getPackageName());
-        $asset->setUrl($url);
-
         if ($asset->getType() === 'javascript') {
-            $this->javascript[$url] = $asset;
+            $this->javascript[$asset->getPath()] = $asset;
         } elseif ($asset->getType() === 'stylesheet') {
-            $this->stylesheet[$url] = $asset;
+            $this->stylesheet[$asset->getPath()] = $asset;
         } else {
             throw new \InvalidArgumentException(sprintf('Requested asset type %s is not valid.', $asset->getType()));
         }
@@ -126,6 +123,9 @@ class Queue implements QueueInterface
      */
     protected function processAsset(FileAssetInterface $asset, Request $request, Response $response)
     {
+        $url = $this->packages->getUrl($asset->getPath(), $asset->getPackageName());
+        $asset->setUrl($url);
+
         if ($asset->getZone() !== Zone::get($request)) {
             return;
         } elseif ($asset->isLate()) {

--- a/tests/phpunit/unit/Asset/File/QueueTest.php
+++ b/tests/phpunit/unit/Asset/File/QueueTest.php
@@ -143,9 +143,9 @@ class QueueTest extends TestCase
     public function testProcessLateWithLocation()
     {
         list($css1, $css2, $js) = $this->getAssets();
-        $css1->setZone('backend')->setLate(false)->setLocation(Target::AFTER_HEAD_CSS);;
-        $css2->setZone('backend')->setLate(false)->setLocation(Target::AFTER_HEAD_CSS);;
-        $js->setZone('backend')->setLate(false)->setLocation(Target::AFTER_HEAD_JS);;
+        $css1->setZone('backend')->setLate(false)->setLocation(Target::AFTER_HEAD_CSS);
+        $css2->setZone('backend')->setLate(false)->setLocation(Target::AFTER_HEAD_CSS);
+        $js->setZone('backend')->setLate(false)->setLocation(Target::AFTER_HEAD_JS);
         $queue = $this->getQueue();
         $queue->add($css1);
         $queue->add($css2);


### PR DESCRIPTION
Before this change, the url of assets was generated through Package->getPath(), which relys on the master request inside the request stack. All of this is executed during initialization of the application inside the Applications constructor.

**Problem**
The request stack is empty during this execution phase as it is only pushed to the stack at start of `$app->run()`. THis means, the old method is working on an empty request and can not see any potential url prefixes from subfolder installs.

Interestingly, bolt's own assets are added inside the twig templates via `{{asset()}}`, which is executed during `$app->run()` and using a proper request.

**Solution**
The url generation has been moved from the `add` to the `processAsset` method. This method is executed during `$app->run()` and contains a filled request stack.

I also changed the key of the assets in 'add() ' from the now non existant `$url` to it's `$path`. It seems to be used only to check for uniqueness of assets and is working correctly there.