### PR TITLE
Added comment about required IP in trustProxies

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -442,7 +442,7 @@ hash_strength: 10
 #       If you do not understand what this does, it is probably best to not
 #       touch it.
 # trustProxies:
-#     - 127.0.0.1
+#     - 127.0.0.1          # Required. Otherwise internal subrequests break.
 #     - 10.0.0.0/8
 
 # If you want Bolt installation get news through a proxy


### PR DESCRIPTION
If you don't include the app’s ip address in trustProxies, internal sub-requests such as fetching the latest activity on the dashboard fail. This PR adds a comment to the default config file so people are aware of that. See discussion on Slack: https://boltcms.slack.com/archives/C094GL7ME/p1567587144104700