### PR TITLE
Fix bolt/bolt#7902 PHP 7.4 exception on empty search

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -541,12 +541,14 @@ class Frontend extends ConfigurableBase
         if ($isLegacy) {
             $result = $this->storage()->searchContent($q, $contenttypes, $filters, $limit, $offset);
 
+            $resultcount = isset($result['no_of_results']) ? $result['no_of_results'] : 0;
+
             /** @var \Bolt\Pager\PagerManager $manager */
             $manager = $this->app['pager'];
             $manager
                 ->createPager($context)
-                ->setCount($result['no_of_results'])
-                ->setTotalpages(ceil($result['no_of_results'] / $pageSize))
+                ->setCount($resultcount)
+                ->setTotalpages(ceil($resultcount / $pageSize))
                 ->setCurrent($page)
                 ->setShowingFrom($offset + 1)
                 ->setShowingTo($offset + ($result ? count($result['results']) : 0));
@@ -572,8 +574,8 @@ class Frontend extends ConfigurableBase
         }
 
         $globals = [
-            'records'      => $result['results'],
-            $context       => $result['query']['sanitized_q'],
+            'records'      => isset($result['results']) ? $result['results'] : false,
+            $context       => isset($result['query']['sanitized_q']) ? $result['query']['sanitized_q'] : false,
             'searchresult' => $result,
         ];
 


### PR DESCRIPTION
PHP 7.4 throws an exception when someone tries to access an array item
on a variable of boolean type. An empty search string results in a "false"
value being allocated to the search results, rather than the expected array.
This commit adds a check that the results array
is populated before attempting to access an array member.

Fixes bolt/bolt#7902