### PR TITLE
add information about how to set up custom ck styles

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -320,6 +320,7 @@ wysiwyg:
         disableNativeSpellChecker: true # If set to 'true' it will stop browsers from underlining spelling mistakes
         allowNbsp: false     # If set to 'false', the editor will strip out `&nbsp;` characters. If set to 'true', it will allow them. ¯\_(ツ)_/¯
         #stylesSet: "custom:/path/to/your/custom/styles.js" see https://ckeditor.com/docs/ckeditor4/latest/guide/dev_styles.html for more informations
+
 # Bolt uses the Google maps API for it's geolocation field and Google now
 # requires that it be loaded with an API key on new domains. You can generate
 # a key at https://developers.google.com/maps/documentation/javascript/get-api-key

--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -300,6 +300,7 @@ debuglog:
 # responsibility not to break the layout.
 wysiwyg:
     images: false            # Allow users to insert images in the content.
+    styles: false            # Allow users to use the custom styles you have defined (you need to set the "stylesSet" param in the ck section bellow)
     anchor: false            # Adds a button to create internal anchors to link to.
     tables: false            # Adds a button to insert and modify tables in the content.
     fontcolor: false         # Allow users to mess around with font coloring.
@@ -318,7 +319,7 @@ wysiwyg:
         autoParagraph: true  # If set to 'true', any pasted content is wrapped in `<p>`-tags for multiple line-breaks
         disableNativeSpellChecker: true # If set to 'true' it will stop browsers from underlining spelling mistakes
         allowNbsp: false     # If set to 'false', the editor will strip out `&nbsp;` characters. If set to 'true', it will allow them. ¯\_(ツ)_/¯
-
+        #stylesSet: "custom:/path/to/your/custom/styles.js" see https://ckeditor.com/docs/ckeditor4/latest/guide/dev_styles.html for more informations
 # Bolt uses the Google maps API for it's geolocation field and Google now
 # requires that it be loaded with an API key on new domains. You can generate
 # a key at https://developers.google.com/maps/documentation/javascript/get-api-key


### PR DESCRIPTION
By default the ckeditor build shipped with bolt support custom styles definition 
( ie the build contains the "styles combo" add, as we can see here : https://ckeditor.com/cke4/builder/9705ed1f5e13d331e24bd0e950b94e0e, this link is the one mentioned in bolt source code : src/vendor/bolt/bolt/app/src/lib/ckeditor/build-config.js ) 

But the default config.yml file does not mentioned it, and it's easy to think we have to create a bolt extension to add the required ckeditor addons (as it has already be done by @SahAssar  : https://discuss.bolt.cm/d/442-adding-ckeditor-plugins/9 )

This PR just add 2 config line to show it's quite easy to implement, and it could have save me few hours of investigation ;)
