### PR TITLE
[SECURITY FIX] filemanager file extensions

### DIFF
--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -405,7 +405,7 @@ class FilesystemManager extends AsyncBase
     private function isExtensionChangedAndIsChangeAllowed($oldName, $newName)
     {
         $user = $this->getUser();
-        if ($this->users()->hasRole($user['id'], 'root')) {
+        if ($this->users()->hasRole($user['id'], 'root') || $this->users()->hasRole($user['id'], 'admin')) {
             return true;
         }
 
@@ -446,7 +446,7 @@ class FilesystemManager extends AsyncBase
         $extension = pathinfo($filename, PATHINFO_EXTENSION);
         $allowedExtensions = $this->getAllowedUploadExtensions();
 
-        return in_array($extension, $allowedExtensions);
+        return $extension === '' || in_array($extension, $allowedExtensions);
     }
 
     /**

--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -130,6 +130,13 @@ class FilesystemManager extends AsyncBase
         $parentPath = $request->request->get('parentPath');
         $filename = $request->request->get('filename');
 
+        if ($this->validateFileExtension($filename) === false) {
+            return $this->json(
+                sprintf("File extension not allowed: %s", $filename),
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+
         try {
             $file = $this->filesystem()->getFile("$namespace://$parentPath/$filename");
             $file->put('');
@@ -315,8 +322,15 @@ class FilesystemManager extends AsyncBase
         $oldName = $request->request->get('oldname');
         $newName = $request->request->get('newname');
 
-        if (!$this->isMatchingExtension($oldName, $newName)) {
+        if (!$this->isExtensionChangedAndIsChangeAllowed($oldName, $newName)) {
             return $this->json(Trans::__('general.phrase.only-root-change-file-extensions'), Response::HTTP_FORBIDDEN);
+        }
+
+        if ($this->validateFileExtension($newName) === false) {
+            return $this->json(
+                sprintf("File extension not allowed: %s", $newName),
+                Response::HTTP_BAD_REQUEST
+            );
         }
 
         try {
@@ -354,6 +368,13 @@ class FilesystemManager extends AsyncBase
         $newName = $request->request->get('newname');
 
         try {
+            $dir = $this->filesystem()->getDir("$namespace://$parent/$oldName");
+            if (!$dir) {
+                return $this->json(
+                    sprintf("Only directories are allowed to be renamed with this method"),
+                    Response::HTTP_BAD_REQUEST
+                );
+            }
             $this->filesystem()->rename("$namespace://$parent/$oldName", "$parent/$newName");
 
             return $this->json($newName, Response::HTTP_OK);
@@ -381,7 +402,7 @@ class FilesystemManager extends AsyncBase
      *
      * @return bool
      */
-    private function isMatchingExtension($oldName, $newName)
+    private function isExtensionChangedAndIsChangeAllowed($oldName, $newName)
     {
         $user = $this->getUser();
         if ($this->users()->hasRole($user['id'], 'root')) {
@@ -408,5 +429,33 @@ class FilesystemManager extends AsyncBase
             $message . ': ' . $exception->getMessage(),
             ['event' => 'exception', 'exception' => $exception]
         );
+    }
+
+    /**
+     * @param string $filename
+     *
+     * @return bool
+     */
+    private function validateFileExtension($filename)
+    {
+        // no UNIX-hidden files
+        if ($filename[0] === '.') {
+            return false;
+        }
+        // only whitelisted extensions
+        $extension = pathinfo($filename, PATHINFO_EXTENSION);
+        $allowedExtensions = $this->getAllowedUploadExtensions();
+
+        return in_array($extension, $allowedExtensions);
+    }
+
+    /**
+     * Get the array of configured acceptable file extensions.
+     *
+     * @return array
+     */
+    private function getAllowedUploadExtensions()
+    {
+        return $this->app['config']->get('general/accept_file_types');
     }
 }

--- a/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
+++ b/tests/phpunit/unit/Controller/Async/FilesystemManagerTest.php
@@ -5,6 +5,7 @@ namespace Bolt\Tests\Controller\Async;
 use Bolt\Common\Json;
 use Bolt\Filesystem\Handler\HandlerInterface;
 use Bolt\Response\TemplateView;
+use Bolt\Storage\Entity\Users;
 use Bolt\Tests\Controller\ControllerUnitTest;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -254,6 +255,8 @@ class FilesystemManagerTest extends ControllerUnitTest
 
     public function testRenameToInvalidExtension()
     {
+        $this->setSessionUser(new Users($this->getService('users')->getUser('admin')));
+
         $this->createObject('file', self::FILE_NAME);
         $response = $this->renameObject('file', self::FILE_NAME, self::FILE_NAME_NOT_ALLOWED);
 


### PR DESCRIPTION
A logged in user could rename previosly uploaded file to any extension. Uploading malicious file and changing it's extension to .php could lead to remote code execution.

Now files can be renamed only to extensions that are allowed for upload.