### PR TITLE
Update test for Doctrine 2.10 compatibility

### DIFF
--- a/tests/phpunit/unit/Field/BaseFieldTest.php
+++ b/tests/phpunit/unit/Field/BaseFieldTest.php
@@ -24,7 +24,7 @@ class BaseFieldTest extends BoltUnitTest
         $this->assertEquals('test.twig', $field->getTemplate());
 
         // This tests the default returns for base
-        $this->assertEquals('Text', (string) $field->getStorageType());
+        $this->assertEquals('Doctrine\\DBAL\\Types\\TextType', get_class($field->getStorageType()));
         $this->assertEquals([], $field->getStorageOptions());
     }
 }


### PR DESCRIPTION
Fixes failing tests on PHP 7.2, because it pulled in Doctrine/DBAL 2.10.