### PR TITLE
fix typo in AccessControlListener.php

### DIFF
--- a/src/EventListener/AccessControlListener.php
+++ b/src/EventListener/AccessControlListener.php
@@ -127,7 +127,7 @@ class AccessControlListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            StorageEvents::PRE_DELETE => 'onStorageEventPostSave',
+            StorageEvents::POST_SAVE => 'onStorageEventPostSave',
             StorageEvents::PRE_DELETE => 'onStorageEventPreDelete',
         ];
     }


### PR DESCRIPTION
Was it a typo or intentionally?

`https://github.com/bolt/bolt/blob/3.6/src/EventListener/AccessControlListener.php#L130`

See double PRE_DELETE:
```php
    public static function getSubscribedEvents()
    {
        return [
            StorageEvents::PRE_DELETE => 'onStorageEventPostSave',
            StorageEvents::PRE_DELETE => 'onStorageEventPreDelete',
        ];
    }
```