### PR TITLE
[3.6] Remove unsupported guzzlehttp version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "ext-xml": "*",
         "ext-zip": "*",
         "filp/whoops": "^2.0",
-        "guzzlehttp/guzzle": "^5.3.1 || ^6.2.1",
+        "guzzlehttp/guzzle": "^6.2.1",
         "ircmaxell/random-lib": "^1.1",
         "jdorn/sql-formatter": "^1.2",
         "monolog/monolog": "^1.12",


### PR DESCRIPTION
If you have version 5.* installed of guzzlehttp/guzzle Bolt will break due to vendor/bolt/bolt/src/Composer/Satis/PingService.php expecting GuzzleHttp\RequestOptions to exist which only is available in version 6.* of guzzlehttp/guzzle

This PR will remove the option to use 5.* and force you to use 6.* preventing the error.