### PR TITLE
[3.6] Make the bootstrap more robust

### DIFF
--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -2,13 +2,19 @@
 
 if (file_exists(__DIR__ . '/../../vendor/autoload.php')) {
     require_once __DIR__ . '/../../vendor/autoload.php';
-} else {
+} elseif (file_exists(__DIR__ . '/../../../vendor/autoload.php')) {
+    require_once __DIR__ . '/../../../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../../vendor/autoload.php')) {
     require_once __DIR__ . '/../../../../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../../../vendor/autoload.php')) {
+    require_once __DIR__ . '/../../../../../vendor/autoload.php';
+} else {
+    exit('Could not find the vendor autoloader');
 }
 
 // Install base location
 if (!defined('TEST_ROOT')) {
-    define('TEST_ROOT', realpath(__DIR__ . '/../../'));
+    define('TEST_ROOT', dirname(dirname(__DIR__)));
 }
 
 // PHPUnit's base location


### PR DESCRIPTION
When using an old version of phpunit like `4.8.28` it does not provide a class called `PHPUnit\Framework\TestCase` required by `bolt/bolt/tests/phpunit/unit/BoltUnitTest.php`
The class is available in version 5.7. The dependancy with `phpunit/php-code-coverage` has also been updated.

Next to the phpunit version there is an issue when running the unittests, it can't seem to find the `vendor/autoload.php`. I've made the bootstrap a bit more defensive.
For context: We have the bootstrap located in: `vendor/bolt/bolt/tests/phpunit/bootstrap.php`