### PR TITLE
fix bolt/bolt#7924 - php 7.4 incompatibility of legacy storage code

### DIFF
--- a/src/Legacy/Storage.php
+++ b/src/Legacy/Storage.php
@@ -1062,7 +1062,7 @@ class Storage
             $decoded['return_single'] = true;
             // if allow_numeric_slug option is set on contenttype, interpret number as slug instead of id
             $contenttype = $this->getContentType($decoded['contenttypes'][0]);
-            $field = ($contenttype['allow_numeric_slugs'] === true ? 'slug' : 'id');
+            $field = !empty($contenttype) ? ($contenttype['allow_numeric_slugs'] === true ? 'slug' : 'id') : 'id';
             $ctypeParameters[$field] = $match[2];
         } elseif (preg_match('#^/?([a-z0-9_(\),-]+)/search(/([0-9]+))?$#i', $textquery, $match)) {
             // like 'page/search or '(entry,page)/search'


### PR DESCRIPTION
Fix php7.4 incompatibility in legacy storage code.

src/Legacy/Storage.php line 1065 would try to test the value of an array member without first checking whether the variable contained the given array key. If the variable was empty, this would produce a falsy value prior to PHP7.4 but throw a fatal exception in PHP 7.4.

This PR adds a check that the $contenttype variable is populated and returns a default value if not, mimicking the outcome of the code if run in PHP < 7.4

Fixes bolt/bolt#7924