### PR TITLE
Fix ContextErrorException in PHP 7.4

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -282,7 +282,11 @@ class ExceptionListener implements EventSubscriberInterface
 
         $trace = $exception->getTrace();
         foreach ($trace as $key => $value) {
-            $trace[$key]['args_safe'] = $this->getSafeArguments($trace[$key]['args']);
+            // See: https://www.php.net/manual/en/migration74.other-changes.php#migration74.other-changes.ini
+            $trace[$key]['args_safe'] = [];
+            if (isset($trace[$key]['args'])) {
+                $trace[$key]['args_safe'] = $this->getSafeArguments($trace[$key]['args']);
+            }
 
             // Don't display the full path, trim 64-char hexadecimal file names.
             if (isset($trace[$key]['file'])) {


### PR DESCRIPTION
Fixes #7864

See: https://www.php.net/manual/en/migration74.other-changes.php#migration74.other-changes.ini

A `ContextErrorException` is thrown when `zend.exception_ignore_args` is set to `On`. The `args` key is not available.

A simple test-case:
```
ini_set('zend.exception_ignore_args', 'On');
trigger_error('test', E_USER_NOTICE );
```