### PR TITLE
[3.6] WIP Use the EntityBuilder provided by  instead a new Instance

### DIFF
--- a/src/Storage/EntityManager.php
+++ b/src/Storage/EntityManager.php
@@ -118,7 +118,7 @@ class EntityManager implements EntityManagerInterface
      */
     public function getEntityBuilder($className = null, ClassMetadata $classMetadata = null)
     {
-        $builder = new Entity\Builder($this->getMapper(), $this->getFieldManager());
+        $builder = $this->createEntityBuilder();
 
         if ($className !== null) {
             $builder->setClass($className);
@@ -129,6 +129,18 @@ class EntityManager implements EntityManagerInterface
         }
 
         return $builder;
+    }
+
+    /**
+     * @return Entity\Builder
+     */
+    private function createEntityBuilder()
+    {
+        if (! $this->builder) {
+            return new Entity\Builder($this->getMapper(), $this->getFieldManager());
+        }
+        $builderClass = get_class($this->builder);
+        return new $builderClass($this->getMapper(), $this->getFieldManager());
     }
 
     /**


### PR DESCRIPTION
As mentioned in https://github.com/bolt/bolt/issues/7764 it's currently not possible to use a custom Entity/Builder for the Backend since it creates a new Instance. With this PR we are use the Builder provided in the StorageServiceProvider (see `src/Provider/StorageServiceProvider.php`)
