### PR TITLE
[WIP] update/bugfix to Export.php that enables exporting select fields that reference multiple other contenttypes

### DIFF
--- a/src/Storage/Migration/Export.php
+++ b/src/Storage/Migration/Export.php
@@ -217,36 +217,36 @@ final class Export
         if (is_array($values)) {
             $val = [];
             foreach ($values as $value) {
-                $reference = $contentTypeName . '/' . $value;
-                $val[] = $this->getContent($reference, $contentTypeName, (string) $value);
+                if (strpos($value, '/') !== false) {
+                    $reference = $value;
+                } else {
+                    $reference = $contentTypeName . '/' . $value;
+                }
+                $lookupResult = $this->getContentUsingSlug($reference);
+                $val[] = $lookupResult;
             }
         } else {
             $reference = $contentTypeName . '/' . $entity->$fieldName;
-            $val = $this->getContent($reference, $contentTypeName, (string) $entity->$fieldName);
+            $lookupResult = $this->getContentUsingSlug($reference);
+
+            $val[] = $lookupResult;
         }
 
         return $val;
     }
 
-    private function getContent(string $reference, string $contentTypeName, string $value)
+    private function getContentUsingSlug(string $search)
     {
-        if (isset($this->referenceCache[$reference])) {
-            return $this->referenceCache[$reference];
-        }
-
-        $referencedContent = $this->query->getContent($contentTypeName, ['id' => $value]);
+        $r = $this->query->getContent($search);
 
         $val = [];
 
-        /** @var Content $r */
-        foreach ($referencedContent as $r) {
+        if ($r instanceof Content) {
             $val[] = [
-                'value' => (string) $value,
+                'value' => (string) $search,
                 '_id' => sprintf('%s/%s', $r->getContenttype(), $r->getSlug())
             ];
         }
-
-        $this->referenceCache[$reference] = $val;
 
         return $val;
     }


### PR DESCRIPTION
This PR updates the Export.php code so it uses a different way to look up (select) field content if it references other contenttypes. This was needed for my project to correctly export select fields that reference multiple content types. The current version would _not_ export any valid data for my select fields.

See https://github.com/bolt/bolt/issues/7972

I don't know if Bolt 3.7 is still being updated for this kind of stuff, and I don't have any experience using 3.7 myself so testing of this fix was limited to my current project only.

Labeled WIP just to warn this is not thoroughly tested and should not just be merged. Waiting for some discussion before marking it as a 'real' PR.