### PR TITLE
Use isIterable over Traversable

### DIFF
--- a/src/Response/TemplateResponse.php
+++ b/src/Response/TemplateResponse.php
@@ -73,7 +73,7 @@ class TemplateResponse extends Response
      */
     protected function setContext($context)
     {
-        Assert::isTraversable($context);
+        Assert::isIterable($context);
 
         $this->context = Bag::from($context);
     }


### PR DESCRIPTION
Traversable was deprecated in assert 1.3.0
