### PR TITLE
Fix querying by ContentType slug

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1370,7 +1370,7 @@ class Storage
                             $this->parseWhereParameter($this->getTablename('taxonomy') . '.taxonomytype', $key),
                             $this->parseWhereParameter($this->getTablename('taxonomy') . '.slug', $value),
                             $this->parseWhereParameter($this->getTablename('taxonomy') . '.name', $value),
-                            $this->parseWhereParameter($this->getTablename('taxonomy') . '.contenttype', $contenttype['name'])
+                            $this->parseWhereParameter($this->getTablename('taxonomy') . '.contenttype', $contenttype['slug'] . ' || ' . $contenttype['name'])
                         );
                     }
                 }


### PR DESCRIPTION
Patches #7893, by allowing the `name` OR the `slug` to be used for querying.