### PR TITLE
FIXED: #7893 Fetching content by Taxonomy does not work if ContentType Name is different than ContentType Slug 

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1370,7 +1370,7 @@ class Storage
                             $this->parseWhereParameter($this->getTablename('taxonomy') . '.taxonomytype', $key),
                             $this->parseWhereParameter($this->getTablename('taxonomy') . '.slug', $value),
                             $this->parseWhereParameter($this->getTablename('taxonomy') . '.name', $value),
-                            $this->parseWhereParameter($this->getTablename('taxonomy') . '.contenttype', $contenttype['slug'])
+                            $this->parseWhereParameter($this->getTablename('taxonomy') . '.contenttype', $contenttype['name'])
                         );
                     }
                 }


### PR DESCRIPTION
Issue #7893 Bug fixed


Fixes: #7893 
Fetching content by Taxonomy does not work if ContentType Name is different than ContentType Slug 


Details
-------
Reason for Bug: decodeContentQuery function builds query using ContentType Slugh whereas taxonomy mapping table uses ContentType Name to map. The query mismatch results 0 rows. After changing the query to lookup mapping by ContentType Name, query results are returned as expected.
   
Target Branch
------------------------

 * `release/3.7` — "stable" branch 
