### PR TITLE
allow rel attribute by default

### DIFF
--- a/app/config/config.yml.dist
+++ b/app/config/config.yml.dist
@@ -217,7 +217,7 @@ thumbnails:
 # will be allowed, regardless of it being in the `allowed_tags` setting.
 htmlcleaner:
     allowed_tags: [ div, span, p, br, hr, s, u, strong, em, i, b, li, ul, ol, mark, blockquote, pre, code, tt, h1, h2, h3, h4, h5, h6, dd, dl, dt, table, tbody, thead, tfoot, th, td, tr, a, img, address, abbr, iframe, caption, sub, sup, figure, figcaption ]
-    allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan, download, hreflang ]
+    allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan, download, hreflang, rel ]
 
 # Uploaded file handling
 #


### PR DESCRIPTION
Allow rel attribute when sanitize HTML

As the ckeditor link options have 'rel' tags in there 'advanced' tab it would be a good idea to allow rel tag by default/ Because it's a bit confusing for the user to be allowed to add the tag but to not store it in the database.

(see discussion here --> https://boltcms.slack.com/archives/C094GL7ME/p1603187487310500)
