### PR TITLE
Allow custom attributes for image fields

### DIFF
--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -54,7 +54,7 @@
 
 {% set attribute_fields = [] %}
 {% for attrib in option.attrib|default([]) %}
-    {% set aid = attrib|lower|replace({'alt text': 'alt'}) %}
+    {% set aid = attrib|lower|replace({' ': '_'}) %}
 
     {% if aid is not empty %}
         {% if aid == 'title' %}
@@ -62,7 +62,7 @@
         {% elseif aid == 'alt' %}
             {% set atitle = __('field.image.label.alt') %}
         {% else %}
-            {% set atitle = aid %}
+            {% set atitle = attrib %}
         {% endif %}
 
         {% set uid = key ~ '-' ~ aid %}

--- a/app/view/twig/editcontent/fields/_image.twig
+++ b/app/view/twig/editcontent/fields/_image.twig
@@ -56,11 +56,13 @@
 {% for attrib in option.attrib|default([]) %}
     {% set aid = attrib|lower|replace({'alt text': 'alt'}) %}
 
-    {% if aid in ['title', 'alt'] %}
+    {% if aid is not empty %}
         {% if aid == 'title' %}
             {% set atitle = __('general.phrase.title') %}
         {% elseif aid == 'alt' %}
             {% set atitle = __('field.image.label.alt') %}
+        {% else %}
+            {% set atitle = aid %}
         {% endif %}
 
         {% set uid = key ~ '-' ~ aid %}


### PR DESCRIPTION
Removing the boudaries that an attribute on an imagefield can only use 'title' of 'alt'.
Make way for custom attributes, such as multilingual captions and more.

Hope this can merge, and may help others!

Fixes: #7741 

