### PR TITLE
Hack around DBAL Sqlite schema diff bug, still needed on DBAL 2.9

### DIFF
--- a/src/Storage/Database/Schema/Comparison/Sqlite.php
+++ b/src/Storage/Database/Schema/Comparison/Sqlite.php
@@ -29,7 +29,9 @@ class Sqlite extends BaseComparator
             $this->ignoredChanges[] = new IgnoredChange('changedColumns', 'type', 'string', 'guid');
             $this->ignoredChanges[] = new IgnoredChange('changedColumns', 'type', 'json', 'string');
         }
-        if (DBAL\Version::compare('2.9.0') > 0) {
+        // A proper fix for this won't land until DBAL 3.0
+        // https://github.com/doctrine/dbal/pull/3221
+        if (DBAL\Version::compare('3.0.0') > 0) {
             $this->ignoredChanges[] = new IgnoredChange('changedColumns', 'default', 'json', 'json');
         }
     }


### PR DESCRIPTION
See: https://github.com/doctrine/dbal/pull/3221
See: https://github.com/bolt/bolt/pull/7570
