### PR TITLE
Make sure stripFields is set to array by default

### DIFF
--- a/src/Legacy/Content.php
+++ b/src/Legacy/Content.php
@@ -213,11 +213,11 @@ class Content implements \ArrayAccess
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
-     * @param array|null        $stripFields
+     * @param array             $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = null)
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = [])
     {
         $excerpter = new Excerpt($this);
         $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus, $stripFields);

--- a/src/Storage/Entity/Content.php
+++ b/src/Storage/Entity/Content.php
@@ -353,11 +353,11 @@ class Content extends Entity
      * @param int               $length
      * @param bool              $includeTitle
      * @param array|string|null $focus
-     * @param array|null        $stripFields
+     * @param array             $stripFields
      *
      * @return string|null
      */
-    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = null)
+    public function getExcerpt($length = 200, $includeTitle = false, $focus = null, $stripFields = [])
     {
         $excerpter = new Excerpt($this);
         $excerpt = $excerpter->getExcerpt($length, $includeTitle, $focus, $stripFields);

--- a/src/Twig/Runtime/RecordRuntime.php
+++ b/src/Twig/Runtime/RecordRuntime.php
@@ -130,11 +130,11 @@ class RecordRuntime
      * @param \Bolt\Legacy\Content|array|string $content
      * @param int                               $length  Defaults to 200 characters
      * @param array|string|null                 $focus
-     * @param array|null                        $stripFields
+     * @param array                             $stripFields
      *
      * @return string Resulting excerpt
      */
-    public function excerpt($content, $length = 200, $focus = null, $stripFields = null)
+    public function excerpt($content, $length = 200, $focus = null, $stripFields = [])
     {
         $excerpter = new Excerpt($content);
 


### PR DESCRIPTION
Details
-------
Is this commit https://github.com/bolt/bolt/pull/7759/commits/70b3f2114b829642d4dca09af5d5661891ac9fad the default for stripFields is set to an array instead of `null`, without changing the calling methods to reflect the same change resulting in `trigger_error` foreach call without parameters which in turn can cause a 500 error if to many errors are triggered.

In the nginx/errorlog you would see:
`2019/05/23 12:26:35 [error] 1368#1368: *76 upstream sent too big header while reading response header from upstream,`

This PR make sure the calling functions are updated to reflect the new default value for stripFields.