### PR TITLE
Excerpt strip fields.

### DIFF
--- a/app/view/twig/_base/_listing.twig
+++ b/app/view/twig/_base/_listing.twig
@@ -168,7 +168,7 @@ row_header:     prop.extended and (prop.first or (prop.has_groupname and prop.ne
                         {{ title|raw }}
                     {% endif %}
                 </strong>
-                {{ content|excerpt(excerptlength - title|length, false, filter|default()) }}
+                {{ content.excerpt(excerptlength - title|length, false, filter|default()) }}
             </span>
         </td>
 

--- a/src/Helpers/Excerpt.php
+++ b/src/Helpers/Excerpt.php
@@ -34,11 +34,11 @@ class Excerpt
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
-     * @param array|null        $stripFields
+     * @param array             $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = null)
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = [])
     {
         $title = null;
         if ($includeTitle && $this->title !== null) {
@@ -52,10 +52,6 @@ class Excerpt
 
         if ($this->body instanceof LegacyContent) {
             $this->body = $this->body->getValues();
-        }
-
-        if (null === $stripFields) {
-            $stripFields = [];
         }
 
         if (!is_array($stripFields)) {

--- a/src/Helpers/Excerpt.php
+++ b/src/Helpers/Excerpt.php
@@ -34,11 +34,11 @@ class Excerpt
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
-     * @param array             $stripFields
+     * @param array|null        $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, array $stripFields = [])
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = null)
     {
         $title = null;
         if ($includeTitle && $this->title !== null) {
@@ -52,6 +52,11 @@ class Excerpt
 
         if ($this->body instanceof LegacyContent) {
             $this->body = $this->body->getValues();
+        }
+
+        if (null !== $stripFields && !is_array($stripFields)) {
+            trigger_error(sprintf('Wrong type for "stripField" parameter. Expected array, got %s. Ignoring "stripField".', gettype($stripFields)), E_USER_DEPRECATED);
+            $stripFields = [];
         }
 
         if (is_array($this->body)) {

--- a/src/Helpers/Excerpt.php
+++ b/src/Helpers/Excerpt.php
@@ -54,7 +54,11 @@ class Excerpt
             $this->body = $this->body->getValues();
         }
 
-        if (null === $stripFields || !is_array($stripFields)) {
+        if (null === $stripFields) {
+            $stripFields = [];
+        }
+
+        if (!is_array($stripFields)) {
             trigger_error(sprintf('Wrong type for "stripField" parameter. Expected array, got %s. Ignoring "stripField".', gettype($stripFields)), E_USER_DEPRECATED);
             $stripFields = [];
         }

--- a/src/Helpers/Excerpt.php
+++ b/src/Helpers/Excerpt.php
@@ -54,7 +54,7 @@ class Excerpt
             $this->body = $this->body->getValues();
         }
 
-        if (null !== $stripFields && !is_array($stripFields)) {
+        if (null === $stripFields || !is_array($stripFields)) {
             trigger_error(sprintf('Wrong type for "stripField" parameter. Expected array, got %s. Ignoring "stripField".', gettype($stripFields)), E_USER_DEPRECATED);
             $stripFields = [];
         }

--- a/src/Helpers/Excerpt.php
+++ b/src/Helpers/Excerpt.php
@@ -34,10 +34,11 @@ class Excerpt
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
+     * @param array             $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null)
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, array $stripFields = [])
     {
         $title = null;
         if ($includeTitle && $this->title !== null) {
@@ -54,8 +55,10 @@ class Excerpt
         }
 
         if (is_array($this->body)) {
-            // Assume it's an array, strip some common fields that we don't need, implode the rest.
-            $stripKeys = [
+            // Assume it's an array, strip some common
+            // fields that we don't need, merge with
+            // the unwanted fields , implode the rest.
+            $stripKeys = array_merge([
                 'id',
                 'slug',
                 'datepublish',
@@ -70,7 +73,7 @@ class Excerpt
                 'taxonomy',
                 'templatefields',
                 'sortorder',
-            ];
+            ], $stripFields);
 
             $excerpt = '';
             array_walk($this->body, function ($value, $key) use (&$excerpt, $stripKeys) {

--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -213,13 +213,14 @@ class Content implements \ArrayAccess
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
+     * @param array             $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null)
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, array $stripFields = [])
     {
         $excerpter = new Excerpt($this);
-        $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus);
+        $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus, $stripFields);
 
         return new Markup($excerpt, 'UTF-8');
     }

--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -213,11 +213,11 @@ class Content implements \ArrayAccess
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
-     * @param array             $stripFields
+     * @param array|null        $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, array $stripFields = [])
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = null)
     {
         $excerpter = new Excerpt($this);
         $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus, $stripFields);

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -353,13 +353,14 @@ class Content extends Entity
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
+     * @param array             $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null)
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, array $stripFields = [])
     {
         $excerpter = new Excerpt($this);
-        $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus);
+        $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus, $stripFields);
 
         return new Markup($excerpt, 'UTF-8');
     }

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -353,11 +353,11 @@ class Content extends Entity
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
-     * @param array             $stripFields
+     * @param array|null        $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, array $stripFields = [])
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = null)
     {
         $excerpter = new Excerpt($this);
         $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus, $stripFields);

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -130,15 +130,15 @@ class RecordRuntime
      * @param \Bolt\Legacy\Content|array|string $content
      * @param int                               $length  Defaults to 200 characters
      * @param array|string|null                 $focus
+     * @param array                             $stripFields
      *
      * @return string Resulting excerpt
      */
