### PR TITLE
Fixes slashes in directory names

### DIFF
--- a/src/Controller/Async/FilesystemManager.php
+++ b/src/Controller/Async/FilesystemManager.php
@@ -106,8 +106,8 @@ class FilesystemManager extends AsyncBase
         $this->checkToken($request);
 
         $namespace = $request->request->get('namespace');
-        $parentPath = Str::makeSafe($request->request->get('parent'), false, '()[]!@$^-_=+{},.~');
-        $folderName = Str::makeSafe($request->request->get('foldername'), false, '()[]!@$^-_=+{},.~');
+        $parentPath = Str::makeSafe($request->request->get('parent'), false, '()[]!@$^-_=+{},.~/');
+        $folderName = Str::makeSafe($request->request->get('foldername'), false, '()[]!@$^-_=+{},.~/');
 
         try {
             $dir = $this->filesystem()->getDir("$namespace://$parentPath/$folderName");


### PR DESCRIPTION
- The 1st line allows slashes in parent's names.
- The 2nd line allows users to create "foo/bar/baz" in one go.