### PR TITLE
Add extra workaround for HTML-like and Image fields in preview

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -228,7 +228,6 @@ class Frontend extends ConfigurableBase
         }
 
         $this->fixBlockFieldsForPreview($content);
-
         $this->fixHTMLFieldsForPreview($content);
 
         $liveEditor = $request->get('_live-editor-preview');
@@ -294,7 +293,7 @@ class Frontend extends ConfigurableBase
      * an image. Like they are in a "real" page.
      *
      * This is needed to make previewing content with block fields fully working.
-     * See:
+     * See: https://github.com/bolt/bolt/issues/7753
      */
     private function fixHTMLFieldsForPreview($record)
     {

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -229,6 +229,8 @@ class Frontend extends ConfigurableBase
 
         $this->fixBlockFieldsForPreview($content);
 
+        $this->fixHTMLFieldsForPreview($content);
+
         $liveEditor = $request->get('_live-editor-preview');
         if (!empty($liveEditor)) {
             $jsFile = (new JavaScript('js/ckeditor/ckeditor.js', 'bolt'))
@@ -279,8 +281,33 @@ class Frontend extends ConfigurableBase
                             $newArray[] = $v;
                         }
                     }
-                    $this->setBlockFieldValue($record, $fieldSlug, $newArray);
+                    $this->setFieldValue($record, $fieldSlug, $newArray);
                 }
+            }
+        }
+
+        return $record;
+    }
+
+    /**
+     * Helper function to make sure HTML-like fields are Twig_Markup, and image fields are
+     * an image. Like they are in a "real" page.
+     *
+     * This is needed to make previewing content with block fields fully working.
+     * See:
+     */
+    private function fixHTMLFieldsForPreview($record)
+    {
+        foreach ($record->contenttype['fields'] as $fieldSlug => $fieldSettings) {
+            if (in_array($fieldSettings['type'], ['html', 'text', 'textarea', 'markdown'])) {
+                $fieldValue = new \Twig_Markup($this->getFieldValue($record, $fieldSlug), "UTF-8");
+
+                $this->setFieldValue($record, $fieldSlug, $fieldValue);
+            }
+            if ($fieldSettings['type'] === 'image') {
+                $fieldValue = $this->getFieldValue($record, $fieldSlug);
+
+                $this->setFieldValue($record, $fieldSlug, $fieldValue['file']);
             }
         }
 
@@ -301,7 +328,18 @@ class Frontend extends ConfigurableBase
         return null;
     }
 
-    private function setBlockFieldValue($record, $field, array $value)
+    private function getFieldValue($record, $field)
+    {
+        if ($record instanceof Content) {
+            return $record->get($field);
+        } elseif (isset($record->values[$field]) && is_array($record->values[$field])) {
+            return $record->values[$field];
+        }
+
+        return null;
+    }
+
+    private function setFieldValue($record, $field, $value)
     {
         if ($record instanceof Content) {
             $record->set($field, $value);

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -306,7 +306,9 @@ class Frontend extends ConfigurableBase
             if ($fieldSettings['type'] === 'image') {
                 $fieldValue = $this->getFieldValue($record, $fieldSlug);
 
-                $this->setFieldValue($record, $fieldSlug, $fieldValue['file']);
+                if (is_array($fieldValue) && isset($fieldValue['file'])) {
+                    $this->setFieldValue($record, $fieldSlug, $fieldValue['file']);
+                }
             }
         }
 


### PR DESCRIPTION
This is a workaround to make "preview" behave more like "Normal view" of a record. 

It builds on #7660, and does a similar thing for HTML-like fields and Image fields. 

 - Fixes #7753 
 - Fixes #7703 
 - Fixes #7718