### PR TITLE
Fix tags in non-english languages and firefox caching selected options

### DIFF
--- a/app/src/js/widgets/fields/fieldSelect.js
+++ b/app/src/js/widgets/fields/fieldSelect.js
@@ -32,6 +32,11 @@
          */
         _create: function () {
             var select = this.element.find('select');
+            // Regigger firefoxes form cache kagigger
+            // See https://stackoverflow.com/questions/1479233/why-doesnt-firefox-show-the-correct-default-select-option
+            var selected = select.find('option[selected]');
+            select.find('option').removeAttr('selected');
+            selected.prop('selected', 'selected');
             var options = {
                 width: '100%',
                 placeholder: {

--- a/app/src/js/widgets/fields/fieldTags.js
+++ b/app/src/js/widgets/fields/fieldTags.js
@@ -35,11 +35,17 @@
                 tagcloud = this.element.find('.tagcloud'),
                 separators = [','],
                 tags = {};
+            // Regigger firefoxes form cache kagigger
+            // See https://stackoverflow.com/questions/1479233/why-doesnt-firefox-show-the-correct-default-select-option
+            var selected = taxonomy.find('option[selected]');
+            taxonomy.find('option').removeAttr('selected');
+            selected.prop('selected', 'selected');
 
             // Initialize the tag selector.
             if (!this.options.allowSpaces) {
                 separators.push(' ');
             }
+
             taxonomy.select2({
                 width: '100%',
                 tags: tags,
@@ -56,9 +62,9 @@
                     var arrayLength = data.length;
                     var optionsHTML = '';
                     for (var i = 0; i < arrayLength; i++) {
-                        if (options.indexOf(data[i].name) < 0) {
-                            options.push(data[i].name);
-                            optionsHTML += '<option value="' + data[i].name + '">' + data[i].name + '</option>';
+                        if (options.indexOf(data[i].slug) < 0) {
+                            options.push(data[i].slug);
+                            optionsHTML += '<option value="' + data[i].slug + '">' + data[i].name + '</option>';
                         }
                     }
                     taxonomy.append($(optionsHTML)).trigger('change');
@@ -80,14 +86,16 @@
                                     .append($('<button/>', {
                                         type: 'button',
                                         text: item.name,
-                                        rel: item.count
+                                        rel: item.count,
+                                        value: item.slug
                                     }))
                                     .append('');
                             });
 
                             tagcloud.find('button').on('click', function () {
-                                var text = $(this).text(),
-                                    option = taxonomy.find('option[value="' + text + '"]');
+                                var slug = $(this).data('slug'),
+                                    text = $(this).text(),
+                                    option = taxonomy.find('option[value="' + slug + '"]');
 
                                 if (option.length > 0) {
                                     // Just select if tag exists…
@@ -96,7 +104,7 @@
                                     // … otherwise add.
                                     taxonomy
                                         .append($('<option/>', {
-                                            value: text,
+                                            value: slug,
                                             text: text,
                                             selected: true
                                         }))

--- a/src/Controller/Async/General.php
+++ b/src/Controller/Async/General.php
@@ -260,7 +260,7 @@ class General extends AsyncBase
         $table .= 'taxonomy';
 
         $query = $this->createQueryBuilder()
-            ->select('name, COUNT(slug) AS count')
+            ->select('slug, name, COUNT(slug) AS count')
             ->from($table)
             ->where('taxonomytype = :taxonomytype')
             ->groupBy('name')
@@ -275,11 +275,11 @@ class General extends AsyncBase
         usort(
             $results,
             function ($a, $b) {
-                if ($a['name'] == $b['name']) {
+                if ($a['slug'] == $b['slug']) {
                     return 0;
                 }
 
-                return ($a['name'] < $b['name']) ? -1 : 1;
+                return ($a['slug'] < $b['slug']) ? -1 : 1;
             }
         );
 
@@ -333,7 +333,7 @@ class General extends AsyncBase
         $table .= 'taxonomy';
 
         $query = $this->createQueryBuilder()
-            ->select("DISTINCT $table.name")
+            ->select("DISTINCT slug, name")
             ->from($table)
             ->where('taxonomytype = :taxonomytype')
             ->orderBy('name', 'ASC')


### PR DESCRIPTION
This fixes two issues:

1. Bolt saw the slug and the name of a tag as always equivalent, this makes them distinct
2. Firefox has a "feature" where it ignores `selected` if a different option has been selected before reload and the reload is not "hard". Since select2 takes over the actual input it didn't see the select as changed, so adding a tag and reloading would make it seem like the tag wasn't added, and then a subsequent save would remove the tag.

Fixes: #7659 