-    public function excerpt($content, $length = 200, $focus = null)
+    public function excerpt($content, $length = 200, $focus = null, array $stripFields = [])
     {
         $excerpter = new Excerpt($content);
-        $excerpt = $excerpter->getExcerpt($length, false, $focus);
 
-        return $excerpt;
+        return $excerpter->getExcerpt($length, false, $focus, $stripFields);
     }
 
     /**

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -130,11 +130,11 @@ class RecordRuntime
      * @param \Bolt\Legacy\Content|array|string $content
      * @param int                               $length  Defaults to 200 characters
      * @param array|string|null                 $focus
-     * @param array                             $stripFields
+     * @param array|null                        $stripFields
      *
      * @return string Resulting excerpt
      */
-    public function excerpt($content, $length = 200, $focus = null, array $stripFields = [])
+    public function excerpt($content, $length = 200, $focus = null, $stripFields = null)
     {
         $excerpter = new Excerpt($content);
 

--- a/tests/phpunit/unit/Content/ContentTest.php
+++ b/tests/phpunit/unit/Content/ContentTest.php
@@ -173,4 +173,43 @@ class ContentTest extends BoltUnitTest
     public function testoffsetUnset()
     {
     }
+
+    public function testExcerptGracefulMiscallOfStripFields()
+    {
+        $app = $this->getApp();
+
+        /** @var Content $content */
+        $content = $app['storage']->getEmptyContent('pages');
+        $content->setValue('body', 'dummy body');
+        /** @var \Twig_Markup $result */
+        $result = $content->getExcerpt(200, null, null, 'miscall stripfield as string');
+
+        $this->assertEquals('dummy body', (string) $result);
+    }
+
+    public function testExcerptStripFields()
+    {
+        $app = $this->getApp();
+
+        /** @var Content $content */
+        $content = $app['storage']->getEmptyContent('pages');
+        $content->setValue('body', 'dummy body');
+        $content->setValue('title', 'dummy title');
+
+        $result = $content->getExcerpt(200, null, null, ['body']);
+
+        $this->assertNotContains('dummy body', (string) $result);
+    }
+
+    public function testNullExcerptStripFields()
+    {
+        $app = $this->getApp();
+
+        /** @var Content $content */
+        $content = $app['storage']->getEmptyContent('pages');
+        $content->setValue('body', 'dummy');
+        $result = $content->getExcerpt();
+
+        $this->assertEquals('dummy', (string) $result);
+    }
 }

--- a/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
@@ -368,10 +368,10 @@ GRINGALET;
 
         /** @var Content $content */
         $content = $app['storage']->getEmptyContent('pages');
-        $content->setValue('body', 'This should not appears in the excerpt');
+        $content->setValue('body', 'This should not appear in the excerpt');
 
-        $result = $handler->excerpt($content, 2000, null, ['body']);
-        $this->assertNotContains('This should not appears in the excerpt', (string) $result);
+        $result = $handler->excerpt($content, 200, null, ['body']);
+        $this->assertNotContains('This should not appear in the excerpt', (string) $result);
     }
 
     public function testExcerptArrayStripFields()
@@ -379,7 +379,7 @@ GRINGALET;
         $handler = $this->getRecordRuntime();
 
         $content = [
-            'dummy'       => 'This should not appears in the excerpt',
+            'dummy'       => 'This should not appear in the excerpt',
             'id'          => 42,
             'slug'        => 'clippy-inc',
             'datecreated' => null,
@@ -394,7 +394,7 @@ GRINGALET;
         ];
 
         $result = $handler->excerpt($content, 200, null, ['dummy']);
-        $this->assertNotContains('This should not appears in the excerpt', (string) $result);
+        $this->assertNotContains('This should not appear in the excerpt', (string) $result);
     }
 
     public function testListTemplatesAll()

--- a/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
+++ b/tests/phpunit/unit/Twig/Runtime/RecordRuntimeTest.php
@@ -361,6 +361,42 @@ GRINGALET;
         $this->assertSame('', $result);
     }
 
+    public function testExcerptContentClassObjectStripFields()
+    {
+        $app = $this->getApp();
+        $handler = $this->getRecordRuntime();
+
+        /** @var Content $content */
+        $content = $app['storage']->getEmptyContent('pages');
+        $content->setValue('body', 'This should not appears in the excerpt');
+
+        $result = $handler->excerpt($content, 2000, null, ['body']);
+        $this->assertNotContains('This should not appears in the excerpt', (string) $result);
+    }
+
+    public function testExcerptArrayStripFields()
+    {
+        $handler = $this->getRecordRuntime();
+
+        $content = [
+            'dummy'       => 'This should not appears in the excerpt',
+            'id'          => 42,
+            'slug'        => 'clippy-inc',
+            'datecreated' => null,
+            'datechanged' => null,
+            'username'    => 'clippy',
+            'ownerid'     => null,
+            'title'       => 'Attack of the Drop Bear',
+            'contenttype' => 'koala',
+            'status'      => 'published',
+            'taxonomy'    => null,
+            'body'        => $this->original,
+        ];
+
+        $result = $handler->excerpt($content, 200, null, ['dummy']);
+        $this->assertNotContains('This should not appears in the excerpt', (string) $result);
+    }
+
     public function testListTemplatesAll()
     {
         $app = $this->getApp();


### PR DESCRIPTION
Fixes #7758

Allow to strip unwanted fields out of the excerpt by adding a fourth argument to Excerpt and related runtime methods.

Doc update on its way.